### PR TITLE
fix: take into account credentials.senderName in sendgrid provider

### DIFF
--- a/apps/api/src/app/events/services/mail-service/handlers/sendgrid.handler.ts
+++ b/apps/api/src/app/events/services/mail-service/handlers/sendgrid.handler.ts
@@ -8,7 +8,11 @@ export class SendgridHandler extends BaseHandler {
   }
 
   buildProvider(credentials, from?: string) {
-    const config: { apiKey: string; from: string } = { apiKey: credentials.apiKey, from };
+    const config: { apiKey: string; from: string; senderName: string } = {
+      apiKey: credentials.apiKey,
+      from,
+      senderName: credentials.senderName,
+    };
 
     this.provider = new SendgridEmailProvider(config);
   }

--- a/packages/application-generic/src/factories/mail/handlers/sendgrid.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/sendgrid.handler.ts
@@ -8,9 +8,10 @@ export class SendgridHandler extends BaseHandler {
   }
 
   buildProvider(credentials, from?: string) {
-    const config: { apiKey: string; from: string } = {
+    const config: { apiKey: string; from: string; senderName: string } = {
       apiKey: credentials.apiKey,
       from,
+      senderName: credentials.senderName,
     };
 
     this.provider = new SendgridEmailProvider(config);

--- a/providers/sendgrid/src/lib/sendgrid.provider.spec.ts
+++ b/providers/sendgrid/src/lib/sendgrid.provider.spec.ts
@@ -4,6 +4,7 @@ import { SendgridEmailProvider } from './sendgrid.provider';
 const mockConfig = {
   apiKey: 'SG.1234',
   from: 'test@tet.com',
+  senderName: 'test',
 };
 
 const mockNovuMessage = {

--- a/providers/sendgrid/src/lib/sendgrid.provider.spec.ts
+++ b/providers/sendgrid/src/lib/sendgrid.provider.spec.ts
@@ -33,7 +33,7 @@ test('should trigger sendgrid correctly', async () => {
     to: mockNovuMessage.to,
     subject: mockNovuMessage.subject,
     html: mockNovuMessage.html,
-    from: mockNovuMessage.from,
+    from: { email: mockNovuMessage.from, name: mockConfig.senderName },
     substitutions: {},
     attachments: [
       {
@@ -42,6 +42,9 @@ test('should trigger sendgrid correctly', async () => {
         filename: 'test.txt',
       },
     ],
+    customArgs: {
+      id: undefined,
+    },
   });
 });
 

--- a/providers/sendgrid/src/lib/sendgrid.provider.ts
+++ b/providers/sendgrid/src/lib/sendgrid.provider.ts
@@ -20,6 +20,7 @@ export class SendgridEmailProvider implements IEmailProvider {
     private config: {
       apiKey: string;
       from: string;
+      senderName: string;
     }
   ) {
     this.sendgridMail = new MailService();
@@ -64,7 +65,10 @@ export class SendgridEmailProvider implements IEmailProvider {
 
   private createMailData(options: IEmailOptions) {
     return {
-      from: options.from || this.config.from,
+      from: {
+        email: options.from || this.config.from,
+        name: this.config.senderName,
+      },
       to: options.to,
       html: options.html,
       subject: options.subject,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Includes the sendgrid credentials.senderName in the provider so it's actually shown, right now it's ignored.

- **Why this change was needed?** (You can also link to an open issue here)

https://github.com/novuhq/novu/issues/1417

- **Other information**:
