### PR TITLE
Fix a typo in quick-start.md & react-components.md file

### DIFF
--- a/docs/docs/notification-center/react-components.md
+++ b/docs/docs/notification-center/react-components.md
@@ -72,7 +72,7 @@ To support dark mode in your application the notification center component can r
 ## Custom UI
 
 If you prefer to build a custom UI, it's possible to use the `useNotification` hook available in our react library.
-Let's see and example on how you can do that:
+Let's see an example on how you can do that:
 
 ```tsx
 import { NovuProvider, useNotifications } from '@novu/notification-center';
@@ -111,7 +111,7 @@ function CustomNotificationCenter() {
 
 ## Realtime sockets
 
-Novu provides a real-time socket API for you to consume to get updates about new notifications added to the user's feed. To use the socket connection you can use the `useSocket` hook provided by the `@novu/notification-center` library. Let's see and example of that:
+Novu provides a real-time socket API for you to consume to get updates about new notifications added to the user's feed. To use the socket connection you can use the `useSocket` hook provided by the `@novu/notification-center` library. Let's see an example of that:
 
 ```tsx
 import { NovuProvider, useSocket } from '@novu/notification-center';

--- a/docs/docs/overview/quick-start.md
+++ b/docs/docs/overview/quick-start.md
@@ -52,7 +52,7 @@ Similiar to the the email, custom variables using hbs syntax can be described to
 
 #### In-app
 
-In the notification center preview you can type the content, you can select content an use `CMD` + `B` to make the selected text bold.
+In the notification center preview you can type the content, you can select content and use `CMD` + `B` to make the selected text bold.
 
 ## Trigger the notification
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 

> **Docs Update**

---

- **What is the current behavior?** 

> **There is a typo at `line 55` of `quick-start.md` file and `line 75 as well as 114` of `react-components.md` file**
