### PR TITLE
🐛  Fix Cors issue when accessing window.parent inside widget

### DIFF
--- a/apps/web/src/hooks/use-novu.ts
+++ b/apps/web/src/hooks/use-novu.ts
@@ -6,7 +6,7 @@ export function useNovu() {
   const authContext = useContext(AuthContext);
 
   useEffect(() => {
-    if ((ENV === 'dev' || ENV === 'prod' || true) && authContext.currentUser) {
+    if ((ENV === 'dev' || ENV === 'prod') && authContext.currentUser) {
       // eslint-disable-next-line func-names,id-length
       (function (n, o, t, i, f) {
         /* eslint-disable */
@@ -27,10 +27,8 @@ export function useNovu() {
         before.parentNode?.insertBefore(elt, before);
       })(window, document, WIDGET_EMEBED_PATH, 'novu', 'script');
 
-      console.log(WIDGET_EMEBED_PATH);
-
       (window as any).novu.init(
-        APP_ID,
+        APP_ID || 'GtUsnlZG4ymp',
         { bellSelector: '#notification-bell', unseenBadgeSelector: '#unseen-badge-selector' },
         {
           $user_id: authContext.currentUser?._id,

--- a/apps/web/src/hooks/use-novu.ts
+++ b/apps/web/src/hooks/use-novu.ts
@@ -28,7 +28,7 @@ export function useNovu() {
       })(window, document, WIDGET_EMEBED_PATH, 'novu', 'script');
 
       (window as any).novu.init(
-        APP_ID || 'GtUsnlZG4ymp',
+        APP_ID,
         { bellSelector: '#notification-bell', unseenBadgeSelector: '#unseen-badge-selector' },
         {
           $user_id: authContext.currentUser?._id,

--- a/apps/widget/src/api/shared.ts
+++ b/apps/widget/src/api/shared.ts
@@ -6,12 +6,12 @@ declare global {
 }
 
 export const API_URL =
-  isBrowser() && ((window as any).Cypress || (window as any).parent.Cypress)
-    ? window._env_.REACT_APP_API_URL || 'http://localhost:1336'
-    : window._env_.REACT_APP_API_URL || 'http://localhost:3000';
+  isBrowser() && (window as any).Cypress
+    ? window._env_.REACT_APP_API_URL || process.env.REACT_APP_API_URL || 'http://localhost:1336'
+    : window._env_.REACT_APP_API_URL || process.env.REACT_APP_API_URL || 'http://localhost:3000';
 export const WS_URL =
-  isBrowser() && ((window as any).Cypress || (window as any).parent.Cypress)
-    ? window._env_.REACT_APP_WS_URL || 'http://localhost:1340'
-    : window._env_.REACT_APP_WS_URL || 'http://localhost:3002';
+  isBrowser() && (window as any).Cypress
+    ? window._env_.REACT_APP_WS_URL || process.env.REACT_APP_WS_URL || 'http://localhost:1340'
+    : window._env_.REACT_APP_WS_URL || process.env.REACT_APP_WS_URL || 'http://localhost:3002';
 
 export const ENV = window._env_.REACT_APP_ENVIRONMENT;


### PR DESCRIPTION
An issue caused by trying to access `window.parent` from within the widget caused the following error.

```
Uncaught DOMException: Blocked a frame with origin "https://widget.novu.co" from accessing a cross-origin frame.
    at Module.<anonymous> (https://dev.widget.novu.co/static/js/main.c14ed694.chunk.js:1:22623)
    at i (https://dev.widget.novu.co/xBbPgsaY6mdU:1:1224)
    at r (https://dev.widget.novu.co/xBbPgsaY6mdU:1:1093)
    at Array.t [as push] (https://dev.widget.novu.co/xBbPgsaY6mdU:1:956)
    at https://dev.widget.novu.co/static/js/main.c14ed694.chunk.js:1:73
```