### PR TITLE
feat: add trigger id to list and settings page

### DIFF
--- a/apps/web/cypress/tests/notifications-editor.spec.ts
+++ b/apps/web/cypress/tests/notifications-editor.spec.ts
@@ -404,9 +404,9 @@ describe('Notifications Creator', function () {
         .contains('Custom Code', { matchCase: false })
         .click();
       cy.get('#codeEditor').type('Hello world code {{name}} <div>Test', { parseSpecialCharSequences: false });
+      cy.intercept('GET', '/v1/notification-templates').as('notification-templates');
       cy.getByTestId('submit-btn').click();
       cy.wait(1000);
-      cy.intercept('/v1/notification-templates').as('notification-templates');
       cy.getByTestId('trigger-snippet-btn').click();
 
       cy.wait('@notification-templates', { timeout: 60000 });

--- a/apps/web/cypress/tests/notifications-editor.spec.ts
+++ b/apps/web/cypress/tests/notifications-editor.spec.ts
@@ -406,7 +406,7 @@ describe('Notifications Creator', function () {
       cy.get('#codeEditor').type('Hello world code {{name}} <div>Test', { parseSpecialCharSequences: false });
       cy.getByTestId('submit-btn').click();
       cy.wait(1000);
-      cy.intercept('GET', '/v1/notification-templates').as('notification-templates');
+      cy.intercept('/v1/notification-templates').as('notification-templates');
       cy.getByTestId('trigger-snippet-btn').click();
 
       cy.wait('@notification-templates', { timeout: 60000 });

--- a/apps/web/cypress/tests/notifications-editor.spec.ts
+++ b/apps/web/cypress/tests/notifications-editor.spec.ts
@@ -409,7 +409,7 @@ describe('Notifications Creator', function () {
       cy.intercept('GET', '/v1/notification-templates').as('notification-templates');
       cy.getByTestId('trigger-snippet-btn').click();
 
-      cy.wait('@notification-templates');
+      cy.wait('@notification-templates', { timeout: 60000 });
       cy.get('tbody').contains('Custom Code HTM').click();
 
       cy.getByTestId('workflowButton').click();

--- a/apps/web/src/components/templates/NotificationSettingsForm.tsx
+++ b/apps/web/src/components/templates/NotificationSettingsForm.tsx
@@ -65,23 +65,13 @@ export const NotificationSettingsForm = ({
   return (
     <Grid gutter={30} grow>
       <Grid.Col md={6} sm={12}>
-        {trigger && (
-          <Input
-            mb={30}
-            data-test-id="trigger-id"
-            disabled={true}
-            value={trigger.identifier || ''}
-            error={errors.name?.message}
-            label="Notification ID"
-            description="This will be used to identify the notification using the API."
-          />
-        )}
         <Controller
           control={control}
           name="name"
           render={({ field }) => (
             <Input
               {...field}
+              mb={30}
               data-test-id="title"
               disabled={readonly}
               required
@@ -93,15 +83,12 @@ export const NotificationSettingsForm = ({
             />
           )}
         />
-      </Grid.Col>
-      <Grid.Col md={6} sm={12}>
         <Controller
           name="description"
           control={control}
           render={({ field }) => (
             <Input
               {...field}
-              mb={30}
               value={field.value || ''}
               disabled={readonly}
               data-test-id="description"
@@ -111,6 +98,19 @@ export const NotificationSettingsForm = ({
             />
           )}
         />
+      </Grid.Col>
+      <Grid.Col md={6} sm={12}>
+        {trigger && (
+          <Input
+            mb={30}
+            data-test-id="trigger-id"
+            disabled={true}
+            value={trigger.identifier || ''}
+            error={errors.name?.message}
+            label="Notification ID"
+            description="This will be used to identify the notification using the API."
+          />
+        )}
         <Controller
           name="notificationGroup"
           control={control}

--- a/apps/web/src/components/templates/NotificationSettingsForm.tsx
+++ b/apps/web/src/components/templates/NotificationSettingsForm.tsx
@@ -1,12 +1,14 @@
 import { Controller, useFormContext } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useEffect } from 'react';
-import { Grid } from '@mantine/core';
+import { ActionIcon, Grid } from '@mantine/core';
 import { getNotificationGroups } from '../../api/notifications';
 import { api } from '../../api/api.client';
-import { Input, Select } from '../../design-system';
+import { Input, Select, Tooltip } from '../../design-system';
 import { useEnvController } from '../../store/use-env-controller';
 import { INotificationTrigger } from '@novu/shared';
+import { useClipboard } from '@mantine/hooks';
+import { Check, Copy } from '../../design-system/icons';
 
 export const NotificationSettingsForm = ({
   editMode,
@@ -15,6 +17,7 @@ export const NotificationSettingsForm = ({
   editMode: boolean;
   trigger?: INotificationTrigger;
 }) => {
+  const idClipboard = useClipboard({ timeout: 1000 });
   const queryClient = useQueryClient();
   const { readonly } = useEnvController();
   const {
@@ -107,8 +110,15 @@ export const NotificationSettingsForm = ({
             disabled={true}
             value={trigger.identifier || ''}
             error={errors.name?.message}
-            label="Notification ID"
+            label="Notification Identifier"
             description="This will be used to identify the notification using the API."
+            rightSection={
+              <Tooltip data-test-id={'Tooltip'} label={idClipboard.copied ? 'Copied!' : 'Copy Key'}>
+                <ActionIcon variant="transparent" onClick={() => idClipboard.copy(trigger.identifier)}>
+                  {idClipboard.copied ? <Check /> : <Copy />}
+                </ActionIcon>
+              </Tooltip>
+            }
           />
         )}
         <Controller

--- a/apps/web/src/components/templates/NotificationSettingsForm.tsx
+++ b/apps/web/src/components/templates/NotificationSettingsForm.tsx
@@ -6,8 +6,15 @@ import { getNotificationGroups } from '../../api/notifications';
 import { api } from '../../api/api.client';
 import { Input, Select } from '../../design-system';
 import { useEnvController } from '../../store/use-env-controller';
+import { INotificationTrigger } from '@novu/shared';
 
-export const NotificationSettingsForm = ({ editMode }: { editMode: boolean }) => {
+export const NotificationSettingsForm = ({
+  editMode,
+  trigger,
+}: {
+  editMode: boolean;
+  trigger?: INotificationTrigger;
+}) => {
   const queryClient = useQueryClient();
   const { readonly } = useEnvController();
   const {
@@ -58,6 +65,17 @@ export const NotificationSettingsForm = ({ editMode }: { editMode: boolean }) =>
   return (
     <Grid gutter={30} grow>
       <Grid.Col md={6} sm={12}>
+        {trigger && (
+          <Input
+            mb={30}
+            data-test-id="trigger-id"
+            disabled={true}
+            value={trigger.identifier || ''}
+            error={errors.name?.message}
+            label="Notification ID"
+            description="This will be used to identify the notification using the API."
+          />
+        )}
         <Controller
           control={control}
           name="name"
@@ -70,18 +88,20 @@ export const NotificationSettingsForm = ({ editMode }: { editMode: boolean }) =>
               value={field.value || ''}
               error={errors.name?.message}
               label="Notification Name"
-              description="This will be used to identify the notification in the app."
+              description="This will be used to identify the notification in the dashboard."
               placeholder="Notification name goes here..."
             />
           )}
         />
+      </Grid.Col>
+      <Grid.Col md={6} sm={12}>
         <Controller
           name="description"
           control={control}
           render={({ field }) => (
             <Input
-              mt={35}
               {...field}
+              mb={30}
               value={field.value || ''}
               disabled={readonly}
               data-test-id="description"
@@ -91,8 +111,6 @@ export const NotificationSettingsForm = ({ editMode }: { editMode: boolean }) =>
             />
           )}
         />
-      </Grid.Col>
-      <Grid.Col md={6} sm={12}>
         <Controller
           name="notificationGroup"
           control={control}

--- a/apps/web/src/components/templates/NotificationSettingsForm.tsx
+++ b/apps/web/src/components/templates/NotificationSettingsForm.tsx
@@ -111,7 +111,7 @@ export const NotificationSettingsForm = ({
             value={trigger.identifier || ''}
             error={errors.name?.message}
             label="Notification Identifier"
-            description="This will be used to identify the notification using the API."
+            description="This will be used to identify the notification template using the API."
             rightSection={
               <Tooltip data-test-id={'Tooltip'} label={idClipboard.copied ? 'Copied!' : 'Copy Key'}>
                 <ActionIcon variant="transparent" onClick={() => idClipboard.copy(trigger.identifier)}>

--- a/apps/web/src/components/templates/TemplateSettings.tsx
+++ b/apps/web/src/components/templates/TemplateSettings.tsx
@@ -27,7 +27,9 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
         </Grid.Col>
         <Grid.Col md={8} sm={6}>
           <div style={{ paddingLeft: 23 }}>
-            {activePage === ActivePageEnum.SETTINGS && <NotificationSettingsForm editMode={editMode} />}
+            {activePage === ActivePageEnum.SETTINGS && (
+              <NotificationSettingsForm editMode={editMode} trigger={trigger} />
+            )}
 
             {template && trigger && activePage === ActivePageEnum.TRIGGER_SNIPPET && (
               <TriggerSnippetTabs trigger={trigger} />

--- a/apps/web/src/design-system/config/inputs.styles.ts
+++ b/apps/web/src/design-system/config/inputs.styles.ts
@@ -55,7 +55,7 @@ export const inputStyles = (theme: MantineTheme) => {
     disabled: {
       backgroundColor: `${dark ? colors.B20 : colors.B98} !important`,
       borderColor: `${dark ? colors.B30 : colors.BGLight} !important`,
-      color: `${secondaryColor} !important`,
+      color: `${primaryColor} !important`,
       '&::placeholder': {
         color: `${secondaryColor} !important`,
       },

--- a/apps/web/src/pages/templates/TemplatesListPage.tsx
+++ b/apps/web/src/pages/templates/TemplatesListPage.tsx
@@ -24,8 +24,8 @@ function NotificationList() {
       accessor: 'identifier',
       Header: 'Trigger ID',
       Cell: ({ triggers }: any) => (
-        <Tooltip label={triggers[0].identifier}>
-          <Text rows={1}>{triggers[0].identifier}</Text>
+        <Tooltip label={triggers ? triggers[0].identifier : 'Unknown'}>
+          <Text rows={1}>{triggers ? triggers[0].identifier : 'Unknown'}</Text>
         </Tooltip>
       ),
     },

--- a/apps/web/src/pages/templates/TemplatesListPage.tsx
+++ b/apps/web/src/pages/templates/TemplatesListPage.tsx
@@ -21,6 +21,15 @@ function NotificationList() {
 
   const columns: ColumnWithStrictAccessor<Data>[] = [
     {
+      accessor: 'identifier',
+      Header: 'Trigger ID',
+      Cell: ({ triggers }: any) => (
+        <Tooltip label={triggers[0].identifier}>
+          <Text rows={1}>{triggers[0].identifier}</Text>
+        </Tooltip>
+      ),
+    },
+    {
       accessor: 'name',
       Header: 'Name',
       Cell: ({ name }: any) => (


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the trigger ID to the list and to the settings page for easier copying and for less confusion
(ref #602 )

- **What is the current behavior?** (You can also link to an open issue here)
List and settings page don't include the ID, the ID can be only seen through the trigger snippet page.

- **What is the new behavior (if this is a feature change)?**
Adds the ID to the settings page + list

- **Other information**:
![image](https://user-images.githubusercontent.com/29684625/177757757-42f3edfb-0fc0-4dd9-8984-573aee7bb03c.png)
![image](https://user-images.githubusercontent.com/29684625/177757844-e5bdb6a3-cebe-40cb-89de-d21f5bb65ccf.png)
![image](https://user-images.githubusercontent.com/29684625/177757888-09f36ac3-d0f9-4097-a9ce-127c4a397a4d.png)

