### PR TITLE
Use content-type: application/json for payload in example script

### DIFF
--- a/apps/web/src/components/templates/TriggerSnippetTabs.tsx
+++ b/apps/web/src/components/templates/TriggerSnippetTabs.tsx
@@ -20,7 +20,7 @@ novu.trigger('${trigger.identifier?.replace(/'/g, "\\'")}', {
 
   const curlSnippet = `curl --location --request POST '${API_ROOT}/v1/events/trigger' \\
      --header 'Authorization: ApiKey <REPLACE_WITH_API_KEY>' \\
-     --header 'Content-Type: environment/json' \\
+     --header 'Content-Type: application/json' \\
      --data-raw '{
         "name": "${trigger.identifier?.replace(/'/g, "\\'")}",
         "payload": {

--- a/packages/cli/src/constants/dashboard/index.html
+++ b/packages/cli/src/constants/dashboard/index.html
@@ -260,7 +260,7 @@
 
                   <code id="curl-user-snippet" class="language-bash ">curl --location --request POST 'https://api.novu.co/v1/events/trigger' \
  --header 'Authorization: ApiKey *********' \
- --header 'Content-Type: environment/json' \
+ --header 'Content-Type: application/json' \
  --data-raw '{
     "name": "REPLACE_WITH_name",
     "payload": {
@@ -318,7 +318,7 @@
   visibility: hidden">
                   <pre data-test-id="trigger-curl-snippet" style="color: white; background: rgb(77, 64, 51); text-shadow: black 0px -0.1em 0.2em; font-family: Consolas, Monaco, &quot;Andale Mono&quot;, &quot;Ubuntu Mono&quot;, monospace; font-size: 1em; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; overflow-wrap: normal; line-height: 1.5; tab-size: 4; hyphens: none; padding: 1em; margin: 0.5em 0px; overflow: auto; border: 0.3em solid rgb(122, 102, 82); border-radius: 0.5em; box-shadow: black 1px 1px 0.5em inset;"><code class="language-shell" style="color: white; background: none; text-shadow: black 0px -0.1em 0.2em; font-family: Consolas, Monaco, &quot;Andale Mono&quot;, &quot;Ubuntu Mono&quot;, monospace; font-size: 1em; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; overflow-wrap: normal; line-height: 1.5; tab-size: 4; hyphens: none;"><span class="token function">curl</span><span> --location --request POST </span><span class="token" style="color: rgb(189, 224, 82);">'REPLACE_WITH_url'</span><span> </span><span class="token">\</span><span>
                     </span><span>     --header </span><span class="token" style="color: rgb(189, 224, 82);">'Authorization: ApiKey REPLACE_WITH_apiKey'</span><span> </span><span class="token">\</span><span>
-                    </span><span>     --header </span><span class="token" style="color: rgb(189, 224, 82);">'Content-Type: environment/json'</span><span> </span><span class="token">\</span><span>
+                    </span><span>     --header </span><span class="token" style="color: rgb(189, 224, 82);">'Content-Type: application/json'</span><span> </span><span class="token">\</span><span>
                     </span><span>     --data-raw </span><span class="token" style="color: rgb(189, 224, 82);">'{
                     </span><span class="token" style="color: rgb(189, 224, 82);">        "name": "REPLACE_WITH_name",
                     </span><span class="token" style="color: rgb(189, 224, 82);">        "payload": {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  - Content-Type should be `application/json`. This updates the trigger sample code to use `application/json` instead of `environment/json`

- **What is the current behavior?** (You can also link to an open issue here)

  - `environment/json` is not valid and results in the request failing if a user uses the example code

- **What is the new behavior (if this is a feature change)?**

  - Correct example code is displayed and will work without modification for a user

- **Other information**:
  - N/A