### PR TITLE
doc: added telnyx doc link to index.md

### DIFF
--- a/docs/docs/channels/sms/index.md
+++ b/docs/docs/channels/sms/index.md
@@ -7,4 +7,4 @@ To read a provider specific documentation:
 - [AWS SNS](/channels/sms/sns)
 - [SMS77](/channels/sms/SMS77)
 - [TWILIO](/channels/sms/twilio)
-- [TELNYX](https://github.com/novuhq/novu/blob/84682038213c26c526f577c3668e028f6da4936a/docs/docs/channels/sms/telnyx.md)
+- [TELNYX](/channels/sms/telnyx)

--- a/docs/docs/channels/sms/index.md
+++ b/docs/docs/channels/sms/index.md
@@ -6,3 +6,4 @@ To read a provider specific documentation:
 
 - [AWS SNS](/channels/sms/sns)
 - [TWILIO](/channels/sms/twilio)
+- [TELNYX](https://github.com/novuhq/novu/blob/84682038213c26c526f577c3668e028f6da4936a/docs/docs/channels/sms/telnyx.md)


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - added telnyx documentation [link ](https://github.com/novuhq/novu/blob/84682038213c26c526f577c3668e028f6da4936a/docs/docs/channels/sms/telnyx.md)in the [index.md](https://github.com/novuhq/novu/blob/84682038213c26c526f577c3668e028f6da4936a/docs/docs/channels/sms/index.md) .
- **Why was this change needed?** (You can also link to an open issue here)
   - As the added documentation of SMS providers should be enlisted in [index.md](https://github.com/novuhq/novu/blob/84682038213c26c526f577c3668e028f6da4936a/docs/docs/channels/sms/index.md)
- **Other information**:
_NA_
