### PR TITLE
fix(translations): French Translations file missing settings translation

### DIFF
--- a/packages/notification-center/src/i18n/languages/fr.ts
+++ b/packages/notification-center/src/i18n/languages/fr.ts
@@ -5,6 +5,7 @@ export const FR: ITranslationEntry = {
     notifications: 'Notifications',
     markAllAsRead: 'tout marquer comme lu',
     poweredBy: 'Propulsé par',
+    settings: 'paramètres',
   },
   lang: 'fr',
 };

--- a/packages/notification-center/src/i18n/languages/fr.ts
+++ b/packages/notification-center/src/i18n/languages/fr.ts
@@ -3,9 +3,9 @@ import { ITranslationEntry } from '../lang';
 export const FR: ITranslationEntry = {
   translations: {
     notifications: 'Notifications',
-    markAllAsRead: 'tout marquer comme lu',
+    markAllAsRead: 'Tout marquer comme lu',
     poweredBy: 'Propulsé par',
-    settings: 'paramètres',
+    settings: 'Paramètres',
   },
   lang: 'fr',
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a bug fix required for adding the settings translation within the French translations file.
See issue: #1676 

- **Why was this change needed?** (You can also link to an open issue here)
It is a necessary change because the settings keyword and translation are missing for French Users.

- **Other information**:
note: I am not a native speaker. 