### PR TITLE
i18n: added Romanian language support

### DIFF
--- a/docs/docs/notification-center/react-components.md
+++ b/docs/docs/notification-center/react-components.md
@@ -209,6 +209,7 @@ The `i18n` prop can accept 2 different types of values
           <li><code>as</code> (Assamese)</li>
           <li><code>tr</code> (Turkish)</li>
           <li><code>te</code> (Telugu)</li>
+          <li><code>ro</code> (Romanian)</li>
         </ul>
       </div>
   </details>

--- a/packages/notification-center/src/i18n/lang.ts
+++ b/packages/notification-center/src/i18n/lang.ts
@@ -37,6 +37,7 @@ import { DA } from './languages/da';
 import { AS } from './languages/as';
 import { TR } from './languages/tr';
 import { TE } from './languages/te';
+import { RO } from './languages/ro';
 
 export interface ITranslationContent {
   readonly notifications: string;
@@ -52,6 +53,7 @@ export interface ITranslationEntry {
 
 export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
   en: EN,
+  ro: RO,
   fi: FI,
   hi: HI,
   fr: FR,
@@ -105,6 +107,7 @@ export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
  */
 export type I18NLanguage =
   | 'en'
+  | 'ro'
   | 'fi'
   | 'hi'
 	| 'id'

--- a/packages/notification-center/src/i18n/languages/ro.ts
+++ b/packages/notification-center/src/i18n/languages/ro.ts
@@ -1,0 +1,11 @@
+import { ITranslationEntry } from '../lang';
+
+export const RO: ITranslationEntry = {
+  translations: {
+    notifications: 'Notificări',
+    markAllAsRead: 'Marcheaza totul ca fiind citit',
+    poweredBy: 'Cu sprijinul',
+    settings: 'Setări',
+  },
+  lang: 'ro',
+};


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces support for the Romanian language for the @novu/notification-center component interface.

- **Why was this change needed?** (You can also link to an open issue here)
For internationalization

- **Other information**:
Resolves #1525 