### PR TITLE
NV-626: fix: Move focus to "YES" in the delete workflow step confirmation modal

### DIFF
--- a/apps/web/src/components/templates/DeleteStepModal.tsx
+++ b/apps/web/src/components/templates/DeleteStepModal.tsx
@@ -44,7 +44,7 @@ export function DeleteStepModal({
             <Button variant="outline" size="md" mt={30} onClick={() => cancel()}>
               No
             </Button>
-            <Button mt={30} size="md" onClick={() => confirm()}>
+            <Button mt={30} size="md" onClick={() => confirm()} data-autofocus>
               Yes
             </Button>
           </Group>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix https://github.com/novuhq/novu/issues/784

- **What is the current behavior?** (You can also link to an open issue here)
https://github.com/novuhq/novu/issues/784
![](https://camo.githubusercontent.com/1fa665e66f0b2069c845a6d8b1daf37ed4e8d01b5e9e0be226e18b4dd9216132/68747470733a2f2f75706c6f6164732e6c696e6561722e6170702f66313366313939362d633962302d346665612d386565372d3263336661663661383332642f39663335383339662d373637612d343737632d393731332d3632356138376438323262642f31393735393265632d333133392d343935642d623735312d653638303131633734633136)

- **What is the new behavior (if this is a feature change)?**
When the confirmation dialog opens, the "YES" button will be automatically focused.
![Record_select-area_20220706121214](https://user-images.githubusercontent.com/8643036/177541311-6da83b5b-695b-49ab-9909-784a5bd1cf5a.gif)
