### PR TITLE
fix: flow editor height

### DIFF
--- a/apps/web/src/components/templates/TemplatePageHeader.tsx
+++ b/apps/web/src/components/templates/TemplatePageHeader.tsx
@@ -63,7 +63,7 @@ export const TemplatePageHeader = ({ templateId, loading, disableSubmit, activeP
   );
 
   return (
-    <Container fluid sx={{ padding: '20px' }}>
+    <Container fluid sx={{ padding: '20px', width: '100%' }}>
       <Group position="apart">
         <div>
           <Title>

--- a/apps/web/src/components/workflow/FlowEditor.tsx
+++ b/apps/web/src/components/workflow/FlowEditor.tsx
@@ -239,7 +239,7 @@ export function FlowEditor({
   return (
     <>
       <Wrapper dark={colorScheme === 'dark'}>
-        <div style={{ height: '500px', width: 'inherit' }} ref={reactFlowWrapper}>
+        <div style={{ minHeight: '500px', height: '100%', width: 'inherit' }} ref={reactFlowWrapper}>
           <ReactFlow
             nodes={nodes}
             edges={edges}
@@ -275,6 +275,7 @@ export function FlowEditor({
 export default FlowEditor;
 
 const Wrapper = styled.div<{ dark: boolean }>`
+  flex: 1 1 0%;
   background: ${({ dark }) => (dark ? colors.B15 : colors.B98)};
   .react-flow__node.react-flow__node-channelNode,
   .react-flow__node.react-flow__node-triggerNode {

--- a/apps/web/src/pages/templates/workflow/WorkflowEditorPage.tsx
+++ b/apps/web/src/pages/templates/workflow/WorkflowEditorPage.tsx
@@ -107,7 +107,7 @@ const WorkflowEditorPage = ({
   return (
     <>
       <Grid gutter={0} grow style={{ minHeight: '100%' }}>
-        <Grid.Col md={9} sm={6}>
+        <Grid.Col md={9} sm={6} style={{ display: 'flex', flexDirection: 'column' }}>
           <TemplatePageHeader
             loading={isLoading || isUpdateLoading}
             disableSubmit={readonly || loadingEditTemplate || isLoading || !isDirty}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes the height of the flow editor to be auto but at least 500px instead of currently hard 500px

- **What is the current behavior?** (You can also link to an open issue here)
![Screenshot 2022-09-05 220145](https://user-images.githubusercontent.com/13546486/188507966-55725153-508e-4603-a73f-b501ad8b0fbc.png)

- **What is the new behavior (if this is a feature change)?**
![Screenshot 2022-09-05 220207](https://user-images.githubusercontent.com/13546486/188507982-d39eddaf-b59a-455a-ad3a-cd4510650aaa.png)

