### PR TITLE
Changed sms77 constructor call

### DIFF
--- a/apps/api/src/app/events/services/sms-service/handlers/sms77.handler.ts
+++ b/apps/api/src/app/events/services/sms-service/handlers/sms77.handler.ts
@@ -5,7 +5,7 @@ import { BaseSmsHandler } from './base.handler';
 
 export class Sms77Handler extends BaseSmsHandler {
   constructor() {
-    super('sns', ChannelTypeEnum.SMS);
+    super('sms77', ChannelTypeEnum.SMS);
   }
   buildProvider(credentials: ICredentials) {
     const config: { apiKey: string; from?: string } = { apiKey: credentials.apiKey, from: credentials.from };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug fix of misspell in sms77 constructor call 

- **What is the current behavior?** (You can also link to an open issue here)
- sms77 provider is not usable as reported in [Issue 582](https://github.com/novuhq/novu/issues/582)

- **What is the new behavior (if this is a feature change)?**
- Hopefully sms77 provider working for SMS integration

- **Other information**:
- Was not tested on my machine, but "sns" for sm77 provider was clearly wrong
