### PR TITLE
fix: curl req for notification-groups gets error 500

### DIFF
--- a/apps/api/src/app/activity/activity.module.ts
+++ b/apps/api/src/app/activity/activity.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { USE_CASES } from './usecases';
 import { ActivityController } from './activity.controller';
 import { SharedModule } from '../shared/shared.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SharedModule],
+  imports: [SharedModule, AuthModule],
   providers: [...USE_CASES],
   controllers: [ActivityController],
 })

--- a/apps/api/src/app/change/change.module.ts
+++ b/apps/api/src/app/change/change.module.ts
@@ -1,10 +1,11 @@
-import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { forwardRef, MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { SharedModule } from '../shared/shared.module';
 import { ChangesController } from './changes.controller';
 import { USE_CASES } from './usecases';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SharedModule],
+  imports: [SharedModule, forwardRef(() => AuthModule)],
   providers: [...USE_CASES],
   exports: [...USE_CASES],
   controllers: [ChangesController],

--- a/apps/api/src/app/environments/environments.module.ts
+++ b/apps/api/src/app/environments/environments.module.ts
@@ -1,11 +1,12 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { SharedModule } from '../shared/shared.module';
 import { USE_CASES } from './usecases';
 import { EnvironmentsController } from './environments.controller';
 import { NotificationGroupsModule } from '../notification-groups/notification-groups.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SharedModule, NotificationGroupsModule],
+  imports: [SharedModule, NotificationGroupsModule, forwardRef(() => AuthModule)],
   controllers: [EnvironmentsController],
   providers: [...USE_CASES],
   exports: [...USE_CASES],

--- a/apps/api/src/app/feeds/feeds.module.ts
+++ b/apps/api/src/app/feeds/feeds.module.ts
@@ -4,9 +4,10 @@ import { FeedsController } from './feeds.controller';
 import { SharedModule } from '../shared/shared.module';
 import { ChangeModule } from '../change/change.module';
 import { MessageTemplateModule } from '../message-template/message-template.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SharedModule, MessageTemplateModule, ChangeModule],
+  imports: [SharedModule, MessageTemplateModule, ChangeModule, AuthModule],
   providers: [...USE_CASES],
   controllers: [FeedsController],
   exports: [...USE_CASES],

--- a/apps/api/src/app/integrations/integrations.module.ts
+++ b/apps/api/src/app/integrations/integrations.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { SharedModule } from '../shared/shared.module';
 import { USE_CASES } from './usecases';
 import { IntegrationsController } from './integrations.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SharedModule],
+  imports: [SharedModule, AuthModule],
   controllers: [IntegrationsController],
   providers: [...USE_CASES],
   exports: [...USE_CASES],

--- a/apps/api/src/app/notification-groups/notification-groups.module.ts
+++ b/apps/api/src/app/notification-groups/notification-groups.module.ts
@@ -1,11 +1,12 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { USE_CASES } from './usecases';
 import { NotificationGroupsController } from './notification-groups.controller';
 import { SharedModule } from '../shared/shared.module';
 import { ChangeModule } from '../change/change.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SharedModule, ChangeModule],
+  imports: [SharedModule, forwardRef(() => AuthModule), ChangeModule],
   providers: [...USE_CASES],
   controllers: [NotificationGroupsController],
   exports: [...USE_CASES],


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix curl request to notification-groups receiving 500, internal server error 

- **Why this change was needed?** (You can also link to an open issue here)
Issues : [1234](https://github.com/novuhq/novu/issues/1234) and [1259](https://github.com/novuhq/novu/issues/1259)

- **Other information**:
Seems that the problem is a missing import of AuthModule in notification-groups

Edit : Found several other places with the same issue. 
This PR will fix several API endpoints, not only notification-groups 
