### PR TITLE
Fixed templates.md by removing comma errors and minor grammatical errors

### DIFF
--- a/docs/docs/platform/templates.md
+++ b/docs/docs/platform/templates.md
@@ -18,7 +18,7 @@ The name will be used to identify the notification template when triggering it. 
 
 ### Notification Group
 
-The Notification group is used to group multiple notification templates into a single group, currently only used behind the scenes for organisational purposes. But, in the upcoming subscriber preferences management, it will be used to group multiple notifications for the subscriber.
+The notification group is used to group multiple notification templates into a single group, currently only used behind the scenes for organisational purposes. But, in the upcoming subscriber preferences management, it will be used to group multiple notifications for the subscriber.
 
 ## Template steps
 

--- a/docs/docs/platform/templates.md
+++ b/docs/docs/platform/templates.md
@@ -14,11 +14,11 @@ This will contain general information regarding the notification itself. Let's e
 
 ### Notification name
 
-The name will be used to identify the notification template when triggering it. A slugified version of the name will be generated after the notification was created. For example a notification template with the name of "Test Notification" will be converted to "test-notification" as the trigger key.
+The name will be used to identify the notification template when triggering it. A slugified version of the name will be generated after the notification was created. For example, a notification template with the name of "Test Notification" will be converted to "test-notification" as the trigger key.
 
 ### Notification Group
 
-Used to group multiple notification templates into a single group, currently only used behind the scenes for organisational purposes. But in the upcoming subscriber preferences management, it will be used to group multiple notifications for the subscriber.
+The Notification group is used to group multiple notification templates into a single group, currently only used behind the scenes for organisational purposes. But, in the upcoming subscriber preferences management, it will be used to group multiple notifications for the subscriber.
 
 ## Template steps
 
@@ -28,7 +28,7 @@ The templates steps are used to organize the different messages in a particular 
 
 A message is particularly tied to a specific channel and will create the content template associated with its channel.
 
-For email channel you can either use our basic visual editor or a fully custom code with [handlebars variables](https://handlebarsjs.com/guide/).
+For email channel, you can either use our basic visual editor or a fully custom code with [handlebars variables](https://handlebarsjs.com/guide/).
 
 ### Variable usage
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixed templates.md by removing comma errors and minor grammatical errors

- **Why this change was needed?** (You can also link to an open issue here)

this change was needed because-:

- But was used as a starting sentence after full stop directly without a comma in the docs
- Previously Notification group meaning started with "Used..." but, in docs its is fixed to "The notification group....."
- Fixed the comma errors, in docs

- **Other information**:
