### PR TITLE
fix(apps/web): close menu on click outside in flow editor

### DIFF
--- a/apps/web/src/design-system/template-button/ChannelButton.tsx
+++ b/apps/web/src/design-system/template-button/ChannelButton.tsx
@@ -10,6 +10,7 @@ import { When } from '../../components/utils/When';
 import { useFormContext } from 'react-hook-form';
 import { useEnvController } from '../../store/use-env-controller';
 import { ChannelTypeEnum } from '@novu/shared';
+import { useClickOutside } from '@mantine/hooks';
 
 const capitalize = (text: string) => {
   return typeof text !== 'string' ? '' : text.charAt(0).toUpperCase() + text.slice(1);
@@ -91,6 +92,7 @@ export function ChannelButton({
   const [disabled, setDisabled] = useState(initDisabled);
   const disabledColor = disabled ? { color: theme.colorScheme === 'dark' ? colors.B40 : colors.B70 } : {};
   const disabledProp = disabled ? { disabled: disabled } : {};
+  const menuRef = useClickOutside(() => setShowDotMenu(false), ['click', 'mousedown', 'touchstart']);
 
   const { watch } = useFormContext();
 
@@ -153,6 +155,7 @@ export function ChannelButton({
                 }}
               >
                 <Menu
+                  ref={menuRef}
                   shadow={theme.colorScheme === 'dark' ? shadows.dark : shadows.light}
                   classNames={menuClasses}
                   withArrow={true}

--- a/apps/web/src/design-system/template-button/TemplateButton.styles.ts
+++ b/apps/web/src/design-system/template-button/TemplateButton.styles.ts
@@ -10,7 +10,6 @@ export const useStyles = createStyles((theme) => {
       background: `${dark ? getGradient(colors.B20) : getGradient(colors.white)} padding-box, ${
         colors.horizontal
       } border-box`,
-      border: '1px solid transparent',
       boxShadow: dark ? shadows.dark : shadows.light,
     },
     button: {
@@ -23,6 +22,7 @@ export const useStyles = createStyles((theme) => {
       backgroundColor: dark ? colors.B17 : colors.B98,
       borderRadius: '7px',
       fontWeight: 700,
+      border: '1px solid transparent',
 
       '&:hover': {
         backgroundColor: dark ? colors.B20 : colors.BGLight,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Fixes menu not closing on click outside in the flow editor
- Also took the liberty to fix a "flickering" bug which can be noticed whenever you click a channel button. Moving from no border to `border: 1px solid transparent` causes this effect. It's a bit subtle and not extremely important/noticeable so let me know if you don't want it as part of this PR 😅 

**What is the current behavior?**

- The `<Menu />` component can not be closed unless we click on the parent anchor tag [here](https://github.com/novuhq/novu/blob/main/apps/web/src/design-system/template-button/ChannelButton.tsx#L152). #761 
- Moved the `border: 1px solid transparent` css style to be applied to the `button` as opposed to **only** when it is active

**What is the new behavior (if this is a feature change)?**

- use the `useClickOutside` hook from [mantine](https://mantine.dev/hooks/use-click-outside/) to close the menu whenever a click is captured outside of the menu
- no more border "flicker" when a `ChannelButton` is clicked/active. The solution is to add a 
