### PR TITLE
:hammer: Update onNotificationClick as mandatory

### DIFF
--- a/apps/web/src/components/widget/NotificationCenterWidget.tsx
+++ b/apps/web/src/components/widget/NotificationCenterWidget.tsx
@@ -1,5 +1,5 @@
 import { NotificationBell, NovuProvider, PopoverNotificationCenter } from '@novu/notification-center';
-import { IUserEntity } from '@novu/shared';
+import { IUserEntity, IMessage } from '@novu/shared';
 import { useMantineColorScheme } from '@mantine/core';
 import React from 'react';
 import { API_ROOT, WS_URL } from '../../config';
@@ -9,8 +9,10 @@ export function NotificationCenterWidget({ user }: { user: IUserEntity | undefin
   const { environment } = useEnvController();
   const { colorScheme } = useMantineColorScheme();
 
-  function handlerOnUrlChange(url: string) {
-    window.location.href = url;
+  function handlerOnNotificationClick(message: IMessage) {
+    if (message.cta.data.url) {
+      window.location.href = message.cta.data.url;
+    }
   }
 
   return (
@@ -21,7 +23,7 @@ export function NotificationCenterWidget({ user }: { user: IUserEntity | undefin
         subscriberId={user?._id as string}
         applicationIdentifier={environment?.identifier as string}
       >
-        <PopoverNotificationCenter colorScheme={colorScheme} onUrlChange={handlerOnUrlChange}>
+        <PopoverNotificationCenter colorScheme={colorScheme} onNotificationClick={handlerOnNotificationClick}>
           {(props) => <NotificationBell {...props} />}
         </PopoverNotificationCenter>
       </NovuProvider>

--- a/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
@@ -7,8 +7,8 @@ import { UnseenCountContext } from '../../store/unseen-count.context';
 import { ColorScheme } from '../../index';
 
 interface IPopoverNotificationCenterProps {
-  onUrlChange: (url: string) => void;
-  onNotificationClick?: (notification: IMessage) => void;
+  onUrlChange?: (url: string) => void;
+  onNotificationClick: (notification: IMessage) => void;
   onUnseenCountChanged?: (unseenCount: number) => void;
   children: (props: INotificationBellProps) => JSX.Element;
   header?: () => JSX.Element;

--- a/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
@@ -7,7 +7,7 @@ import { UnseenCountContext } from '../../store/unseen-count.context';
 import { ColorScheme } from '../../index';
 
 interface IPopoverNotificationCenterProps {
-  onUrlChange?: (url: string) => void;
+  onUrlChange: (url: string) => void;
   onNotificationClick?: (notification: IMessage) => void;
   onUnseenCountChanged?: (unseenCount: number) => void;
   children: (props: INotificationBellProps) => JSX.Element;


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
feature/update (i am not sure)

- **What is the current behavior?** 
If the user of the NotificationCenter does not provide a handler for URL change, the redirection will not work on notification click.

- **What is the new behavior ?**
In order to help NotificationCenter users, we added the onUrlChange as mandatory so the user will be aware of the need to provide the URL change handler.

- **Other Information**:
I could not locate the issue that related to this PR, if anyone is aware of it please feel free to add it here :)
