### PR TITLE
Corrected a Typo

### DIFF
--- a/docs/docs/notification-center/react-components.md
+++ b/docs/docs/notification-center/react-components.md
@@ -34,7 +34,7 @@ function Header() {
 
 ## Use your own backend and socket url
 
-By default, Novu's hosted services of api and socket are used. Should you want, you could override them and configure your own.
+By default, Novu's hosted services of API and socket are used. Should you want, you could override them and configure your own.
 
 ```tsx
 import {


### PR DESCRIPTION
Abbreviations should always be capitalized if they are spelled letter by letter which is the case for API.  Thank you for reading my PR in advance.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs Update
- **Why was this change needed?** (You can also link to an open issue here)
To enhance the quality of the documentation.

