### PR TITLE
Fixed typo `email` in the `How to add a provider ?` page

### DIFF
--- a/docs/docs/community/create-provider.md
+++ b/docs/docs/community/create-provider.md
@@ -123,7 +123,7 @@ export class SendgridEmailProvider implements IEmailProvider {
 
 ### SMS Provider
 
-This is a code example of a basic email provider, with minimal fields required by our `ISmsProvider` interface.
+This is a code example of a basic sms provider, with minimal fields required by our `ISmsProvider` interface.
 
 ```typescript
 import { ChannelTypeEnum, ISmsOptions, ISmsProvider } from '@novu/stateless';


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  docs update
- **Why was this change needed?** (You can also link to an open issue here)

  The typo `a basic email provider` in the SMS provider section shoul be changed to `a basic sms provider`

![Screenshot (609)](https://user-images.githubusercontent.com/70086051/194722515-183bb18e-587b-46a0-b46d-100836f8a289.png)

