### PR TITLE
Fix docs broken /docs/ redirect

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,8 +1,9 @@
 {
-  "rewrites": [
+  "redirects": [
     { 
       "source": "/docs/:slug*",
-      "destination": "/:slug*"
+      "destination": "/:slug*",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It changes the rewrite to redirect on docs.

- **What is the current behavior?** (You can also link to an open issue here)
Docs flash the right page for a little time. If I'm correct, then client side rendering kicks in, tries to get the URL, and because it is proxied (rewritten), clientside rendering cannot find the page and results in a 404.

- **What is the new behavior (if this is a feature change)?**
Redirecting user instead of proxying.

- **Other information**:
