### PR TITLE
feat: add endpoint for execution details

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -25,6 +25,7 @@ import { ChangeModule } from './app/change/change.module';
 import { SubscribersModule } from './app/subscribers/subscribers.module';
 import { FeedsModule } from './app/feeds/feeds.module';
 import { MessagesModule } from './app/messages/messages.module';
+import { ExecutionDetailsModule } from './app/execution-details/execution-details.module';
 
 const modules: Array<Type | DynamicModule | Promise<DynamicModule> | ForwardReference> = [
   OrganizationModule,
@@ -47,6 +48,7 @@ const modules: Array<Type | DynamicModule | Promise<DynamicModule> | ForwardRefe
   SubscribersModule,
   FeedsModule,
   MessagesModule,
+  ExecutionDetailsModule,
 ];
 
 const providers = [];

--- a/apps/api/src/app/execution-details/dtos/execution-details-response.dto.ts
+++ b/apps/api/src/app/execution-details/dtos/execution-details-response.dto.ts
@@ -1,0 +1,65 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/dal';
+import { ChannelTypeEnum } from '@novu/shared';
+
+export class ExecutionDetailsResponseDto {
+  @ApiPropertyOptional()
+  _id?: string;
+
+  @ApiProperty()
+  _organizationId: string;
+
+  @ApiProperty()
+  _jobId: string;
+
+  @ApiProperty()
+  _environmentId: string;
+
+  @ApiProperty()
+  _notificationId: string;
+
+  @ApiProperty()
+  _notificationTemplateId: string;
+
+  @ApiProperty()
+  _subscriberId: string;
+
+  @ApiPropertyOptional()
+  _messageId?: string;
+
+  @ApiProperty()
+  providerId: string;
+
+  @ApiProperty()
+  transactionId: string;
+
+  @ApiProperty({
+    enum: ChannelTypeEnum,
+  })
+  channel: ChannelTypeEnum;
+
+  @ApiProperty()
+  detail: string;
+  @ApiProperty({
+    enum: ExecutionDetailsSourceEnum,
+  })
+  source: ExecutionDetailsSourceEnum;
+
+  @ApiProperty({
+    enum: ExecutionDetailsStatusEnum,
+  })
+  status: ExecutionDetailsStatusEnum;
+
+  @ApiProperty({
+    type: Boolean,
+  })
+  isTest: boolean;
+
+  @ApiProperty({
+    type: Boolean,
+  })
+  isRetry: boolean;
+
+  @ApiPropertyOptional()
+  createdAt?: string;
+}

--- a/apps/api/src/app/execution-details/e2e/get-execution-details.e2e.ts
+++ b/apps/api/src/app/execution-details/e2e/get-execution-details.e2e.ts
@@ -1,0 +1,49 @@
+import { ExecutionDetailsRepository, ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/dal';
+import { ChannelTypeEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import axios from 'axios';
+import { expect } from 'chai';
+
+const axiosInstance = axios.create();
+
+describe('Execution details - Get execution details by notification id - /v1/execution-details/notification/:notificationId (GET)', function () {
+  let session: UserSession;
+  const executionDetailsRepository: ExecutionDetailsRepository = new ExecutionDetailsRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  it('should get execution details', async function () {
+    const notificationId = ExecutionDetailsRepository.createObjectId();
+    const detail = await executionDetailsRepository.create({
+      _jobId: ExecutionDetailsRepository.createObjectId(),
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      _notificationId: notificationId,
+      _notificationTemplateId: ExecutionDetailsRepository.createObjectId(),
+      _subscriberId: session.subscriberId,
+      providerId: '',
+      transactionId: 'transactionId',
+      channel: ChannelTypeEnum.EMAIL,
+      detail: '',
+      source: ExecutionDetailsSourceEnum.INTERNAL,
+      status: ExecutionDetailsStatusEnum.SUCCESS,
+      isTest: false,
+      isRetry: false,
+    });
+
+    const {
+      data: { data },
+    } = await axiosInstance.get(`${session.serverUrl}/v1/execution-details/notification/${notificationId}`, {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    });
+    const responseDetail = data[0];
+    expect(responseDetail._notificationId).to.equal(notificationId);
+    expect(responseDetail.channel).to.equal(detail.channel);
+    expect(responseDetail._id).to.equal(detail._id);
+  });
+});

--- a/apps/api/src/app/execution-details/execution-details.controller.ts
+++ b/apps/api/src/app/execution-details/execution-details.controller.ts
@@ -1,0 +1,39 @@
+import { ClassSerializerInterceptor, Controller, Get, Param, UseGuards, UseInterceptors } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiOkResponse } from '@nestjs/swagger';
+import { IJwtPayload } from '@novu/shared';
+import { UserSession } from '../shared/framework/user.decorator';
+import { JwtAuthGuard } from '../auth/framework/auth.guard';
+import { ExternalApiAccessible } from '../auth/framework/external-api.decorator';
+import { GetExecutionDetails } from './usecases/get-execution-details/get-execution-details.usecase';
+import { GetExecutionDetailsCommand } from './usecases/get-execution-details/get-execution-details.command';
+import { ExecutionDetailsResponseDto } from './dtos/execution-details-response.dto';
+
+@Controller('/execution-details')
+@UseInterceptors(ClassSerializerInterceptor)
+@UseGuards(JwtAuthGuard)
+@ApiTags('Execution Details')
+export class ExecutionDetailsController {
+  constructor(private getExecutionDetails: GetExecutionDetails) {}
+
+  @Get('/notification/:notificationId')
+  @ApiOperation({
+    summary: 'Get execution details',
+  })
+  @ApiOkResponse({
+    type: [ExecutionDetailsResponseDto],
+  })
+  @ExternalApiAccessible()
+  async getExecutionDetailsForNotification(
+    @UserSession() user: IJwtPayload,
+    @Param('notificationId') notificationId: string
+  ): Promise<ExecutionDetailsResponseDto[]> {
+    return this.getExecutionDetails.execute(
+      GetExecutionDetailsCommand.create({
+        organizationId: user.organizationId,
+        environmentId: user.environmentId,
+        userId: user._id,
+        notificationId,
+      })
+    );
+  }
+}

--- a/apps/api/src/app/execution-details/execution-details.module.ts
+++ b/apps/api/src/app/execution-details/execution-details.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { USE_CASES } from './usecases';
+import { ExecutionDetailsController } from './execution-details.controller';
+import { SharedModule } from '../shared/shared.module';
+
+@Module({
+  imports: [SharedModule],
+  providers: [...USE_CASES],
+  exports: [...USE_CASES],
+  controllers: [ExecutionDetailsController],
+})
+export class ExecutionDetailsModule {}

--- a/apps/api/src/app/execution-details/execution-details.module.ts
+++ b/apps/api/src/app/execution-details/execution-details.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { USE_CASES } from './usecases';
 import { ExecutionDetailsController } from './execution-details.controller';
 import { SharedModule } from '../shared/shared.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SharedModule],
+  imports: [SharedModule, AuthModule],
   providers: [...USE_CASES],
   exports: [...USE_CASES],
   controllers: [ExecutionDetailsController],

--- a/apps/api/src/app/execution-details/usecases/get-execution-details/get-execution-details.command.ts
+++ b/apps/api/src/app/execution-details/usecases/get-execution-details/get-execution-details.command.ts
@@ -1,0 +1,7 @@
+import { EnvironmentWithUserCommand } from '@novu/application-generic';
+import { IsDefined } from 'class-validator';
+
+export class GetExecutionDetailsCommand extends EnvironmentWithUserCommand {
+  @IsDefined()
+  notificationId: string;
+}

--- a/apps/api/src/app/execution-details/usecases/get-execution-details/get-execution-details.usecase.ts
+++ b/apps/api/src/app/execution-details/usecases/get-execution-details/get-execution-details.usecase.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { ExecutionDetailsEntity, ExecutionDetailsRepository } from '@novu/dal';
+import { GetExecutionDetailsCommand } from './get-execution-details.command';
+
+@Injectable()
+export class GetExecutionDetails {
+  constructor(private executionDetailsRepository: ExecutionDetailsRepository) {}
+
+  async execute(command: GetExecutionDetailsCommand): Promise<ExecutionDetailsEntity[]> {
+    return this.executionDetailsRepository.find({
+      _notificationId: command.notificationId,
+      _environmentId: command.environmentId,
+      _organizationId: command.organizationId,
+    });
+  }
+}

--- a/apps/api/src/app/execution-details/usecases/index.ts
+++ b/apps/api/src/app/execution-details/usecases/index.ts
@@ -1,0 +1,3 @@
+import { GetExecutionDetails } from './get-execution-details/get-execution-details.usecase';
+
+export const USE_CASES = [GetExecutionDetails];

--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -17,6 +17,7 @@ import {
   JobRepository,
   FeedRepository,
   SubscriberPreferenceRepository,
+  ExecutionDetailsRepository,
 } from '@novu/dal';
 import { AnalyticsService } from './services/analytics/analytics.service';
 import { QueueService } from './services/queue';
@@ -44,6 +45,7 @@ const DAL_MODELS = [
   JobRepository,
   FeedRepository,
   SubscriberPreferenceRepository,
+  ExecutionDetailsRepository,
 ];
 
 function getStorageServiceClass() {

--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -86,6 +86,7 @@ export async function bootstrap(expressApp?): Promise<INestApplication> {
     .addTag('Environments')
     .addTag('Feeds')
     .addTag('Messages')
+    .addTag('Execution Details')
     .build();
   const document = SwaggerModule.createDocument(app, options);
 


### PR DESCRIPTION
To be able to get execution details for each notification we need an endpoint to get it from the frontend. This PR will create that endpoint in a new module and controller.
