### PR TITLE
style: bg-color of step card and zindex of error tooltip

### DIFF
--- a/apps/web/src/design-system/template-button/ChannelButton.tsx
+++ b/apps/web/src/design-system/template-button/ChannelButton.tsx
@@ -118,6 +118,7 @@ export function ChannelButton({
       onMouseLeave={() => setPopoverOpened(false)}
       data-test-id={testId}
       className={cx(classes.button, { [classes.active]: active })}
+      style={{ pointerEvents: 'all' }}
       sx={{
         backgroundColor: theme.colorScheme === 'dark' ? colors.B17 : colors.white,
       }}
@@ -237,6 +238,7 @@ export function ChannelButton({
           mb={20}
           placement="center"
           position="right"
+          zIndex={4}
           target={<ErrorCircle data-test-id="error-circle" dark={theme.colorScheme === 'dark'} />}
         >
           {errors.toString() || 'Something is missing here'}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Change of background color of Step card on hovering anywhere on card

- And fixed z-index of error tooltip in workflow editor
- **Why this change was needed?** (You can also link to an open issue here)
https://github.com/novuhq/novu/issues/1263
Background color of step card was changing only on 3 dots hover.
And error tooltip was coming over the Delete Step confirmation modal, resulting in covering the CTAs
- **Other information**:
![image](https://user-images.githubusercontent.com/65118743/191250279-1f8054b0-333f-467a-b13c-fe26ad49e6a1.png)
