### PR TITLE
feat: configure redirect and rewrite rules for Netlify

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
-  from = "/docs/:slug"
-  to = "/:slug"
+  from = "/docs/*"
+  to = "/:splat"
   status = 301
   force = false
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,12 @@
+[[redirects]]
+  from = "/docs/:slug"
+  to = "/:slug"
+  status = 301
+  force = false
+
+[[redirects]]
+  from = "/api"
+  to = "https://novuapidocs.gatsbyjs.io/api/"
+  status = 200
+  force = true
+  headers = {X-From = "Netlify"}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update: This pull request adds configure `redirect and rewrite` rules for `Netlify`.
- **What is the current behavior?** (You can also link to an open issue here)
at the moment we have a configuration file for redirects only for `Vercel`, which does not allow to place on `Netlify`
- **What is the new behavior (if this is a feature change)?**
allows you to keep the links working correctly when transferring the documentation to `Netlify`
- **Other information**:
I didn't delete the configuration file for Vercel (`vercel.json`) with redirects so that you could migrate to Netlify painlessly and not encounter possible problems with links between migrations, so please delete it after the migration is finished. Thanks!