### PR TITLE
Add remove notification

### DIFF
--- a/apps/web/src/api/api.client.ts
+++ b/apps/web/src/api/api.client.ts
@@ -42,4 +42,13 @@ export const api = {
         return Promise.reject(error?.response?.data || error?.response || error);
       });
   },
+  delete(url: string, payload = {}) {
+    return axios
+      .delete(`${API_ROOT}${url}`, payload)
+      .then((response) => response.data?.data)
+      .catch((error) => {
+        // eslint-disable-next-line promise/no-return-wrap
+        return Promise.reject(error?.response?.data || error?.response || error);
+      });
+  },
 };

--- a/apps/web/src/api/templates.ts
+++ b/apps/web/src/api/templates.ts
@@ -16,3 +16,7 @@ export async function getTemplateById(id: string) {
 export async function updateTemplateStatus(templateId: string, active: boolean) {
   return api.put(`/v1/notification-templates/${templateId}/status`, { active });
 }
+
+export async function deleteTemplateById(templateId: string) {
+  return api.delete(`/v1/notification-templates/${templateId}`);
+}

--- a/apps/web/src/components/templates/DeleteConfirmModal.tsx
+++ b/apps/web/src/components/templates/DeleteConfirmModal.tsx
@@ -1,4 +1,5 @@
-import { Group, Modal, useMantineTheme } from '@mantine/core';
+import { Alert, Group, Modal, useMantineTheme } from '@mantine/core';
+import { WarningOutlined } from '@ant-design/icons';
 import { Button, colors, shadows, Title, Text } from '../../design-system';
 
 export function DeleteConfirmModal({
@@ -6,11 +7,15 @@ export function DeleteConfirmModal({
   isOpen,
   cancel,
   confirm,
+  isLoading,
+  error,
 }: {
   target: string;
   isOpen: boolean;
   cancel: () => void;
   confirm: () => void;
+  isLoading?: boolean;
+  error?: string;
 }) {
   const theme = useMantineTheme();
 
@@ -41,12 +46,22 @@ export function DeleteConfirmModal({
         }}
       >
         <div>
+          {error && (
+            <Alert
+              icon={<WarningOutlined size={16} />}
+              title="An error occurred!"
+              color={`linear-gradient(0deg, ${colors.B17} 0%, ${colors.B17} 100%)`}
+              mb={32}
+            >
+              {error}
+            </Alert>
+          )}
           <Text>Would you like to delete this {target}?</Text>
           <Group position="right">
             <Button variant="outline" size="md" mt={30} onClick={() => cancel()}>
               No
             </Button>
-            <Button mt={30} size="md" onClick={() => confirm()} data-autofocus>
+            <Button mt={30} size="md" onClick={() => confirm()} loading={isLoading} data-autofocus>
               Yes
             </Button>
           </Group>

--- a/apps/web/src/components/templates/DeleteConfirmModal.tsx
+++ b/apps/web/src/components/templates/DeleteConfirmModal.tsx
@@ -1,11 +1,13 @@
 import { Group, Modal, useMantineTheme } from '@mantine/core';
 import { Button, colors, shadows, Title, Text } from '../../design-system';
 
-export function DeleteStepModal({
+export function DeleteConfirmModal({
+  target,
   isOpen,
   cancel,
   confirm,
 }: {
+  target: string;
   isOpen: boolean;
   cancel: () => void;
   confirm: () => void;
@@ -29,7 +31,7 @@ export function DeleteStepModal({
             paddingTop: '180px',
           },
         }}
-        title={<Title size={2}>Delete step</Title>}
+        title={<Title size={2}>Delete {target}</Title>}
         sx={{ backdropFilter: 'blur(10px)' }}
         shadow={theme.colorScheme === 'dark' ? shadows.dark : shadows.medium}
         radius="md"
@@ -39,7 +41,7 @@ export function DeleteStepModal({
         }}
       >
         <div>
-          <Text>Would you like to delete this step?</Text>
+          <Text>Would you like to delete this {target}?</Text>
           <Group position="right">
             <Button variant="outline" size="md" mt={30} onClick={() => cancel()}>
               No

--- a/apps/web/src/components/templates/NotificationSettingsForm.tsx
+++ b/apps/web/src/components/templates/NotificationSettingsForm.tsx
@@ -65,23 +65,13 @@ export const NotificationSettingsForm = ({
   return (
     <Grid gutter={30} grow>
       <Grid.Col md={6} sm={12}>
-        {trigger && (
-          <Input
-            mb={30}
-            data-test-id="trigger-id"
-            disabled={true}
-            value={trigger.identifier || ''}
-            error={errors.name?.message}
-            label="Notification ID"
-            description="This will be used to identify the notification using the API."
-          />
-        )}
         <Controller
           control={control}
           name="name"
           render={({ field }) => (
             <Input
               {...field}
+              mb={30}
               data-test-id="title"
               disabled={readonly}
               required
@@ -93,15 +83,12 @@ export const NotificationSettingsForm = ({
             />
           )}
         />
-      </Grid.Col>
-      <Grid.Col md={6} sm={12}>
         <Controller
           name="description"
           control={control}
           render={({ field }) => (
             <Input
               {...field}
-              mb={30}
               value={field.value || ''}
               disabled={readonly}
               data-test-id="description"
@@ -111,6 +98,19 @@ export const NotificationSettingsForm = ({
             />
           )}
         />
+      </Grid.Col>
+      <Grid.Col md={6} sm={12}>
+        {trigger && (
+          <Input
+            mb={30}
+            data-test-id="trigger-id"
+            disabled={true}
+            value={trigger.identifier || ''}
+            error={errors.name?.message}
+            label="Notification ID"
+            description="This will be used to identify the notification using the API."
+          />
+        )}
         <Controller
           name="notificationGroup"
           control={control}

--- a/apps/web/src/components/templates/TemplateSettings.tsx
+++ b/apps/web/src/components/templates/TemplateSettings.tsx
@@ -16,20 +16,32 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
 
   const { editMode, template, trigger, deleteTemplate } = useTemplateController(templateId);
   const [toDelete, setToDelete] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isError, setIsError] = useState<string | undefined>(undefined);
 
   const navigate = useNavigate();
 
   const confirmDelete = async () => {
-    navigate('/templates');
-    await deleteTemplate();
-    setToDelete(false);
+    setIsDeleting(true);
+    setIsError(undefined);
+    try {
+      await deleteTemplate();
+      setIsDeleting(false);
+      setToDelete(false);
+      navigate('/templates');
+    } catch (e: any) {
+      setIsDeleting(false);
+      setIsError(e?.message || 'Unknown error');
+    }
   };
 
   const cancelDelete = () => {
     setToDelete(false);
+    setIsDeleting(false);
   };
 
   const onDelete = () => {
+    setIsError(undefined);
     setToDelete(true);
   };
 
@@ -71,6 +83,8 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
                   isOpen={toDelete}
                   confirm={confirmDelete}
                   cancel={cancelDelete}
+                  isLoading={isDeleting}
+                  error={isError}
                 />
               </>
             )}

--- a/apps/web/src/components/templates/TemplateSettings.tsx
+++ b/apps/web/src/components/templates/TemplateSettings.tsx
@@ -1,11 +1,12 @@
 import { Grid, useMantineColorScheme } from '@mantine/core';
-import { colors } from '../../design-system';
+import { Button, colors } from '../../design-system';
 import { NotificationSettingsForm } from './NotificationSettingsForm';
 import { TemplatesSideBar } from './TemplatesSideBar';
 import { TriggerSnippetTabs } from './TriggerSnippetTabs';
 import styled from '@emotion/styled';
 import { useTemplateController } from './use-template-controller.hook';
 import { ActivePageEnum } from '../../pages/templates/editor/TemplateEditorPage';
+import { Trash } from '../../design-system/icons';
 
 export const TemplateSettings = ({ activePage, setActivePage, showErrors, templateId }) => {
   const { colorScheme } = useMantineColorScheme();
@@ -25,10 +26,29 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
             />
           </SideBarWrapper>
         </Grid.Col>
-        <Grid.Col md={8} sm={6}>
+        <Grid.Col md={8} sm={6} styles={{ position: 'relative' }}>
           <div style={{ paddingLeft: 23 }}>
             {activePage === ActivePageEnum.SETTINGS && (
-              <NotificationSettingsForm editMode={editMode} trigger={trigger} />
+              <>
+                <NotificationSettingsForm editMode={editMode} trigger={trigger} />
+                {editMode && (
+                  <DeleteNotificationButton
+                    mt={10}
+                    variant="outline"
+                    data-test-id="delete-notification-button"
+                    onClick={() => {
+                      /** TODO: implement */
+                    }}
+                  >
+                    <Trash
+                      style={{
+                        marginRight: '5px',
+                      }}
+                    />
+                    Delete Template
+                  </DeleteNotificationButton>
+                )}
+              </>
             )}
 
             {template && trigger && activePage === ActivePageEnum.TRIGGER_SNIPPET && (
@@ -44,4 +64,16 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
 const SideBarWrapper = styled.div<{ dark: boolean }>`
   border-right: 1px solid ${({ dark }) => (dark ? colors.B20 : colors.BGLight)};
   height: 100%;
+`;
+
+const DeleteNotificationButton = styled(Button)`
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
+  background: rgba(229, 69, 69, 0.15);
+  color: ${colors.error};
+  box-shadow: none;
+  :hover {
+    background: rgba(229, 69, 69, 0.15);
+  }
 `;

--- a/apps/web/src/components/templates/TemplateSettings.tsx
+++ b/apps/web/src/components/templates/TemplateSettings.tsx
@@ -19,9 +19,9 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
 
   const navigate = useNavigate();
 
-  const confirmDelete = () => {
+  const confirmDelete = async () => {
     navigate('/templates');
-    deleteTemplate();
+    await deleteTemplate();
     setToDelete(false);
   };
 

--- a/apps/web/src/components/templates/TemplateSettings.tsx
+++ b/apps/web/src/components/templates/TemplateSettings.tsx
@@ -7,11 +7,31 @@ import styled from '@emotion/styled';
 import { useTemplateController } from './use-template-controller.hook';
 import { ActivePageEnum } from '../../pages/templates/editor/TemplateEditorPage';
 import { Trash } from '../../design-system/icons';
+import { useState } from 'react';
+import { DeleteConfirmModal } from './DeleteConfirmModal';
+import { useNavigate } from 'react-router-dom';
 
 export const TemplateSettings = ({ activePage, setActivePage, showErrors, templateId }) => {
   const { colorScheme } = useMantineColorScheme();
 
-  const { editMode, template, trigger } = useTemplateController(templateId);
+  const { editMode, template, trigger, deleteTemplate } = useTemplateController(templateId);
+  const [toDelete, setToDelete] = useState(false);
+
+  const navigate = useNavigate();
+
+  const confirmDelete = () => {
+    navigate('/templates');
+    deleteTemplate();
+    setToDelete(false);
+  };
+
+  const cancelDelete = () => {
+    setToDelete(false);
+  };
+
+  const onDelete = () => {
+    setToDelete(true);
+  };
 
   return (
     <div style={{ marginLeft: 12, marginRight: 12, padding: 17.5, minHeight: 500 }}>
@@ -26,7 +46,7 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
             />
           </SideBarWrapper>
         </Grid.Col>
-        <Grid.Col md={8} sm={6} styles={{ position: 'relative' }}>
+        <Grid.Col md={8} sm={6} style={{ position: 'relative' }}>
           <div style={{ paddingLeft: 23 }}>
             {activePage === ActivePageEnum.SETTINGS && (
               <>
@@ -36,9 +56,7 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
                     mt={10}
                     variant="outline"
                     data-test-id="delete-notification-button"
-                    onClick={() => {
-                      /** TODO: implement */
-                    }}
+                    onClick={onDelete}
                   >
                     <Trash
                       style={{
@@ -48,6 +66,12 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
                     Delete Template
                   </DeleteNotificationButton>
                 )}
+                <DeleteConfirmModal
+                  target="notification template"
+                  isOpen={toDelete}
+                  confirm={confirmDelete}
+                  cancel={cancelDelete}
+                />
               </>
             )}
 

--- a/apps/web/src/components/templates/use-template-controller.hook.ts
+++ b/apps/web/src/components/templates/use-template-controller.hook.ts
@@ -11,7 +11,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import { useFormContext } from 'react-hook-form';
 import * as Sentry from '@sentry/react';
-import { createTemplate, updateTemplate } from '../../api/templates';
+import { createTemplate, updateTemplate, deleteTemplateById } from '../../api/templates';
 import { useTemplateFetcher } from './use-template.fetcher';
 import { QueryKeys } from '../../api/query.keys';
 import { useTemplateEditor } from './TemplateEditorProvider';
@@ -52,6 +52,8 @@ export function useTemplateController(templateId: string) {
   const navigate = useNavigate();
   const { template, refetch, loading: loadingEditTemplate } = useTemplateFetcher(templateId);
   const client = useQueryClient();
+
+  const deleteTemplate = () => deleteTemplateById(templateId);
 
   const { isLoading, mutateAsync: createNotification } = useMutation<
     INotificationTemplate,
@@ -188,6 +190,7 @@ export function useTemplateController(templateId: string) {
     deleteStep,
     editMode,
     template,
+    deleteTemplate,
     onSubmit,
     isEmbedModalVisible,
     trigger,

--- a/apps/web/src/pages/templates/workflow/WorkflowEditorPage.tsx
+++ b/apps/web/src/pages/templates/workflow/WorkflowEditorPage.tsx
@@ -13,7 +13,7 @@ import { When } from '../../../components/utils/When';
 import { Trash } from '../../../design-system/icons';
 import { TemplatePageHeader } from '../../../components/templates/TemplatePageHeader';
 import { ActivePageEnum } from '../editor/TemplateEditorPage';
-import { DeleteStepModal } from '../../../components/templates/DeleteStepModal';
+import { DeleteConfirmModal } from '../../../components/templates/DeleteConfirmModal';
 
 const capitalize = (text: string) => {
   return typeof text !== 'string' ? '' : text.charAt(0).toUpperCase() + text.slice(1);
@@ -188,7 +188,7 @@ const WorkflowEditorPage = ({
           </SideBarWrapper>
         </Grid.Col>
       </Grid>
-      <DeleteStepModal isOpen={toDelete.length > 0} confirm={confirmDelete} cancel={cancelDelete} />
+      <DeleteConfirmModal target="step" isOpen={toDelete.length > 0} confirm={confirmDelete} cancel={cancelDelete} />
     </div>
   );
 };


### PR DESCRIPTION
**NOTE! Depends on #808 **

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a button to remove the notification template

- **What is the current behavior?** (You can also link to an open issue here)
There isn't a button

- **What is the new behavior (if this is a feature change)?**
There now is a button that opens a modal and then deletes the template

- **Other information**:
![image](https://user-images.githubusercontent.com/29684625/177771603-b3ed6e93-7701-42df-901c-00fc84e6b5cc.png)
![image](https://user-images.githubusercontent.com/29684625/177771639-3557a3a7-f281-49af-9dc6-1278142e3058.png)
