### PR TITLE
Add navigation to Activity feed in command palette

### DIFF
--- a/apps/web/src/components/utils/Spotlight.tsx
+++ b/apps/web/src/components/utils/Spotlight.tsx
@@ -1,7 +1,7 @@
 import { SpotlightProvider } from '@mantine/spotlight';
 import { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Bolt, Box, Settings } from '../../design-system/icons';
+import { Activity, Bolt, Box, Settings } from '../../design-system/icons';
 import { SpotlightContext } from '../../store/spotlightContext';
 
 export const SpotLight = ({ children }) => {
@@ -27,6 +27,12 @@ export const SpotLight = ({ children }) => {
         title: 'Go to Settings',
         onTrigger: () => navigate('/settings'),
         icon: <Settings />,
+      },
+      {
+        id: 'navigate-activities',
+        title: 'Go to Activities',
+        onTrigger: () => navigate('/activities'),
+        icon: <Activity />,
       },
       {
         id: 'navigate-docs',


### PR DESCRIPTION
Introduces the ability to navigate to activity feed in the command palette

fixes https://github.com/novuhq/novu/issues/1459

What kind of change does this PR introduce?
Feature: Add new navigation to activity feed as described in [NV-934]

Why was this change needed? To fix https://github.com/novuhq/novu/issues/1459
