### PR TITLE
feat: add on tab click property to notification center

### DIFF
--- a/packages/notification-center/src/components/notification-center/NotificationCenter.tsx
+++ b/packages/notification-center/src/components/notification-center/NotificationCenter.tsx
@@ -19,6 +19,7 @@ export interface INotificationCenterProps {
   onActionClick?: (templateIdentifier: string, type: ButtonTypeEnum, message: IMessage) => void;
   tabs?: ITab[];
   showUserPreferences?: boolean;
+  onTabClick?: (tab: ITab) => void;
 }
 
 export function NotificationCenter(props: INotificationCenterProps) {
@@ -40,6 +41,7 @@ export function NotificationCenter(props: INotificationCenterProps) {
           actionsResultBlock: props.actionsResultBlock,
           tabs: props.tabs,
           showUserPreferences: props.showUserPreferences ?? true,
+          onTabClick: props.onTabClick ? props.onTabClick : () => {},
         }}
       >
         <NovuThemeProvider colorScheme={props.colorScheme} theme={props.theme}>

--- a/packages/notification-center/src/components/notification-center/components/FeedsTabs.tsx
+++ b/packages/notification-center/src/components/notification-center/components/FeedsTabs.tsx
@@ -9,7 +9,7 @@ import { NotificationCenterContext } from '../../../store';
 import { useApi, useNovuContext } from '../../../hooks';
 
 export function FeedsTabs() {
-  const { tabs } = useContext<INotificationCenterContext>(NotificationCenterContext);
+  const { tabs, onTabClick } = useContext<INotificationCenterContext>(NotificationCenterContext);
 
   return (
     <>
@@ -24,6 +24,9 @@ export function FeedsTabs() {
                   <UnseenBadgeContainer storeId={tab.storeId} />
                 </TabLabelWrapper>
               }
+              onClick={() => {
+                onTabClick(tab);
+              }}
             >
               <NotificationsListTab tab={tab} />
             </Tab>

--- a/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
@@ -21,6 +21,7 @@ interface IPopoverNotificationCenterProps {
   actionsResultBlock?: (templateIdentifier: string, messageAction: IMessageAction) => JSX.Element;
   tabs?: ITab[];
   showUserPreferences?: boolean;
+  onTabClick?: (tab: ITab) => void;
 }
 
 export function PopoverNotificationCenter({ children, ...props }: IPopoverNotificationCenterProps) {
@@ -52,6 +53,7 @@ export function PopoverNotificationCenter({ children, ...props }: IPopoverNotifi
         listItem={props.listItem}
         tabs={props.tabs}
         showUserPreferences={props.showUserPreferences}
+        onTabClick={props.onTabClick}
       />
     </Popover>
   );

--- a/packages/notification-center/src/index.ts
+++ b/packages/notification-center/src/index.ts
@@ -65,6 +65,7 @@ export interface INotificationCenterContext {
   actionsResultBlock: (templateIdentifier: string, messageAction: IMessageAction) => JSX.Element;
   tabs?: ITab[];
   showUserPreferences?: boolean;
+  onTabClick?: (tab: ITab) => void;
 }
 
 export interface IStore {

--- a/packages/notification-center/src/store/notification-center.context.ts
+++ b/packages/notification-center/src/store/notification-center.context.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IMessage, ButtonTypeEnum } from '@novu/shared';
-import { INotificationCenterContext } from '../index';
+import { INotificationCenterContext, ITab } from '../index';
 
 export const NotificationCenterContext = React.createContext<INotificationCenterContext>({
   onUrlChange: (url: string) => {},
@@ -14,4 +14,5 @@ export const NotificationCenterContext = React.createContext<INotificationCenter
   actionsResultBlock: null,
   tabs: [],
   showUserPreferences: true,
+  onTabClick: (tab: ITab) => {},
 } as any);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
So developer can track what tab subscriber is viewing to customize headers and items
- **What is the current behavior?** (You can also link to an open issue here)
This does not exists today
- **What is the new behavior (if this is a feature change)?**
The developer can provide a function to get what tab subscriber have clicked on
