### PR TITLE
Add SendGrid provider doc

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -25,6 +25,8 @@
   // MD014/commands-show-output - Dollar signs used before commands without showing output
   "MD014": false,
 
+  "MD013/line-length": false,
+
   // MD044/proper-names - Proper names should have the correct capitalization
   "MD044": {
     "code_blocks": false,

--- a/docs/docs/channels/email/_category_.json
+++ b/docs/docs/channels/email/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Email",
+  "position": 1
+}

--- a/docs/docs/channels/email/index.mdx
+++ b/docs/docs/channels/email/index.mdx
@@ -23,24 +23,26 @@ this article, we’ll go over the benefits of planning for your webinar and top 
 <Tabs>
   <TabItem value="nodejs" label="Node.js" default>
 
-  ```ts
-  import { Novu } from '@novu/node';
-  
-  const novu = new Novu(process.env.NOVU_API_KEY);
-  
-  novu.trigger('event-name', {
-    to: {
-      subscriberId: '...'
-    },
-    payload: {
-      attachments: [{
+```ts
+import { Novu } from 'packages/node/build/main/index';
+
+const novu = new Novu(process.env.NOVU_API_KEY);
+
+novu.trigger('event-name', {
+  to: {
+    subscriberId: '...',
+  },
+  payload: {
+    attachments: [
+      {
         file: fs.readFileSync(__dirname + '/data/test.jpeg'),
         name: 'test.jpeg',
-        mime: 'image/jpg'
-      }]
-    }
-  })
-  ```
+        mime: 'image/jpg',
+      },
+    ],
+  },
+});
+```
 
   </TabItem>
 </Tabs>

--- a/docs/docs/channels/email/sendgrid.md
+++ b/docs/docs/channels/email/sendgrid.md
@@ -1,0 +1,33 @@
+# SendGrid
+
+You can use the [SendGrid](https://sendgrid.com/) provider to send transactional emails to your customers using the Novu Platform with a single API to create multi-channel experiences.
+
+## Getting Started
+
+To use the Sendgrid channel, you will need to create a Sendgrid account and add your API key to the SendGrid integration on the Novu platform
+
+## Find the API Key
+
+To find your Sendgrid API key, log into your Sendgrid account and navigate to the [API Keys](https://app.sendgrid.com/settings/api_keys) page.
+It is suggested that you create a new API key for use with Novu. To successfully send emails, you will need to add the following permissions to your API key:
+
+- **Mail Send** - Full Access
+- (Optional) Template Engine - Read Only
+
+## Authenticate your sender identity
+
+Before you can send emails, you will need to authenticate your sender identity. This is due to the latest regulatory changes regarding SPAM rules and email fraud. Most of the providers including Sendgrid require you to authenticate your sender identity before you can send emails.
+
+SendGrid allows you to authenticate your sender identity using one of the following methods:
+
+- [Single Sender Verification](https://docs.sendgrid.com/ui/sending-email/sender-verification) - This is the easiest way to authenticate your sender identity.
+- [Entire Domain Authentication](https://docs.sendgrid.com/ui/account-and-settings/how-to-set-up-domain-authentication) - This is recommended if you are sending emails from multiple accounts under your domain.
+
+## Create a SendGrid integration with Novu
+
+- Visit the [Integrations](https://web.novu.co/integrations) page on the Novu.
+- Locate SendGrid and click on the **Connect** button.
+- Enter your SendGrid API starting with `SG.`
+- Fill the `From email address` using the authenticated email from previous step.
+- Click on the **Save** button.
+- You should now be able to send notifications using SendGrid in Novu.

--- a/docs/docs/channels/push/_category_.json
+++ b/docs/docs/channels/push/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Push Notifications",
-  "position": 1
+  "position": 3
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds SendGrid documentation on how to get an API Key and authenticate sender

- **Why was this change needed?** (You can also link to an open issue here)
As part of our work on the documentation and in preparation for hacktoberfest

- **Other information**:
