### PR TITLE
feat: implement Postmark provider connection test

### DIFF
--- a/providers/postmark/src/lib/postmark.provider.spec.ts
+++ b/providers/postmark/src/lib/postmark.provider.spec.ts
@@ -43,3 +43,18 @@ test('should trigger postmark correctly', async () => {
     ],
   });
 });
+
+test('should check provider integration correctly', async () => {
+  const provider = new PostmarkEmailProvider(mockConfig);
+  const spy = jest
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    .spyOn(provider['client'], 'sendEmail')
+    .mockImplementation(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return {} as any;
+    });
+
+  const response = await provider.checkIntegration(mockNovuMessage);
+  expect(spy).toHaveBeenCalled();
+  expect(response.success).toBe(true);
+});

--- a/providers/postmark/src/lib/postmark.provider.ts
+++ b/providers/postmark/src/lib/postmark.provider.ts
@@ -6,7 +6,7 @@ import {
   ICheckIntegrationResponse,
   CheckIntegrationResponseEnum,
 } from '@novu/stateless';
-import { ServerClient, Models } from 'postmark';
+import { Errors, ServerClient, Message, Models } from 'postmark';
 
 export class PostmarkEmailProvider implements IEmailProvider {
   id = 'postmark';
@@ -25,7 +25,46 @@ export class PostmarkEmailProvider implements IEmailProvider {
   async sendMessage(
     options: IEmailOptions
   ): Promise<ISendMessageSuccessResponse> {
-    const response = await this.client.sendEmail({
+    const mailData = this.createMailData(options);
+    const response = await this.client.sendEmail(mailData);
+
+    return {
+      id: response.MessageID,
+      date: response.SubmittedAt,
+    };
+  }
+
+  async checkIntegration(
+    options: IEmailOptions
+  ): Promise<ICheckIntegrationResponse> {
+    try {
+      const mailData = this.createMailData(options);
+      await this.client.sendEmail(mailData);
+
+      return {
+        success: true,
+        message: 'Integrated successfully!',
+        code: CheckIntegrationResponseEnum.SUCCESS,
+      };
+    } catch (error) {
+      if (error instanceof Errors.PostmarkError) {
+        return {
+          success: false,
+          message: error?.message,
+          code: mapError(error),
+        };
+      } else {
+        return {
+          success: false,
+          message: error?.message,
+          code: CheckIntegrationResponseEnum.FAILED,
+        };
+      }
+    }
+  }
+
+  private createMailData(options: IEmailOptions): Message {
+    return {
       From: options.from || this.config.from,
       To: getFormattedTo(options.to),
       HtmlBody: options.html,
@@ -39,21 +78,6 @@ export class PostmarkEmailProvider implements IEmailProvider {
             attachment.mime
           )
       ),
-    });
-
-    return {
-      id: response.MessageID,
-      date: response.SubmittedAt,
-    };
-  }
-
-  async checkIntegration(
-    options: IEmailOptions
-  ): Promise<ICheckIntegrationResponse> {
-    return {
-      success: true,
-      message: 'Integrated successfully!',
-      code: CheckIntegrationResponseEnum.SUCCESS,
     };
   }
 }
@@ -62,4 +86,23 @@ const getFormattedTo = (to: string | string[]): string => {
   if (Array.isArray(to)) return to.join(', ');
 
   return to;
+};
+
+const mapError = (error: Errors.PostmarkError) => {
+  if (error instanceof Errors.InvalidAPIKeyError) {
+    return CheckIntegrationResponseEnum.BAD_CREDENTIALS;
+  } else if (error instanceof Errors.ApiInputError) {
+    // https://postmarkapp.com/developer/api/overview#error-codes
+    switch (error.code) {
+      case 10:
+        return CheckIntegrationResponseEnum.BAD_CREDENTIALS;
+      case 400:
+      case 401:
+        return CheckIntegrationResponseEnum.INVALID_EMAIL;
+      default:
+        return CheckIntegrationResponseEnum.FAILED;
+    }
+  } else {
+    return CheckIntegrationResponseEnum.FAILED;
+  }
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Implement `PostmarkProvider.checkIntegration` so that users can test their credentials when configuring a Postmark provider.

- **Why was this change needed?** (You can also link to an open issue here)
#1470

- **Other information**:
Postmark does not provide any dedicated endpoint/method to test credentials (https://postmarkapp.com/developer/api/overview). As such, I have resorted to using the same send functionality to test credentials. Another alternative is to use a `GET` endpoint (to avoid sending an actual email), but it will not validate the `From` email address.