### PR TITLE
feat: add endpoint to get all subscribers

### DIFF
--- a/apps/api/src/app/subscribers/e2e/get-subscribers.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/get-subscribers.e2e.ts
@@ -1,0 +1,45 @@
+import { UserSession } from '@novu/testing';
+import { SubscriberRepository } from '@novu/dal';
+import { expect } from 'chai';
+import axios from 'axios';
+
+const axiosInstance = axios.create();
+
+describe('Get Subscribers - /subscribers (GET)', function () {
+  let session: UserSession;
+  const subscriberRepository = new SubscriberRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  it('should list created subscriber', async function () {
+    await axiosInstance.post(
+      `${session.serverUrl}/v1/subscribers`,
+      {
+        subscriberId: '123',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@doe.com',
+        phone: '+972523333333',
+      },
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+
+    const response = await axiosInstance.get(`${session.serverUrl}/v1/subscribers`, {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    });
+
+    const { data: body } = response;
+    expect(body.data.length).to.equal(1);
+    const subscriber = body.data[0];
+    expect(subscriber.subscriberId).to.equal('123');
+  });
+});

--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
 import { CreateSubscriber, CreateSubscriberCommand } from './usecases/create-subscriber';
 import { UpdateSubscriber, UpdateSubscriberCommand } from './usecases/update-subscriber';
 import { RemoveSubscriber, RemoveSubscriberCommand } from './usecases/remove-subscriber';
@@ -8,14 +8,29 @@ import { UserSession } from '../shared/framework/user.decorator';
 import { IJwtPayload } from '@novu/shared';
 import { CreateSubscriberBodyDto } from './dto/create-subscriber.dto';
 import { UpdateSubscriberBodyDto } from './dto/update-subscriber.dto';
+import { GetSubscribers } from './usecases/get-subscribers/get-subscriber.usecase';
+import { GetSubscribersCommand } from './usecases/get-subscribers';
 
 @Controller('/subscribers')
 export class SubscribersController {
   constructor(
     private createSubscriberUsecase: CreateSubscriber,
     private updateSubscriberUsecase: UpdateSubscriber,
-    private removeSubscriberUsecase: RemoveSubscriber
+    private removeSubscriberUsecase: RemoveSubscriber,
+    private getSubscribersUsecase: GetSubscribers
   ) {}
+
+  @Get('')
+  @ExternalApiAccessible()
+  @UseGuards(JwtAuthGuard)
+  getNotificationTemplates(@UserSession() user: IJwtPayload) {
+    return this.getSubscribersUsecase.execute(
+      GetSubscribersCommand.create({
+        organizationId: user.organizationId,
+        environmentId: user.environmentId,
+      })
+    );
+  }
 
   @Post('/')
   @ExternalApiAccessible()

--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
 import { CreateSubscriber, CreateSubscriberCommand } from './usecases/create-subscriber';
 import { UpdateSubscriber, UpdateSubscriberCommand } from './usecases/update-subscriber';
 import { RemoveSubscriber, RemoveSubscriberCommand } from './usecases/remove-subscriber';
@@ -23,11 +23,12 @@ export class SubscribersController {
   @Get('')
   @ExternalApiAccessible()
   @UseGuards(JwtAuthGuard)
-  getNotificationTemplates(@UserSession() user: IJwtPayload) {
-    return this.getSubscribersUsecase.execute(
+  async getSubscribers(@UserSession() user: IJwtPayload, @Query('page') page = 0) {
+    return await this.getSubscribersUsecase.execute(
       GetSubscribersCommand.create({
         organizationId: user.organizationId,
         environmentId: user.environmentId,
+        page: page ? Number(page) : 0,
       })
     );
   }

--- a/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.command.ts
@@ -1,0 +1,8 @@
+import { CommandHelper } from '../../../shared/commands/command.helper';
+import { EnvironmentCommand } from '../../../shared/commands/project.command';
+
+export class GetSubscribersCommand extends EnvironmentCommand {
+  static create(data: GetSubscribersCommand) {
+    return CommandHelper.create(GetSubscribersCommand, data);
+  }
+}

--- a/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.command.ts
@@ -1,3 +1,4 @@
+import { IsNumber, IsOptional } from 'class-validator';
 import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
@@ -5,4 +6,8 @@ export class GetSubscribersCommand extends EnvironmentCommand {
   static create(data: GetSubscribersCommand) {
     return CommandHelper.create(GetSubscribersCommand, data);
   }
+
+  @IsNumber()
+  @IsOptional()
+  page: number;
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.usecase.ts
@@ -7,9 +7,25 @@ export class GetSubscribers {
   constructor(private subscriberRepository: SubscriberRepository) {}
 
   async execute(command: GetSubscribersCommand) {
-    return this.subscriberRepository.find({
+    const LIMIT = 10;
+
+    const query = {
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
+    };
+
+    const totalCount = await this.subscriberRepository.count(query);
+
+    const data = await this.subscriberRepository.find(query, '', {
+      limit: LIMIT,
+      skip: command.page * LIMIT,
     });
+
+    return {
+      page: command.page,
+      totalCount,
+      pageSize: LIMIT,
+      data,
+    };
   }
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.usecase.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { SubscriberRepository } from '@novu/dal';
+import { GetSubscribersCommand } from './get-subscriber.command';
+
+@Injectable()
+export class GetSubscribers {
+  constructor(private subscriberRepository: SubscriberRepository) {}
+
+  async execute(command: GetSubscribersCommand) {
+    return this.subscriberRepository.find({
+      _environmentId: command.environmentId,
+      _organizationId: command.organizationId,
+    });
+  }
+}

--- a/apps/api/src/app/subscribers/usecases/get-subscribers/index.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscribers/index.ts
@@ -1,0 +1,2 @@
+export * from './get-subscriber.command';
+export * from './get-subscriber.usecase';

--- a/apps/api/src/app/subscribers/usecases/index.ts
+++ b/apps/api/src/app/subscribers/usecases/index.ts
@@ -1,5 +1,6 @@
 import { CreateSubscriber } from './create-subscriber';
 import { UpdateSubscriber } from './update-subscriber';
 import { RemoveSubscriber } from './remove-subscriber';
+import { GetSubscribers } from './get-subscribers';
 
-export const USE_CASES = [CreateSubscriber, UpdateSubscriber, RemoveSubscriber];
+export const USE_CASES = [CreateSubscriber, UpdateSubscriber, RemoveSubscriber, GetSubscribers];

--- a/packages/node/src/lib/subscribers/subscribers.ts
+++ b/packages/node/src/lib/subscribers/subscribers.ts
@@ -8,6 +8,14 @@ export class Subscribers {
     this.http = http;
   }
 
+  async list(page: number) {
+    return await this.http.get(`/subscribers`, {
+      params: {
+        page,
+      },
+    });
+  }
+
   async identify(subscriberId: string, data: ISubscriberPayload) {
     return await this.http.post(`/subscribers`, {
       subscriberId,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It adds a endpoint to get all subscribers
- **What is the current behavior?** (You can also link to an open issue here)
The endpoint does not exists.
- **Other information**:
I think this could be a nice way to be able to debug subscribers but also to be able to list all subscribers inside of Novu in calling application.