### PR TITLE
fix: close button acts as submit button

### DIFF
--- a/apps/web/src/pages/integrations/components/ConnectIntegrationForm.tsx
+++ b/apps/web/src/pages/integrations/components/ConnectIntegrationForm.tsx
@@ -181,7 +181,7 @@ export function ConnectIntegrationForm({
 
   return (
     <Form onSubmit={handleSubmit(onCreatIntegration)}>
-      <CloseButton onClick={onClose}>
+      <CloseButton type="button" onClick={onClose}>
         <Close />
       </CloseButton>
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR includes a small change to the ConnectIntegrationForm to prevent the Close button from acting as submit button.

- **Why this change was needed?** (You can also link to an open issue here)

Prior to this change, closing one of the Integration forms using the close button in the top right corner of the modal will submit the form. This isn't as problematic in case of validation errors (although those still show for a split second prior to the modal closing) but fairly annoying when trying to close out of a form without field (like the Slack or Discord integration) which are enabled when just trying to close out the form.

- **Other information**:

\-