### PR TITLE
feat: added nest module async provider option

### DIFF
--- a/packages/nest/src/interfaces/novu-options.interface.ts
+++ b/packages/nest/src/interfaces/novu-options.interface.ts
@@ -1,3 +1,4 @@
+import { ModuleMetadata, Type } from '@nestjs/common';
 import {
   IDirectProvider,
   IEmailProvider,
@@ -5,11 +6,26 @@ import {
   ITemplate,
 } from '@novu/stateless';
 
-export interface NovuOptions {
-  //
-  // This interface describes the options you want to pass to
-  // NovuModule.
-  //
+export interface INovuOptions {
+  /*
+   *
+   * This interface describes the options you want to pass to
+   * NovuModule.
+   *
+   */
   providers: (IEmailProvider | ISmsProvider | IDirectProvider)[];
   templates: ITemplate[];
+}
+
+export interface INovuOptionsFactory {
+  createNovuOptions(): Promise<INovuOptions> | INovuOptions;
+}
+
+export interface INovuModuleAsyncOptions
+  extends Pick<ModuleMetadata, 'imports'> {
+  connectionName?: string;
+  useExisting?: Type<INovuOptionsFactory>;
+  useClass?: Type<INovuOptionsFactory>;
+  useFactory?: (...args: any[]) => Promise<INovuOptions> | INovuOptions;
+  inject?: any[];
 }

--- a/packages/nest/src/interfaces/novu-options.interface.ts
+++ b/packages/nest/src/interfaces/novu-options.interface.ts
@@ -23,7 +23,6 @@ export interface INovuOptionsFactory {
 
 export interface INovuModuleAsyncOptions
   extends Pick<ModuleMetadata, 'imports'> {
-  connectionName?: string;
   useExisting?: Type<INovuOptionsFactory>;
   useClass?: Type<INovuOptionsFactory>;
   useFactory?: (...args: any[]) => Promise<INovuOptions> | INovuOptions;

--- a/packages/nest/src/module/novu.module.ts
+++ b/packages/nest/src/module/novu.module.ts
@@ -1,16 +1,26 @@
 import { DynamicModule, Global, Module } from '@nestjs/common';
-import { NovuOptions } from '../interfaces';
-import { createNovuProviders } from '../providers';
+import { INovuModuleAsyncOptions, INovuOptions } from '../interfaces';
+import { createAsyncNovuProviders, createNovuProviders } from '../providers';
 
 @Global()
 @Module({})
 export class NovuModule {
-  public static forRoot(options: NovuOptions): DynamicModule {
+  public static forRoot(options: INovuOptions): DynamicModule {
     const providers = createNovuProviders(options);
 
     return {
       module: NovuModule,
       providers,
+      exports: providers,
+    };
+  }
+
+  public static forRootAsync(options: INovuModuleAsyncOptions): DynamicModule {
+    const providers = createAsyncNovuProviders(options);
+
+    return {
+      module: NovuModule,
+      providers: [],
       exports: providers,
     };
   }

--- a/packages/nest/src/module/novu.module.ts
+++ b/packages/nest/src/module/novu.module.ts
@@ -22,6 +22,7 @@ export class NovuModule {
       module: NovuModule,
       providers: [],
       exports: providers,
+      imports: options.imports || [],
     };
   }
 }

--- a/packages/nest/src/providers/novu.providers.ts
+++ b/packages/nest/src/providers/novu.providers.ts
@@ -1,32 +1,73 @@
+import { Provider } from '@nestjs/common';
 import { NovuStateless } from '@novu/stateless';
-import { NovuOptions } from '../interfaces';
 import { NOVU_OPTIONS } from '../helpers/constants';
+import {
+  INovuModuleAsyncOptions,
+  INovuOptions,
+  INovuOptionsFactory,
+} from '../interfaces';
 import { NovuService } from '../services';
 
-export function createNovuProviders(options: NovuOptions) {
+async function novuServiceFactory(options: INovuOptions) {
+  const novu = new NovuStateless();
+  if (options.providers) {
+    for (const provider of options.providers) {
+      await novu.registerProvider(provider);
+    }
+  }
+
+  if (options.templates) {
+    for (const template of options.templates) {
+      await novu.registerTemplate(template);
+    }
+  }
+
+  return novu;
+}
+
+export function createNovuProviders(options: INovuOptions): Provider[] {
   return [
     {
       provide: NovuService,
-      useFactory: async () => {
-        const novu = new NovuStateless();
-        if (options.providers) {
-          for (const provider of options.providers) {
-            await novu.registerProvider(provider);
-          }
-        }
-
-        if (options.templates) {
-          for (const template of options.templates) {
-            await novu.registerTemplate(template);
-          }
-        }
-
-        return novu;
-      },
+      useFactory: novuServiceFactory,
+      inject: [NOVU_OPTIONS],
     },
     {
       provide: NOVU_OPTIONS,
       useValue: options,
+    },
+  ];
+}
+
+export function createAsyncNovuProviders(
+  options: INovuModuleAsyncOptions
+): Provider[] {
+  if (options.useFactory) {
+    return [
+      {
+        provide: NovuService,
+        useFactory: novuServiceFactory,
+        inject: [NOVU_OPTIONS],
+      },
+      {
+        provide: NOVU_OPTIONS,
+        useFactory: options.useFactory,
+        inject: options.inject || [],
+      },
+    ];
+  }
+
+  return [
+    {
+      provide: NovuService,
+      useFactory: novuServiceFactory,
+      inject: [NOVU_OPTIONS],
+    },
+    {
+      provide: NOVU_OPTIONS,
+      useFactory: (instance: INovuOptionsFactory) =>
+        instance.createNovuOptions(),
+      inject: [options.useExisting || options.useClass],
     },
   ];
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Adds `forRootAsync` method to nestjs module to provide config values dynamically
- closes #318 

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
