### PR TITLE
Display pagination when there is total or page size is greater than one

### DIFF
--- a/apps/web/src/design-system/table/Table.tsx
+++ b/apps/web/src/design-system/table/Table.tsx
@@ -144,7 +144,7 @@ export function Table({
           })}
         </tbody>
       </MantineTable>
-      {pagination && total && pageSize>1 (
+      {pagination && total && pageSize > 1 && (
         <Pagination
           styles={{
             active: {

--- a/apps/web/src/design-system/table/Table.tsx
+++ b/apps/web/src/design-system/table/Table.tsx
@@ -144,7 +144,7 @@ export function Table({
           })}
         </tbody>
       </MantineTable>
-      {pagination && (
+      {pagination && total && pageSize>1 (
         <Pagination
           styles={{
             active: {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
It will not render pagination if there is no total count or page size is less than one.

- **What is the current behavior?**
This fix is related to issue #417 

- **What is the new behavior (if this is a feature change)?**
There will be no pagination for page size less than or equal to one or total count is zero.

