### PR TITLE
fix: fixes markAllAsRead field to its correct translation

### DIFF
--- a/packages/notification-center/src/i18n/languages/or.ts
+++ b/packages/notification-center/src/i18n/languages/or.ts
@@ -3,7 +3,7 @@ import { ITranslationEntry } from '../lang';
 export const OR: ITranslationEntry = {
   translations: {
     notifications: 'ବିଜ୍ଞପ୍ତି',
-    markAllAsRead: 'ସମସ୍ତଙ୍କୁ ପଢ଼ିବା ପରି ଚିହ୍ନିତ କର',
+    markAllAsRead: 'ସମସ୍ତଙ୍କୁ ପଢ଼ିଥିବା ପରି ଚିହ୍ନିତ କର',
     poweredBy: 'ଦ୍ୱାରା ପରିଚାଳିତ',
     settings: 'ସେଟିଂ',
   },


### PR DESCRIPTION
Signed-off-by: Abhilipsa Sahoo <abhilipsasahoo03@gmail.com>

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix: fixes markAllAsRead field to its correct translation in Odia language. 

- **Why this change was needed?** (You can also link to an open issue here)
This change was needed to solve issue #1492 

