### PR TITLE
Added Twilio SMS Docs

### DIFF
--- a/docs/docs/channels/sms/index.md
+++ b/docs/docs/channels/sms/index.md
@@ -5,3 +5,4 @@ Novu can be used to send SMS to your customers using a unified delivery API. You
 To read a provider specific documentation:
 
 - [AWS SNS](/channels/sms/sns)
+- [TWILIO](/channels/sms/twilio)

--- a/docs/docs/channels/sms/twilio.md
+++ b/docs/docs/channels/sms/twilio.md
@@ -1,0 +1,24 @@
+# Twilio SMS
+
+You can utilize the [Twilio](https://www.twilio.com/) API to communicate in all sorts of ways with your customers. Mainly though, using SMS messaging will you get the best value.
+
+## Setup Twilio
+
+First go to [Twilio](https://www.twilio.com/) and create an account, probably starting with their free trial. Next, to send out SMS messages with Twilio they will provide us with a phone number that we can use, in the middle of page we should have access to a Getting a Phone Number step cycle.
+
+## Getting and utilizing the Phone Number
+
+When first using Twilio there should be a section in the main console. Otherwise
+you may have to [Buy](https://console.twilio.com/us1/develop/phone-numbers/manage/search?frameUrl=%2Fconsole%2Fphone-numbers%2Fsearch%3Fx-target-region%3Dus1&currentFrameUrl=%2Fconsole%2Fphone-numbers%2Fsearch%3FisoCountry%3DUS%26searchTerm%3D%26searchFilter%3Dleft%26searchType%3Dnumber%26x-target-region%3Dus1%26__override_layout__%3Dembed%26bifrost%3Dtrue) a number from that link to begin using it. Assuming this is the first run through though, utilize the free number given to us. Simply follow of their many [Tutorials](https://www.twilio.com/docs/usage/requests-to-twilio) within their docs to understand every part of the process. 
+
+In short, no matter the language you prefer the process is the same. Load the Account SID and Auth token into the code, using some sort of safe environment such as .env variables, nobody should have access to this but you. Create a client object from Twilio that take the SID and Token as variables then create a message with the client. The message is an object that has three things, that free number from earlier, the number you would like to send to, and a body message that you want to sent through SMS.
+
+
+## Create a Twilio integration with Novu
+
+- Visit the [Integrations](https://web.novu.co/integrations) page on Novu.
+- Locate **Twilio** and click on the **Connect** button.
+- Go to your [Console](https://console.twilio.com/) on Twilio and access the Account Info section at the bottom of the page
+- Enter your `Account SID`, `Auth Token`  and `Twilio Phone Number`.
+- Click on the **Save** button.
+- You should now be able to send SMS notifications using **Twilio** in Novu.


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR was a fix to issue #1662  (https://github.com/novuhq/novu/issues/1662) which simply requested a documentation page for Twilio's SMS system. It goes in detail of creating an account, sending a message, and linking with Novu which is how many of the other Documentation pages were structured.

- **Why was this change needed?** (You can also link to an open issue here)
This change was needed because documentation is currently lacking in the areas of setup for many of these channels which would be a lot easier on users.

- **Other information**:
