### PR TITLE
fix: added docs and libs folders to lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,14 @@
     "providers/**/*.{ts,json}": [
       "prettier --ignore-path ./.prettierignore --write",
       "stop-only --file"
+    ],
+    "docs/**/*.{ts,tsx,json}": [
+      "prettier --ignore-path ./.prettierignore --write",
+      "stop-only --file"
+    ],
+    "libs/**/*.{ts,js,json}": [
+      "prettier --ignore-path ./.prettierignore --write",
+      "stop-only --file"
     ]
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -119,14 +119,17 @@
   "lint-staged": {
     "apps/**/*.{ts,tsx,json}": [
       "prettier --ignore-path ./.prettierignore --write",
+      "eslint --fix",
       "stop-only --file"
     ],
     "packages/**/*.{ts,json}": [
       "prettier --ignore-path ./.prettierignore --write",
+      "eslint --fix",
       "stop-only --file"
     ],
     "providers/**/*.{ts,json}": [
       "prettier --ignore-path ./.prettierignore --write",
+      "eslint --fix apps/api",
       "stop-only --file"
     ],
     "docs/**/*.{ts,tsx,json}": [
@@ -135,6 +138,7 @@
     ],
     "libs/**/*.{ts,js,json}": [
       "prettier --ignore-path ./.prettierignore --write",
+      "eslint --fix",
       "stop-only --file"
     ]
   },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fixes https://github.com/novuhq/novu/issues/1003

- **What is the current behavior?** (You can also link to an open issue here)
lint-staged is not running on the docs and libs folder of the project

- **What is the new behavior (if this is a feature change)?**
the docs and libs folder are now also being checked for staged files to lint

  for the docs it checks ts / tsx and json
  for the libs it checks ts / js and json

- **Other information**:
Running lint-staged is already a part of the husky precommit stage as it seems.
