### PR TITLE
Updated i18-Gujarati Support with appropriate language code

### DIFF
--- a/docs/docs/notification-center/react-components.md
+++ b/docs/docs/notification-center/react-components.md
@@ -176,7 +176,7 @@ The `i18n` prop can accept 2 different types of values
           <li><code>fa</code> (Farsi)</li>
           <li><code>fi</code> (Finnish)</li>
           <li><code>fr</code> (French)</li>
-          <li><code>gj</code> (Georgian)</li>
+          <li><code>gu</code> (Gujarati)</li>
           <li><code>hi</code> (Hindi)</li>
           <li><code>it</code> (Italian)</li>
           <li><code>ka</code> (Kannada)</li>

--- a/packages/notification-center/src/i18n/lang.ts
+++ b/packages/notification-center/src/i18n/lang.ts
@@ -9,7 +9,7 @@ import { UK } from './languages/uk';
 import { ES } from './languages/es';
 import { FA } from './languages/fa';
 import { AR } from './languages/ar';
-import { GJ } from './languages/gj';
+import { GU } from './languages/gu';
 import { DE } from './languages/de';
 import { BN } from './languages/bn';
 import { ML } from './languages/ml';
@@ -40,7 +40,7 @@ export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
   fi: FI,
   hi: HI,
   fr: FR,
-  gj: GJ,
+  gu: GU,
   ru: RU,
   es: ES,
   it: IT,
@@ -79,7 +79,7 @@ export type I18NLanguage =
   | 'hi'
   | 'it'
   | 'ka'
-  | 'gj'
+  | 'gu'
   | 'ru'
   | 'uk'
   | 'es'

--- a/packages/notification-center/src/i18n/languages/gu.ts
+++ b/packages/notification-center/src/i18n/languages/gu.ts
@@ -1,10 +1,10 @@
 import { ITranslationEntry } from '../lang';
 
-export const GJ: ITranslationEntry = {
+export const GU: ITranslationEntry = {
   translations: {
     notifications: 'સૂચના',
     markAllAsRead: 'બધાને વાંચેલા તરીકે ચિહ્નિત કરો',
     poweredBy: 'દ્વારા સંચાલિત',
   },
-  lang: 'gj',
+  lang: 'gu',
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This pr updates i18-Gujarati Support with it's appropriate language code and fixed typo where "Gujarati" was referred to "Georgian"
- **Why this change was needed?** (You can also link to an open issue here)
Language codes should be correct
- **Other information**:
