### PR TITLE
feat(api): Inforce API key generation is unique

### DIFF
--- a/apps/api/src/app/environments/usecases/create-environment/create-environment.usecase.ts
+++ b/apps/api/src/app/environments/usecases/create-environment/create-environment.usecase.ts
@@ -1,20 +1,25 @@
 import { Injectable } from '@nestjs/common';
 import { EnvironmentRepository } from '@novu/dal';
-import * as hat from 'hat';
 import { nanoid } from 'nanoid';
+
+import { CreateEnvironmentCommand } from './create-environment.command';
+
+import { GenerateUniqueApiKey } from '../generate-unique-api-key/generate-unique-api-key.usecase';
 // eslint-disable-next-line max-len
 import { CreateNotificationGroupCommand } from '../../../notification-groups/usecases/create-notification-group/create-notification-group.command';
 import { CreateNotificationGroup } from '../../../notification-groups/usecases/create-notification-group/create-notification-group.usecase';
-import { CreateEnvironmentCommand } from './create-environment.command';
 
 @Injectable()
 export class CreateEnvironment {
   constructor(
     private environmentRepository: EnvironmentRepository,
-    private createNotificationGroup: CreateNotificationGroup
+    private createNotificationGroup: CreateNotificationGroup,
+    private generateUniqueApiKey: GenerateUniqueApiKey
   ) {}
 
   async execute(command: CreateEnvironmentCommand) {
+    const key = await this.generateUniqueApiKey.execute();
+
     const environment = await this.environmentRepository.create({
       _organizationId: command.organizationId,
       name: command.name,
@@ -22,7 +27,7 @@ export class CreateEnvironment {
       _parentId: command.parentEnvironmentId,
       apiKeys: [
         {
-          key: hat(),
+          key,
           _userId: command.userId,
         },
       ],

--- a/apps/api/src/app/environments/usecases/generate-unique-api-key/generate-unique-api-key.spec.ts
+++ b/apps/api/src/app/environments/usecases/generate-unique-api-key/generate-unique-api-key.spec.ts
@@ -1,0 +1,64 @@
+import { EnvironmentRepository } from '@novu/dal';
+import { InternalServerErrorException } from '@nestjs/common';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { GenerateUniqueApiKey } from './generate-unique-api-key.usecase';
+
+const environmentRepository = new EnvironmentRepository();
+const generateUniqueApiKey = new GenerateUniqueApiKey(environmentRepository);
+
+let generateApiKeyStub;
+let findByApiKeyStub;
+describe('Generate Unique Api Key', () => {
+  beforeEach(() => {
+    findByApiKeyStub = sinon.stub(environmentRepository, 'findByApiKey');
+    generateApiKeyStub = sinon.stub(generateUniqueApiKey, 'generateApiKey' as any);
+  });
+
+  afterEach(() => {
+    findByApiKeyStub.restore();
+    generateApiKeyStub.restore();
+  });
+
+  it('should generate an API key for the environment without any clashing', async () => {
+    const expectedApiKey = 'expected-api-key';
+    generateApiKeyStub.onFirstCall().returns(expectedApiKey);
+
+    const apiKey = await generateUniqueApiKey.execute();
+
+    expect(typeof apiKey).to.be.string;
+    expect(apiKey).to.be.equal(expectedApiKey);
+  });
+
+  it('should generate a different valid API key after first one clashes with an existing one', async () => {
+    const clashingApiKey = 'clashing-api-key';
+    const expectedApiKey = 'expected-api-key';
+    generateApiKeyStub.onFirstCall().returns(clashingApiKey);
+    generateApiKeyStub.onSecondCall().returns(expectedApiKey);
+    findByApiKeyStub.onFirstCall().returns({ key: clashingApiKey });
+    findByApiKeyStub.onSecondCall().returns(undefined);
+
+    const apiKey = await generateUniqueApiKey.execute();
+    expect(typeof apiKey).to.be.string;
+    expect(apiKey).to.be.equal(expectedApiKey);
+  });
+
+  it('should throw an error if the generation clashes 3 times', async () => {
+    const clashingApiKey = 'clashing-api-key';
+    generateApiKeyStub.onFirstCall().returns(clashingApiKey);
+    generateApiKeyStub.onSecondCall().returns(clashingApiKey);
+    generateApiKeyStub.onThirdCall().returns(clashingApiKey);
+    findByApiKeyStub.onFirstCall().returns({ key: clashingApiKey });
+    findByApiKeyStub.onSecondCall().returns({ key: clashingApiKey });
+    findByApiKeyStub.onThirdCall().returns({ key: clashingApiKey });
+
+    try {
+      await generateUniqueApiKey.execute();
+      throw new Error('Should not reach here');
+    } catch (e) {
+      expect(e).to.be.instanceOf(InternalServerErrorException);
+      expect(e.message).to.eql('Clashing of the API key generation');
+    }
+  });
+});

--- a/apps/api/src/app/environments/usecases/generate-unique-api-key/generate-unique-api-key.usecase.ts
+++ b/apps/api/src/app/environments/usecases/generate-unique-api-key/generate-unique-api-key.usecase.ts
@@ -1,0 +1,39 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { EnvironmentRepository } from '@novu/dal';
+import * as hat from 'hat';
+
+const API_KEY_GENERATION_MAX_RETRIES = 3;
+
+@Injectable()
+export class GenerateUniqueApiKey {
+  constructor(private environmentRepository: EnvironmentRepository) {}
+
+  async execute(): Promise<string> {
+    let apiKey: string;
+    let count = 0;
+    let isApiKeyUsed = true;
+    while (isApiKeyUsed) {
+      apiKey = this.generateApiKey();
+      const environment = await this.environmentRepository.findByApiKey(apiKey);
+      isApiKeyUsed = environment ? true : false;
+      count += 1;
+
+      if (count === API_KEY_GENERATION_MAX_RETRIES) {
+        const errorMessage = 'Clashing of the API key generation';
+        throw new InternalServerErrorException(new Error(errorMessage), errorMessage);
+      }
+    }
+
+    return apiKey;
+  }
+
+  /**
+   * Extracting the generation functionality so it can be stubbed for functional testing
+   *
+   * @requires hat
+   * @todo Dependency is no longer accessible to source code due of removal from Github. Consider look for an alternative.
+   */
+  private generateApiKey(): string {
+    return hat();
+  }
+}

--- a/apps/api/src/app/environments/usecases/index.ts
+++ b/apps/api/src/app/environments/usecases/index.ts
@@ -1,4 +1,5 @@
 import { CreateEnvironment } from './create-environment/create-environment.usecase';
+import { GenerateUniqueApiKey } from './generate-unique-api-key/generate-unique-api-key.usecase';
 import { GetApiKeys } from './get-api-keys/get-api-keys.usecase';
 import { GetEnvironment } from './get-environment';
 import { GetMyEnvironments } from './get-my-environments/get-my-environments.usecase';
@@ -7,6 +8,7 @@ import { UpdateWidgetSettings } from './update-widget-settings/update-widget-set
 export const USE_CASES = [
   //
   CreateEnvironment,
+  GenerateUniqueApiKey,
   GetApiKeys,
   GetEnvironment,
   GetMyEnvironments,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
We should create UUID with hat and then validate it against the database to avoid collisions. 

- **Why this change was needed?** (You can also link to an open issue here)
Right now we are using hat to randomly generate API Keys, there is a chance of collision when generated.

- **Other information**:
N/A