### PR TITLE
feat: Add i18n support for the notification center widget

### DIFF
--- a/packages/notification-center/src/components/notification-center/components/layout/Layout.tsx
+++ b/packages/notification-center/src/components/notification-center/components/layout/Layout.tsx
@@ -3,7 +3,7 @@ import { Loader } from '../Loader';
 import { HeaderContainer as Header } from './header/HeaderContainer';
 import { FooterContainer as Footer } from './footer/FooterContainer';
 import React from 'react';
-import { useNovuContext } from 'packages/notification-center/src/hooks';
+import { useNovuContext } from '../../../../hooks';
 import { useNovuThemeProvider } from '../../../../hooks/use-novu-theme-provider.hook';
 import { INovuTheme } from '../../../../store/novu-theme.context';
 

--- a/packages/notification-center/src/components/notification-center/components/layout/footer/Footer.tsx
+++ b/packages/notification-center/src/components/notification-center/components/layout/footer/Footer.tsx
@@ -1,15 +1,17 @@
 /* eslint-disable max-len */
-import React from 'react';
+import { I18NContext } from '../../../../../store/i18n.context';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { useNovuThemeProvider } from '../../../../../hooks/use-novu-theme-provider.hook';
 import { INovuTheme } from '../../../../../store/novu-theme.context';
 
 export function Footer() {
   const { theme } = useNovuThemeProvider();
+  const i18n = useContext(I18NContext);
 
   return (
     <FooterWrapper>
-      <Text theme={theme}>Powered By </Text>
+      <Text theme={theme}>{i18n.poweredBy} </Text>
       <a
         rel="noreferrer"
         target="_blank"

--- a/packages/notification-center/src/components/notification-center/components/layout/header/Header.tsx
+++ b/packages/notification-center/src/components/notification-center/components/layout/header/Header.tsx
@@ -1,16 +1,18 @@
 import styled from 'styled-components';
 import { Badge } from '@mantine/core';
 import { colors } from '../../../../../shared/config/colors';
-import React from 'react';
+import React, { useContext } from 'react';
 import { useNovuThemeProvider } from '../../../../../hooks/use-novu-theme-provider.hook';
+import { I18NContext } from '../../../../../store/i18n.context';
 
 export function Header({ unseenCount }: { unseenCount: number }) {
   const { theme, common } = useNovuThemeProvider();
+  const i18n = useContext(I18NContext);
 
   return (
     <HeaderWrapper>
       <div style={{ display: 'flex', flexDirection: 'row', gap: '10px', alignItems: 'center' }}>
-        <Text fontColor={theme.header.fontColor}>Notifications </Text>
+        <Text fontColor={theme.header.fontColor}>{i18n.notifications} </Text>
         {unseenCount && unseenCount > 0 ? (
           <Badge
             data-test-id="unseen-count-label"
@@ -33,7 +35,7 @@ export function Header({ unseenCount }: { unseenCount: number }) {
           </Badge>
         ) : null}
       </div>
-      <MarkReadAction style={{ display: 'none' }}>Mark all as read</MarkReadAction>
+      <MarkReadAction style={{ display: 'none' }}>{i18n.markAllAsRead}</MarkReadAction>
     </HeaderWrapper>
   );
 }

--- a/packages/notification-center/src/components/novu-provider/NovuProvider.tsx
+++ b/packages/notification-center/src/components/novu-provider/NovuProvider.tsx
@@ -11,6 +11,8 @@ import { ApiService } from '../../api/api.service';
 import { useApi } from '../../hooks/use-api.hook';
 import { AuthProvider } from '../notification-center/components';
 import { IOrganizationEntity } from '@novu/shared';
+import { NovuI18NProvider } from '../../store/i18n.context';
+import { I18NLanguage, ITranslationEntry } from '../../lang';
 
 interface INovuProviderProps {
   children: React.ReactNode;
@@ -21,6 +23,7 @@ interface INovuProviderProps {
   socketUrl?: string;
   onLoad?: (data: { organization: IOrganizationEntity }) => void;
   subscriberHash?: string;
+  i18n?: I18NLanguage | ITranslationEntry;
 }
 
 let api: ApiService;
@@ -52,7 +55,9 @@ export function NovuProvider(props: INovuProviderProps) {
         <AuthProvider>
           <SessionInitialization applicationIdentifier={props.applicationIdentifier} subscriberId={props.subscriberId}>
             <SocketInitialization>
-              <UnseenProvider>{props.children}</UnseenProvider>
+              <NovuI18NProvider i18n={props.i18n}>
+                <UnseenProvider>{props.children}</UnseenProvider>
+              </NovuI18NProvider>
             </SocketInitialization>
           </SessionInitialization>
         </AuthProvider>

--- a/packages/notification-center/src/lang.ts
+++ b/packages/notification-center/src/lang.ts
@@ -1,0 +1,15 @@
+export interface ITranslationEntry {
+  readonly notifications: string;
+  readonly markAllAsRead: string;
+  readonly poweredBy: string;
+}
+
+export type I18NLanguage = 'en';
+
+export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
+  en: {
+    notifications: 'Notifications',
+    markAllAsRead: 'Mark all as read',
+    poweredBy: 'Powered By',
+  },
+};

--- a/packages/notification-center/src/store/i18n.context.tsx
+++ b/packages/notification-center/src/store/i18n.context.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { I18NLanguage, ITranslationEntry, TRANSLATIONS } from '../lang';
+
+export const I18NContext = React.createContext<ITranslationEntry>({
+  markAllAsRead: '',
+  notifications: '',
+  poweredBy: '',
+});
+
+interface INovuI18NProviderProps {
+  i18n?: I18NLanguage | ITranslationEntry;
+  children: JSX.Element;
+}
+
+export function NovuI18NProvider({ i18n, ...props }: INovuI18NProviderProps) {
+  const i18nEntry = React.useMemo<ITranslationEntry>(() => {
+    if (!i18n) {
+      return TRANSLATIONS.en;
+    }
+
+    if (typeof i18n === 'string') {
+      return TRANSLATIONS[i18n];
+    }
+
+    return i18n;
+  }, [i18n]);
+
+  return <I18NContext.Provider {...props} value={i18nEntry} />;
+}


### PR DESCRIPTION
### What kind of change does this PR introduce?
**Feature**

### What is the current behavior?
The `notification-center` react component doesn't have i18n support

### What is the new behavior (if this is a feature change)?

This PR adds i18n support. it only has translations for the English language for now.
Users can their own label translations if they do not wish to use English.

### Other Information
- I'm not sure if this change affects the vanilla js embed, I'll have to take a look at it separately.
- This currently does not support pluralization since it's not needed to translate any of the labels that we currently have. It might be needed later on though.
- We might need to pass the user-provided i18n language to **moment.js** when calculating the relative time for each notification since I believe **moment.js** uses English by default.

@scopsy Lemme know what you think.