### PR TITLE
fix: embed <--> widget communication issue on safari

### DIFF
--- a/apps/widget/src/components/notification-center/NotificationCenterWidget.tsx
+++ b/apps/widget/src/components/notification-center/NotificationCenterWidget.tsx
@@ -33,24 +33,24 @@ export function NotificationCenterWidget(props: INotificationCenterWidgetProps) 
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handler = async (event: { data: any }) => {
-      if (event.data.type === 'INIT_IFRAME') {
-        setUserDataPayload(event.data.value.data);
+    const handler = ({ data }: any) => {
+      if (data && data.type === 'INIT_IFRAME') {
+        setUserDataPayload(data.value.data);
 
-        if (event.data.value.backendUrl) {
-          setBackendUrl(event.data.value.backendUrl);
+        if (data.value.backendUrl) {
+          setBackendUrl(data.value.backendUrl);
         }
 
-        if (event.data.value.socketUrl) {
-          setSocketUrl(event.data.value.socketUrl);
+        if (data.value.socketUrl) {
+          setSocketUrl(data.value.socketUrl);
         }
 
-        if (event.data.value.theme) {
-          setTheme(event.data.value.theme);
+        if (data.value.theme) {
+          setTheme(data.value.theme);
         }
 
-        if (event.data.value.i18n) {
-          setI18n(event.data.value.i18n);
+        if (data.value.i18n) {
+          setI18n(data.value.i18n);
         }
 
         setFrameInitialized(true);
@@ -63,6 +63,8 @@ export function NotificationCenterWidget(props: INotificationCenterWidgetProps) 
     }
 
     window.addEventListener('message', handler);
+
+    window.parent.postMessage({ type: 'WIDGET_READY' }, '*');
 
     return () => window.removeEventListener('message', handler);
   }, []);

--- a/libs/embed/src/shared/eventTypes.js
+++ b/libs/embed/src/shared/eventTypes.js
@@ -1,3 +1,4 @@
+export const WIDGET_READY = 'WIDGET_READY';
 export const INIT_IFRAME = 'INIT_IFRAME';
 export const SET_COOKIE = 'SET_COOKIE';
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
**Bug fix:** ticket: #1090 

- **What is the current behavior?**
Currently on Safari, it's not possible to open the Embedded Notification Center Widget.

The issue can be seen on the below screenshots.
Chrome:
![Screenshot 2022-08-29 at 00 24 30](https://user-images.githubusercontent.com/2607232/188288636-cfa7626e-f3b3-4aa1-864f-58635ea01500.png)
Safari:
![Screenshot 2022-08-29 at 00 24 05](https://user-images.githubusercontent.com/2607232/188288641-a54d29ad-8801-470a-95de-a8e3990356a8.png)

As you can see on Safari `Embed` sends the `INIT_IFRAME` message before the `Widget` gets the opportunity to register the event listener.

- **What is the new behavior (if this is a feature change)?**
This fix solves the issue described above.
The `Embed <--> Widget` communication is reversed and works based on the `postMessage` API.

---

1. When the `Embed` code is running in the browser it creates the `iframe` DOM element for the `Widget`.
2. Right after it registers the `message` event listener on that `iframe` to receive events from the `Widget`.
3. When the `Widget` is loaded and React triggers the `useEffect` hook (on mount) - it registers it's own event listener on the `window` object to receive events from the `Embed`.
4. Then right after it sends the `WIDGET_READY` event to the `Embed`.
5. `Embed` receives that event and sends back `INIT_IFRAME` to `Widget` with a configuration object.
6. `Widget` receive it and does the initialization. 

In short:
1. `WIDGET --> WIDGET_READY --> EMBED`
2. `EMBED --> INIT_IFRAME --> WIDGET`
3. Widget initialized.

**Unfortunately, currently it's not possible to run Cypress tests in Safari.
And I haven't checked the fix on the iOS Safari.**

---

- **Screenshots**:

![Screenshot 2022-09-03 at 14 00 12](https://user-images.githubusercontent.com/2607232/188288172-0d8d65c0-05d0-4b5f-8efa-09fe2d129c74.png)
![Screenshot 2022-09-03 at 13 59 44](https://user-images.githubusercontent.com/2607232/188288173-024c4ef6-f7ea-4db3-8d0f-ce80ff0dc284.png)
![Screenshot 2022-09-03 at 13 58 24](https://user-images.githubusercontent.com/2607232/188288174-1daf3f33-687a-4c4e-803f-9ca076e75644.png)
![Screenshot 2022-09-03 at 14 02 10](https://user-images.githubusercontent.com/2607232/188288168-4156527d-b77d-43f8-80cd-4a6bec4bdf50.png)

Cypress tests:
![Screenshot 2022-09-03 at 23 03 42](https://user-images.githubusercontent.com/2607232/188288183-88a035e4-20c0-4548-bd49-397e60e13c18.png)

