### PR TITLE
fix: also normalize email on password reset

### DIFF
--- a/apps/api/src/app/auth/e2e/login.e2e.ts
+++ b/apps/api/src/app/auth/e2e/login.e2e.ts
@@ -38,6 +38,19 @@ describe('User login - /auth/login (POST)', async () => {
     expect(jwtContent.email).to.equal('testytest22@gmail.com');
   });
 
+  it('should login the user correctly with uppercase email', async () => {
+    const { body } = await session.testAgent.post('/v1/auth/login').send({
+      email: userCredentials.email.toUpperCase(),
+      password: userCredentials.password,
+    });
+
+    const jwtContent = (await jwt.decode(body.data.token)) as IJwtPayload;
+
+    expect(jwtContent.firstName).to.equal('test');
+    expect(jwtContent.lastName).to.equal('user');
+    expect(jwtContent.email).to.equal('testytest22@gmail.com');
+  });
+
   it('should fail on bad password', async () => {
     const { body } = await session.testAgent.post('/v1/auth/login').send({
       email: userCredentials.email,

--- a/apps/api/src/app/auth/e2e/password-reset.e2e.ts
+++ b/apps/api/src/app/auth/e2e/password-reset.e2e.ts
@@ -23,6 +23,17 @@ describe('Password reset - /auth/reset (POST)', async () => {
     expect(found.resetToken).to.be.ok;
   });
 
+  it('should request a password reset for existing user with uppercase email', async () => {
+    const { body } = await session.testAgent.post('/v1/auth/reset/request').send({
+      email: session.user.email.toUpperCase(),
+    });
+
+    expect(body.data.success).to.equal(true);
+    const found = await userRepository.findById(session.user._id);
+
+    expect(found.resetToken).to.be.ok;
+  });
+
   it('should change a password after reset', async () => {
     const { body } = await session.testAgent.post('/v1/auth/reset/request').send({
       email: session.user.email,

--- a/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.usecase.ts
+++ b/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.usecase.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Novu } from '@novu/node';
 import { UserRepository } from '@novu/dal';
 import { v4 as uuidv4 } from 'uuid';
+import { normalizeEmail } from '../../../shared/helpers/email-normalization.service';
 import { PasswordResetRequestCommand } from './password-reset-request.command';
 
 @Injectable()
@@ -9,7 +10,8 @@ export class PasswordResetRequest {
   constructor(private userRepository: UserRepository) {}
 
   async execute(command: PasswordResetRequestCommand): Promise<{ success: boolean }> {
-    const foundUser = await this.userRepository.findByEmail(command.email);
+    const email = normalizeEmail(command.email);
+    const foundUser = await this.userRepository.findByEmail(email);
     if (foundUser) {
       const token = uuidv4();
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This adds the missing normalize email method to the password reset function. I also added tests in both login / reset password e2e to test for this.
