### PR TITLE
NV-631 - fix(web): Redirect to getting started on first session

### DIFF
--- a/apps/web/cypress/tests/auth.spec.ts
+++ b/apps/web/cypress/tests/auth.spec.ts
@@ -15,7 +15,7 @@ describe('User Sign-up and Login', function () {
       cy.location('pathname').should('equal', '/auth/application');
       cy.getByTestId('app-creation').type('Organization Name');
       cy.getByTestId('submit-btn').click();
-      cy.location('pathname').should('equal', '/templates');
+      cy.location('pathname').should('equal', '/quickstart');
     });
   });
 

--- a/apps/web/src/components/auth/CreateOrganizationForm.tsx
+++ b/apps/web/src/components/auth/CreateOrganizationForm.tsx
@@ -77,7 +77,7 @@ export function CreateOrganization({}: Props) {
     }
 
     setLoading(false);
-    navigate('/');
+    navigate('/quickstart');
   };
 
   return (

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -12,6 +12,7 @@ export default function LoginPage() {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const queryToken = params.get('token');
+  const source = params.get('source');
 
   useEffect(() => {
     if (queryToken) {
@@ -26,7 +27,7 @@ export default function LoginPage() {
       if (!user.organizationId || !user.environmentId) {
         navigate('/auth/application');
       } else {
-        navigate('/');
+        navigate(source === 'cli' ? '/quickstart' : '/');
       }
     }
   }, [token]);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -181,7 +181,7 @@ async function raiseDemoDashboard(httpServer: HttpServer, config: ConfigService,
 }
 
 function buildTemplate(notificationGroupId: string): ICreateNotificationTemplateDto {
-  const redirectUrl = `${CLIENT_LOGIN_URL}?token={{token}}`;
+  const redirectUrl = `${CLIENT_LOGIN_URL}?token={{token}}&source=cli`;
 
   const steps = [
     {
@@ -220,7 +220,7 @@ function storeDashboardData(
   decodedToken,
   applicationIdentifier: string
 ) {
-  const dashboardURL = `${CLIENT_LOGIN_URL}?token=${config.getToken()}`;
+  const dashboardURL = `${CLIENT_LOGIN_URL}?token=${config.getToken()}&source=cli`;
 
   const tmpPayload: { key: string; value: string }[] = [
     { key: 'embedPath', value: EMBED_PATH },
@@ -286,7 +286,7 @@ async function checkExistingEnvironment(config: ConfigService): Promise<IEnviron
 
 async function handleExistingSession(result: string, config: ConfigService) {
   if (result === 'visitDashboard') {
-    const dashboardURL = `${CLIENT_LOGIN_URL}?token=${config.getToken()}`;
+    const dashboardURL = `${CLIENT_LOGIN_URL}?token=${config.getToken()}&source=cli`;
 
     await open(dashboardURL);
   } else if (result === 'exit') {


### PR DESCRIPTION
### What kind of change does this PR introduce?
Bug fix (I think)

### What is the current behavior?
Users are always redirected to the ***Notifications*** page upon signup/login.
https://github.com/novuhq/novu/issues/799

### What is the new behavior (if this is a feature change)?
Users will be redirected to the ***Getting Started*** page on their first session, and the ***Notifications*** page for any subsequent sessions.

### Other Information

Using local storage to track the session has the following issues.
- Logging in from a new device will always redirect to the ***Getting Started*** page.
- Logging out does not clear the *first session* flag, which means that creating a new account after logging out will always redirect to the ***Notifications*** page (not sure if this should be changed).
