### PR TITLE
feat(web): nv-1061-scaffold-for-notification-execution

### DIFF
--- a/apps/web/src/components/activity/ExecutionDetailsModal.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailsModal.tsx
@@ -1,0 +1,42 @@
+import { Group, Modal, useMantineTheme } from '@mantine/core';
+import { colors, shadows, Title, Text } from '../../design-system';
+
+import { GotAQuestionButton } from '../utils/GotAQuestionButton';
+
+export function ExecutionDetailsModal({ modalVisibility, onClose }: { modalVisibility: boolean; onClose: () => void }) {
+  const theme = useMantineTheme();
+
+  return (
+    <>
+      <Modal
+        opened={modalVisibility}
+        overlayColor={theme.colorScheme === 'dark' ? colors.BGDark : colors.BGLight}
+        overlayOpacity={0.7}
+        styles={{
+          modal: {
+            backgroundColor: theme.colorScheme === 'dark' ? colors.B15 : colors.white,
+          },
+          body: {
+            paddingTop: '5px',
+          },
+          inner: {
+            paddingTop: '180px',
+          },
+        }}
+        title={<Title size={2}>Execution details</Title>}
+        sx={{ backdropFilter: 'blur(10px)' }}
+        shadow={theme.colorScheme === 'dark' ? shadows.dark : shadows.medium}
+        radius="md"
+        size="lg"
+        onClose={onClose}
+      >
+        <div>
+          <Text>TODO</Text>
+          <Group position="right">
+            <GotAQuestionButton mt={30} size="md" />
+          </Group>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/apps/web/src/components/activity/ExecutionDetailsModal.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailsModal.tsx
@@ -7,36 +7,34 @@ export function ExecutionDetailsModal({ modalVisibility, onClose }: { modalVisib
   const theme = useMantineTheme();
 
   return (
-    <>
-      <Modal
-        opened={modalVisibility}
-        overlayColor={theme.colorScheme === 'dark' ? colors.BGDark : colors.BGLight}
-        overlayOpacity={0.7}
-        styles={{
-          modal: {
-            backgroundColor: theme.colorScheme === 'dark' ? colors.B15 : colors.white,
-          },
-          body: {
-            paddingTop: '5px',
-          },
-          inner: {
-            paddingTop: '180px',
-          },
-        }}
-        title={<Title size={2}>Execution details</Title>}
-        sx={{ backdropFilter: 'blur(10px)' }}
-        shadow={theme.colorScheme === 'dark' ? shadows.dark : shadows.medium}
-        radius="md"
-        size="lg"
-        onClose={onClose}
-      >
-        <div>
-          <Text>TODO</Text>
-          <Group position="right">
-            <GotAQuestionButton mt={30} size="md" />
-          </Group>
-        </div>
-      </Modal>
-    </>
+    <Modal
+      opened={modalVisibility}
+      overlayColor={theme.colorScheme === 'dark' ? colors.BGDark : colors.BGLight}
+      overlayOpacity={0.7}
+      styles={{
+        modal: {
+          backgroundColor: theme.colorScheme === 'dark' ? colors.B15 : colors.white,
+        },
+        body: {
+          paddingTop: '5px',
+        },
+        inner: {
+          paddingTop: '180px',
+        },
+      }}
+      title={<Title size={2}>Execution details</Title>}
+      sx={{ backdropFilter: 'blur(10px)' }}
+      shadow={theme.colorScheme === 'dark' ? shadows.dark : shadows.medium}
+      radius="md"
+      size="lg"
+      onClose={onClose}
+    >
+      <div>
+        <Text>TODO</Text>
+        <Group position="right">
+          <GotAQuestionButton mt={30} size="md" />
+        </Group>
+      </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/utils/GotAQuestionButton.tsx
+++ b/apps/web/src/components/utils/GotAQuestionButton.tsx
@@ -1,0 +1,13 @@
+import { Button, Size } from '../../design-system';
+
+function onClick() {
+  window?.open('https://discord.novu.co', '_blank')?.focus();
+}
+
+export function GotAQuestionButton({ mt, size }: { mt: number; size: Size }) {
+  return (
+    <Button mt={mt} size={size} onClick={onClick}>
+      Got a question?
+    </Button>
+  );
+}

--- a/apps/web/src/components/utils/GotAQuestionButton.tsx
+++ b/apps/web/src/components/utils/GotAQuestionButton.tsx
@@ -1,18 +1,24 @@
-import { useIntercom } from 'react-use-intercom';
+import { useCallback, useEffect, useState } from 'react';
+import { IntercomContextValues, useIntercom } from 'react-use-intercom';
 
 import { INTERCOM_APP_ID } from '../../config';
 import { Button, Size } from '../../design-system';
 
-export function GotAQuestionButton({ mt, size }: { mt: number; size: Size }) {
-  if (!INTERCOM_APP_ID) {
-    return null;
-  }
+const useShowIntercom = () => {
+  const { show } = useIntercom();
+  const [isIntercomEnabled] = useState<boolean>(!!INTERCOM_APP_ID);
 
-  const { boot } = useIntercom();
+  return useCallback(() => isIntercomEnabled && show, [isIntercomEnabled, show]);
+};
+
+export function GotAQuestionButton({ mt, size }: { mt: number; size: Size }) {
+  const showIntercom = useShowIntercom();
 
   return (
-    <Button mt={mt} size={size} onClick={boot}>
-      Got a question?
-    </Button>
+    showIntercom && (
+      <Button mt={mt} size={size} onClick={showIntercom}>
+        Got a question?
+      </Button>
+    )
   );
 }

--- a/apps/web/src/components/utils/GotAQuestionButton.tsx
+++ b/apps/web/src/components/utils/GotAQuestionButton.tsx
@@ -1,12 +1,17 @@
+import { useIntercom } from 'react-use-intercom';
+
+import { INTERCOM_APP_ID } from '../../config';
 import { Button, Size } from '../../design-system';
 
-function onClick() {
-  window?.open('https://discord.novu.co', '_blank')?.focus();
-}
-
 export function GotAQuestionButton({ mt, size }: { mt: number; size: Size }) {
+  if (!INTERCOM_APP_ID) {
+    return null;
+  }
+
+  const { boot } = useIntercom();
+
   return (
-    <Button mt={mt} size={size} onClick={onClick}>
+    <Button mt={mt} size={size} onClick={boot}>
       Got a question?
     </Button>
   );

--- a/apps/web/src/design-system/button/Button.tsx
+++ b/apps/web/src/design-system/button/Button.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { Button as MantineButton, SharedButtonProps } from '@mantine/core';
+
 import useStyles from './Button.styles';
+
 import { SpacingProps } from '../shared/spacing.props';
+
+export type Size = 'md' | 'lg' | undefined;
 
 interface IButtonProps extends JSX.ElementChildrenAttribute, SpacingProps {
   loading?: boolean;
-  size?: 'md' | 'lg';
+  size?: Size;
   variant?: 'outline' | 'filled';
   disabled?: boolean;
   icon?: React.ReactNode;

--- a/apps/web/src/design-system/index.ts
+++ b/apps/web/src/design-system/index.ts
@@ -1,4 +1,5 @@
 export { Button } from './button/Button';
+export type { Size } from './button/Button';
 export { Checkbox } from './checkbox/Checkbox';
 export { colors, shadows } from './config';
 export { Input } from './input/Input';

--- a/apps/web/src/pages/activities/ActivitiesPage.tsx
+++ b/apps/web/src/pages/activities/ActivitiesPage.tsx
@@ -6,15 +6,18 @@ import { Controller, useForm } from 'react-hook-form';
 import * as capitalize from 'lodash.capitalize';
 import styled from '@emotion/styled';
 import { format, formatDistanceToNow, isAfter, subDays } from 'date-fns';
+
+import { ActivityStatistics } from './components/ActivityStatistics';
+import { ActivityGraph } from './components/ActivityGraph';
+
 import { useTemplates } from '../../api/hooks/use-templates';
 import { getActivityList } from '../../api/activity';
 import PageContainer from '../../components/layout/components/PageContainer';
 import PageMeta from '../../components/layout/components/PageMeta';
 import PageHeader from '../../components/layout/components/PageHeader';
+import { ExecutionDetailsModal } from '../../components/activity/ExecutionDetailsModal';
 import { Data, Table } from '../../design-system/table/Table';
 import { Select, Tag, Text, Tooltip, Input, colors } from '../../design-system';
-import { ActivityStatistics } from './components/ActivityStatistics';
-import { ActivityGraph } from './components/ActivityGraph';
 
 interface IFiltersForm {
   channels?: ChannelTypeEnum[];
@@ -23,6 +26,7 @@ interface IFiltersForm {
 export function ActivitiesPage() {
   const { templates, loading: loadingTemplates } = useTemplates(0, 100);
   const [page, setPage] = useState<number>(0);
+  const [isModalOpen, toggleModal] = useState<boolean>(false);
   const [filters, setFilters] = useState<IFiltersForm>({ channels: [] });
   const { data, isLoading, isFetching } = useQuery<{ data: any[]; totalCount: number; pageSize: number }>(
     ['activitiesList', page, filters],
@@ -52,6 +56,14 @@ export function ActivitiesPage() {
           subscriber.lastName ? capitalize(subscriber.lastName) : ''
         }`
       : 'Deleted Subscriber';
+  }
+
+  function onRowClick() {
+    toggleModal((state) => !state);
+  }
+
+  function onModalClose() {
+    toggleModal(false);
   }
 
   const columns: ColumnWithStrictAccessor<Data>[] = [
@@ -230,6 +242,7 @@ export function ActivitiesPage() {
         loading={isLoading || isFetching}
         data={data?.data || []}
         columns={columns}
+        onRowClick={onRowClick}
         pagination={{
           pageSize: data?.pageSize,
           current: page,
@@ -237,6 +250,7 @@ export function ActivitiesPage() {
           onPageChange: handleTableChange,
         }}
       />
+      <ExecutionDetailsModal modalVisibility={isModalOpen} onClose={onModalClose} />
     </PageContainer>
   );
 }

--- a/apps/web/src/pages/activities/components/ActivityGraph.tsx
+++ b/apps/web/src/pages/activities/components/ActivityGraph.tsx
@@ -6,10 +6,12 @@ import { useEffect, useState } from 'react';
 import { useMantineTheme } from '@mantine/core';
 import * as cloneDeep from 'lodash.clonedeep';
 import { differenceInDays, format, isSameDay, subDays } from 'date-fns';
-import { getActivityGraphStats } from '../../../api/activity';
-import { IActivityGraphStats } from '../interfaces';
+
 import { MessageContainer } from './MessageContainer';
 import { ActivityGraphGlobalStyles } from './ActivityGraphGlobalStyles';
+
+import { getActivityGraphStats } from '../../../api/activity';
+import { IActivityGraphStats } from '../interfaces';
 import { getOptions, getChartData } from '../services';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (feature)
Creates a parent component as a scaffold to hold the information for execution details. Also creates a new reusable component `GotAQuestionButton` that takes user to the Intercom server for support.

- **Why was this change needed?** (You can also link to an open issue here)
We need a parent component to render the execution details of the different notifications from the activity feed.

- **Other information**:
N/A