### PR TITLE
Add navigation to Settings in command palette

### DIFF
--- a/apps/web/src/components/utils/Spotlight.tsx
+++ b/apps/web/src/components/utils/Spotlight.tsx
@@ -1,7 +1,7 @@
 import { SpotlightProvider } from '@mantine/spotlight';
 import { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Bolt } from '../../design-system/icons';
+import { Bolt, Settings } from '../../design-system/icons';
 import { SpotlightContext } from '../../store/spotlightContext';
 
 export const SpotLight = ({ children }) => {
@@ -15,6 +15,12 @@ export const SpotLight = ({ children }) => {
         title: 'Go to Notification Template',
         onTrigger: () => navigate('/templates'),
         icon: <Bolt />,
+      },
+      {
+        id: 'navigate-settings',
+        title: 'Go to Settings',
+        onTrigger: () => navigate('/settings'),
+        icon: <Settings />,
       },
       {
         id: 'navigate-docs',


### PR DESCRIPTION


Introduces ability to navigate to settings in command palette

fixes #1461

What kind of change does this PR introduce?
Feature: Add new navigation to settings as described in [NV-935]

Why was this change needed? To fix #1461
