### PR TITLE
feat: implement Mandrill provider connection test

### DIFF
--- a/providers/mandrill/src/lib/mandrill.interface.ts
+++ b/providers/mandrill/src/lib/mandrill.interface.ts
@@ -4,6 +4,9 @@ export interface MandrillInterface {
   messages: {
     send: (options: IMandrillSendOptions) => Promise<IMandrillSendResponse[]>;
   };
+  users: {
+    ping: () => Promise<string>;
+  };
 }
 
 export interface IMandrillSendOptions {

--- a/providers/mandrill/src/lib/mandrill.provider.spec.ts
+++ b/providers/mandrill/src/lib/mandrill.provider.spec.ts
@@ -1,10 +1,12 @@
 import { MandrillProvider } from './mandrill.provider';
 
+const mockConfig = {
+  apiKey: 'API_KEY',
+  from: 'test@test.com',
+};
+
 test('should trigger mandrill correctly', async () => {
-  const provider = new MandrillProvider({
-    apiKey: 'API_KEY',
-    from: 'test@test.com',
-  });
+  const provider = new MandrillProvider(mockConfig);
   const spy = jest
     // eslint-disable-next-line @typescript-eslint/dot-notation
     .spyOn(provider['transporter'].messages, 'send')
@@ -12,23 +14,50 @@ test('should trigger mandrill correctly', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return [{}] as any;
     });
-
-  await provider.sendMessage({
+  const mockNovuMessage = {
     to: 'test2@test.com',
     subject: 'test subject',
     html: '<div> Mail Content </div>',
     attachments: [
       { mime: 'text/plain', file: Buffer.from('test'), name: 'test.txt' },
     ],
-  });
+  };
+
+  await provider.sendMessage(mockNovuMessage);
 
   expect(spy).toHaveBeenCalled();
   expect(spy).toHaveBeenCalledWith({
-    to: 'test2@test.com',
-    html: '<div> Mail Content </div>',
-    subject: 'test subject',
-    attachments: [
-      { mime: 'text/plain', file: Buffer.from('test'), name: 'test.txt' },
-    ],
+    message: {
+      from_email: mockConfig.from,
+      subject: mockNovuMessage.subject,
+      html: mockNovuMessage.html,
+      to: [
+        {
+          email: mockNovuMessage.to,
+          type: 'to',
+        },
+      ],
+      attachments: [
+        {
+          content: 'test',
+          type: 'text/plain',
+          name: 'test.txt',
+        },
+      ],
+    },
   });
+});
+
+test('should check provider integration correctly', async () => {
+  const provider = new MandrillProvider(mockConfig);
+  const spy = jest
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    .spyOn(provider['transporter'].users, 'ping')
+    .mockImplementation(async () => {
+      return 'PONG!';
+    });
+
+  const response = await provider.checkIntegration();
+  expect(spy).toHaveBeenCalled();
+  expect(response.success).toBe(true);
 });

--- a/providers/mandrill/src/lib/mandrill.provider.spec.ts
+++ b/providers/mandrill/src/lib/mandrill.provider.spec.ts
@@ -6,10 +6,11 @@ test('should trigger mandrill correctly', async () => {
     from: 'test@test.com',
   });
   const spy = jest
-    .spyOn(provider, 'sendMessage')
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    .spyOn(provider['transporter'].messages, 'send')
     .mockImplementation(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return {} as any;
+      return [{}] as any;
     });
 
   await provider.sendMessage({

--- a/providers/mandrill/src/lib/mandrill.provider.ts
+++ b/providers/mandrill/src/lib/mandrill.provider.ts
@@ -64,13 +64,21 @@ export class MandrillProvider implements IEmailProvider {
     };
   }
 
-  async checkIntegration(
-    options: IEmailOptions
-  ): Promise<ICheckIntegrationResponse> {
-    return {
-      success: true,
-      message: 'Integrated successfully!',
-      code: CheckIntegrationResponseEnum.SUCCESS,
-    };
+  async checkIntegration(): Promise<ICheckIntegrationResponse> {
+    try {
+      await this.transporter.users.ping();
+
+      return {
+        success: true,
+        message: 'Integrated successfully!',
+        code: CheckIntegrationResponseEnum.SUCCESS,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: error?.message,
+        code: CheckIntegrationResponseEnum.FAILED,
+      };
+    }
   }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Fix Mandrill provider test (`mandrill.provider.spec.ts`): The test was mocking `MandrillProvider.sendMessage`, the function being tested itself, which defeats the purpose of the test. Fixed by mocking `MandrillProvider.transporter.messages.send` instead.
    - Implement `MandrillProvider.checkIntegration` so that users can test their credentials when configuring a Mandrill provider.

- **Why was this change needed?** (You can also link to an open issue here)
#1467

- **Other information**:
Mailchimp Transactional provides a [/users/ping](https://mailchimp.com/developer/transactional/api/users/ping/) endpoint to test API keys (https://mailchimp.com/developer/transactional/guides/quick-start/#make-your-first-api-call).