### PR TITLE
fix: add set credentials info in push

### DIFF
--- a/docs/docs/channels/push/fcm.md
+++ b/docs/docs/channels/push/fcm.md
@@ -13,20 +13,33 @@ Device/notification identifiers can be set by using [Subscriber Credentials](/pl
 <Tabs>
   <TabItem value="nodejs" label="Node.js" default>
 
-  ```ts
-  import { Novu } from '@novu/node';
-  
-  const novu = new Novu(process.env.NOVU_API_KEY);
-  
-  novu.trigger('event-name', {
-    to: {
-      subscriberId: '...'
-    },
-    payload: {
-      abc: 'def',
-    },
-  })
-  ```
+```ts
+import { Novu } from '@novu/node';
+
+const novu = new Novu(process.env.NOVU_API_KEY);
+
+novu.trigger('event-name', {
+  to: {
+    subscriberId: '...',
+  },
+  payload: {
+    abc: 'def',
+  },
+});
+```
 
   </TabItem>
 </Tabs>
+
+Before triggering the notification to a subscriber(user) with push as a step in workflow, make sure you have added subscriber(user) device token as follows:-
+
+```typescript
+import { Novu, PushProviderIdEnum } from '@novu/node';
+
+const novu = new Novu(process.env.NOVU_API_KEY);
+
+const body = req.body; // From your HTTPS listener
+await novu.subscribers.setCredentials('subscriberId', PushProviderIdEnum.FCM, {
+  deviceTokens: ['<token1>', 'token2'],
+});
+```


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
   fix: add set credentials info in push
- **What is the current behavior?** (You can also link to an open issue here)
   adding device token info is missing in push docs
- **What is the new behavior (if this is a feature change)?**
  added
- **Other information**:
https://discord.com/channels/895029566685462578/1014486587918274663/1014582004215447634