### PR TITLE
Linked License, Contribution Guidelines and Contributors List in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,16 @@ Just <a href="https://discord.gg/novu">Join Our Discord</a> server and ask for h
 ## 🔗 Links
 
 - [Home page](https://novu.co/)
+- [Contribution Guidelines](https://github.com/AmanNegi/novu/blob/main/CONTRIBUTING.md)
+
+## 🛡️ License
+
+Novu is licensed under the MIT License - see the [LICENSE](https://github.com/novuhq/novu/blob/main/LICENSE) file for details.
+
+## 💪 Thanks to all Contributors
+
+Thanks a lot for spending your time helping Novu grow. Thanks a lot! Keep rocking 🥂
+
+<a href="https://github.com/novuhq/novu/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=novuhq/novu" />
+</a>


### PR DESCRIPTION
Linked License, Contribution Guidelines, and Contributors List in README.md. (#1160)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
-> In this PR, I have changed README.md which would be counted under docs update.

- **What is the current behavior?** (You can also link to an open issue here)
-> Currently, the License, Contribution Guidelines, and Contributors List are not embedded in README.md (#1160)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
