### PR TITLE
Improved documentation: Corrected spelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const novu = new Novu(process.env.NOVU_API_KEY);
 await novu.trigger('<TRIGGER_NAME>',
   {
     to: {
-      subscriberId: '<UUNIQUE_IDENTIFIER>',
+      subscriberId: '<UNIQUE_IDENTIFIER>',
       email: 'john@doemail.com',
       firstName: 'John',
       lastName: 'Doe',


### PR DESCRIPTION
- **Docs Update**
Corrected spelling in README.md:  <UUNIQUE_IDENTIFIER> to <UNIQUE_IDENTIFIER>
