### PR TITLE
feat: implement Nodemailer provider connection test

### DIFF
--- a/providers/nodemailer/src/lib/nodemailer.provider.spec.ts
+++ b/providers/nodemailer/src/lib/nodemailer.provider.spec.ts
@@ -50,3 +50,11 @@ test('should trigger nodemailer correctly', async () => {
     ],
   });
 });
+
+test('should check provider integration correctly', async () => {
+  const provider = new NodemailerProvider(mockConfig);
+  const response = await provider.checkIntegration(mockNovuMessage);
+
+  expect(sendMailMock).toHaveBeenCalled();
+  expect(response.success).toBe(true);
+});


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Implement `NodemailerProvider.checkIntegration` so that users can test their credentials when configuring a Nodemailer provider.

- **Why was this change needed?** (You can also link to an open issue here)
#1468

- **Other information**:
Since `nodemailer` is a library, not a service, it does not provide any dedicated endpoint to test credentials. We can test the credentials by opening a SMTP connection (nodemailer/nodemailer#341), but that requires importing an extra dependency ([smtp-connection](https://www.npmjs.com/package/smtp-connection)). As such, I have resorted to using the same send functionality to test credentials.