### PR TITLE
Updated the API Key insertion step for SendGrid.

### DIFF
--- a/docs/docs/channels/email/sendgrid.md
+++ b/docs/docs/channels/email/sendgrid.md
@@ -27,7 +27,7 @@ SendGrid allows you to authenticate your sender identity using one of the follow
 
 - Visit the [Integrations](https://web.novu.co/integrations) page on the Novu.
 - Locate SendGrid and click on the **Connect** button.
-- Enter your SendGrid API starting with `SG.`
+- Enter your SendGrid API Key.
 - Fill the `From email address` using the authenticated email from the previous step.
 - Click on the **Save** button.
 - You should now be able to send notifications using SendGrid in Novu.


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs Update
- **Why this change was needed?** (You can also link to an open issue here)
Cause a little misconception on how the API Key should be added.
- **Other information**:
SendGrid by default adds 'SG.' to their API key. So mentioning that we add "SG." might develop a misconception of adding other prefixes for other Email providers. 