### PR TITLE
feat: add invite link

### DIFF
--- a/apps/web/src/components/invites/MembersTable.tsx
+++ b/apps/web/src/components/invites/MembersTable.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import * as capitalize from 'lodash.capitalize';
 import useStyles from '../../design-system/config/text.styles';
 import { MemberRole } from './MemberRole';
+import { When } from '../utils/When';
+import { useClipboard } from '@mantine/hooks';
 
 export function MembersTable({
   members,
@@ -16,6 +18,7 @@ export function MembersTable({
   onChangeMemberRole,
 }) {
   const { classes, theme } = useStyles();
+  const clipboardInviteLink = useClipboard({ timeout: 1000 });
 
   function isEnableMemberActions(currentMember): boolean {
     const currentUserRoles = members?.find((memberEntity) => memberEntity._userId == currentUser?._id)?.roles || [];
@@ -26,8 +29,13 @@ export function MembersTable({
     return isNotMyself && isAllowedToRemove;
   }
 
-  function canResendInvite(currentMember): boolean {
-    return currentMember && currentMember.memberStatus === MemberStatusEnum.INVITED;
+  function memberInvited(currentMember): boolean {
+    return currentMember?.memberStatus === MemberStatusEnum.INVITED;
+  }
+
+  function onCopyInviteLinkClick(currentMemberToken: any): void {
+    const inviteLink = `${window.location.origin.toString()}/auth/invitation/${currentMemberToken}`;
+    clipboardInviteLink.copy(inviteLink);
   }
 
   return (
@@ -83,7 +91,16 @@ export function MembersTable({
                   >
                     Remove Member
                   </DropdownItem>
-                  {canResendInvite(member) ? (
+                  <When truthy={memberInvited(member)}>
+                    <DropdownItem
+                      key="resendInviteBtn"
+                      data-test-id="resend-invite-btn"
+                      onClick={() => onCopyInviteLinkClick(member.invite.token)}
+                      icon={<Mail />}
+                    >
+                      Copy Invite Link
+                    </DropdownItem>
+
                     <DropdownItem
                       key="resendInviteBtn"
                       data-test-id="resend-invite-btn"
@@ -92,7 +109,7 @@ export function MembersTable({
                     >
                       Resend Invite
                     </DropdownItem>
-                  ) : null}
+                  </When>
                 </Dropdown>
               </div>
             ) : null}

--- a/apps/web/src/components/invites/MembersTable.tsx
+++ b/apps/web/src/components/invites/MembersTable.tsx
@@ -19,6 +19,7 @@ export function MembersTable({
 }) {
   const { classes, theme } = useStyles();
   const clipboardInviteLink = useClipboard({ timeout: 1000 });
+  const selfHosted = process.env.REACT_APP_DOCKER_HOSTED_ENV === 'true';
 
   function isEnableMemberActions(currentMember): boolean {
     const currentUserRoles = members?.find((memberEntity) => memberEntity._userId == currentUser?._id)?.roles || [];
@@ -74,7 +75,7 @@ export function MembersTable({
                 />
               </div>
             </ActionsSider>
-            {isEnableMemberActions(member) ? (
+            <When truthy={isEnableMemberActions(member)}>
               <div>
                 <Dropdown
                   control={
@@ -93,27 +94,28 @@ export function MembersTable({
                   </DropdownItem>
                   <When truthy={memberInvited(member)}>
                     <DropdownItem
-                      key="resendInviteBtn"
-                      data-test-id="resend-invite-btn"
+                      key="copyInviteBtn"
+                      data-test-id="copy-invite-btn"
                       onClick={() => onCopyInviteLinkClick(member.invite.token)}
                       icon={<Mail />}
                     >
                       Copy Invite Link
                     </DropdownItem>
 
-                    <DropdownItem
-                      key="resendInviteBtn"
-                      data-test-id="resend-invite-btn"
-                      onClick={() => onResendInviteMember(member)}
-                      icon={<Mail />}
-                    >
-                      Resend Invite
-                    </DropdownItem>
+                    <When truthy={!selfHosted}>
+                      <DropdownItem
+                        key="resendInviteBtn"
+                        data-test-id="resend-invite-btn"
+                        onClick={() => onResendInviteMember(member)}
+                        icon={<Mail />}
+                      >
+                        Resend Invite
+                      </DropdownItem>
+                    </When>
                   </When>
                 </Dropdown>
               </div>
-            ) : null}
-
+            </When>
             <Divider className={classes.seperator} />
           </MemberRowWrapper>
         );
@@ -121,11 +123,6 @@ export function MembersTable({
     </Container>
   );
 }
-
-const AddMemberRow = styled.div`
-  margin-top: 30px;
-`;
-
 const ActionsSider = styled.div`
   margin-left: auto;
 `;

--- a/apps/web/src/pages/invites/MembersInvitePage.tsx
+++ b/apps/web/src/pages/invites/MembersInvitePage.tsx
@@ -62,8 +62,17 @@ export function MembersInvitePage() {
       setInvitedMember(email);
     }
 
-    await sendInvite(email);
-    await refetch();
+    try {
+      await sendInvite(email);
+      await refetch();
+    } catch (e: any) {
+      if (e?.message === 'Already invited') {
+        showNotification({
+          message: `User with email: ${email} is already invited`,
+          color: 'red',
+        });
+      } else throw e;
+    }
 
     if (!selfHosted) {
       showNotification({


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added an option to copy the order link for the path for users that run the service on self-hosted docker mode

- **Why this change was needed?** (You can also link to an open issue here)
Due to this reason, the application sends emails invite, while hosting it on docker self-hosted the ability to send emails is missing.

- **Other information**:

Before
![image](https://user-images.githubusercontent.com/39195835/192771985-dae8f5fd-d709-4484-8118-8a264de93f86.png)


After
![image](https://user-images.githubusercontent.com/39195835/192771859-63e6aeb4-0ff1-4020-8422-b02c8acdc37d.png)

