### PR TITLE
changed invite link to a working one

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Novu provides a single API to manage providers across multiple channels with a s
 
 We are more than happy to help you. If you are getting some errors or problems while working with the project, or want to discuss something related to the project.
 
-Just <a href="https://discord.gg/TT6TttXjRe">Join Our Discord</a> server and ask for help.
+Just <a href="https://discord.gg/novu">Join Our Discord</a> server and ask for help.
 
 ## 🔗 Links
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small change on the readme when you click the invite to the discord server it shows the invite is invalid
- **What is the current behavior?** (You can also link to an open issue here)
![image](https://user-images.githubusercontent.com/106613029/183733004-d4ac3764-d63a-4d4c-9089-f5450a78f62b.png)
it says the invite is invalid
- **What is the new behavior (if this is a feature change)?**
It will allow people to join the discord server
- **Other information**:
