### PR TITLE
feat(api): create execution details use case

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { TestingModule } from './app/testing/testing.module';
 import { HealthModule } from './app/health/health.module';
 import { OrganizationModule } from './app/organization/organization.module';
 import { EnvironmentsModule } from './app/environments/environments.module';
+import { ExecutionDetailsModule } from './app/execution-details/execution-details.module';
 import { NotificationTemplateModule } from './app/notification-template/notification-template.module';
 import { EventsModule } from './app/events/events.module';
 import { WidgetsModule } from './app/widgets/widgets.module';
@@ -25,7 +26,6 @@ import { ChangeModule } from './app/change/change.module';
 import { SubscribersModule } from './app/subscribers/subscribers.module';
 import { FeedsModule } from './app/feeds/feeds.module';
 import { MessagesModule } from './app/messages/messages.module';
-import { ExecutionDetailsModule } from './app/execution-details/execution-details.module';
 
 const modules: Array<Type | DynamicModule | Promise<DynamicModule> | ForwardReference> = [
   OrganizationModule,
@@ -34,6 +34,7 @@ const modules: Array<Type | DynamicModule | Promise<DynamicModule> | ForwardRefe
   AuthModule,
   HealthModule,
   EnvironmentsModule,
+  ExecutionDetailsModule,
   NotificationTemplateModule,
   EventsModule,
   WidgetsModule,
@@ -48,7 +49,6 @@ const modules: Array<Type | DynamicModule | Promise<DynamicModule> | ForwardRefe
   SubscribersModule,
   FeedsModule,
   MessagesModule,
-  ExecutionDetailsModule,
 ];
 
 const providers = [];

--- a/apps/api/src/app/execution-details/dtos/execution-details-response.dto.ts
+++ b/apps/api/src/app/execution-details/dtos/execution-details-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/dal';
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
 import { ChannelTypeEnum } from '@novu/shared';
 
 export class ExecutionDetailsResponseDto {
@@ -40,6 +40,7 @@ export class ExecutionDetailsResponseDto {
 
   @ApiProperty()
   detail: string;
+
   @ApiProperty({
     enum: ExecutionDetailsSourceEnum,
   })

--- a/apps/api/src/app/execution-details/dtos/execution-details.dto.ts
+++ b/apps/api/src/app/execution-details/dtos/execution-details.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ExecutionDetailsEntity } from '@novu/dal';
+import * as mongoose from 'mongoose';
+
+import { CreateExecutionDetailsCommand } from '../usecases/create-execution-details/create-execution-details.command';
+
+export class CreateExecutionDetailsResponseDto {
+  @ApiProperty()
+  id: string;
+  @ApiProperty()
+  createdAt: string;
+}
+
+export const mapExecutionDetailsCommandToEntity = (command: CreateExecutionDetailsCommand): ExecutionDetailsEntity => {
+  const {
+    jobId: _jobId,
+    environmentId: _environmentId,
+    organizationId: _organizationId,
+    subscriberId: _subscriberId,
+    notificationId: _notificationId,
+    notificationTemplateId: _notificationTemplateId,
+    messageId: _messageId,
+    ...nonUnderscoredFields
+  } = command;
+
+  return {
+    _jobId,
+    _environmentId,
+    _organizationId,
+    _subscriberId,
+    _notificationId,
+    _notificationTemplateId,
+    _messageId,
+    ...nonUnderscoredFields,
+  };
+};

--- a/apps/api/src/app/execution-details/e2e/get-execution-details.e2e.ts
+++ b/apps/api/src/app/execution-details/e2e/get-execution-details.e2e.ts
@@ -1,5 +1,5 @@
-import { ExecutionDetailsRepository, ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/dal';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ExecutionDetailsRepository } from '@novu/dal';
+import { ChannelTypeEnum, ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import axios from 'axios';
 import { expect } from 'chai';

--- a/apps/api/src/app/execution-details/execution-details.module.ts
+++ b/apps/api/src/app/execution-details/execution-details.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
+
 import { USE_CASES } from './usecases';
 import { ExecutionDetailsController } from './execution-details.controller';
+
 import { SharedModule } from '../shared/shared.module';
 import { AuthModule } from '../auth/auth.module';
 

--- a/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.command.ts
+++ b/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.command.ts
@@ -1,0 +1,45 @@
+import { IsMongoId, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ChannelTypeEnum, ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
+import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
+
+export class CreateExecutionDetailsCommand extends EnvironmentWithSubscriber {
+  @IsNotEmpty()
+  jobId: string;
+
+  @IsNotEmpty()
+  notificationId: string;
+
+  @IsNotEmpty()
+  notificationTemplateId: string;
+
+  @IsOptional()
+  messageId: string;
+
+  @IsNotEmpty()
+  providerId: string;
+
+  @IsNotEmpty()
+  transactionId: string;
+
+  @IsNotEmpty()
+  channel: ChannelTypeEnum;
+
+  @IsNotEmpty()
+  detail: string;
+
+  @IsNotEmpty()
+  source: ExecutionDetailsSourceEnum;
+
+  @IsNotEmpty()
+  status: ExecutionDetailsStatusEnum;
+
+  @IsNotEmpty()
+  isTest: boolean;
+
+  @IsNotEmpty()
+  isRetry: boolean;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.spec.ts
+++ b/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.spec.ts
@@ -1,0 +1,53 @@
+import { Test } from '@nestjs/testing';
+import { UserSession } from '@novu/testing';
+import { ExecutionDetailsRepository } from '@novu/dal';
+import { ChannelTypeEnum, ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
+import { expect } from 'chai';
+
+import { CreateExecutionDetails } from './create-execution-details.usecase';
+import { CreateExecutionDetailsCommand } from './create-execution-details.command';
+
+import { SharedModule } from '../../../shared/shared.module';
+import { ExecutionDetailsModule } from '../../execution-details.module';
+
+describe('Create Execution Details', function () {
+  let useCase: CreateExecutionDetails;
+  let session: UserSession;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SharedModule, ExecutionDetailsModule],
+      providers: [],
+    }).compile();
+
+    session = new UserSession();
+    await session.initialize();
+
+    useCase = moduleRef.get<CreateExecutionDetails>(CreateExecutionDetails);
+  });
+
+  it('should create the execution details for a job of a notification', async function () {
+    const command = CreateExecutionDetailsCommand.create({
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      subscriberId: session.subscriberId,
+      jobId: ExecutionDetailsRepository.createObjectId(),
+      notificationId: ExecutionDetailsRepository.createObjectId(),
+      notificationTemplateId: ExecutionDetailsRepository.createObjectId(),
+      messageId: ExecutionDetailsRepository.createObjectId(),
+      providerId: 'test-provider-id',
+      transactionId: 'test-transaction-id',
+      channel: ChannelTypeEnum.SMS,
+      detail: 'test',
+      source: ExecutionDetailsSourceEnum.WEBHOOK,
+      status: ExecutionDetailsStatusEnum.SUCCESS,
+      isTest: false,
+      isRetry: false,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result).to.ownProperty('id');
+    expect(result).to.ownProperty('createdAt');
+  });
+});

--- a/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.usecase.ts
+++ b/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.usecase.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { ExecutionDetailsRepository } from '@novu/dal';
+import {
+  CreateExecutionDetailsResponseDto,
+  mapExecutionDetailsCommandToEntity,
+} from '../../dtos/execution-details.dto';
+import { CreateExecutionDetailsCommand } from './create-execution-details.command';
+
+@Injectable()
+export class CreateExecutionDetails {
+  constructor(private executionDetailsRepository: ExecutionDetailsRepository) {}
+
+  async execute(command: CreateExecutionDetailsCommand): Promise<CreateExecutionDetailsResponseDto> {
+    // TODO: Which checks to do? If the notification and job belong to the environment and organization provided?
+    const entity = mapExecutionDetailsCommandToEntity(command);
+    const { _id, createdAt } = await this.executionDetailsRepository.create(entity);
+
+    /**
+     * Response for a HTTP 201
+     * TODO: Provide more data for a HTTP 200. Discuss which one choose.
+     */
+    return {
+      id: _id,
+      createdAt,
+    };
+  }
+}

--- a/apps/api/src/app/execution-details/usecases/index.ts
+++ b/apps/api/src/app/execution-details/usecases/index.ts
@@ -1,3 +1,4 @@
+import { CreateExecutionDetails } from './create-execution-details/create-execution-details.usecase';
 import { GetExecutionDetails } from './get-execution-details/get-execution-details.usecase';
 
-export const USE_CASES = [GetExecutionDetails];
+export const USE_CASES = [CreateExecutionDetails, GetExecutionDetails];

--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -4,6 +4,7 @@ import {
   UserRepository,
   OrganizationRepository,
   EnvironmentRepository,
+  ExecutionDetailsRepository,
   NotificationTemplateRepository,
   SubscriberRepository,
   NotificationRepository,
@@ -17,7 +18,6 @@ import {
   JobRepository,
   FeedRepository,
   SubscriberPreferenceRepository,
-  ExecutionDetailsRepository,
 } from '@novu/dal';
 import { AnalyticsService } from './services/analytics/analytics.service';
 import { QueueService } from './services/queue';
@@ -32,6 +32,7 @@ const DAL_MODELS = [
   UserRepository,
   OrganizationRepository,
   EnvironmentRepository,
+  ExecutionDetailsRepository,
   NotificationTemplateRepository,
   SubscriberRepository,
   NotificationRepository,
@@ -45,7 +46,6 @@ const DAL_MODELS = [
   JobRepository,
   FeedRepository,
   SubscriberPreferenceRepository,
-  ExecutionDetailsRepository,
 ];
 
 function getStorageServiceClass() {

--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -84,6 +84,7 @@ export async function bootstrap(expressApp?): Promise<INestApplication> {
     .addTag('Notification groups')
     .addTag('Changes')
     .addTag('Environments')
+    .addTag('Execution details')
     .addTag('Feeds')
     .addTag('Messages')
     .addTag('Execution Details')

--- a/libs/dal/src/repositories/execution-details/execution-details.entity.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.entity.ts
@@ -1,21 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-
-import { NotificationStepEntity } from '../notification-template';
-
-export enum ExecutionDetailsSourceEnum {
-  CREDENTIALS = 'Credentials',
-  INTERNAL = 'Internal',
-  PAYLOAD = 'Payload',
-  WEBHOOK = 'Webhook',
-}
-
-export enum ExecutionDetailsStatusEnum {
-  FAILED = 'Failed',
-  PENDING = 'Pending',
-  QUEUED = 'Queued',
-  READ_CONFIRMATION = 'ReadConfirmation',
-  SUCCESS = 'Success',
-}
+import { ChannelTypeEnum, ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
 
 export class ExecutionDetailsEntity {
   _id?: string;

--- a/libs/dal/src/repositories/execution-details/execution-details.repository.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.repository.ts
@@ -1,6 +1,6 @@
-import { ChannelTypeEnum, StepTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
 
-import { ExecutionDetailsEntity, ExecutionDetailsStatusEnum } from './execution-details.entity';
+import { ExecutionDetailsEntity } from './execution-details.entity';
 import { ExecutionDetails } from './execution-details.schema';
 
 import { BaseRepository } from '../base-repository';

--- a/libs/dal/src/repositories/execution-details/execution-details.schema.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.schema.ts
@@ -1,11 +1,8 @@
 import * as mongoose from 'mongoose';
 import { Schema, Document } from 'mongoose';
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
 
-import {
-  ExecutionDetailsEntity,
-  ExecutionDetailsSourceEnum,
-  ExecutionDetailsStatusEnum,
-} from './execution-details.entity';
+import { ExecutionDetailsEntity } from './execution-details.entity';
 
 import { schemaOptions } from '../schema-default.options';
 

--- a/libs/shared/src/entities/execution-details/execution-details.interface.ts
+++ b/libs/shared/src/entities/execution-details/execution-details.interface.ts
@@ -1,0 +1,14 @@
+export enum ExecutionDetailsSourceEnum {
+  CREDENTIALS = 'Credentials',
+  INTERNAL = 'Internal',
+  PAYLOAD = 'Payload',
+  WEBHOOK = 'Webhook',
+}
+
+export enum ExecutionDetailsStatusEnum {
+  FAILED = 'Failed',
+  PENDING = 'Pending',
+  QUEUED = 'Queued',
+  READ_CONFIRMATION = 'ReadConfirmation',
+  SUCCESS = 'Success',
+}

--- a/libs/shared/src/entities/execution-details/index.ts
+++ b/libs/shared/src/entities/execution-details/index.ts
@@ -1,0 +1,1 @@
+export * from './execution-details.interface';

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -2,6 +2,7 @@ export * from './entities/user';
 export * from './entities/organization';
 export * from './entities/notification-template';
 export * from './entities/environment';
+export * from './entities/execution-details';
 export * from './entities/messages';
 export * from './entities/feed/feed.interface';
 export * from './entities/notification';


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Feature)
Implement the use case to create execution details.

- **Why this change was needed?** (You can also link to an open issue here)
We need a use case that allows to create execution details on demand for a notification/job to store the data.

- **Other information**:
N/A