### PR TITLE
fix: not set as dirty when clicking on trigger

### DIFF
--- a/apps/web/src/components/workflow/FlowEditor.tsx
+++ b/apps/web/src/components/workflow/FlowEditor.tsx
@@ -144,7 +144,7 @@ export function FlowEditor({
     event.preventDefault();
     setSelectedNodeId(node.id);
     if (node.id === '1') {
-      onDelete();
+      setSelectedNodeId('');
     }
   }, []);
 


### PR DESCRIPTION
Click on Trigger Node to not set form as dirty -> Update button not enabled
