### PR TITLE
feat: added subject variables to variable manager

### DIFF
--- a/apps/web/src/components/templates/email-editor/EmailContentCard.tsx
+++ b/apps/web/src/components/templates/email-editor/EmailContentCard.tsx
@@ -101,7 +101,7 @@ export function EmailContentCard({
       <div data-test-id="editor-type-selector">
         <Tabs active={activeTab} onTabChange={onTabChange} menuTabs={menuTabs} />
       </div>
-      <VariableManager index={index} contents={['content', 'htmlContent']} />
+      <VariableManager index={index} contents={['content', 'htmlContent', 'subject']} />
     </>
   );
 }


### PR DESCRIPTION
As stated in issue #1396, variables added in the message are recognized but variables added in the subject are not. So to fix this I went through the code understanding what was happening and found out that we just needed to add a subject string to the contents prop in component VariableManager. I hope it works as I was unable to run the website on my system due to some problem after spending a lot of my time figuring it out.

#1396

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
subject variables to variable manager
- **Why this change was needed?** (You can also link to an open issue here)
issue #1396
- **Other information**:
