### PR TITLE
feat: show supported locales for notification-center in docs

### DIFF
--- a/docs/docs/notification-center/react-components.md
+++ b/docs/docs/notification-center/react-components.md
@@ -145,21 +145,43 @@ The `i18n` prop can accept 2 different types of values
 - 2 letter language string
 
   ```tsx
-  i18n="en" // We currently only support English
+  i18n="en"
   ```
+
+  <details>
+    <summary>Supported languages</summary>
+    <div>
+      <ul>
+        <li><code>ar</code> (Arabic)</li>
+        <li><code>de</code> (German)</li>
+        <li><code>en</code> (English)</li>
+        <li><code>fa</code> (Farsi)</li>
+        <li><code>fi</code> (Finnish)</li>
+        <li><code>fr</code> (French)</li>
+        <li><code>gj</code> (Georgian)</li>
+        <li><code>hi</code> (Hindi)</li>
+        <li><code>it</code> (Italian)</li>
+        <li><code>ru</code> (Russian)</li>
+        <li><code>es</code> (Spanish)</li>
+        <li><code>uk</code> (Ukrainian)</li>
+      </ul>
+    </div>
+</details>
 
 - Translation object
 
   ```tsx
   i18n={{
-    // Make sure that the following is a proper 2 letter language code,
-    // since this is used by moment.js in order to calculate the relative time for each notification
+    // Make sure that the following is a proper language code,
+    // since this is used by date-fns in order to calculate the relative time for each notification
+    // supported languages by date-fns: https://github.com/date-fns/date-fns/tree/main/src/locale
     lang: "de",
     
     translations: {
-      poweredBy: "unterstützt von",
+      poweredBy: "von",
       markAllAsRead: "Alles als gelesen markieren",
       notifications: "Benachrichtigungen",
+      settings: "Einstellungen",
     },
   }}
   ```

--- a/packages/notification-center/src/i18n/lang.ts
+++ b/packages/notification-center/src/i18n/lang.ts
@@ -5,10 +5,11 @@ import { HI } from './languages/hi';
 import { IT } from './languages/it';
 import { RU } from './languages/ru';
 import { UK } from './languages/uk';
-import { SP } from './languages/sp';
+import { ES } from './languages/es';
 import { FA } from './languages/fa';
 import { AR } from './languages/ar';
 import { GJ } from './languages/gj';
+import { DE } from './languages/de';
 
 export interface ITranslationContent {
   readonly notifications: string;
@@ -29,11 +30,12 @@ export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
   fr: FR,
   gj: GJ,
   ru: RU,
-  sp: SP,
+  es: ES,
   it: IT,
   ar: AR,
   fa: FA,
   uk: UK,
+  de: DE,
 };
 
 /**
@@ -43,5 +45,8 @@ export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
  * For example:
  * - For English use "en"
  * - For French use "fr"
+ *
+ * Any new language should also be added to the documentation
+ * https://docs.novu.co/notification-center/react-components#customize-the-ui-language
  */
-export type I18NLanguage = 'en' | 'fi' | 'hi' | 'it' | 'gj' | 'ru' | 'uk' | 'sp' | 'ar' | 'fa' | 'fr';
+export type I18NLanguage = 'en' | 'fi' | 'hi' | 'it' | 'gj' | 'ru' | 'uk' | 'es' | 'ar' | 'fa' | 'fr' | 'de';

--- a/packages/notification-center/src/i18n/languages/de.ts
+++ b/packages/notification-center/src/i18n/languages/de.ts
@@ -1,0 +1,11 @@
+import { ITranslationEntry } from '../lang';
+
+export const DE: ITranslationEntry = {
+  translations: {
+    notifications: 'Benachrichtigungen',
+    markAllAsRead: 'Alle als gelesen markieren',
+    poweredBy: 'von',
+    settings: 'Einstellungen',
+  },
+  lang: 'de',
+};

--- a/packages/notification-center/src/i18n/languages/es.ts
+++ b/packages/notification-center/src/i18n/languages/es.ts
@@ -1,10 +1,10 @@
 import { ITranslationEntry } from '../lang';
 
-export const SP: ITranslationEntry = {
+export const ES: ITranslationEntry = {
   translations: {
     notifications: 'Notificaciones',
     markAllAsRead: 'marcar todo como leido',
     poweredBy: 'Energizado por',
   },
-  lang: 'sp',
+  lang: 'es',
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - Adds a list of supported locales for the react notification center component
  - Added german locale to the notifiction center
  - Modified docs text for ````date-fns`` and link to supported locales

- **What is the current behavior?** (You can also link to an open issue here)
![Screenshot 2022-08-16 175756](https://user-images.githubusercontent.com/13546486/184925046-4819b589-5d13-42ec-9011-5c742602926b.png)

- **What is the new behavior (if this is a feature change)?**
![Screenshot 2022-08-16 175426](https://user-images.githubusercontent.com/13546486/184925075-483b6a8f-e734-414a-b9bc-c299738ab599.png)

- **Other information**:
