### PR TITLE
i18n - Fix spanish translation

### DIFF
--- a/packages/notification-center/src/i18n/languages/es.ts
+++ b/packages/notification-center/src/i18n/languages/es.ts
@@ -5,6 +5,7 @@ export const ES: ITranslationEntry = {
     notifications: 'Notificaciones',
     markAllAsRead: 'marcar todo como leido',
     poweredBy: 'Con tecnología de',
+    settings: 'Configuración',
   },
   lang: 'es',
 };

--- a/packages/notification-center/src/i18n/languages/es.ts
+++ b/packages/notification-center/src/i18n/languages/es.ts
@@ -3,7 +3,7 @@ import { ITranslationEntry } from '../lang';
 export const ES: ITranslationEntry = {
   translations: {
     notifications: 'Notificaciones',
-    markAllAsRead: 'marcar todo como leido',
+    markAllAsRead: 'marcar todo como leído',
     poweredBy: 'Con tecnología de',
     settings: 'Configuración',
   },

--- a/packages/notification-center/src/i18n/languages/es.ts
+++ b/packages/notification-center/src/i18n/languages/es.ts
@@ -4,7 +4,7 @@ export const ES: ITranslationEntry = {
   translations: {
     notifications: 'Notificaciones',
     markAllAsRead: 'marcar todo como leido',
-    poweredBy: 'Energizado por',
+    poweredBy: 'Con tecnología de',
   },
   lang: 'es',
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It's a fix for a Spanish translation. It seems that `poweredBy` label it was machine translated, and it was not natural in Spanish.

- **Why this change was needed?** (You can also link to an open issue here)
To have a more precise translation in Spanish.