### PR TITLE
Added toggleTabIndex attribute in PasswordInput for focus Management …

### DIFF
--- a/apps/web/src/design-system/password-input/PasswordInput.tsx
+++ b/apps/web/src/design-system/password-input/PasswordInput.tsx
@@ -24,7 +24,15 @@ export const PasswordInput = React.forwardRef<HTMLInputElement, IPasswordInputPr
     const defaultDesign = { radius: 'md', size: 'md', styles: inputStyles } as PasswordInputProps;
 
     return (
-      <StyledPassword ref={ref} {...defaultDesign} onChange={onChange} autoComplete="off" value={value} {...props} />
+      <StyledPassword
+        ref={ref}
+        {...defaultDesign}
+        onChange={onChange}
+        autoComplete="off"
+        value={value}
+        {...props}
+        toggleTabIndex={0}
+      />
     );
   }
 );


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix)

- **What is the current behavior?** (#1027 )

- **What is the new behavior (if this is a feature change)?**
After adding `toggleTabIndex`, user can access password visibility toggle button of `PasswordInput` using keyboard. User can use `spacebar` for toggling password visibility.

- **Other information**:
After solving issue -
https://user-images.githubusercontent.com/64790109/184625724-e492cdd1-b59f-4490-9736-5017d2122b41.mp4


