### PR TITLE
fix(api): added logic to check for existing brand-image-key and reuse it

### DIFF
--- a/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.usecase.ts
+++ b/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.usecase.ts
@@ -3,18 +3,34 @@ import * as hat from 'hat';
 import { StorageService } from '../../../shared/services/storage/storage.service';
 import { UploadUrlResponse } from '../../dtos/upload-url-response.dto';
 import { GetSignedUrlCommand } from './get-signed-url.command';
+import { GetOrganization } from '../../../organization/usecases/get-organization/get-organization.usecase';
 
 const mimeTypes = {
   jpeg: 'image/jpeg',
   png: 'image/png',
+  jpg: 'image/jpeg',
 };
 
 @Injectable()
 export class GetSignedUrl {
-  constructor(private storageService: StorageService) {}
+  constructor(private storageService: StorageService, private getOrganization: GetOrganization) {}
 
   async execute(command: GetSignedUrlCommand): Promise<UploadUrlResponse> {
-    const path = `${command.organizationId}/${command.environmentId}/${hat()}.${command.extension}`;
+    const organization = await this.getOrganization.execute({ id: command.organizationId, userId: command.userId });
+
+    let path = `${command.organizationId}/${command.environmentId}/${hat()}.${command.extension}`;
+
+    if (organization.branding.logo) {
+      const currentImageName = organization.branding.logo.split('/').pop().split('.');
+      const currentImagePrefix = currentImageName.shift();
+      const currentImageExt = currentImageName.pop();
+
+      if (currentImageExt === command.extension) {
+        path = `${command.organizationId}/${command.environmentId}/${currentImagePrefix}.${currentImageExt}`;
+      } else {
+        path = `${command.organizationId}/${command.environmentId}/${currentImagePrefix}.${command.extension}`;
+      }
+    }
 
     const response = await this.storageService.getSignedUrl(path, mimeTypes[command.extension]);
 

--- a/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.usecase.ts
+++ b/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.usecase.ts
@@ -4,6 +4,7 @@ import { StorageService } from '../../../shared/services/storage/storage.service
 import { UploadUrlResponse } from '../../dtos/upload-url-response.dto';
 import { GetSignedUrlCommand } from './get-signed-url.command';
 import { GetOrganization } from '../../../organization/usecases/get-organization/get-organization.usecase';
+import { getFileExtensionFromPath } from '../../../shared/services/helper/helper.service';
 
 const mimeTypes = {
   jpeg: 'image/jpeg',
@@ -21,9 +22,8 @@ export class GetSignedUrl {
     let path = `${command.organizationId}/${command.environmentId}/${hat()}.${command.extension}`;
 
     if (organization.branding.logo) {
-      const currentImageName = organization.branding.logo.split('/').pop().split('.');
-      const currentImagePrefix = currentImageName.shift();
-      const currentImageExt = currentImageName.pop();
+      const currentImagePrefix = organization.branding.logo.split('/').pop().split('.').shift();
+      const currentImageExt = getFileExtensionFromPath(organization.branding.logo);
 
       if (currentImageExt === command.extension) {
         path = `${command.organizationId}/${command.environmentId}/${currentImagePrefix}.${currentImageExt}`;

--- a/apps/api/src/app/storage/usecases/index.ts
+++ b/apps/api/src/app/storage/usecases/index.ts
@@ -1,6 +1,4 @@
+import { GetOrganization } from '../../organization/usecases/get-organization/get-organization.usecase';
 import { GetSignedUrl } from './get-signed-url/get-signed-url.usecase';
 
-export const USE_CASES = [
-  GetSignedUrl,
-  //
-];
+export const USE_CASES = [GetSignedUrl, GetOrganization];


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Updated existing `GetSignedUrl` storage usecase function to check if there exists an logo for the organization, if it exists, we reuse the unique key from `logo`.

- **Why was this change needed?** (You can also link to an open issue here)
#829 
