### PR TITLE
fix: update stack ordering to put spotlight on front

### DIFF
--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -17,7 +17,7 @@ export function AppLayout() {
           navbar={<SideNav />}
           header={<HeaderNav />}
           styles={(theme) => ({
-            root: { minHeight: '100vh' },
+            root: { minHeight: '100vh', position: 'relative', zIndex: 1 },
             body: { height: 'calc(100vh - 65px)' },
             main: { backgroundColor: theme.colorScheme === 'dark' ? colors.BGDark : colors.BGLight, overflow: 'auto' },
           })}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes the spotlight issue seen during Office Hours where other elements are displayed on top.

- **Why was this change needed?** (You can also link to an open issue here)

Its an unexpected behavior

- **Other information**:

![image](https://user-images.githubusercontent.com/53674742/195148787-6fc84638-6ba3-47d0-b1e4-d45d2784ab6b.png)
