### PR TITLE
Allow adding new nodes to middle of workflow

### DIFF
--- a/apps/web/src/components/templates/use-template-controller.hook.ts
+++ b/apps/web/src/components/templates/use-template-controller.hook.ts
@@ -186,7 +186,27 @@ export function useTemplateController(templateId: string) {
     navigate('/templates');
   };
 
-  const addStep = (channelType: StepTypeEnum, id: string) => {
+  const addStep = (channelType: StepTypeEnum, id: string, index = -1) => {
+    if (index !== -1) {
+      console.log(index);
+      console.log(steps.fields);
+      steps.insert(index, {
+        _id: id,
+        template: {
+          type: channelType,
+          content: [],
+          contentType: 'editor',
+          subject: '',
+          name: 'Email Message Template',
+          variables: [],
+        },
+        active: true,
+        filters: [],
+      });
+      console.log(steps.fields);
+
+      return;
+    }
     steps.append({
       _id: id,
       template: {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Allows nodes to be dropped in middle of the workflow instead of having to remove nodes to get a node to a desired place.

- **What is the current behavior?** (You can also link to an open issue here)
You need to delete all before nodes to put a node in between of the workflow

- **What is the new behavior (if this is a feature change)?**
![Peek 2022-09-08 18-00](https://user-images.githubusercontent.com/29684625/189156858-6441af8c-6966-4ce9-8b2a-8c4cd0231988.gif)

- **Other information**:
