### PR TITLE
feat: change email template text direction to text align

### DIFF
--- a/apps/api/src/app/content-templates/usecases/compile-template/compile-template.spec.ts
+++ b/apps/api/src/app/content-templates/usecases/compile-template/compile-template.spec.ts
@@ -87,6 +87,34 @@ describe('Compile Template', function () {
     expect(result).to.contain('Button content of text');
   });
 
+  it('should include text align for text blocks', async function () {
+    const result = await useCase.execute(
+      CompileTemplateCommand.create({
+        templateId: 'basic',
+        data: {
+          branding: {
+            color: '#e7e7e7e9',
+          },
+          blocks: [
+            {
+              type: 'text',
+              styles: {
+                textAlign: 'center',
+              },
+              content: '<b>Hello TESTTTT content </b>',
+            },
+            {
+              type: 'button',
+              content: 'Button content of text',
+            },
+          ],
+        },
+      })
+    );
+
+    expect(result).to.contain('text-align: center');
+  });
+
   it('should allow the user to specify handlebars helpers', async function () {
     const result = await useCase.execute(
       CompileTemplateCommand.create({

--- a/apps/api/src/app/content-templates/usecases/compile-template/templates/basic.handlebars
+++ b/apps/api/src/app/content-templates/usecases/compile-template/templates/basic.handlebars
@@ -310,7 +310,9 @@
                                   {{#each blocks}}
                                     <div style="margin-bottom: 10px" data-test-id="block-item-wrapper">
                                       {{#equals type 'text'}}
-                                        <div>
+                                        <div style="
+                                                text-align: {{#if styles.textAlign}}{{styles.textAlign}}{{else}}left{{/if}};
+                                        ">
                                           <div>
                                             <p>
                                               {{{content}}}

--- a/apps/api/src/app/widgets/dtos/message-response.dto.ts
+++ b/apps/api/src/app/widgets/dtos/message-response.dto.ts
@@ -5,9 +5,9 @@ import { NotificationTemplateResponse } from '../../notification-template/dto/no
 
 class EmailBlockStyles {
   @ApiProperty({
-    enum: ['ltr', 'rtl'],
+    enum: ['left', 'right', 'center'],
   })
-  textDirection?: 'ltr' | 'rtl';
+  textAlign?: 'left' | 'right' | 'center';
 }
 
 class EmailBlock {

--- a/apps/web/src/components/templates/email-editor/ButtonRowContent.tsx
+++ b/apps/web/src/components/templates/email-editor/ButtonRowContent.tsx
@@ -55,10 +55,7 @@ export function ButtonRowContent({
   }, [block.url]);
 
   return (
-    <div
-      style={{ textAlign: 'center', direction: block?.styles?.textDirection || 'ltr' }}
-      data-test-id="button-block-wrapper"
-    >
+    <div style={{ textAlign: block?.styles?.textAlign || 'left' }} data-test-id="button-block-wrapper">
       <Popover
         styles={(theme) => ({
           inner: {

--- a/apps/web/src/components/templates/email-editor/ContentRow.tsx
+++ b/apps/web/src/components/templates/email-editor/ContentRow.tsx
@@ -19,10 +19,10 @@ export function ContentRow({
   onRemove: () => void;
   allowRemove: boolean;
   block: IEmailBlock;
-  onStyleChanged: (data: { textDirection: 'ltr' | 'rtl' }) => void;
+  onStyleChanged: (data: { textAlign: 'left' | 'right' | 'center' }) => void;
 }) {
   const { readonly } = useEnvController();
-  const [textDirection, setTextDirection] = useState<'ltr' | 'rtl'>(block?.styles?.textDirection || 'ltr');
+  const [textAlign, settextAlign] = useState<'left' | 'right' | 'center'>(block?.styles?.textAlign || 'left');
   const parentRef = useRef<HTMLDivElement>(null);
   const theme = useMantineTheme();
 
@@ -37,19 +37,20 @@ export function ContentRow({
 
   useEffect(() => {
     onStyleChanged({
-      textDirection,
+      textAlign,
     });
-  }, [textDirection]);
+  }, [textAlign]);
 
   const changeRowStyles = (value) => {
-    setTextDirection(value);
+    settextAlign(value);
   };
 
   const rowStyleMenu = [
-    <DropdownItem key="ltr" sx={{ '&:hover': { backgroundColor: 'transparent' } }}>
-      <RadioGroup value={textDirection} onChange={changeRowStyles}>
-        <Radio value="ltr" data-test-id="align-left-btn" label="Align Left" />
-        <Radio value="rtl" data-test-id="align-right-btn" label="Align Right" />
+    <DropdownItem key="left" sx={{ '&:hover': { backgroundColor: 'transparent' } }}>
+      <RadioGroup value={textAlign} onChange={changeRowStyles}>
+        <Radio value="left" data-test-id="align-left-btn" label="Align Left" />
+        <Radio value="center" data-test-id="align-center-btn" label="Align Center" />
+        <Radio value="right" data-test-id="align-right-btn" label="Align Right" />
       </RadioGroup>
     </DropdownItem>,
     <DropdownItem

--- a/apps/web/src/components/templates/email-editor/EmailMessageEditor.tsx
+++ b/apps/web/src/components/templates/email-editor/EmailMessageEditor.tsx
@@ -47,7 +47,7 @@ export function EmailMessageEditor({
     }
   }, [blocks, isMounted]);
 
-  function onBlockStyleChanged(blockIndex: number, styles: { textDirection: 'rtl' | 'ltr' }) {
+  function onBlockStyleChanged(blockIndex: number, styles: { textAlign: 'left' | 'right' | 'center' }) {
     blocks[blockIndex].styles = {
       ...styles,
     };

--- a/apps/web/src/components/templates/email-editor/TextRowContent.tsx
+++ b/apps/web/src/components/templates/email-editor/TextRowContent.tsx
@@ -55,7 +55,7 @@ export function TextRowContent({ block, onTextChange }: { block: IEmailBlock; on
           width: '90%',
           outline: 'none',
           backgroundColor: 'transparent',
-          direction: block.styles?.textDirection || 'ltr',
+          textAlign: block.styles?.textAlign || 'left',
         }}
       />
 

--- a/libs/dal/src/repositories/message-template/message-template.entity.ts
+++ b/libs/dal/src/repositories/message-template/message-template.entity.ts
@@ -38,6 +38,6 @@ export class IEmailBlock {
   url?: string;
 
   styles?: {
-    textDirection?: 'rtl' | 'ltr';
+    textAlign?: 'left' | 'right' | 'center';
   };
 }

--- a/libs/shared/src/consts/providers/provider-credentials.ts
+++ b/libs/shared/src/consts/providers/provider-credentials.ts
@@ -143,19 +143,19 @@ export const nodemailerConfig: IConfigCredentials[] = [
     key: CredentialsKeyEnum.Domain,
     displayName: 'DKIM: Domain name',
     type: 'string',
-    required: true,
+    required: false,
   },
   {
     key: CredentialsKeyEnum.SecretKey,
     displayName: 'DKIM: Private key',
     type: 'string',
-    required: true,
+    required: false,
   },
   {
     key: CredentialsKeyEnum.AccountSid,
     displayName: 'DKIM: Key selector',
     type: 'string',
-    required: true,
+    required: false,
   },
   ...mailConfigBase,
 ];

--- a/libs/shared/src/entities/message-template/message-template.interface.ts
+++ b/libs/shared/src/entities/message-template/message-template.interface.ts
@@ -5,7 +5,7 @@ export interface IEmailBlock {
   content: string;
   url?: string;
   styles?: {
-    textDirection?: 'ltr' | 'rtl';
+    textAlign?: 'left' | 'right' | 'center';
   };
 }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fixes https://github.com/novuhq/novu/issues/1057

  Also I changed the DKIM settings for the nodemailer provider to not be required - I stumpled upon this when trying to setup nodemailer for testing and it is not something that is required. It's also optional in the interface in the nodemailer integration package.

- **What is the current behavior?** (You can also link to an open issue here)
see https://github.com/novuhq/novu/issues/1057

- **What is the new behavior (if this is a feature change)?**
![Screenshot 2022-08-18 030802](https://user-images.githubusercontent.com/13546486/185271058-bdd51011-c1cb-4ef7-848e-6d5673a143d7.png)
![Screenshot 2022-08-18 030743](https://user-images.githubusercontent.com/13546486/185271070-8e6f929d-db2b-42ee-b898-72ac7b608fcc.png)
![Screenshot 2022-08-18 030710](https://user-images.githubusercontent.com/13546486/185271075-6d6cb3ee-3fcd-4eab-8eec-66f076c6ca37.png)

- **Other information**:
The text direction seems to have never been actually used in the email template itself. So it seems the text direction change was only on the frontend anyways.
