### PR TITLE
fix: notification center moment locale change

### DIFF
--- a/packages/notification-center/src/components/notification-center/components/notification-item/NotificationListItem.tsx
+++ b/packages/notification-center/src/components/notification-center/components/notification-item/NotificationListItem.tsx
@@ -7,7 +7,6 @@ import { INovuTheme } from '../../../../store/novu-theme.context';
 import { useNovuThemeProvider } from '../../../../hooks/use-novu-theme-provider.hook';
 import { ActionContainer } from './ActionContainer';
 import { NotificationCenterContext } from '../../../../store/notification-center.context';
-import { useTranslations } from '../../../../hooks/use-translations';
 
 export function NotificationListItem({
   notification,
@@ -18,7 +17,6 @@ export function NotificationListItem({
 }) {
   const { theme: novuTheme } = useNovuThemeProvider();
   const { onActionClick, listItem } = useContext(NotificationCenterContext);
-  const { lang } = useTranslations();
 
   function handleNotificationClick() {
     onClick(notification);
@@ -47,7 +45,7 @@ export function NotificationListItem({
           }}
         />
         <TimeMark novuTheme={novuTheme} unseen={!notification.seen}>
-          {moment(notification.createdAt).locale(lang).fromNow()}
+          {moment(notification.createdAt).fromNow()}
         </TimeMark>
         <ActionWrapper
           templateIdentifier={notification.templateIdentifier}

--- a/packages/notification-center/src/store/i18n.context.tsx
+++ b/packages/notification-center/src/store/i18n.context.tsx
@@ -1,4 +1,6 @@
+import moment from 'moment';
 import React from 'react';
+import 'moment/min/locales.min';
 import { I18NLanguage, ITranslationEntry, TRANSLATIONS } from '../i18n/lang';
 
 export const I18NContext = React.createContext<ITranslationEntry>({
@@ -27,6 +29,10 @@ export function NovuI18NProvider({ i18n = 'en', ...props }: INovuI18NProviderPro
 
     return i18n;
   }, [i18n]);
+
+  React.useEffect(() => {
+    moment.locale(i18nEntry.lang)
+  }, [i18nEntry])
 
   return <I18NContext.Provider {...props} value={i18nEntry} />;
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fixes https://github.com/novuhq/novu/issues/1018

- **What is the current behavior?** (You can also link to an open issue here)
![image](https://user-images.githubusercontent.com/13546486/184551133-ca1bd133-d573-4c47-8cea-8a3c50b44ee7.png)

- **What is the new behavior (if this is a feature change)?**
![image](https://user-images.githubusercontent.com/13546486/184551136-f46fb76c-5dfd-49d5-b27d-b5ad61adbe24.png)

- **Other information**:
Afaik, moment's ```locale()``` method can no longer be used in chains. It now changes the global moment instance. See https://stackoverflow.com/a/17493350 - Also it requires an import of ```moment/min/locales.min``` for the locales to work.

  Because of that the language of the timestamp did not change. I fixed this.
  
  Also I was unable to replicate the issue of the "Notifications" header not changing the text that was pointed out in the linked issue.