### PR TITLE
Fix embed runtime env variables

### DIFF
--- a/libs/embed/package.json
+++ b/libs/embed/package.json
@@ -28,7 +28,7 @@
     "build:prod": "tsc && cross-env ENVIRONMENT=production rollup -c rollup.config.ts",
     "start": "cross-env ENVIRONMENT=local rollup -c rollup.config.ts -w",
     "start:dev": "concurrently \"pnpm start\"",
-    "start:docker": "http-server -p 4701 dist",
+    "start:docker": "pnpm build && http-server -p 4701 dist",
     "start:test:web": "http-server -p 4701 -o test",
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",

--- a/scripts/pnpm-context.mjs
+++ b/scripts/pnpm-context.mjs
@@ -169,7 +169,7 @@ async function getMetafilesFromPnpmSelector(selector, cwd, options = {}) {
 async function getPackagePathsFromPnpmSelector(selector, cwd) {
   const projects = await readProjects(cwd, [parsePackageSelector(selector, cwd)]);
 
-  return Object.keys(projects.selectedProjectsGraph).map((p) => relative(cwd, p).replaceAll('\\', '/'));
+  return Object.keys(projects.selectedProjectsGraph).map((p) => relative(cwd, p).replace(/\\/g, '/'));
 }
 
 /**


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix)
At the current state, the environment variables are embeded in the static page on rollup build (@rollup/plugin-replace), in this PR we added a build step so that rollup rebuild the environment variables.

- **Why this change was needed?** (You can also link to an open issue here)
While using the docker-compose environment the user will want to use the prebuilt images and update the environment variable in runtime (docker-compose up). 

- **Other information**:
Closes #1249 
Closes NV-895