### PR TITLE
[NV-767] - Switch deprecated faker.name.title function to jobTitle

### DIFF
--- a/libs/testing/src/environment.service.ts
+++ b/libs/testing/src/environment.service.ts
@@ -7,7 +7,7 @@ export class EnvironmentService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async createEnvironment(organizationId: any) {
     return await this.environmentRepository.create({
-      name: faker.name.title(),
+      name: faker.name.jobTitle(),
       _organizationId: organizationId,
     });
   }

--- a/libs/testing/src/notification-template.service.ts
+++ b/libs/testing/src/notification-template.service.ts
@@ -83,7 +83,7 @@ export class NotificationTemplateService {
     const data = {
       _notificationGroupId: groups[0]._id,
       _environmentId: this.environmentId,
-      name: faker.name.title(),
+      name: faker.name.jobTitle(),
       _organizationId: this.organizationId,
       _creatorId: this.userId,
       active: true,


### PR DESCRIPTION
## Why?

Faker.js has deprecated `faker.name.title` in favor of the `jobTitle`.

## What?

Update all the place that used `faker.name.title` to the new method.