### PR TITLE
fix(translations): Gujarati Translations file missing translation for 'settings'

### DIFF
--- a/packages/notification-center/src/i18n/languages/gu.ts
+++ b/packages/notification-center/src/i18n/languages/gu.ts
@@ -5,6 +5,7 @@ export const GU: ITranslationEntry = {
     notifications: 'સૂચના',
     markAllAsRead: 'બધાને વાંચેલા તરીકે ચિહ્નિત કરો',
     poweredBy: 'દ્વારા સંચાલિત',
+    settings: 'સેટિંગ્સ',
   },
   lang: 'gu',
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a bug fix required for adding the settings translation within the Gujarati translations file.
**See issue:** #1679

- **Why was this change needed?** (You can also link to an open issue here)
It is a necessary change because the settings keyword and translation are missing for Gujarati Users.

- **Other information**:
note: I am not a native speaker.