### PR TITLE
fix: Disable the delete step button on production

### DIFF
--- a/apps/web/src/components/templates/TemplateSettings.tsx
+++ b/apps/web/src/components/templates/TemplateSettings.tsx
@@ -10,9 +10,11 @@ import { Trash } from '../../design-system/icons';
 import { useState } from 'react';
 import { DeleteConfirmModal } from './DeleteConfirmModal';
 import { useNavigate } from 'react-router-dom';
+import { useEnvController } from '../../store/use-env-controller';
 
 export const TemplateSettings = ({ activePage, setActivePage, showErrors, templateId }) => {
   const { colorScheme } = useMantineColorScheme();
+  const { readonly } = useEnvController();
 
   const { editMode, template, trigger, deleteTemplate } = useTemplateController(templateId);
   const [toDelete, setToDelete] = useState(false);
@@ -67,6 +69,7 @@ export const TemplateSettings = ({ activePage, setActivePage, showErrors, templa
                   <DeleteNotificationButton
                     mt={10}
                     variant="outline"
+                    disabled={readonly}
                     data-test-id="delete-notification-button"
                     onClick={onDelete}
                   >


### PR DESCRIPTION
### What kind of change does this PR introduce?
Bug fix

### What is the current behavior?
#846

### What is the new behavior (if this is a feature change)?
The **Delete Template** button will disabled on production
![image](https://user-images.githubusercontent.com/8643036/179384295-fd68e854-28fb-4cfa-ace5-0a5d77908be9.png)
