### PR TITLE
Proper Error Message when used without NovuProvider

### DIFF
--- a/packages/notification-center/src/components/notification-center/NotificationCenter.tsx
+++ b/packages/notification-center/src/components/notification-center/NotificationCenter.tsx
@@ -1,12 +1,12 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { IMessage } from '@novu/shared';
 
-import { NovuContext } from '../../store/novu-provider.context';
 import { NotificationCenterContext } from '../../store/notification-center.context';
 import { AppContent } from './components';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ColorScheme } from '../../index';
 import { ThemeContext } from '../../store/novu-theme.context';
+import { useNovuContext } from '../../hooks';
 
 export interface INotificationCenterProps {
   onUrlChange?: (url: string) => void;
@@ -19,7 +19,7 @@ export interface INotificationCenterProps {
 
 export function NotificationCenter(props: INotificationCenterProps) {
   const queryClient = new QueryClient();
-  const { applicationIdentifier } = useContext(NovuContext);
+  const { applicationIdentifier } = useNovuContext();
 
   return (
     <ThemeContext.Provider value={{ colorScheme: props.colorScheme }}>

--- a/packages/notification-center/src/components/notification-center/components/layout/Layout.tsx
+++ b/packages/notification-center/src/components/notification-center/components/layout/Layout.tsx
@@ -5,11 +5,11 @@ import { FooterContainer as Footer } from './footer/FooterContainer';
 import { shadows } from '../../../../shared/config/shadows';
 import { colors } from '../../../../shared/config/colors';
 import React, { useContext } from 'react';
-import { NovuContext } from '../../../../store/novu-provider.context';
 import { ThemeContext } from '../../../../store/novu-theme.context';
+import { useNovuContext } from 'packages/notification-center/src/hooks';
 
 export function Layout({ children }: { children: JSX.Element }) {
-  const { initialized } = useContext(NovuContext);
+  const { initialized } = useNovuContext();
   const { colorScheme } = useContext(ThemeContext);
 
   return (

--- a/packages/notification-center/src/hooks/index.ts
+++ b/packages/notification-center/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './use-auth.hook';
 export * from './use-socket.hook';
 export * from './use-unseen-count.hook';
 export * from './use-notifications.hook';
+export * from './use-novu-context.hook';

--- a/packages/notification-center/src/hooks/use-api.hook.ts
+++ b/packages/notification-center/src/hooks/use-api.hook.ts
@@ -1,8 +1,10 @@
 import { useContext } from 'react';
 import { ApiContext, IApiContext } from '../store/api.context';
+import { useProviderCheck } from './use-check-provider.hook';
 
 export function useApi() {
-  const { api } = useContext<IApiContext>(ApiContext);
+  const context = useContext<IApiContext>(ApiContext);
+  const api = useProviderCheck(context.api);
 
   return { api };
 }

--- a/packages/notification-center/src/hooks/use-check-provider.hook.ts
+++ b/packages/notification-center/src/hooks/use-check-provider.hook.ts
@@ -1,4 +1,10 @@
-export function useProviderCheck<T>(context: T) {
+/**
+ * Custom hook to check if the context Consumer is wrapped inside the ContextProvider
+ * @param context
+ * @returns context
+ */
+
+export function useProviderCheck<T>(context: T): T {
   if (context === null || context === undefined) {
     throw new Error('Component must be wrapped within the NovuProvider');
   }

--- a/packages/notification-center/src/hooks/use-check-provider.hook.ts
+++ b/packages/notification-center/src/hooks/use-check-provider.hook.ts
@@ -1,0 +1,7 @@
+export function useProviderCheck<T>(context: T) {
+  if (context === null || context === undefined) {
+    throw new Error('Component must be wrapped within the NovuProvider');
+  }
+
+  return context;
+}

--- a/packages/notification-center/src/hooks/use-check-provider.hook.ts
+++ b/packages/notification-center/src/hooks/use-check-provider.hook.ts
@@ -6,7 +6,7 @@
 
 export function useProviderCheck<T>(context: T): T {
   if (context === null || context === undefined) {
-    throw new Error('Component must be wrapped within the NovuProvider');
+    throw new Error('Component must be wrapped within the NovuProvider before using hooks from @novu/notification-center');
   }
 
   return context;

--- a/packages/notification-center/src/hooks/use-novu-context.hook.ts
+++ b/packages/notification-center/src/hooks/use-novu-context.hook.ts
@@ -3,7 +3,11 @@ import { INovuProviderContext } from '../index';
 import { NovuContext } from '../store/novu-provider.context';
 import { useProviderCheck } from './use-check-provider.hook';
 
-export function useNovuContext() {
+/**
+ * custom hook for accessing NovuContext
+ * @returns INovuProviderContext
+ */
+export function useNovuContext(): INovuProviderContext {
   const novuContext = useContext<INovuProviderContext>(NovuContext);
   const context = useProviderCheck<INovuProviderContext>(novuContext);
 

--- a/packages/notification-center/src/hooks/use-novu-context.hook.ts
+++ b/packages/notification-center/src/hooks/use-novu-context.hook.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { INovuProviderContext } from '../index';
+import { NovuContext } from '../store/novu-provider.context';
+
+export function useNovuContext() {
+  const context = useContext<INovuProviderContext>(NovuContext);
+
+  if (context === undefined) {
+    throw new Error('Component must be wrapped within the NovuProvider');
+  }
+
+  return context;
+}

--- a/packages/notification-center/src/hooks/use-novu-context.hook.ts
+++ b/packages/notification-center/src/hooks/use-novu-context.hook.ts
@@ -1,13 +1,11 @@
 import { useContext } from 'react';
 import { INovuProviderContext } from '../index';
 import { NovuContext } from '../store/novu-provider.context';
+import { useProviderCheck } from './use-check-provider.hook';
 
 export function useNovuContext() {
-  const context = useContext<INovuProviderContext>(NovuContext);
-
-  if (context === undefined) {
-    throw new Error('Component must be wrapped within the NovuProvider');
-  }
+  const novuContext = useContext<INovuProviderContext>(NovuContext);
+  const context = useProviderCheck<INovuProviderContext>(novuContext);
 
   return context;
 }

--- a/packages/notification-center/src/store/novu-provider.context.ts
+++ b/packages/notification-center/src/store/novu-provider.context.ts
@@ -1,11 +1,4 @@
 import React from 'react';
 import { INovuProviderContext } from '../index';
 
-export const NovuContext = React.createContext<INovuProviderContext>({
-  backendUrl: null,
-  subscriberId: null,
-  initialized: false,
-  socketUrl: null,
-  onLoad: null,
-  subscriberHash: null,
-});
+export const NovuContext = React.createContext<INovuProviderContext | null>(null);

--- a/packages/notification-center/src/store/socket/use-socket-controller.ts
+++ b/packages/notification-center/src/store/socket/use-socket-controller.ts
@@ -2,12 +2,12 @@ import { useContext, useEffect, useState } from 'react';
 import io from 'socket.io-client';
 import { AuthContext } from '../auth.context';
 import { IAuthContext, ISocket } from '../../index';
-import { NovuContext } from '../novu-provider.context';
+import { useNovuContext } from '../../hooks';
 
 let socket;
 
 export function useSocketController() {
-  const { socketUrl } = useContext(NovuContext);
+  const { socketUrl } = useNovuContext();
   const { token } = useContext<IAuthContext>(AuthContext);
   const [socketInstance, setSocketInstance] = useState<ISocket | null>(null);
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #629 
- **What is the current behavior?** (You can also link to an open issue here)
Currently, when using hooks or components from the `notification-center` without wrapping it with the `NovuProvider` throws unclear error message.
- **What is the new behavior (if this is a feature change)?**
It will throw a proper error message suggesting the fix.
Error Message: **`Component must be wrapped within the NovuProvider`**

![image](https://user-images.githubusercontent.com/29251776/172821783-42b52411-5ed9-4840-9240-932d4c75b84e.png)

- **Other information**:
