### PR TITLE
feat: add the externalUrlRegex param for Algolia

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -45,6 +45,7 @@ const codeTheme = require('./src/utils/prism');
           apiKey: '67ce2424b44097b63a6f21a6615de538',
           indexName: 'novu',
           contextualSearch: true,
+          externalUrlRegex: 'https://docs.novu.co/api/.*',
         },
         docs: {
           sidebar: {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update: This pull request adds the `externalUrlRegex` param for Algolia.
- **What is the current behavior?** (You can also link to an open issue here)
When you go to a page from the documentation search, we get to a page that does not exist
- **What is the new behavior (if this is a feature change)?**
This option allows for `window.location` instead of `history.push`. Which solves the problem with links for API documentation. You can find more about this [here](https://docusaurus.io/docs/search#connecting-algolia)
- **Other information**:
N/A