### PR TITLE
fix: so default payload are overrided by the provided payload

### DIFF
--- a/apps/api/src/app/events/usecases/trigger-event/trigger-event.usecase.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/trigger-event.usecase.ts
@@ -59,7 +59,7 @@ export class TriggerEvent {
       })
     );
 
-    command.payload = merge({}, command.payload, defaultPayload);
+    command.payload = merge({}, defaultPayload, command.payload);
 
     const jobs: JobEntity[][] = [];
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix so default value are used as default and not overriding provided values
- **Why this change was needed?** (You can also link to an open issue here)
So defaults are defaults and not overrides
- **Other information**:
Text from Lodash docs about merge function:

"This method is like [_.assign](https://lodash.com/docs/4.17.15#assign) except that it recursively merges own and inherited enumerable string keyed properties of source objects into the destination object. Source properties that resolve to undefined are skipped if a destination value exists. Array and plain object properties are merged recursively. Other objects and value types are overridden by assignment. Source objects are applied from left to right. Subsequent sources overwrite property assignments of previous sources."