### PR TITLE
Docker-compose for local development

### DIFF
--- a/environment/local/docker-compose.yml
+++ b/environment/local/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.1'
+
+services:
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: "localstack/localstack:0.12.7"
+    network_mode: bridge
+    environment:
+      - SERVICES=s3
+    ports:
+      - "4566:4566"
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    healthcheck:
+      test: "bash -c 'AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test aws --endpoint-url=http://localhost:4566 s3 ls'"
+      retries: 5
+      interval: 10s
+  mongo:
+    container_name: "${MONGO_DOCKER_NAME-mongo_main}"
+    image: mongo
+    network_mode: bridge
+    ports:
+      - "27017:27017"
+    volumes:
+      - "${TMPDIR:-/tmp/mongo}:/db/data"
+    healthcheck:
+      test: "bash -c 'mongo --host localhost:27017 --eval \"printjson(rs.status())\"'"
+      retries: 5
+      interval: 10s
+  redis:
+    container_name: "${REDIS_DOCKER_NAME-redis_main}"
+    image: redis
+    network_mode: bridge
+    ports:
+      - "6379:6379"
+    volumes:
+      - "${TMPDIR:-/tmp/redis}:/data"
+    healthcheck:
+      test: "bash -c 'redis-cli ping'"
+      retries: 5
+      interval: 10s
+    


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added docker-compose.yml for local development, so people wont have to install redis and mongodb locally.

- **What is the current behavior?** (You can also link to an open issue here)
People install mongodb and redis locally.

- **What is the new behavior (if this is a feature change)?**
They can just launch the docker-compose.yml without installing any software manually.

- **Other information**:
