### PR TITLE
fix: remove maxwidth in hmac desc

### DIFF
--- a/apps/web/src/pages/settings/tabs/components/Security.tsx
+++ b/apps/web/src/pages/settings/tabs/components/Security.tsx
@@ -1,5 +1,5 @@
 import { Button, colors, Switch, Text } from '../../../../design-system';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { ColorScheme, InputWrapper, useMantineTheme } from '@mantine/core';
 import { inputStyles } from '../../../../design-system/config/inputs.styles';
@@ -69,8 +69,8 @@ function DescriptionText() {
   const { colorScheme } = useMantineTheme();
 
   return (
-    <InlineDiv>
-      HMAC used to verify that the request performed by the specific user. Read more
+    <div>
+      HMAC used to verify that the request performed by the specific user. Read more{' '}
       <StyledHref
         colorScheme={colorScheme}
         className={'security-doc-href'}
@@ -80,7 +80,7 @@ function DescriptionText() {
       >
         here.
       </StyledHref>
-    </InlineDiv>
+    </div>
   );
 }
 
@@ -88,10 +88,6 @@ const Title = styled(Text)`
   padding-bottom: 17px;
   font-size: 20px;
   font-weight: 700;
-`;
-
-const InlineDiv = styled.div`
-  max-width: 400px;
 `;
 
 const RowDiv = styled.div`


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
   fix: remove max width style and add space before link
- **What is the current behavior?** (You can also link to an open issue here)
<img width="1124" alt="Screenshot 2022-08-26 at 11 47 52 PM" src="https://user-images.githubusercontent.com/39362422/186967315-3edc1486-3031-4e1a-bd90-f8735a80fcf5.png">

- **What is the new behavior (if this is a feature change)?**
    
<img width="1124" alt="Screenshot 2022-08-26 at 11 47 01 PM" src="https://user-images.githubusercontent.com/39362422/186967223-3ecfee3e-6084-404c-bca0-8b0cc4cef808.png">

- **Other information**:
