### PR TITLE
fix: change redirect match to slug

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,8 +1,8 @@
 {
   "rewrites": [
     { 
-      "source": "/docs/:match*",
-      "destination": "/:match*"
+      "source": "/docs/:slug*",
+      "destination": "/:slug*"
     }
   ]
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes the redirects bug.
- **What is the current behavior?** (You can also link to an open issue here)
The pages with the prefix `/docs` are not redirected to `/`
- **What is the new behavior (if this is a feature change)?**
The redirects work correctly. Redirect https://example.com/docs/some-doc to https://example.com/some-doc
- **Other information**:
