### PR TITLE
fix: redirects for API documentation

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -11,8 +11,8 @@
   force = false
 
 [[redirects]]
-  from = "/api/*"
-  to = "https://novuapidocs.gatsbyjs.io/api/:splat"
+  from = "/api/:splat/"
+  to = "https://novuapidocs.gatsbyjs.io/api/:splat/"
   status = 200
   force = true
   headers = {X-From = "Netlify"}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This pull request adds fixes for redirects for API documentation.
- **What is the current behavior?** (You can also link to an open issue here)
When you go to a page from the documentation search, we get to a page that does not exist
<img width="2056" alt="Screenshot 2022-09-01 at 15 43 38" src="https://user-images.githubusercontent.com/17677196/187916721-dfa5065a-6ac4-42f0-a33e-8c641aac7409.png">

- **What is the new behavior (if this is a feature change)?**
<img width="2056" alt="Screenshot 2022-09-01 at 15 45 45" src="https://user-images.githubusercontent.com/17677196/187917005-a84cdd06-775c-4ca7-91f7-5ec99d2c6312.png">

- **Other information**:
N/A