### PR TITLE
feat: improve the command.create static function to be reused

### DIFF
--- a/_templates/usecase/new/command.ejs.t
+++ b/_templates/usecase/new/command.ejs.t
@@ -1,13 +1,8 @@
 ---
 to: apps/api/src/app/<%= module %>/usecases/<%= name %>/<%= name %>.command.ts
 ---
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class <%= h.changeCase.pascal(name) %>Command extends EnvironmentWithUserCommand {
-  static create(data: <%= h.changeCase.pascal(name) %>Command) {
-    return CommandHelper.create<<%= h.changeCase.pascal(name) %>Command>(<%= h.changeCase.pascal(name) %>Command, data);
-  }
-}
+export class <%= h.changeCase.pascal(name) %>Command extends EnvironmentWithUserCommand {}
 
 

--- a/apps/api/src/app/activity/usecases/get-acticity-graph-states/get-acticity-graph-states.command.ts
+++ b/apps/api/src/app/activity/usecases/get-acticity-graph-states/get-acticity-graph-states.command.ts
@@ -1,12 +1,7 @@
 import { IsNumber, IsOptional } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class GetActivityGraphStatsCommand extends EnvironmentWithUserCommand {
-  static create(data: GetActivityGraphStatsCommand) {
-    return CommandHelper.create<GetActivityGraphStatsCommand>(GetActivityGraphStatsCommand, data);
-  }
-
   @IsNumber()
   @IsOptional()
   days: number;

--- a/apps/api/src/app/activity/usecases/get-activity-feed/get-activity-feed.command.ts
+++ b/apps/api/src/app/activity/usecases/get-activity-feed/get-activity-feed.command.ts
@@ -1,13 +1,8 @@
-import { IsArray, IsEnum, IsMongoId, IsNumber, IsOptional, IsPositive, IsString } from 'class-validator';
+import { IsArray, IsEnum, IsMongoId, IsNumber, IsOptional, IsString } from 'class-validator';
 import { ChannelTypeEnum } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class GetActivityFeedCommand extends EnvironmentWithUserCommand {
-  static create(data: GetActivityFeedCommand) {
-    return CommandHelper.create<GetActivityFeedCommand>(GetActivityFeedCommand, data);
-  }
-
   @IsNumber()
   @IsOptional()
   page: number;

--- a/apps/api/src/app/activity/usecases/get-activity-stats/get-activity-stats.command.ts
+++ b/apps/api/src/app/activity/usecases/get-activity-stats/get-activity-stats.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class GetActivityStatsCommand extends EnvironmentWithUserCommand {
-  static create(data: GetActivityStatsCommand) {
-    return CommandHelper.create<GetActivityStatsCommand>(GetActivityStatsCommand, data);
-  }
-}
+export class GetActivityStatsCommand extends EnvironmentWithUserCommand {}

--- a/apps/api/src/app/auth/usecases/login/login.command.ts
+++ b/apps/api/src/app/auth/usecases/login/login.command.ts
@@ -1,11 +1,7 @@
 import { IsDefined, IsEmail, IsNotEmpty } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class LoginCommand {
-  static create(data: LoginCommand) {
-    return CommandHelper.create(LoginCommand, data);
-  }
-
+export class LoginCommand extends BaseCommand {
   @IsDefined()
   @IsNotEmpty()
   @IsEmail()

--- a/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.command.ts
+++ b/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsEmail } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
-import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class PasswordResetRequestCommand {
-  static create(data: PasswordResetRequestCommand) {
-    return CommandHelper.create<PasswordResetRequestCommand>(PasswordResetRequestCommand, data);
-  }
-
+export class PasswordResetRequestCommand extends BaseCommand {
   @IsEmail()
   @IsDefined()
   email: string;

--- a/apps/api/src/app/auth/usecases/password-reset/password-reset.command.ts
+++ b/apps/api/src/app/auth/usecases/password-reset/password-reset.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsString, IsUUID, MinLength } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
-import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class PasswordResetCommand {
-  static create(data: PasswordResetCommand) {
-    return CommandHelper.create<PasswordResetCommand>(PasswordResetCommand, data);
-  }
-
+export class PasswordResetCommand extends BaseCommand {
   @IsString()
   @IsDefined()
   @MinLength(8)

--- a/apps/api/src/app/auth/usecases/register/user-register.command.ts
+++ b/apps/api/src/app/auth/usecases/register/user-register.command.ts
@@ -1,11 +1,7 @@
 import { IsDefined, IsEmail, IsNotEmpty, IsOptional, MinLength } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class UserRegisterCommand {
-  static create(data: UserRegisterCommand) {
-    return CommandHelper.create(UserRegisterCommand, data);
-  }
-
+export class UserRegisterCommand extends BaseCommand {
   @IsDefined()
   @IsNotEmpty()
   @IsEmail()

--- a/apps/api/src/app/auth/usecases/switch-environment/switch-environment.command.ts
+++ b/apps/api/src/app/auth/usecases/switch-environment/switch-environment.command.ts
@@ -1,12 +1,7 @@
 import { IsNotEmpty } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
 
 export class SwitchEnvironmentCommand extends OrganizationCommand {
-  static create(data: SwitchEnvironmentCommand) {
-    return CommandHelper.create(SwitchEnvironmentCommand, data);
-  }
-
   @IsNotEmpty()
   newEnvironmentId: string;
 }

--- a/apps/api/src/app/auth/usecases/switch-organization/switch-organization.command.ts
+++ b/apps/api/src/app/auth/usecases/switch-organization/switch-organization.command.ts
@@ -1,12 +1,7 @@
 import { IsNotEmpty } from 'class-validator';
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 
 export class SwitchOrganizationCommand extends AuthenticatedCommand {
-  static create(data: SwitchOrganizationCommand) {
-    return CommandHelper.create(SwitchOrganizationCommand, data);
-  }
-
   @IsNotEmpty()
   newOrganizationId: string;
 }

--- a/apps/api/src/app/change/usecases/apply-change/apply-change.command.ts
+++ b/apps/api/src/app/change/usecases/apply-change/apply-change.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsMongoId } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class ApplyChangeCommand extends EnvironmentWithUserCommand {
-  static create(data: ApplyChangeCommand) {
-    return CommandHelper.create(ApplyChangeCommand, data);
-  }
-
   @IsDefined()
   @IsMongoId()
   changeId: string;

--- a/apps/api/src/app/change/usecases/bulk-apply-change/bulk-apply-change.command.ts
+++ b/apps/api/src/app/change/usecases/bulk-apply-change/bulk-apply-change.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsArray } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class BulkApplyChangeCommand extends EnvironmentWithUserCommand {
-  static create(data: BulkApplyChangeCommand) {
-    return CommandHelper.create(BulkApplyChangeCommand, data);
-  }
-
   @IsDefined()
   @IsArray()
   changeIds: string[];

--- a/apps/api/src/app/change/usecases/count-changes/count-changes.command.ts
+++ b/apps/api/src/app/change/usecases/count-changes/count-changes.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class CountChangesCommand extends EnvironmentWithUserCommand {
-  static create(data: CountChangesCommand) {
-    return CommandHelper.create(CountChangesCommand, data);
-  }
-}
+export class CountChangesCommand extends EnvironmentWithUserCommand {}

--- a/apps/api/src/app/change/usecases/create-change.command.ts
+++ b/apps/api/src/app/change/usecases/create-change.command.ts
@@ -1,18 +1,13 @@
 import { ChangeEntityTypeEnum } from '@novu/shared';
 import { IsDefined, IsMongoId, IsOptional, IsString } from 'class-validator';
 import { Document } from 'mongoose';
-import { CommandHelper } from '../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../shared/commands/project.command';
 
 export interface IItem extends Pick<Document, '_id'> {
-  [key: string]: any;
+  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export class CreateChangeCommand extends EnvironmentWithUserCommand {
-  static create(data: CreateChangeCommand) {
-    return CommandHelper.create(CreateChangeCommand, data);
-  }
-
   @IsDefined()
   item: IItem;
 

--- a/apps/api/src/app/change/usecases/get-changes/get-changes.command.ts
+++ b/apps/api/src/app/change/usecases/get-changes/get-changes.command.ts
@@ -1,12 +1,7 @@
 import { IsBoolean, IsDefined } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class GetChangesCommand extends EnvironmentWithUserCommand {
-  static create(data: GetChangesCommand) {
-    return CommandHelper.create(GetChangesCommand, data);
-  }
-
   @IsDefined()
   @IsBoolean()
   promoted: boolean;

--- a/apps/api/src/app/change/usecases/promote-change-to-environment/promote-change-to-environment.command.ts
+++ b/apps/api/src/app/change/usecases/promote-change-to-environment/promote-change-to-environment.command.ts
@@ -1,13 +1,8 @@
 import { ChangeEntityTypeEnum } from '@novu/shared';
 import { IsDefined, IsMongoId, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class PromoteChangeToEnvironmentCommand extends EnvironmentWithUserCommand {
-  static create(data: PromoteChangeToEnvironmentCommand) {
-    return CommandHelper.create(PromoteChangeToEnvironmentCommand, data);
-  }
-
   @IsDefined()
   @IsMongoId()
   itemId: string;

--- a/apps/api/src/app/change/usecases/promote-type-change.command.ts
+++ b/apps/api/src/app/change/usecases/promote-type-change.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined } from 'class-validator';
-import { CommandHelper } from '../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../shared/commands/project.command';
 import { IItem } from './create-change.command';
 
 export class PromoteTypeChangeCommand extends EnvironmentWithUserCommand {
-  static create(data: PromoteTypeChangeCommand) {
-    return CommandHelper.create(PromoteTypeChangeCommand, data);
-  }
-
   @IsDefined()
   item: IItem;
 }

--- a/apps/api/src/app/change/usecases/update-change/update-change.command.ts
+++ b/apps/api/src/app/change/usecases/update-change/update-change.command.ts
@@ -1,13 +1,8 @@
 import { ChangeEntityTypeEnum } from '@novu/shared';
 import { IsDefined, IsMongoId, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class UpdateChangeCommand extends EnvironmentWithUserCommand {
-  static create(data: UpdateChangeCommand) {
-    return CommandHelper.create(UpdateChangeCommand, data);
-  }
-
   @IsMongoId()
   _entityId: string;
 

--- a/apps/api/src/app/channels/usecases/update-mail-settings/update-mail-settings.command.ts
+++ b/apps/api/src/app/channels/usecases/update-mail-settings/update-mail-settings.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsEmail } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class UpdateMailSettingsCommand extends EnvironmentWithUserCommand {
-  static create(data: UpdateMailSettingsCommand) {
-    return CommandHelper.create<UpdateMailSettingsCommand>(UpdateMailSettingsCommand, data);
-  }
-
   @IsDefined()
   @IsEmail()
   senderEmail: string;

--- a/apps/api/src/app/channels/usecases/update-sms-settings/update-sms-settings.command.ts
+++ b/apps/api/src/app/channels/usecases/update-sms-settings/update-sms-settings.command.ts
@@ -1,5 +1,4 @@
 import { IsDefined, ValidateNested } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 class TwillioSettings {
@@ -14,10 +13,6 @@ class TwillioSettings {
 }
 
 export class UpdateSmsSettingsCommand extends EnvironmentWithUserCommand {
-  static create(data: UpdateSmsSettingsCommand) {
-    return CommandHelper.create<UpdateSmsSettingsCommand>(UpdateSmsSettingsCommand, data);
-  }
-
   @IsDefined()
   @ValidateNested()
   twillio: TwillioSettings;

--- a/apps/api/src/app/content-templates/usecases/compile-template/compile-template.command.ts
+++ b/apps/api/src/app/content-templates/usecases/compile-template/compile-template.command.ts
@@ -1,11 +1,7 @@
 import { IsDefined, IsObject, IsOptional } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class CompileTemplateCommand {
-  static create(data: CompileTemplateCommand) {
-    return CommandHelper.create<CompileTemplateCommand>(CompileTemplateCommand, data);
-  }
-
+export class CompileTemplateCommand extends BaseCommand {
   @IsDefined()
   templateId: 'basic' | 'custom';
 

--- a/apps/api/src/app/environments/usecases/create-environment/create-environment.command.ts
+++ b/apps/api/src/app/environments/usecases/create-environment/create-environment.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsMongoId, IsOptional } from 'class-validator';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 
 export class CreateEnvironmentCommand extends OrganizationCommand {
-  static create(data: CreateEnvironmentCommand) {
-    return CommandHelper.create(CreateEnvironmentCommand, data);
-  }
-
   @IsDefined()
   name: string;
 

--- a/apps/api/src/app/environments/usecases/get-api-keys/get-api-keys.command.ts
+++ b/apps/api/src/app/environments/usecases/get-api-keys/get-api-keys.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class GetApiKeysCommand extends EnvironmentWithUserCommand {
-  static create(data: GetApiKeysCommand) {
-    return CommandHelper.create(GetApiKeysCommand, data);
-  }
-}
+export class GetApiKeysCommand extends EnvironmentWithUserCommand {}

--- a/apps/api/src/app/environments/usecases/get-environment/get-environment.command.ts
+++ b/apps/api/src/app/environments/usecases/get-environment/get-environment.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class GetEnvironmentCommand extends EnvironmentWithUserCommand {
-  static create(data: GetEnvironmentCommand) {
-    return CommandHelper.create(GetEnvironmentCommand, data);
-  }
-}
+export class GetEnvironmentCommand extends EnvironmentWithUserCommand {}

--- a/apps/api/src/app/environments/usecases/get-my-environments/get-my-environments.command.ts
+++ b/apps/api/src/app/environments/usecases/get-my-environments/get-my-environments.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
 
-export class GetMyEnvironmentsCommand extends OrganizationCommand {
-  static create(data: GetMyEnvironmentsCommand) {
-    return CommandHelper.create(GetMyEnvironmentsCommand, data);
-  }
-}
+export class GetMyEnvironmentsCommand extends OrganizationCommand {}

--- a/apps/api/src/app/environments/usecases/update-widget-settings/update-widget-settings.command.ts
+++ b/apps/api/src/app/environments/usecases/update-widget-settings/update-widget-settings.command.ts
@@ -1,11 +1,7 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
-import { EnvironmentCommand } from '../../../shared/commands/project.command';
 import { IsDefined } from 'class-validator';
+import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class UpdateWidgetSettingsCommand extends EnvironmentCommand {
-  static create(data: UpdateWidgetSettingsCommand) {
-    return CommandHelper.create(UpdateWidgetSettingsCommand, data);
-  }
   @IsDefined()
   notificationCenterEncryption: boolean;
 }

--- a/apps/api/src/app/events/usecases/cancel-digest/cancel-digest.command.ts
+++ b/apps/api/src/app/events/usecases/cancel-digest/cancel-digest.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class CancelDigestCommand extends EnvironmentWithUserCommand {
-  static create(data: CancelDigestCommand) {
-    return CommandHelper.create(CancelDigestCommand, data);
-  }
-
   @IsString()
   @IsDefined()
   transactionId: string;

--- a/apps/api/src/app/events/usecases/filter-steps/filter-steps.command.ts
+++ b/apps/api/src/app/events/usecases/filter-steps/filter-steps.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined, IsMongoId } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
-import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { NotificationStepEntity } from '@novu/dal';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class FilterStepsCommand extends EnvironmentWithUserCommand {
-  static create(data: FilterStepsCommand) {
-    return CommandHelper.create(FilterStepsCommand, data);
-  }
-
   @IsMongoId()
   subscriberId: string;
 

--- a/apps/api/src/app/events/usecases/process-subscriber/process-subscriber.command.ts
+++ b/apps/api/src/app/events/usecases/process-subscriber/process-subscriber.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
-import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { ISubscribersDefine } from '@novu/node';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class ProcessSubscriberCommand extends EnvironmentWithUserCommand {
-  static create(data: ProcessSubscriberCommand) {
-    return CommandHelper.create(ProcessSubscriberCommand, data);
-  }
-
   @IsDefined()
   @IsString()
   identifier: string;
@@ -16,7 +11,7 @@ export class ProcessSubscriberCommand extends EnvironmentWithUserCommand {
   payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
   @IsDefined()
-  to: ISubscribersDefine; // eslint-disable-line @typescript-eslint/no-explicit-any
+  to: ISubscribersDefine;
 
   @IsString()
   @IsDefined()

--- a/apps/api/src/app/events/usecases/queue-next-job/queue-next-job.command.ts
+++ b/apps/api/src/app/events/usecases/queue-next-job/queue-next-job.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class QueueNextJobCommand extends EnvironmentWithUserCommand {
-  static create(data: QueueNextJobCommand) {
-    return CommandHelper.create(QueueNextJobCommand, data);
-  }
-
   @IsDefined()
   parentId: string;
 }

--- a/apps/api/src/app/events/usecases/send-message/send-message.command.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined, IsOptional, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
-import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { NotificationStepEntity } from '@novu/dal';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class SendMessageCommand extends EnvironmentWithUserCommand {
-  static create(data: SendMessageCommand) {
-    return CommandHelper.create(SendMessageCommand, data);
-  }
-
   @IsDefined()
   @IsString()
   identifier: string;
@@ -16,7 +11,7 @@ export class SendMessageCommand extends EnvironmentWithUserCommand {
   payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
   @IsDefined()
-  step: NotificationStepEntity; // eslint-disable-line @typescript-eslint/no-explicit-any
+  step: NotificationStepEntity;
 
   @IsString()
   @IsDefined()

--- a/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.command.ts
+++ b/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class TriggerEventToAllCommand extends EnvironmentWithUserCommand {
-  static create(data: TriggerEventToAllCommand) {
-    return CommandHelper.create(TriggerEventToAllCommand, data);
-  }
-
   @IsDefined()
   @IsString()
   identifier: string;

--- a/apps/api/src/app/events/usecases/trigger-event/trigger-event.command.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/trigger-event.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
-import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { ISubscribersDefine } from '@novu/node';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class TriggerEventCommand extends EnvironmentWithUserCommand {
-  static create(data: TriggerEventCommand) {
-    return CommandHelper.create(TriggerEventCommand, data);
-  }
-
   @IsDefined()
   @IsString()
   identifier: string;
@@ -16,7 +11,7 @@ export class TriggerEventCommand extends EnvironmentWithUserCommand {
   payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
   @IsDefined()
-  to: ISubscribersDefine[]; // eslint-disable-line @typescript-eslint/no-explicit-any
+  to: ISubscribersDefine[];
 
   @IsString()
   @IsDefined()

--- a/apps/api/src/app/feeds/usecases/create-feed/create-feed.command.ts
+++ b/apps/api/src/app/feeds/usecases/create-feed/create-feed.command.ts
@@ -1,12 +1,7 @@
 import { IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class CreateFeedCommand extends EnvironmentWithUserCommand {
-  static create(data: CreateFeedCommand) {
-    return CommandHelper.create<CreateFeedCommand>(CreateFeedCommand, data);
-  }
-
   @IsString()
   name: string;
 }

--- a/apps/api/src/app/feeds/usecases/delete-feed/delete-feed.command.ts
+++ b/apps/api/src/app/feeds/usecases/delete-feed/delete-feed.command.ts
@@ -1,12 +1,7 @@
 import { IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class DeleteFeedCommand extends EnvironmentWithUserCommand {
-  static create(data: DeleteFeedCommand) {
-    return CommandHelper.create<DeleteFeedCommand>(DeleteFeedCommand, data);
-  }
-
   @IsString()
   feedId: string;
 }

--- a/apps/api/src/app/feeds/usecases/get-feeds/get-feeds.command.ts
+++ b/apps/api/src/app/feeds/usecases/get-feeds/get-feeds.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class GetFeedsCommand extends EnvironmentWithUserCommand {
-  static create(data: GetFeedsCommand) {
-    return CommandHelper.create<GetFeedsCommand>(GetFeedsCommand, data);
-  }
-}
+export class GetFeedsCommand extends EnvironmentWithUserCommand {}

--- a/apps/api/src/app/integrations/usecases/create-integration/create-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/create-integration/create-integration.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined } from 'class-validator';
 import { ChannelTypeEnum, ICredentialsDto } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class CreateIntegrationCommand extends EnvironmentCommand {
-  static create(data: CreateIntegrationCommand) {
-    return CommandHelper.create(CreateIntegrationCommand, data);
-  }
-
   @IsDefined()
   providerId: string;
 

--- a/apps/api/src/app/integrations/usecases/deactivate-integration/deactivate-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/deactivate-integration/deactivate-integration.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined } from 'class-validator';
 import { ChannelTypeEnum } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class DeactivateSimilarChannelIntegrationsCommand extends EnvironmentCommand {
-  static create(data: DeactivateSimilarChannelIntegrationsCommand) {
-    return CommandHelper.create(DeactivateSimilarChannelIntegrationsCommand, data);
-  }
-
   @IsDefined()
   integrationId: string;
 

--- a/apps/api/src/app/integrations/usecases/get-active-integration/get-active-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/get-active-integration/get-active-integration.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
-export class GetActiveIntegrationsCommand extends EnvironmentCommand {
-  static create(data: GetActiveIntegrationsCommand) {
-    return CommandHelper.create(GetActiveIntegrationsCommand, data);
-  }
-}
+export class GetActiveIntegrationsCommand extends EnvironmentCommand {}

--- a/apps/api/src/app/integrations/usecases/get-integrations/get-integrations.command.ts
+++ b/apps/api/src/app/integrations/usecases/get-integrations/get-integrations.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
-export class GetIntegrationsCommand extends EnvironmentCommand {
-  static create(data: GetIntegrationsCommand) {
-    return CommandHelper.create(GetIntegrationsCommand, data);
-  }
-}
+export class GetIntegrationsCommand extends EnvironmentCommand {}

--- a/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.command.ts
@@ -1,11 +1,7 @@
 import { IsDefined } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class RemoveIntegrationCommand extends EnvironmentCommand {
-  static create(data: RemoveIntegrationCommand) {
-    return CommandHelper.create(RemoveIntegrationCommand, data);
-  }
   @IsDefined()
   integrationId: string;
 }

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
@@ -1,12 +1,8 @@
 import { IsDefined } from 'class-validator';
-import { ChannelTypeEnum, ICredentialsDto } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { ICredentialsDto } from '@novu/shared';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class UpdateIntegrationCommand extends EnvironmentCommand {
-  static create(data: UpdateIntegrationCommand) {
-    return CommandHelper.create(UpdateIntegrationCommand, data);
-  }
   @IsDefined()
   integrationId: string;
 

--- a/apps/api/src/app/invites/usecases/accept-invite/accept-invite.command.ts
+++ b/apps/api/src/app/invites/usecases/accept-invite/accept-invite.command.ts
@@ -1,12 +1,7 @@
 import { IsString } from 'class-validator';
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 
 export class AcceptInviteCommand extends AuthenticatedCommand {
-  static create(data: AcceptInviteCommand) {
-    return CommandHelper.create(AcceptInviteCommand, data);
-  }
-
   @IsString()
   readonly token: string;
 }

--- a/apps/api/src/app/invites/usecases/bulk-invite/bulk-invite.command.ts
+++ b/apps/api/src/app/invites/usecases/bulk-invite/bulk-invite.command.ts
@@ -1,12 +1,7 @@
 import { MemberRoleEnum } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
 
 export class BulkInviteCommand extends OrganizationCommand {
-  static create(data: BulkInviteCommand) {
-    return CommandHelper.create(BulkInviteCommand, data);
-  }
-
   invitees: {
     email: string;
     role?: MemberRoleEnum;

--- a/apps/api/src/app/invites/usecases/get-invite/get-invite.command.ts
+++ b/apps/api/src/app/invites/usecases/get-invite/get-invite.command.ts
@@ -1,11 +1,7 @@
 import { IsNotEmpty } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class GetInviteCommand {
-  static create(data: GetInviteCommand) {
-    return CommandHelper.create(GetInviteCommand, data);
-  }
-
+export class GetInviteCommand extends BaseCommand {
   @IsNotEmpty()
   readonly token: string;
 }

--- a/apps/api/src/app/invites/usecases/invite-member/invite-member.command.ts
+++ b/apps/api/src/app/invites/usecases/invite-member/invite-member.command.ts
@@ -1,13 +1,8 @@
-import { IsDefined, IsEmail, IsString, IsEnum } from 'class-validator';
+import { IsDefined, IsEmail, IsEnum } from 'class-validator';
 import { MemberRoleEnum } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
 
 export class InviteMemberCommand extends OrganizationCommand {
-  static create(data: InviteMemberCommand) {
-    return CommandHelper.create(InviteMemberCommand, data);
-  }
-
   @IsEmail()
   readonly email: string;
 

--- a/apps/api/src/app/logs/usecases/create-log/create-log.command.ts
+++ b/apps/api/src/app/logs/usecases/create-log/create-log.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined, IsEnum, IsMongoId, IsOptional, IsString } from 'class-validator';
 import { LogCodeEnum, LogStatusEnum } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class CreateLogCommand extends EnvironmentWithUserCommand {
-  static create(data: CreateLogCommand) {
-    return CommandHelper.create<CreateLogCommand>(CreateLogCommand, data);
-  }
-
   @IsDefined()
   @IsString()
   transactionId: string;

--- a/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.command.ts
+++ b/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined, IsEnum, IsMongoId, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { ChannelTypeEnum, IEmailBlock, IMessageCTA } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class CreateMessageTemplateCommand extends EnvironmentWithUserCommand {
-  static create(data: CreateMessageTemplateCommand) {
-    return CommandHelper.create<CreateMessageTemplateCommand>(CreateMessageTemplateCommand, data);
-  }
-
   @IsDefined()
   @IsEnum(ChannelTypeEnum)
   type: ChannelTypeEnum;

--- a/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.command.ts
+++ b/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined, IsEnum, IsMongoId, IsOptional, ValidateNested } from 'class-validator';
 import { ChannelTypeEnum, IEmailBlock, IMessageCTA } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class UpdateMessageTemplateCommand extends EnvironmentWithUserCommand {
-  static create(data: UpdateMessageTemplateCommand) {
-    return CommandHelper.create<UpdateMessageTemplateCommand>(UpdateMessageTemplateCommand, data);
-  }
-
   @IsDefined()
   @IsMongoId()
   templateId: string;

--- a/apps/api/src/app/notification-groups/usecases/create-notification-group/create-notification-group.command.ts
+++ b/apps/api/src/app/notification-groups/usecases/create-notification-group/create-notification-group.command.ts
@@ -1,12 +1,7 @@
 import { IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class CreateNotificationGroupCommand extends EnvironmentWithUserCommand {
-  static create(data: CreateNotificationGroupCommand) {
-    return CommandHelper.create<CreateNotificationGroupCommand>(CreateNotificationGroupCommand, data);
-  }
-
   @IsString()
   name: string;
 }

--- a/apps/api/src/app/notification-groups/usecases/get-notification-groups/get-notification-groups.command.ts
+++ b/apps/api/src/app/notification-groups/usecases/get-notification-groups/get-notification-groups.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class GetNotificationGroupsCommand extends EnvironmentWithUserCommand {
-  static create(data: GetNotificationGroupsCommand) {
-    return CommandHelper.create<GetNotificationGroupsCommand>(GetNotificationGroupsCommand, data);
-  }
-}
+export class GetNotificationGroupsCommand extends EnvironmentWithUserCommand {}

--- a/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.command.ts
+++ b/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.command.ts
@@ -1,12 +1,7 @@
 import { IsBoolean, IsDefined, IsMongoId } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class ChangeTemplateActiveStatusCommand extends EnvironmentWithUserCommand {
-  static create(data: ChangeTemplateActiveStatusCommand) {
-    return CommandHelper.create<ChangeTemplateActiveStatusCommand>(ChangeTemplateActiveStatusCommand, data);
-  }
-
   @IsBoolean()
   @IsDefined()
   active: boolean;

--- a/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.command.ts
+++ b/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.command.ts
@@ -16,15 +16,10 @@ import {
   IMessageAction,
   DigestUnitEnum,
 } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { MessageTemplateDto } from '../../dto';
 
 export class CreateNotificationTemplateCommand extends EnvironmentWithUserCommand {
-  static create(data: CreateNotificationTemplateCommand) {
-    return CommandHelper.create(CreateNotificationTemplateCommand, data);
-  }
-
   @IsMongoId()
   @IsDefined()
   notificationGroupId: string;

--- a/apps/api/src/app/notification-template/usecases/get-notification-template/get-notification-template.command.ts
+++ b/apps/api/src/app/notification-template/usecases/get-notification-template/get-notification-template.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsMongoId } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class GetNotificationTemplateCommand extends EnvironmentWithUserCommand {
-  static create(data: GetNotificationTemplateCommand) {
-    return CommandHelper.create<GetNotificationTemplateCommand>(GetNotificationTemplateCommand, data);
-  }
-
   @IsDefined()
   @IsMongoId()
   templateId: string;

--- a/apps/api/src/app/notification-template/usecases/get-notification-templates/get-notification-templates.command.ts
+++ b/apps/api/src/app/notification-template/usecases/get-notification-templates/get-notification-templates.command.ts
@@ -1,9 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
-import { OrganizationCommand } from '../../../shared/commands/organization.command';
-import { EnvironmentCommand, EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class GetNotificationTemplatesCommand extends EnvironmentWithUserCommand {
-  static create(data: GetNotificationTemplatesCommand) {
-    return CommandHelper.create(GetNotificationTemplatesCommand, data);
-  }
-}
+export class GetNotificationTemplatesCommand extends EnvironmentWithUserCommand {}

--- a/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.command.ts
+++ b/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.command.ts
@@ -1,13 +1,8 @@
 import { IsArray, IsDefined, IsMongoId, IsOptional, IsString, ValidateNested } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { NotificationStepDto } from '../../dto';
 
 export class UpdateNotificationTemplateCommand extends EnvironmentWithUserCommand {
-  static create(data: UpdateNotificationTemplateCommand) {
-    return CommandHelper.create<UpdateNotificationTemplateCommand>(UpdateNotificationTemplateCommand, data);
-  }
-
   @IsDefined()
   @IsMongoId()
   templateId: string;

--- a/apps/api/src/app/organization/usecases/create-organization/create-organization.command.ts
+++ b/apps/api/src/app/organization/usecases/create-organization/create-organization.command.ts
@@ -1,11 +1,6 @@
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 
 export class CreateOrganizationCommand extends AuthenticatedCommand {
-  static create(data: CreateOrganizationCommand) {
-    return CommandHelper.create(CreateOrganizationCommand, data);
-  }
-
   public readonly logo?: string;
 
   public readonly name: string;

--- a/apps/api/src/app/organization/usecases/get-my-organization/get-my-organization.command.ts
+++ b/apps/api/src/app/organization/usecases/get-my-organization/get-my-organization.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined } from 'class-validator';
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 
 export class GetMyOrganizationCommand extends AuthenticatedCommand {
-  static create(data: GetMyOrganizationCommand) {
-    return CommandHelper.create(GetMyOrganizationCommand, data);
-  }
-
   @IsDefined()
   public readonly id: string;
 }

--- a/apps/api/src/app/organization/usecases/get-organization/get-organization.command.ts
+++ b/apps/api/src/app/organization/usecases/get-organization/get-organization.command.ts
@@ -1,10 +1,5 @@
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 
 export class GetOrganizationCommand extends AuthenticatedCommand {
-  static create(data: GetOrganizationCommand) {
-    return CommandHelper.create(GetOrganizationCommand, data);
-  }
-
   public readonly id: string;
 }

--- a/apps/api/src/app/organization/usecases/membership/add-member/add-member.command.ts
+++ b/apps/api/src/app/organization/usecases/membership/add-member/add-member.command.ts
@@ -1,13 +1,8 @@
 import { MemberRoleEnum } from '@novu/shared';
 import { ArrayNotEmpty } from 'class-validator';
-import { CommandHelper } from '../../../../shared/commands/command.helper';
 import { OrganizationCommand } from '../../../../shared/commands/organization.command';
 
 export class AddMemberCommand extends OrganizationCommand {
-  static create(data: AddMemberCommand) {
-    return CommandHelper.create(AddMemberCommand, data);
-  }
-
   @ArrayNotEmpty()
   public readonly roles: MemberRoleEnum[];
 }

--- a/apps/api/src/app/organization/usecases/membership/membership/add-member/add-member.command.ts
+++ b/apps/api/src/app/organization/usecases/membership/membership/add-member/add-member.command.ts
@@ -1,13 +1,8 @@
 import { MemberRoleEnum } from '@novu/shared';
 import { ArrayNotEmpty } from 'class-validator';
 import { OrganizationCommand } from '../../../../../shared/commands/organization.command';
-import { CommandHelper } from '../../../../../shared/commands/command.helper';
 
 export class AddMemberCommand extends OrganizationCommand {
-  static create(data: AddMemberCommand) {
-    return CommandHelper.create(AddMemberCommand, data);
-  }
-
   @ArrayNotEmpty()
   public readonly roles: MemberRoleEnum[];
 }

--- a/apps/api/src/app/organization/usecases/membership/membership/change-member-role/change-member-role.command.ts
+++ b/apps/api/src/app/organization/usecases/membership/membership/change-member-role/change-member-role.command.ts
@@ -1,13 +1,8 @@
 import { MemberRoleEnum } from '@novu/shared';
 import { IsDefined, IsEnum } from 'class-validator';
 import { OrganizationCommand } from '../../../../../shared/commands/organization.command';
-import { CommandHelper } from '../../../../../shared/commands/command.helper';
 
 export class ChangeMemberRoleCommand extends OrganizationCommand {
-  static create(data: ChangeMemberRoleCommand) {
-    return CommandHelper.create(ChangeMemberRoleCommand, data);
-  }
-
   @IsEnum(MemberRoleEnum)
   @IsDefined()
   role: MemberRoleEnum;

--- a/apps/api/src/app/organization/usecases/membership/membership/get-members/get-members.command.ts
+++ b/apps/api/src/app/organization/usecases/membership/membership/get-members/get-members.command.ts
@@ -1,8 +1,3 @@
 import { OrganizationCommand } from '../../../../../shared/commands/organization.command';
-import { CommandHelper } from '../../../../../shared/commands/command.helper';
 
-export class GetMembersCommand extends OrganizationCommand {
-  static create(data: GetMembersCommand) {
-    return CommandHelper.create(GetMembersCommand, data);
-  }
-}
+export class GetMembersCommand extends OrganizationCommand {}

--- a/apps/api/src/app/organization/usecases/membership/membership/remove-member/remove-member.command.ts
+++ b/apps/api/src/app/organization/usecases/membership/membership/remove-member/remove-member.command.ts
@@ -1,12 +1,7 @@
 import { IsString } from 'class-validator';
 import { OrganizationCommand } from '../../../../../shared/commands/organization.command';
-import { CommandHelper } from '../../../../../shared/commands/command.helper';
 
 export class RemoveMemberCommand extends OrganizationCommand {
-  static create(data: RemoveMemberCommand) {
-    return CommandHelper.create(RemoveMemberCommand, data);
-  }
-
   @IsString()
   memberId: string;
 }

--- a/apps/api/src/app/organization/usecases/membership/remove-member/remove-member.command.ts
+++ b/apps/api/src/app/organization/usecases/membership/remove-member/remove-member.command.ts
@@ -1,12 +1,7 @@
 import { IsString } from 'class-validator';
-import { CommandHelper } from '../../../../shared/commands/command.helper';
 import { OrganizationCommand } from '../../../../shared/commands/organization.command';
 
 export class RemoveMemberCommand extends OrganizationCommand {
-  static create(data: RemoveMemberCommand) {
-    return CommandHelper.create(RemoveMemberCommand, data);
-  }
-
   @IsString()
   memberId: string;
 }

--- a/apps/api/src/app/organization/usecases/update-branding-details/update-branding-details.command.ts
+++ b/apps/api/src/app/organization/usecases/update-branding-details/update-branding-details.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsHexColor, IsOptional, IsUrl } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
 
 export class UpdateBrandingDetailsCommand extends AuthenticatedCommand {
-  static create(data: UpdateBrandingDetailsCommand) {
-    return CommandHelper.create<UpdateBrandingDetailsCommand>(UpdateBrandingDetailsCommand, data);
-  }
-
   @IsDefined()
   public readonly id: string;
 

--- a/apps/api/src/app/shared/commands/authenticated.command.ts
+++ b/apps/api/src/app/shared/commands/authenticated.command.ts
@@ -1,6 +1,7 @@
 import { IsNotEmpty } from 'class-validator';
+import { BaseCommand } from './base.command';
 
-export abstract class AuthenticatedCommand {
+export abstract class AuthenticatedCommand extends BaseCommand {
   @IsNotEmpty()
   public readonly userId: string;
 }

--- a/apps/api/src/app/shared/commands/base.command.spec.ts
+++ b/apps/api/src/app/shared/commands/base.command.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import { IsDefined, IsEmail, IsNotEmpty } from 'class-validator';
+import * as sinon from 'sinon';
+import * as Sentry from '@sentry/node';
+import { BadRequestException } from '@nestjs/common';
+
+import { BaseCommand } from './base.command';
+
+export class TestCommand extends BaseCommand {
+  @IsDefined()
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @IsDefined()
+  password: string;
+}
+
+describe('BaseCommand', function () {
+  before(() => {
+    sinon.stub(Sentry, 'addBreadcrumb');
+  });
+
+  it('should throw BadRequestException with error messages when field values are not valid', async function () {
+    expect(() => TestCommand.create({ email: undefined, password: undefined }))
+      .to.throw(BadRequestException)
+      .deep.include({
+        response: {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: [
+            'email should not be null or undefined',
+            'email must be an email',
+            'email should not be empty',
+            'password should not be null or undefined',
+          ],
+        },
+      });
+  });
+
+  it('should throw BadRequestException with error message when only one field is not valid', async function () {
+    expect(() => TestCommand.create({ email: 'test@test.com', password: undefined }))
+      .to.throw(BadRequestException)
+      .deep.include({
+        response: {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: ['password should not be null or undefined'],
+        },
+      });
+  });
+
+  it('should return object of type that extends the base', async function () {
+    const obj = { email: 'test@test.com', password: 'P@ssw0rd' };
+    const res = TestCommand.create(obj);
+
+    expect(res instanceof TestCommand).to.be.true;
+    expect(res).to.deep.equal(obj);
+  });
+});

--- a/apps/api/src/app/shared/commands/base.command.ts
+++ b/apps/api/src/app/shared/commands/base.command.ts
@@ -1,13 +1,12 @@
-import { ClassConstructor, plainToClass } from 'class-transformer';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { plainToClass } from 'class-transformer';
 import { validateSync } from 'class-validator';
 import * as Sentry from '@sentry/node';
 import { BadRequestException, flatten } from '@nestjs/common';
 
-export class CommandHelper {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-  static create<T>(command: ClassConstructor<T>, data: any): T {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const convertedObject = plainToClass<T, any>(command, {
+export abstract class BaseCommand {
+  static create<T extends BaseCommand>(this: new (...args: any[]) => T, data: T): T {
+    const convertedObject = plainToClass<T, any>(this, {
       ...data,
     });
 
@@ -16,7 +15,7 @@ export class CommandHelper {
       const mappedErrors = flatten(errors.map((item) => Object.values(item.constraints)));
 
       Sentry.addBreadcrumb({
-        category: 'CommandHelper',
+        category: 'BaseCommand',
         data: mappedErrors,
       });
 

--- a/apps/api/src/app/shared/commands/project.command.ts
+++ b/apps/api/src/app/shared/commands/project.command.ts
@@ -1,6 +1,7 @@
 import { IsNotEmpty } from 'class-validator';
+import { BaseCommand } from './base.command';
 
-export abstract class EnvironmentWithUserCommand {
+export abstract class EnvironmentWithUserCommand extends BaseCommand {
   @IsNotEmpty()
   readonly environmentId: string;
 
@@ -11,7 +12,7 @@ export abstract class EnvironmentWithUserCommand {
   readonly userId: string;
 }
 
-export abstract class EnvironmentWithSubscriber {
+export abstract class EnvironmentWithSubscriber extends BaseCommand {
   @IsNotEmpty()
   readonly environmentId: string;
 
@@ -22,7 +23,7 @@ export abstract class EnvironmentWithSubscriber {
   readonly subscriberId: string;
 }
 
-export abstract class EnvironmentCommand {
+export abstract class EnvironmentCommand extends BaseCommand {
   @IsNotEmpty()
   readonly environmentId: string;
 

--- a/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.command.ts
+++ b/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.command.ts
@@ -1,12 +1,7 @@
-import { IsEnum, IsIn, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { IsIn, IsString } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class GetSignedUrlCommand extends EnvironmentWithUserCommand {
-  static create(data: GetSignedUrlCommand) {
-    return CommandHelper.create<GetSignedUrlCommand>(GetSignedUrlCommand, data);
-  }
-
   @IsString()
   @IsIn(['jpg', 'png', 'jpeg'])
   extension: string;

--- a/apps/api/src/app/subscribers/usecases/create-subscriber/create-subscriber.command.ts
+++ b/apps/api/src/app/subscribers/usecases/create-subscriber/create-subscriber.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsEmail, IsOptional, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class CreateSubscriberCommand extends EnvironmentCommand {
-  static create(data: CreateSubscriberCommand) {
-    return CommandHelper.create(CreateSubscriberCommand, data);
-  }
-
   @IsString()
   @IsDefined()
   subscriberId: string;

--- a/apps/api/src/app/subscribers/usecases/get-subscriber/get-subscriber.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber/get-subscriber.command.ts
@@ -1,12 +1,7 @@
 import { IsDefined, IsOptional, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class GetSubscriberCommand extends EnvironmentCommand {
-  static create(data: GetSubscriberCommand) {
-    return CommandHelper.create(GetSubscriberCommand, data);
-  }
-
   @IsString()
   @IsDefined()
   subscriberId: string;

--- a/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.command.ts
@@ -1,12 +1,7 @@
 import { IsNumber, IsOptional } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class GetSubscribersCommand extends EnvironmentCommand {
-  static create(data: GetSubscribersCommand) {
-    return CommandHelper.create(GetSubscribersCommand, data);
-  }
-
   @IsNumber()
   @IsOptional()
   page: number;

--- a/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.command.ts
+++ b/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.command.ts
@@ -1,12 +1,7 @@
 import { IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class RemoveSubscriberCommand extends EnvironmentCommand {
-  static create(data: RemoveSubscriberCommand) {
-    return CommandHelper.create(RemoveSubscriberCommand, data);
-  }
-
   @IsString()
   subscriberId: string;
 }

--- a/apps/api/src/app/subscribers/usecases/update-subscriber/update-subscriber.command.ts
+++ b/apps/api/src/app/subscribers/usecases/update-subscriber/update-subscriber.command.ts
@@ -1,12 +1,7 @@
 import { IsEmail, IsOptional, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class UpdateSubscriberCommand extends EnvironmentCommand {
-  static create(data: UpdateSubscriberCommand) {
-    return CommandHelper.create(UpdateSubscriberCommand, data);
-  }
-
   @IsString()
   subscriberId: string;
 

--- a/apps/api/src/app/testing/usecases/create-session/create-session.command.ts
+++ b/apps/api/src/app/testing/usecases/create-session/create-session.command.ts
@@ -1,7 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class CreateSessionCommand {
-  static create(data: CreateSessionCommand) {
-    return CommandHelper.create(CreateSessionCommand, data);
-  }
-}
+export class CreateSessionCommand extends BaseCommand {}

--- a/apps/api/src/app/testing/usecases/seed-data/seed-data.command.ts
+++ b/apps/api/src/app/testing/usecases/seed-data/seed-data.command.ts
@@ -1,7 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class SeedDataCommand {
-  static create(data: SeedDataCommand) {
-    return CommandHelper.create(SeedDataCommand, data);
-  }
-}
+export class SeedDataCommand extends BaseCommand {}

--- a/apps/api/src/app/user/usecases/create-user/create-user.dto.ts
+++ b/apps/api/src/app/user/usecases/create-user/create-user.dto.ts
@@ -1,11 +1,7 @@
 import { AuthProviderEnum } from '@novu/shared';
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class CreateUserCommand {
-  static create(data: CreateUserCommand) {
-    return CommandHelper.create(CreateUserCommand, data);
-  }
-
+export class CreateUserCommand extends BaseCommand {
   email: string;
 
   firstName: string;

--- a/apps/api/src/app/user/usecases/get-my-profile/get-my-profile.dto.ts
+++ b/apps/api/src/app/user/usecases/get-my-profile/get-my-profile.dto.ts
@@ -1,8 +1,3 @@
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 
-export class GetMyProfileCommand extends AuthenticatedCommand {
-  static create(data: GetMyProfileCommand) {
-    return CommandHelper.create<GetMyProfileCommand>(GetMyProfileCommand, data);
-  }
-}
+export class GetMyProfileCommand extends AuthenticatedCommand {}

--- a/apps/api/src/app/user/usecases/update-on-boarding/update-on-boarding.command.ts
+++ b/apps/api/src/app/user/usecases/update-on-boarding/update-on-boarding.command.ts
@@ -1,12 +1,7 @@
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { IsBoolean, IsOptional } from 'class-validator';
 
 export class UpdateOnBoardingCommand extends AuthenticatedCommand {
-  static create(data: UpdateOnBoardingCommand) {
-    return CommandHelper.create<UpdateOnBoardingCommand>(UpdateOnBoardingCommand, data);
-  }
-
   @IsBoolean()
   @IsOptional()
   showOnBoarding?: boolean;

--- a/apps/api/src/app/widgets/usecases/get-notifications-feed/get-notifications-feed.command.ts
+++ b/apps/api/src/app/widgets/usecases/get-notifications-feed/get-notifications-feed.command.ts
@@ -1,12 +1,7 @@
 import { IsArray, IsNumber, IsOptional } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 
 export class GetNotificationsFeedCommand extends EnvironmentWithSubscriber {
-  static create(data: GetNotificationsFeedCommand) {
-    return CommandHelper.create<GetNotificationsFeedCommand>(GetNotificationsFeedCommand, data);
-  }
-
   @IsNumber()
   page: number;
 

--- a/apps/api/src/app/widgets/usecases/get-organization-data/get-organization-data.command.ts
+++ b/apps/api/src/app/widgets/usecases/get-organization-data/get-organization-data.command.ts
@@ -1,8 +1,3 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 
-export class GetOrganizationDataCommand extends EnvironmentWithSubscriber {
-  static create(data: GetOrganizationDataCommand) {
-    return CommandHelper.create<GetOrganizationDataCommand>(GetOrganizationDataCommand, data);
-  }
-}
+export class GetOrganizationDataCommand extends EnvironmentWithSubscriber {}

--- a/apps/api/src/app/widgets/usecases/get-unseen-count/get-unseen-count.command.ts
+++ b/apps/api/src/app/widgets/usecases/get-unseen-count/get-unseen-count.command.ts
@@ -1,12 +1,7 @@
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 import { IsArray, IsBoolean, IsOptional } from 'class-validator';
 
 export class GetUnseenCountCommand extends EnvironmentWithSubscriber {
-  static create(data: GetUnseenCountCommand) {
-    return CommandHelper.create<GetUnseenCountCommand>(GetUnseenCountCommand, data);
-  }
-
   @IsOptional()
   @IsArray()
   feedId: string[];

--- a/apps/api/src/app/widgets/usecases/get-widget-settings/get-widget-settings.command.ts
+++ b/apps/api/src/app/widgets/usecases/get-widget-settings/get-widget-settings.command.ts
@@ -1,11 +1,7 @@
 import { IsDefined, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class GetWidgetSettingsCommand {
-  static create(data: GetWidgetSettingsCommand) {
-    return CommandHelper.create<GetWidgetSettingsCommand>(GetWidgetSettingsCommand, data);
-  }
-
+export class GetWidgetSettingsCommand extends BaseCommand {
   @IsDefined()
   @IsString()
   identifier: string;

--- a/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.command.ts
+++ b/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.command.ts
@@ -1,11 +1,7 @@
 import { IsDefined, IsEmail, IsOptional, IsString } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
+import { BaseCommand } from '../../../shared/commands/base.command';
 
-export class InitializeSessionCommand {
-  static create(data: InitializeSessionCommand) {
-    return CommandHelper.create<InitializeSessionCommand>(InitializeSessionCommand, data);
-  }
-
+export class InitializeSessionCommand extends BaseCommand {
   @IsDefined()
   @IsString()
   subscriberId: string;

--- a/apps/api/src/app/widgets/usecases/mark-action-as-done/update-message-actions.command.ts
+++ b/apps/api/src/app/widgets/usecases/mark-action-as-done/update-message-actions.command.ts
@@ -1,13 +1,8 @@
 import { IsDefined, IsMongoId, IsOptional } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
-import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 import { ButtonTypeEnum, MessageActionStatusEnum } from '@novu/shared';
+import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 
 export class UpdateMessageActionsCommand extends EnvironmentWithSubscriber {
-  static create(data: UpdateMessageActionsCommand) {
-    return CommandHelper.create<UpdateMessageActionsCommand>(UpdateMessageActionsCommand, data);
-  }
-
   @IsMongoId()
   messageId: string;
 
@@ -18,5 +13,5 @@ export class UpdateMessageActionsCommand extends EnvironmentWithSubscriber {
   status: MessageActionStatusEnum;
 
   @IsOptional()
-  payload?: any;
+  payload?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }

--- a/apps/api/src/app/widgets/usecases/mark-message-as-seen/mark-message-as-seen.command.ts
+++ b/apps/api/src/app/widgets/usecases/mark-message-as-seen/mark-message-as-seen.command.ts
@@ -1,12 +1,7 @@
 import { IsMongoId } from 'class-validator';
-import { CommandHelper } from '../../../shared/commands/command.helper';
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 
 export class MarkMessageAsSeenCommand extends EnvironmentWithSubscriber {
-  static create(data: MarkMessageAsSeenCommand) {
-    return CommandHelper.create<MarkMessageAsSeenCommand>(MarkMessageAsSeenCommand, data);
-  }
-
   @IsMongoId()
   messageId: string;
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
[Issue link](https://github.com/novuhq/novu/issues/928)
  Small refactor:
  * Renamed the `CommandHelper` to abstract `BaseCommand`
  * Changed all the commands to extend from the `BaseCommand`
  * Added basic tests for the `BaseCommand`

- **What is the current behavior?**
Currently, when creating a usecase command the code in the `create` function is duplicated, ex:
```
static create(data: GetActivityGraphStatsCommand) {
    return CommandHelper.create<GetActivityGraphStatsCommand>(GetActivityGraphStatsCommand, data);
}
```

- **What is the new behavior?**
The command will need to extend the `BaseCommand` and then the `create` function will be inherited with type check safety.

- **Other info**
I ran the E2E tests locally and they were passing, the same about API tests.
