### PR TITLE
Updated integrations.md sentences error

### DIFF
--- a/docs/docs/platform/integrations.md
+++ b/docs/docs/platform/integrations.md
@@ -1,6 +1,6 @@
 # Integrations Store
 
-Novu integrations page used to configure the final delivery providers for each channel. Novu is an open-source project, meaning that if you are missing a particular provider you can always submit a new provider entry. You can read more about it here.
+Novu integrations page is used to configure the final delivery providers for each channel. Novu is an open-source project, which allows you to submit a new provider entry whenever you are missing a particular provider. You can read more about it here.
 
 ## Provider Channels
 
@@ -19,7 +19,7 @@ When visiting the integration store and connecting a provider you will be asked 
 For email providers, you will be required to add the following data:
 
 - **Sender Email Address** - Will be used to send an email from address, usually you would have to whitelabel this address or domain with your email provider.
-- **Sender From Name** - The name that will be displayed as the sender identity the email is coming from.
+- **Sender From Name** - The name that will be displayed as the sender identity for the email.
 
 ## Missing a provider?
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Updated integrations.md sentences error

- **Why was this change needed?** (You can also link to an open issue here)

- made changes in the sentence "Novu is an open-source project, meaning that if you are missing a particular provider you can always submit a new provider entry." -> "Novu is an open-source project, which allows you to submit a new provider entry whenever you are missing a particular provider"

here the word **meaning** is not fitting the sentence

- "The name that will be displayed as the sender identity the email is coming from." ->"The name that will be displayed as the sender identity for the email"

- **Other information**:
