### PR TITLE
fix: so message identifier is saved from send method

### DIFF
--- a/apps/api/src/app/events/usecases/send-message/send-message-sms.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message-sms.usecase.ts
@@ -182,12 +182,26 @@ export class SendMessageSms extends SendMessageType {
     try {
       const smsHandler = this.smsFactory.getHandler(integration);
 
-      await smsHandler.send({
+      const result = await smsHandler.send({
         to: phone,
         from: integration.credentials.from,
         content,
         attachments: null,
+        id: message._id,
       });
+      if (!result.id) {
+        return;
+      }
+      await this.messageRepository.update(
+        {
+          _id: message._id,
+        },
+        {
+          $set: {
+            identifier: result.id,
+          },
+        }
+      );
     } catch (e) {
       await this.sendErrorStatus(
         message,

--- a/packages/stateless/src/lib/provider/provider.interface.ts
+++ b/packages/stateless/src/lib/provider/provider.interface.ts
@@ -24,6 +24,7 @@ export interface ISmsOptions {
   content: string;
   from?: string;
   attachments?: IAttachmentOptions[];
+  id?: string;
 }
 export interface IPushOptions {
   target: string[];


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add so identifier are saved for sms messages.
- **Why this change was needed?** (You can also link to an open issue here)
To be able to use sms webhooks
