### PR TITLE
fix: slug for redirects on API pages

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -12,7 +12,7 @@
 
 [[redirects]]
   from = "/api/*"
-  to = "https://novuapidocs.gatsbyjs.io/api/"
+  to = "https://novuapidocs.gatsbyjs.io/api/:splat"
   status = 200
   force = true
   headers = {X-From = "Netlify"}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This pull request adds fixes slug for redirects on API pages.
- **What is the current behavior?** (You can also link to an open issue here)
<img width="2056" alt="Screenshot 2022-08-31 at 19 18 39" src="https://user-images.githubusercontent.com/17677196/187729896-a0bf42cd-dfbf-4976-bc27-872f589b1ca5.png">

- **What is the new behavior (if this is a feature change)?**
Status: `200`
- **Other information**:
N/A