### PR TITLE
fix: so subscriber is used to filter activity feed

### DIFF
--- a/apps/api/src/app/activity/usecases/get-activity-feed/get-activity-feed.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-activity-feed/get-activity-feed.usecase.ts
@@ -1,21 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import {
-  MessageEntity,
-  MessageRepository,
-  NotificationEntity,
-  NotificationRepository,
-  SubscriberRepository,
-} from '@novu/dal';
+import { MessageRepository, SubscriberRepository } from '@novu/dal';
 import { ActivitiesResponseDto } from '../../dtos/activities-response.dto';
 import { GetActivityFeedCommand } from './get-activity-feed.command';
 
 @Injectable()
 export class GetActivityFeed {
-  constructor(
-    private notificationRepository: NotificationRepository,
-    private messageRepository: MessageRepository,
-    private subscribersRepository: SubscriberRepository
-  ) {}
+  constructor(private messageRepository: MessageRepository, private subscribersRepository: SubscriberRepository) {}
 
   async execute(command: GetActivityFeedCommand): Promise<ActivitiesResponseDto> {
     const LIMIT = 10;
@@ -38,7 +28,7 @@ export class GetActivityFeed {
 
     const { data: messages, totalCount } = await this.messageRepository.getFeed(
       command.environmentId,
-      { channels: command.channels, templates: command.templates, emails: command.emails },
+      { channels: command.channels, templates: command.templates, emails: command.emails, subscriberId },
       command.page * LIMIT,
       LIMIT
     );


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
So activity feed is filtered by subscriber as well
- **Why this change was needed?** (You can also link to an open issue here)
Because today it is not possible to filter on subscriber

