### PR TITLE
fix: cleanup email workflow visuals

### DIFF
--- a/apps/web/src/components/templates/email-editor/ContentRow.tsx
+++ b/apps/web/src/components/templates/email-editor/ContentRow.tsx
@@ -1,9 +1,10 @@
 import { IEmailBlock } from '@novu/shared';
 import { useEffect, useRef, useState } from 'react';
-import { ActionIcon, MenuItem as DropdownItem, RadioGroup, Radio, useMantineTheme } from '@mantine/core';
+import { ActionIcon, MenuItem as DropdownItem, MenuLabel } from '@mantine/core';
 import styled from '@emotion/styled';
+import { AlignCenterOutlined, AlignLeftOutlined, AlignRightOutlined } from '@ant-design/icons';
 import { DotsHorizontalOutlined, Trash } from '../../../design-system/icons';
-import { colors, Dropdown } from '../../../design-system';
+import { Button, colors, Dropdown } from '../../../design-system';
 import { useEnvController } from '../../../store/use-env-controller';
 
 export function ContentRow({
@@ -23,8 +24,14 @@ export function ContentRow({
 }) {
   const { readonly } = useEnvController();
   const [textAlign, settextAlign] = useState<'left' | 'right' | 'center'>(block?.styles?.textAlign || 'left');
+  const [dropdownOpen, setDropdownOpen] = useState<boolean>(false);
   const parentRef = useRef<HTMLDivElement>(null);
-  const theme = useMantineTheme();
+
+  const textAlignments = [
+    ['left', <AlignLeftOutlined />],
+    ['center', <AlignCenterOutlined />],
+    ['right', <AlignRightOutlined />],
+  ];
 
   function onHover() {
     if (!parentRef.current) return;
@@ -41,18 +48,25 @@ export function ContentRow({
     });
   }, [textAlign]);
 
-  const changeRowStyles = (value) => {
-    settextAlign(value);
+  const changeRowStyles = (e, dir) => {
+    e.preventDefault();
+    e.stopPropagation();
+    settextAlign(dir);
   };
 
   const rowStyleMenu = [
-    <DropdownItem key="left" sx={{ '&:hover': { backgroundColor: 'transparent' } }}>
-      <RadioGroup value={textAlign} onChange={changeRowStyles}>
-        <Radio value="left" data-test-id="align-left-btn" label="Align Left" />
-        <Radio value="center" data-test-id="align-center-btn" label="Align Center" />
-        <Radio value="right" data-test-id="align-right-btn" label="Align Right" />
-      </RadioGroup>
-    </DropdownItem>,
+    <MenuLabel style={{ fontSize: '14px' }}>Align Text</MenuLabel>,
+    <TextAlignmentWrapper>
+      {textAlignments.map(([dir, icon]) => (
+        <Button
+          onClick={(e) => changeRowStyles(e, dir)}
+          data-test-id={`align-${dir}-button`}
+          variant={dir === textAlign ? 'filled' : 'outline'}
+        >
+          {icon}
+        </Button>
+      ))}
+    </TextAlignmentWrapper>,
     <DropdownItem
       key="removeBtn"
       disabled={!allowRemove}
@@ -67,29 +81,39 @@ export function ContentRow({
   return (
     <div onMouseEnter={onHover} ref={parentRef} data-test-id="editor-row">
       <ContentRowWrapper>
-        <div style={{ width: 'calc(100% - 20px)' }}>{children}</div>
-        {!readonly && (
-          <Dropdown
-            control={
-              <SettingsButton data-test-id="settings-row-btn">
-                <ActionIcon variant="transparent">
-                  <DotsHorizontalOutlined color={theme.colorScheme === 'dark' ? colors.B30 : colors.B80} />
-                </ActionIcon>
-              </SettingsButton>
-            }
-          >
-            {rowStyleMenu}
-          </Dropdown>
-        )}
+        <div style={{ width: '100%' }}>{children}</div>
+        <SettingsWrapper>
+          {!readonly && (
+            <Dropdown
+              onClose={() => setDropdownOpen(false)}
+              onOpen={() => setDropdownOpen(true)}
+              control={
+                <SettingsButton data-test-id="settings-row-btn" visible={dropdownOpen}>
+                  <ActionIcon variant="transparent">
+                    <DotsHorizontalOutlined color={colors.B60} />
+                  </ActionIcon>
+                </SettingsButton>
+              }
+            >
+              {rowStyleMenu}
+            </Dropdown>
+          )}
+        </SettingsWrapper>
       </ContentRowWrapper>
     </div>
   );
 }
 
-const SettingsButton = styled.div`
-  display: none;
-  right: -10px;
-  position: absolute;
+const SettingsWrapper = styled.div`
+  width: 50px;
+  height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: end;
+`;
+
+const SettingsButton = styled.div<{ visible: boolean }>`
+  display: ${({ visible }) => (visible ? 'inline-block' : 'none')};
 `;
 
 const ContentRowWrapper = styled.div`
@@ -97,10 +121,23 @@ const ContentRowWrapper = styled.div`
   outline: transparent;
   padding-bottom: 10px;
   display: flex;
+  align-items: center;
 
   &:hover {
     ${SettingsButton} {
       display: inline-block;
     }
+  }
+`;
+
+const TextAlignmentWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 15px 15px 15px;
+
+  button {
+    padding: 0;
+    margin: 0 5px;
+    width: 100%;
   }
 `;

--- a/apps/web/src/components/templates/email-editor/ControlBar.tsx
+++ b/apps/web/src/components/templates/email-editor/ControlBar.tsx
@@ -1,9 +1,8 @@
-import { ActionIcon, Divider, MenuItem as DropdownItem, useMantineTheme } from '@mantine/core';
+import { ActionIcon, Divider, MenuItem as DropdownItem } from '@mantine/core';
 import { DoubleArrowRight, PlusCircleOutlined, TextAlignment } from '../../../design-system/icons';
 import { colors, Dropdown } from '../../../design-system';
 
 export function ControlBar({ top, onBlockAdd }: { top: number; onBlockAdd: (type: 'button' | 'text') => void }) {
-  const theme = useMantineTheme();
   const actionsMenu = [
     <DropdownItem
       key="control-bar-add"
@@ -28,12 +27,13 @@ export function ControlBar({ top, onBlockAdd }: { top: number; onBlockAdd: (type
       data-test-id="control-bar"
       variant="dashed"
       mx={0}
+      color={colors.B60}
       style={{ top: `${top}px` }}
       label={
         <Dropdown
           control={
             <ActionIcon data-test-id="control-add" variant="transparent">
-              <PlusCircleOutlined color={theme.colorScheme === 'dark' ? colors.B30 : colors.B80} />
+              <PlusCircleOutlined color={colors.B60} />
             </ActionIcon>
           }
         >

--- a/apps/web/src/components/templates/email-editor/EmailMessageEditor.tsx
+++ b/apps/web/src/components/templates/email-editor/EmailMessageEditor.tsx
@@ -118,47 +118,49 @@ export function EmailMessageEditor({
 
   return (
     <Card withBorder sx={styledCard}>
-      <div onClick={() => !branding?.logo && navigate(getBrandSettingsUrl())}>
-        <Dropzone
-          styles={{
-            root: {
-              borderRadius: '7px',
-              padding: '10px',
-              border: 'none',
-              height: '80px',
-              backgroundColor: theme.colorScheme === 'dark' ? colors.B17 : colors.B98,
-            },
-          }}
-          disabled
-          multiple={false}
-          onDrop={(file) => {}}
-          data-test-id="upload-image-button"
-        >
-          {(status) => (
-            <Group position="center" style={{ height: '100%' }}>
-              {!branding?.logo ? (
-                <Group
-                  style={{ height: '100%' }}
-                  spacing={5}
-                  position="center"
-                  direction="column"
-                  data-test-id="logo-upload-button"
-                >
-                  <Upload style={{ width: 30, height: 30, color: colors.B60 }} />
-                  <Text color={theme.colorScheme === 'dark' ? colors.B40 : colors.B70}>Upload Brand Logo</Text>
-                </Group>
-              ) : (
-                <img
-                  data-test-id="brand-logo"
-                  src={branding?.logo}
-                  alt=""
-                  style={{ width: 'inherit', maxHeight: '80%' }}
-                />
-              )}
-            </Group>
-          )}
-        </Dropzone>
-      </div>
+      <Container pl={0} pr={0}>
+        <div onClick={() => !branding?.logo && navigate(getBrandSettingsUrl())}>
+          <Dropzone
+            styles={{
+              root: {
+                borderRadius: '7px',
+                padding: '10px',
+                border: 'none',
+                height: '80px',
+                backgroundColor: theme.colorScheme === 'dark' ? colors.B17 : colors.B98,
+              },
+            }}
+            disabled
+            multiple={false}
+            onDrop={(file) => {}}
+            data-test-id="upload-image-button"
+          >
+            {(status) => (
+              <Group position="center" style={{ height: '100%' }}>
+                {!branding?.logo ? (
+                  <Group
+                    style={{ height: '100%' }}
+                    spacing={5}
+                    position="center"
+                    direction="column"
+                    data-test-id="logo-upload-button"
+                  >
+                    <Upload style={{ width: 30, height: 30, color: colors.B60 }} />
+                    <Text color={colors.B60}>Upload Brand Logo</Text>
+                  </Group>
+                ) : (
+                  <img
+                    data-test-id="brand-logo"
+                    src={branding?.logo}
+                    alt=""
+                    style={{ width: 'inherit', maxHeight: '80%' }}
+                  />
+                )}
+              </Group>
+            )}
+          </Dropzone>
+        </div>
+      </Container>
 
       <Container
         mt={30}

--- a/apps/web/src/components/templates/email-editor/TextRowContent.tsx
+++ b/apps/web/src/components/templates/email-editor/TextRowContent.tsx
@@ -1,12 +1,10 @@
 import { IEmailBlock } from '@novu/shared';
 import { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
-import { useMantineTheme } from '@mantine/core';
 import { colors } from '../../../design-system';
 import { useEnvController } from '../../../store/use-env-controller';
 
 export function TextRowContent({ block, onTextChange }: { block: IEmailBlock; onTextChange: (text: string) => void }) {
-  const theme = useMantineTheme();
   const { readonly } = useEnvController();
   const ref = useRef<HTMLDivElement>(null);
   const [text, setText] = useState<string>(block.content);
@@ -16,13 +14,17 @@ export function TextRowContent({ block, onTextChange }: { block: IEmailBlock; on
     ref.current?.focus();
   }, [ref]);
 
-  function handleTextChange(data) {
-    onTextChange(data);
+  function checkPlaceholderVisibility(data = block.content) {
     let showPlaceHolder = !data;
 
     if (data === '<br>') showPlaceHolder = true;
 
     setVisiblePlaceholder(showPlaceHolder);
+  }
+
+  function handleTextChange(data: string) {
+    onTextChange(data);
+    checkPlaceholderVisibility(data);
   }
 
   useEffect(() => {
@@ -32,11 +34,7 @@ export function TextRowContent({ block, onTextChange }: { block: IEmailBlock; on
   }, [block.content]);
 
   useEffect(() => {
-    let showPlaceHolder = !block.content;
-
-    if (block.content === '<br>') showPlaceHolder = true;
-
-    setVisiblePlaceholder(showPlaceHolder);
+    checkPlaceholderVisibility();
   }, [block.content, text]);
 
   return (
@@ -51,15 +49,14 @@ export function TextRowContent({ block, onTextChange }: { block: IEmailBlock; on
         suppressContentEditableWarning
         onKeyUp={(e: any) => handleTextChange(e.target.innerHTML)}
         style={{
-          display: 'inline-block',
-          width: '90%',
           outline: 'none',
+          width: '100%',
           backgroundColor: 'transparent',
           textAlign: block.styles?.textAlign || 'left',
         }}
       />
 
-      <PlaceHolder color={theme.colorScheme === 'dark' ? colors.B40 : colors.B70} show={visiblePlaceholder}>
+      <PlaceHolder color={colors.B60} show={visiblePlaceholder}>
         Type the email content here...
       </PlaceHolder>
     </div>

--- a/apps/web/src/components/workflow/FlowEditor.tsx
+++ b/apps/web/src/components/workflow/FlowEditor.tsx
@@ -276,14 +276,14 @@ const Wrapper = styled.div<{ dark: boolean }>`
   }
   .react-flow__handle {
     background: transparent;
-    border: 1px solid ${({ dark }) => (dark ? colors.B40 : colors.B80)};
+    border: 1px solid ${colors.B60};
   }
   .react-flow__attribution {
     background: transparent;
     opacity: 0.5;
   }
   .react-flow__edge-path {
-    stroke: ${({ dark }) => (dark ? colors.B40 : colors.B80)};
+    stroke: ${colors.B60};
     border-radius: 10px;
     stroke-dasharray: 5;
   }
@@ -307,7 +307,7 @@ const Wrapper = styled.div<{ dark: boolean }>`
     border: none;
 
     svg {
-      fill: ${({ dark }) => (dark ? colors.B40 : colors.B80)};
+      fill: ${colors.B60};
     }
   }
 `;

--- a/apps/web/src/components/workflow/node-types/AddNode.tsx
+++ b/apps/web/src/components/workflow/node-types/AddNode.tsx
@@ -34,7 +34,7 @@ export default memo(({ data }: { data: NodeData }) => {
               transparent: {
                 zIndex: 9999,
                 pointerEvents: 'all',
-                color: theme.colorScheme === 'dark' ? (data.showDropZone ? colors.white : colors.B30) : colors.B80,
+                color: theme.colorScheme === 'dark' ? (data.showDropZone ? colors.white : colors.B60) : colors.B60,
                 '&:hover': {
                   color: theme.colorScheme === 'dark' ? colors.white : colors.B40,
                 },

--- a/apps/web/src/design-system/button/Button.tsx
+++ b/apps/web/src/design-system/button/Button.tsx
@@ -11,7 +11,7 @@ interface IButtonProps extends JSX.ElementChildrenAttribute, SpacingProps {
   icon?: React.ReactNode;
   fullWidth?: boolean;
   submit?: boolean;
-  onClick?: () => void;
+  onClick?: (e: any) => void;
   inherit?: boolean;
 }
 

--- a/apps/web/src/design-system/dropdown/Dropdown.tsx
+++ b/apps/web/src/design-system/dropdown/Dropdown.tsx
@@ -8,6 +8,8 @@ interface IDropdownProps extends JSX.ElementChildrenAttribute {
   opened?: boolean;
   gutter?: number;
   placement?: 'center' | 'end' | 'start';
+  onOpen?: () => void;
+  onClose?: () => void;
   sx?: Sx | Sx[];
 }
 export function Dropdown({ children, ...props }: IDropdownProps) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This cleans up some visual bugs in the email workflow

  - Improved colors for better visibility (light / dark)
  - Remove overlap on settings button with button row
  - Better centering for settings button
  - Better menu for the align setting
  - Fixed a bug where selecting the text row caused the cursor to be at right side
  - Dropdown toggle now stays visible while the menu itself is open

- **Before**
![Screenshot 2022-08-26 192243](https://user-images.githubusercontent.com/13546486/186958975-71fe9c1e-e9bb-4487-bcc1-f0bd1637d396.png)

- **After**
![Screenshot 2022-08-26 191033](https://user-images.githubusercontent.com/13546486/186959043-2c7d0df3-399e-4a79-99fb-87bd5f5c89d3.png)
![Screenshot 2022-08-26 191052](https://user-images.githubusercontent.com/13546486/186959049-122879b3-ddc8-4bfb-a27a-9b6d8596f3b1.png)

