### PR TITLE
update: link in "missing a feature?"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ To learn a detailed guide on running the project locally, visit [https://docs.no
 
 ## Missing a Feature?
 
-If a feature is missing, you can _request_ a new one by [submitting an issue](#submitting-an-issue) to our GitHub Repository.
+If a feature is missing, you can directly _request_ a new one [here](https://github.com/novuhq/novu/issues/new?assignees=&labels=feature&template=feature_request.yml&title=%F0%9F%9A%80+Feature%3A+). You also can do the same by choosing "🚀 Feature" when raising a [New Issue](https://github.com/novuhq/novu/issues/new/choose) on our GitHub Repository.
 If you would like to _implement_ it, an issue with your proposal must be submitted first, to be sure that we can use it. Please consider the guidelines given below.
 
 ## Coding guidelines


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    This PR introduces Doc Update in [CONTRIBUTING.md](https://github.com/novuhq/novu/blob/main/CONTRIBUTING.md).
- **Why was this change needed?** (You can also link to an open issue here)
    - Solves issue #1508.
    - Previously provided link in [Missing a Feature?](https://github.com/novuhq/novu/blob/main/CONTRIBUTING.md#missing-a-feature) section was redirecting the contributor to the [Submitting an issue](https://github.com/novuhq/novu/blob/main/CONTRIBUTING.md#submitting-an-issue) section. Where nothing about raising a feature request was mentioned explicitly.
    - Added a link which would enable the contributor to directly submit a feature request form.
    - Also, added instructions to follow next time to request a feature by raising a [New Issue](https://github.com/novuhq/novu/issues/new/choose).
- **Other information**:
    _NA_