### PR TITLE
Changed the Contribution Guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Just <a href="https://discord.gg/novu">Join Our Discord</a> server and ask for h
 ## 🔗 Links
 
 - [Home page](https://novu.co/)
-- [Contribution Guidelines](https://github.com/AmanNegi/novu/blob/main/CONTRIBUTING.md)
+- [Contribution Guidelines](https://github.com/novuhq/novu/blob/main/CONTRIBUTING.md)
 - [Run Novu Locally](https://docs.novu.co/community/run-locally)
 
 ## 🛡️ License


### PR DESCRIPTION
The "Contribution Guidelines" link pointed to a CONTRIBUTING.md file in a forked repository. After the change, it points to the CONTRIBUTING.md file of novuhq/novu.
Issue Reference: https://github.com/novuhq/novu/issues/1313 

