### PR TITLE
docs: add gitpod quick open

### DIFF
--- a/docs/docs/community/run-locally.md
+++ b/docs/docs/community/run-locally.md
@@ -4,6 +4,10 @@ sidebar_position: 1
 
 # Run Novu locally
 
+## ⚡ Immediate working space with GitPod
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/novuhq/novu)
+
 ## Requirements
 
 - Node.js version v16.15.1


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs: Adds a GitPod link to the documentation

- **Why this change was needed?** (You can also link to an open issue here)

We have a .gitpod.yml file and a complete gitpod configuration for running Novu, then why do we not have it on the running locally page for people who want to get it running quick?

- **Other information**:
