### PR TITLE
Feat position notification center

### DIFF
--- a/apps/web/src/components/widget/NotificationCenterWidget.tsx
+++ b/apps/web/src/components/widget/NotificationCenterWidget.tsx
@@ -41,7 +41,6 @@ function PopoverWrapper() {
       colorScheme={colorScheme}
       onNotificationClick={handlerOnNotificationClick}
       onActionClick={handlerOnActionClick}
-      position="bottom-end"
     >
       {({ unseenCount }) => {
         return <NotificationBell colorScheme={colorScheme} unseenCount={unseenCount} />;

--- a/apps/web/src/components/widget/NotificationCenterWidget.tsx
+++ b/apps/web/src/components/widget/NotificationCenterWidget.tsx
@@ -41,6 +41,7 @@ function PopoverWrapper() {
       colorScheme={colorScheme}
       onNotificationClick={handlerOnNotificationClick}
       onActionClick={handlerOnActionClick}
+      position="bottom-end"
     >
       {({ unseenCount }) => {
         return <NotificationBell colorScheme={colorScheme} unseenCount={unseenCount} />;

--- a/docs/docs/notification-center/react-components.md
+++ b/docs/docs/notification-center/react-components.md
@@ -91,10 +91,10 @@ Use `position` prop to position the popover relative to the Bell icon
 </PopoverNotificationCenter>
 ```
 
-| Prop     | Type                                                                                                                                                               | Default  | Description                                       |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------------------- |
-| position | 'top' \| 'bottom' \| 'left' \| 'right' \| 'top-start' \| 'top-end' \| 'bottom-start' \| 'bottom-end' \| 'left-start' \| 'left-end' \| 'right-start' \| 'right-end' | 'bottom' | Position of the popover relative to the bell icon |
-| offset   | number                                                                                                                                                             |          | Gap between the Bell icon and Popover in px       |
+| Prop     | Type                                                                                                                                                               | Default      | Description                                       |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ | ------------------------------------------------- |
+| position | 'top' \| 'bottom' \| 'left' \| 'right' \| 'top-start' \| 'top-end' \| 'bottom-start' \| 'bottom-end' \| 'left-start' \| 'left-end' \| 'right-start' \| 'right-end' | 'bottom-end' | Position of the popover relative to the bell icon |
+| offset   | number                                                                                                                                                             |              | Gap between the Bell icon and Popover in px       |
 
 ## Custom UI
 

--- a/docs/docs/notification-center/react-components.md
+++ b/docs/docs/notification-center/react-components.md
@@ -81,21 +81,20 @@ To support dark mode in your application the notification center component can r
 </PopoverNotificationCenter>
 ```
 
-## Modify the Popover's `position` and `placement`
+## Modify the Popover's `position`
 
-Use `position` and `placement` props to position the popover relative to the Bell icon
+Use `position` prop to position the popover relative to the Bell icon
 
 ```tsx
-<PopoverNotificationCenter position="bottom" placement="end">
+<PopoverNotificationCenter position="left-start">
   {({ unseenCount }) => <NotificationBell unseenCount={unseenCount} />}
 </PopoverNotificationCenter>
 ```
 
-| Prop      | Type                                   | Default  | Description                                              |
-| --------- | -------------------------------------- | -------- | -------------------------------------------------------- |
-| position  | 'top' \| 'bottom' \| 'left' \| 'right' | 'bottom' | Position of the popover relative to the bell icon        |
-| placement | 'start' \| 'center' \| 'end'           | 'end'    | Placement of the popover with relative to the `position` |
-| offset    | number                                 |          | Gap between the Bell icon and Popover in px              |
+| Prop     | Type                                                                                                                                                               | Default  | Description                                       |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------------------- |
+| position | 'top' \| 'bottom' \| 'left' \| 'right' \| 'top-start' \| 'top-end' \| 'bottom-start' \| 'bottom-end' \| 'left-start' \| 'left-end' \| 'right-start' \| 'right-end' | 'bottom' | Position of the popover relative to the bell icon |
+| offset   | number                                                                                                                                                             |          | Gap between the Bell icon and Popover in px       |
 
 ## Custom UI
 

--- a/docs/docs/notification-center/react-components.md
+++ b/docs/docs/notification-center/react-components.md
@@ -81,6 +81,22 @@ To support dark mode in your application the notification center component can r
 </PopoverNotificationCenter>
 ```
 
+## Modify the Popover's `position` and `placement`
+
+Use `position` and `placement` props to position the popover relative to the Bell icon
+
+```tsx
+<PopoverNotificationCenter position="bottom" placement="end">
+  {({ unseenCount }) => <NotificationBell unseenCount={unseenCount} />}
+</PopoverNotificationCenter>
+```
+
+| Prop      | Type                                   | Default  | Description                                              |
+| --------- | -------------------------------------- | -------- | -------------------------------------------------------- |
+| position  | 'top' \| 'bottom' \| 'left' \| 'right' | 'bottom' | Position of the popover relative to the bell icon        |
+| placement | 'start' \| 'center' \| 'end'           | 'end'    | Placement of the popover with relative to the `position` |
+| offset    | number                                 |          | Gap between the Bell icon and Popover in px              |
+
 ## Custom UI
 
 If you prefer to build a custom UI, it's possible to use the `useNotification` hook available in our react library.

--- a/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
@@ -26,7 +26,7 @@ interface IPopoverNotificationCenterProps {
   offset?: number;
   position?:
     | PopoverProps['position']
-    | `${NonNullable<PopoverProps['position']>}-${NonNullable<PopoverProps['placement']>}`;
+    | `${NonNullable<PopoverProps['position']>}-${NonNullable<Exclude<PopoverProps['placement'], 'center'>>}`;
 }
 
 export function PopoverNotificationCenter({ children, ...props }: IPopoverNotificationCenterProps) {

--- a/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PopoverProps } from '@mantine/core';
 import { IMessage, IMessageAction, ButtonTypeEnum } from '@novu/shared';
 import { NotificationCenter } from '../notification-center';
 import { INotificationBellProps } from '../notification-bell';
@@ -22,6 +23,8 @@ interface IPopoverNotificationCenterProps {
   tabs?: ITab[];
   showUserPreferences?: boolean;
   onTabClick?: (tab: ITab) => void;
+  position?: PopoverProps['position'];
+  placement?: PopoverProps['placement'];
 }
 
 export function PopoverNotificationCenter({ children, ...props }: IPopoverNotificationCenterProps) {
@@ -39,7 +42,12 @@ export function PopoverNotificationCenter({ children, ...props }: IPopoverNotifi
   }
 
   return (
-    <Popover theme={theme} bell={(bellProps) => children({ ...bellProps, unseenCount, theme })}>
+    <Popover
+      theme={theme}
+      bell={(bellProps) => children({ ...bellProps, unseenCount, theme })}
+      position={props.position}
+      placement={props.placement}
+    >
       <NotificationCenter
         onNotificationClick={props.onNotificationClick}
         onUnseenCountChanged={handlerOnUnseenCount}

--- a/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
@@ -23,6 +23,7 @@ interface IPopoverNotificationCenterProps {
   tabs?: ITab[];
   showUserPreferences?: boolean;
   onTabClick?: (tab: ITab) => void;
+  offset?: number;
   position?: PopoverProps['position'];
   placement?: PopoverProps['placement'];
 }
@@ -47,6 +48,7 @@ export function PopoverNotificationCenter({ children, ...props }: IPopoverNotifi
       bell={(bellProps) => children({ ...bellProps, unseenCount, theme })}
       position={props.position}
       placement={props.placement}
+      offset={props.offset}
     >
       <NotificationCenter
         onNotificationClick={props.onNotificationClick}

--- a/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
@@ -24,8 +24,9 @@ interface IPopoverNotificationCenterProps {
   showUserPreferences?: boolean;
   onTabClick?: (tab: ITab) => void;
   offset?: number;
-  position?: PopoverProps['position'];
-  placement?: PopoverProps['placement'];
+  position?:
+    | PopoverProps['position']
+    | `${NonNullable<PopoverProps['position']>}-${NonNullable<PopoverProps['placement']>}`;
 }
 
 export function PopoverNotificationCenter({ children, ...props }: IPopoverNotificationCenterProps) {
@@ -47,7 +48,6 @@ export function PopoverNotificationCenter({ children, ...props }: IPopoverNotifi
       theme={theme}
       bell={(bellProps) => children({ ...bellProps, unseenCount, theme })}
       position={props.position}
-      placement={props.placement}
       offset={props.offset}
     >
       <NotificationCenter

--- a/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Popover as MantinePopover } from '@mantine/core';
+import { Popover as MantinePopover, PopoverProps } from '@mantine/core';
 import styled from 'styled-components';
 import { INovuTheme } from '../../../store/novu-theme.context';
 
@@ -7,9 +7,11 @@ interface INovuPopoverProps {
   bell: (props: any) => JSX.Element;
   children: JSX.Element;
   theme: INovuTheme;
+  position?: PopoverProps['position'];
+  placement?: PopoverProps['placement'];
 }
 
-export function Popover({ children, bell, theme }: INovuPopoverProps) {
+export function Popover({ children, bell, theme, position = 'bottom', placement = 'end' }: INovuPopoverProps) {
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   function handlerBellClick() {
@@ -21,8 +23,8 @@ export function Popover({ children, bell, theme }: INovuPopoverProps) {
       opened={isVisible}
       onClose={() => setIsVisible(false)}
       target={<BellContainer onClick={handlerBellClick}> {bell({})}</BellContainer>}
-      position={'bottom'}
-      placement={'end'}
+      position={position}
+      placement={placement}
       withArrow
       styles={{
         inner: { margin: 0, padding: 0 },

--- a/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
@@ -24,7 +24,7 @@ export function Popover({ children, bell, theme, offset, position = 'bottom' }: 
       return position.split('-') as PositionType;
     }
 
-    return [position, 'end'] as PositionType;
+    return [position, 'center'] as PositionType;
   }, [position]);
 
   return (

--- a/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
@@ -24,7 +24,7 @@ export function Popover({ children, bell, theme, offset, position = 'bottom' }: 
       return position.split('-') as PositionType;
     }
 
-    return [position, 'center'] as PositionType;
+    return [position, 'end'] as PositionType;
   }, [position]);
 
   return (

--- a/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
@@ -7,11 +7,12 @@ interface INovuPopoverProps {
   bell: (props: any) => JSX.Element;
   children: JSX.Element;
   theme: INovuTheme;
+  offset?: number;
   position?: PopoverProps['position'];
   placement?: PopoverProps['placement'];
 }
 
-export function Popover({ children, bell, theme, position = 'bottom', placement = 'end' }: INovuPopoverProps) {
+export function Popover({ children, bell, theme, offset, position = 'bottom', placement = 'end' }: INovuPopoverProps) {
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   function handlerBellClick() {
@@ -36,6 +37,7 @@ export function Popover({ children, bell, theme, position = 'bottom', placement 
           borderColor: `${theme.popover?.arrowColor}`,
         },
       }}
+      gutter={offset}
     >
       {children}
     </MantinePopover>

--- a/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/components/Popover.tsx
@@ -1,31 +1,39 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Popover as MantinePopover, PopoverProps } from '@mantine/core';
 import styled from 'styled-components';
 import { INovuTheme } from '../../../store/novu-theme.context';
 
+type PositionType = [PopoverProps['position'], PopoverProps['placement']];
 interface INovuPopoverProps {
   bell: (props: any) => JSX.Element;
   children: JSX.Element;
   theme: INovuTheme;
   offset?: number;
-  position?: PopoverProps['position'];
-  placement?: PopoverProps['placement'];
+  position?: PopoverProps['position'] | `${PopoverProps['position']}-${PopoverProps['placement']}`;
 }
 
-export function Popover({ children, bell, theme, offset, position = 'bottom', placement = 'end' }: INovuPopoverProps) {
+export function Popover({ children, bell, theme, offset, position = 'bottom' }: INovuPopoverProps) {
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
   function handlerBellClick() {
     setIsVisible(!isVisible);
   }
 
+  const [modPosition, modPlacement] = useMemo<PositionType>(() => {
+    if (position.includes('-')) {
+      return position.split('-') as PositionType;
+    }
+
+    return [position, 'end'] as PositionType;
+  }, [position]);
+
   return (
     <MantinePopover
       opened={isVisible}
       onClose={() => setIsVisible(false)}
       target={<BellContainer onClick={handlerBellClick}> {bell({})}</BellContainer>}
-      position={position}
-      placement={placement}
+      position={modPosition}
+      placement={modPlacement}
       withArrow
       styles={{
         inner: { margin: 0, padding: 0 },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added `position` & `offset` props for the `notification-center`
Fixes #1174 
- **What is the current behavior?** (You can also link to an open issue here)
Currently, there's no option to modify the position of the popover
- **What is the new behavior (if this is a feature change)?**
Allows custom positions to update the popover positions
- **Other information**:
  - `position='left-start'`: <img width="1155" alt="image" src="https://user-images.githubusercontent.com/29251776/188361614-159d9cb9-0b9c-49e4-a1af-713ae2f49c5d.png">
  - `position='right-start`: ![image](https://user-images.githubusercontent.com/29251776/188362043-be6f0741-46f5-4c97-b17e-a9c0ce98b328.png)


