### PR TITLE
feat: add so limit can be provided to endpoint

### DIFF
--- a/apps/api/src/app/messages/messages.controller.ts
+++ b/apps/api/src/app/messages/messages.controller.ts
@@ -26,6 +26,12 @@ export class MessagesController {
   })
   @ApiQuery({ name: 'page', type: Number, required: false, description: 'The page to fetch, defaults to 0' })
   @ApiQuery({
+    name: 'limit',
+    type: Number,
+    required: false,
+    description: 'The number of messages to fetch, defaults to 10',
+  })
+  @ApiQuery({
     name: 'subscriberId',
     type: String,
     required: false,
@@ -40,6 +46,7 @@ export class MessagesController {
   async getMessages(
     @UserSession() user: IJwtPayload,
     @Query('page') page = 0,
+    @Query('limit') limit = 10,
     @Query('subscriberId') subscriberId,
     @Query('channel') channel: ChannelTypeEnum
   ): Promise<ActivitiesResponseDto> {
@@ -50,6 +57,7 @@ export class MessagesController {
         page: page ? Number(page) : 0,
         channel,
         subscriberId,
+        limit: limit ? Number(limit) : 10,
       })
     );
   }

--- a/apps/api/src/app/messages/usecases/get-messages/get-messages.command.ts
+++ b/apps/api/src/app/messages/usecases/get-messages/get-messages.command.ts
@@ -12,4 +12,8 @@ export class GetMessagesCommand extends EnvironmentCommand {
 
   @IsOptional()
   channel?: ChannelTypeEnum;
+
+  @IsNumber()
+  @IsOptional()
+  limit?: number;
 }

--- a/apps/api/src/app/messages/usecases/get-messages/get-messages.usecase.ts
+++ b/apps/api/src/app/messages/usecases/get-messages/get-messages.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { MessageEntity, MessageRepository, SubscriberRepository } from '@novu/dal';
 import { GetMessagesCommand } from './get-messages.command';
 
@@ -7,7 +7,11 @@ export class GetMessages {
   constructor(private messageRepository: MessageRepository, private subscriberRepository: SubscriberRepository) {}
 
   async execute(command: GetMessagesCommand) {
-    const LIMIT = 10;
+    const LIMIT = command.limit;
+
+    if (LIMIT > 1000) {
+      throw new BadRequestException('Limit can not be larger then 1000');
+    }
 
     const query: Partial<MessageEntity> = {
       _environmentId: command.environmentId,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Make limit a query param
- **Why this change was needed?** (You can also link to an open issue here)
So larger amount of messages can be fetched with one request
