### PR TITLE
refactor: fetch on load & stable refetch

### DIFF
--- a/packages/notification-center/src/hooks/use-notifications.hook.ts
+++ b/packages/notification-center/src/hooks/use-notifications.hook.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useCallback } from 'react';
 import { INotificationsContext } from '../index';
 import { NotificationsContext } from '../store/notifications.context';
 import { ButtonTypeEnum, MessageActionStatusEnum } from '@novu/shared';
@@ -37,9 +37,13 @@ export function useNotifications(props?: IUseNotificationsProps) {
     await mapUpdateAction(messageId, actionButtonType, status, payload, storeId);
   }
 
-  async function refetch() {
+  const refetch = useCallback(async () => {
     await mapRefetch(storeId);
-  }
+  }, []);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
 
   return {
     notifications,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
1. Automatic fetching of notifications while using the `useNotification` hook.
2. Stable referential identity for `refetch` method
- **What is the current behavior?** (You can also link to an open issue here)
1. users have to manually invoke `refetch` on load to get the notification
2. adding `refetch` as a dependency results in infinite loop
- **What is the new behavior (if this is a feature change)?**
1. Automatic fetching of notifications while using the `useNotification` hook.
2. Stable referential identity for `refetch` method
- **Other information**:
