### PR TITLE
fix: Fix lint staged for multiple folders and added eslint step

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:promise/recommended',
   ],
-  ignorePatterns: ['.eslintrc.js'],
+  ignorePatterns: ['.eslintrc.js', '*.json'],
   plugins: ['import', 'promise', '@typescript-eslint', 'prettier'],
   parser: '@typescript-eslint/parser',
   settings: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:promise/recommended',
   ],
-  ignorePatterns: ['.eslintrc.js', '*.json'],
+  ignorePatterns: ['.eslintrc.js', '*.json', 'jest.config.js'],
   plugins: ['import', 'promise', '@typescript-eslint', 'prettier'],
   parser: '@typescript-eslint/parser',
   settings: {

--- a/package.json
+++ b/package.json
@@ -119,22 +119,27 @@
   "lint-staged": {
     "apps/**/*.{ts,tsx,json}": [
       "prettier --ignore-path ./.prettierignore --write",
+      "eslint --fix",
       "stop-only --file"
     ],
     "packages/**/*.{ts,json}": [
       "prettier --ignore-path ./.prettierignore --write",
+      "eslint --fix",
       "stop-only --file"
     ],
     "providers/**/*.{ts,json}": [
       "prettier --ignore-path ./.prettierignore --write",
+      "eslint --fix",
       "stop-only --file"
     ],
     "docs/**/*.{ts,tsx,json}": [
       "prettier --ignore-path ./.prettierignore --write",
+      "eslint --fix",
       "stop-only --file"
     ],
     "libs/**/*.{ts,js,json}": [
       "prettier --ignore-path ./.prettierignore --write",
+      "eslint --fix",
       "stop-only --file"
     ]
   },


### PR DESCRIPTION
This fixes the additional eslint step added to lint-staged. I verified it by modifiy different files inside docs/, libs/, etc...
linking to https://github.com/novuhq/novu/pull/1010

cc @scopsy - Can you check if the error still persists? 
