### PR TITLE
Update .prettierrc

### DIFF
--- a/docs/.prettierrc
+++ b/docs/.prettierrc
@@ -1,6 +1,6 @@
 {
   "printWidth": 100,
-  "tabWidth": 2,
+  "tabWidth": 4,
   "useTabs": false,
   "semi": true,
   "singleQuote": true,
@@ -11,4 +11,12 @@
   "bracketSameLine": false,
   "arrowParens": "always",
   "endOfLine": "lf"
+  {
+  "overrides": [
+    {
+      "files": ".prettierrc",
+      "options": { "parser": "json" }
+    }
+  ]
+}
 }


### PR DESCRIPTION
Set the parser option.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Updated Prettier file

- **Why was this change needed?** (You can also link to an open issue here)
By default, Prettier automatically infers which parser to use based on the input file extension. Combined with overrides you can teach Prettier how to parse files it does not recognize.

- **Other information**:
