### PR TITLE
fix (docs): missing link to guide on how to create a provider

### DIFF
--- a/docs/docs/platform/integrations.md
+++ b/docs/docs/platform/integrations.md
@@ -23,4 +23,4 @@ For email providers, you will be required to add the following data:
 
 ## Missing a provider?
 
-Novu is an open-source platform, meaning that if you are missing a particular provider you can create the provider best on the guide specified [here](/community/create-provider).
+Novu is an open-source platform, meaning that if you are missing a particular provider you can create one using the guide specified [here](/community/create-provider).

--- a/docs/docs/platform/integrations.md
+++ b/docs/docs/platform/integrations.md
@@ -23,4 +23,4 @@ For email providers, you will be required to add the following data:
 
 ## Missing a provider?
 
-Novu is an open-source platform, meaning that if you are missing a particular provider you can create the provider best on the guide specified here.
+Novu is an open-source platform, meaning that if you are missing a particular provider you can create the provider best on the guide specified [here](/community/create-provider).


### PR DESCRIPTION
Hey guys, really cool project!

I was reading the docs and came across a missing link on the [Integrations Store](https://docs.novu.co/platform/integrations) page. I think the "here" should point to the guide on how to create a custom provider.

PR adds just a tiny fix 👍
