### PR TITLE
feat: add a step to deploy API documentation

### DIFF
--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -129,4 +129,10 @@ jobs:
           service: ${{ env.api_ecs_service }}
           cluster: ${{ env.api_ecs_cluster }}
           wait-for-service-stability: true
+      
+      - name: Deploy API Documentation
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ secrets.API_DOCS_BUILD_WEBHOOK }}
+          method: 'POST'
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This pull request the step to deploy API documentation.
- **What is the current behavior?** (You can also link to an open issue here)
N/A
- **What is the new behavior (if this is a feature change)?**
when running the `Deploy PROD API` action adds a final step that starts building the project with the API documentation
- **Other information**:
you need to add a secret named `API_DOCS_BUILD_WEBHOOK` for this repository with the desired value