### PR TITLE
docs: fix formatting of the requirements section

### DIFF
--- a/docs/docs/community/run-locally.md
+++ b/docs/docs/community/run-locally.md
@@ -15,7 +15,8 @@ sidebar_position: 1
 - Redis
 - **(Optional)** pnpm - Needed if you want to install new packages
 - **(Optional)** localstack (required only in S3 related modules)
-  Need help installing the requirements? Read more [here](https://novuhq.notion.site/Dev-Machine-Setup-98d274c80fa249b0b0be75b9a7a72acb#a0e6bf0db22f46d8a2677692f986e366)
+
+Need help installing the requirements? Read more [here](https://novuhq.notion.site/Dev-Machine-Setup-98d274c80fa249b0b0be75b9a7a72acb#a0e6bf0db22f46d8a2677692f986e366)
 
 ## Setup the project
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix the format of the requirements section where the localstack bullet seems to be linked with the next sentence.

![image](https://user-images.githubusercontent.com/53674742/195008900-ca02f435-cf28-4271-b7f3-9034e35df9d6.png)

- **Why was this change needed?** (You can also link to an open issue here)

To avoid confusion. I missed the call-to-action to the notion page during the first couple of times I looked at the page. Which would've have been useful when I was installing the dependencies.

- **Other information**:
