### PR TITLE
Template IDs for invites and password reset can be configured by environment

### DIFF
--- a/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.usecase.ts
+++ b/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.usecase.ts
@@ -18,7 +18,7 @@ export class PasswordResetRequest {
       if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'prod') {
         const novu = new Novu(process.env.NOVU_API_KEY);
 
-        await novu.trigger('password-reset-llS-wzWMq', {
+        await novu.trigger(process.env.NOVU_TEMPLATEID_PASSWORD_RESET || 'password-reset-llS-wzWMq', {
           to: {
             subscriberId: foundUser._id,
             email: foundUser.email,

--- a/apps/api/src/app/invites/usecases/accept-invite/accept-invite.usecase.ts
+++ b/apps/api/src/app/invites/usecases/accept-invite/accept-invite.usecase.ts
@@ -48,7 +48,7 @@ export class AcceptInvite {
       if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'prod') {
         const novu = new Novu(process.env.NOVU_API_KEY);
 
-        await novu.trigger('invite-accepted-dEQAsKD1E', {
+        await novu.trigger(rocess.env.NOVU_TEMPLATEID_INVITE_ACCEPTED || 'invite-accepted-dEQAsKD1E', {
           to: {
             subscriberId: inviter._id,
             firstName: capitalize(inviter.firstName),

--- a/apps/api/src/app/invites/usecases/accept-invite/accept-invite.usecase.ts
+++ b/apps/api/src/app/invites/usecases/accept-invite/accept-invite.usecase.ts
@@ -48,7 +48,7 @@ export class AcceptInvite {
       if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'prod') {
         const novu = new Novu(process.env.NOVU_API_KEY);
 
-        await novu.trigger(rocess.env.NOVU_TEMPLATEID_INVITE_ACCEPTED || 'invite-accepted-dEQAsKD1E', {
+        await novu.trigger(process.env.NOVU_TEMPLATEID_INVITE_ACCEPTED || 'invite-accepted-dEQAsKD1E', {
           to: {
             subscriberId: inviter._id,
             firstName: capitalize(inviter.firstName),

--- a/apps/api/src/app/invites/usecases/invite-member/invite-member.usecase.ts
+++ b/apps/api/src/app/invites/usecases/invite-member/invite-member.usecase.ts
@@ -32,7 +32,7 @@ export class InviteMember {
     if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'prod') {
       const novu = new Novu(process.env.NOVU_API_KEY);
 
-      await novu.trigger('invite-to-organization-wBnO8NpDn', {
+      await novu.trigger(process.env.NOVU_TEMPLATEID_INVITE_TO_ORGANISATION || 'invite-to-organization-wBnO8NpDn', {
         to: {
           subscriberId: command.email,
           email: command.email,


### PR DESCRIPTION
Fixes #625 

For now all template IDs are lower case and you can't create notification template with trigger like 'invite-to-organization-wBnO8NpDn'