### PR TITLE
fix: fix decision of when should create another digest event

### DIFF
--- a/apps/api/src/app/events/e2e/delay-events.e2e.ts
+++ b/apps/api/src/app/events/e2e/delay-events.e2e.ts
@@ -8,7 +8,7 @@ import {
 import { UserSession, SubscribersService } from '@novu/testing';
 
 import { expect } from 'chai';
-import { StepTypeEnum, DelayTypeEnum, DigestUnitEnum } from '@novu/shared';
+import { StepTypeEnum, DelayTypeEnum, DigestUnitEnum, DigestTypeEnum } from '@novu/shared';
 import axios from 'axios';
 import { WorkflowQueueService } from '../services/workflow.queue.service';
 import { addSeconds, differenceInMilliseconds } from 'date-fns';
@@ -211,6 +211,134 @@ describe('Trigger event - Delay triggered events - /v1/events/trigger (POST)', f
 
     const delay = await workflowQueueService.queue.getDelayed();
     expect(delay[0].opts.delay).to.approximately(diff, 5);
+  });
+
+  it('should not include delayed event in digested sent message', async function () {
+    template = await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.DELAY,
+          content: '',
+          metadata: {
+            unit: DigestUnitEnum.MINUTES,
+            amount: 5,
+            type: DelayTypeEnum.REGULAR,
+          },
+        },
+        {
+          type: StepTypeEnum.DIGEST,
+          content: '',
+          metadata: {
+            unit: DigestUnitEnum.MINUTES,
+            amount: 5,
+            type: DigestTypeEnum.REGULAR,
+          },
+        },
+        {
+          type: StepTypeEnum.SMS,
+          content: 'Event {{eventNumber}}. Digested Events {{step.events.length}}' as string,
+        },
+      ],
+    });
+
+    await triggerEvent({
+      eventNumber: '1',
+    });
+
+    await awaitRunningJobs(2);
+
+    const delayedJob = await jobRepository.findOne({
+      _templateId: template._id,
+      type: StepTypeEnum.DELAY,
+    });
+
+    await runJob.execute(
+      RunJobCommand.create({
+        jobId: delayedJob._id,
+        environmentId: delayedJob._environmentId,
+        organizationId: delayedJob._organizationId,
+        userId: delayedJob._userId,
+      })
+    );
+
+    const digestedJob = await jobRepository.findOne({
+      _templateId: template._id,
+      type: StepTypeEnum.DIGEST,
+    });
+
+    await triggerEvent({
+      eventNumber: '2',
+    });
+
+    await awaitRunningJobs(1);
+
+    await runJob.execute(
+      RunJobCommand.create({
+        jobId: digestedJob._id,
+        environmentId: digestedJob._environmentId,
+        organizationId: digestedJob._organizationId,
+        userId: digestedJob._userId,
+      })
+    );
+
+    await awaitRunningJobs(1);
+    const messages = await messageRepository.find({
+      _environmentId: session.environment._id,
+      _subscriberId: subscriber._id,
+      channel: StepTypeEnum.SMS,
+    });
+
+    expect(messages[0].content).to.include('Event 1');
+    expect(messages[0].content).to.include('Digested Events 1');
+  });
+
+  it('should send a single message for same exact scheduled delay', async function () {
+    template = await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.DELAY,
+          content: '',
+          metadata: {
+            type: DelayTypeEnum.SCHEDULED,
+            delayPath: 'sendAt',
+          },
+        },
+        {
+          type: StepTypeEnum.DIGEST,
+          content: '',
+          metadata: {
+            unit: DigestUnitEnum.SECONDS,
+            amount: 3,
+            type: DigestTypeEnum.REGULAR,
+          },
+        },
+        {
+          type: StepTypeEnum.SMS,
+          content: 'Digested Events {{step.events.length}}' as string,
+        },
+      ],
+    });
+
+    const dateValue = addSeconds(new Date(), 5);
+
+    await triggerEvent({
+      eventNumber: '1',
+      sendAt: dateValue,
+    });
+    await triggerEvent({
+      eventNumber: '2',
+      sendAt: dateValue,
+    });
+    await awaitRunningJobs(1);
+
+    const messages = await messageRepository.find({
+      _environmentId: session.environment._id,
+      _subscriberId: subscriber._id,
+      channel: StepTypeEnum.SMS,
+    });
+
+    expect(messages.length).to.equal(1);
+    expect(messages[0].content).to.include('Digested Events 2');
   });
 
   it('should fail for missing or invalid path for scheduled delay', async function () {

--- a/apps/api/src/app/events/services/workflow.queue.service.ts
+++ b/apps/api/src/app/events/services/workflow.queue.service.ts
@@ -3,8 +3,7 @@ import { Queue, Worker, QueueBaseOptions, JobsOptions, QueueScheduler } from 'bu
 import { JobEntity, JobRepository, JobStatusEnum } from '@novu/dal';
 import { RunJob } from '../usecases/run-job/run-job.usecase';
 import { RunJobCommand } from '../usecases/run-job/run-job.command';
-import { getRedisPrefix, StepTypeEnum } from '@novu/shared';
-import { differenceInMilliseconds } from 'date-fns';
+import { getRedisPrefix } from '@novu/shared';
 
 @Injectable()
 export class WorkflowQueueService {
@@ -63,47 +62,12 @@ export class WorkflowQueueService {
   }
 
   public async addToQueue(id: string, data: JobEntity, delay?: number | undefined) {
-    let updatedDelay = delay;
     const options: JobsOptions = {
       removeOnComplete: true,
       removeOnFail: true,
+      delay,
     };
-    if (data.type === StepTypeEnum.DELAY) {
-      updatedDelay = await this.calcDelay(data, delay);
-    }
 
-    await this.queue.add(id, data, { delay: updatedDelay, ...options });
-  }
-
-  private async calcDelay(data: JobEntity, delay?: number | undefined) {
-    const delayedJobsInQueue = await this.queue.getDelayed();
-    if (delayedJobsInQueue.length) {
-      const delayedJobs = await this.jobRepository.find(
-        {
-          status: JobStatusEnum.DELAYED,
-          type: StepTypeEnum.DELAY,
-          _subscriberId: data._subscriberId,
-          _templateId: data._templateId,
-          _environmentId: data._environmentId,
-        },
-        '_id'
-      );
-      const delayedJobsIds = delayedJobs.map((job) => job._id);
-      const calcDelayDiffs = delayedJobsInQueue
-        .filter((delayed) => delayedJobsIds.includes(delayed.data._id))
-        .map((delayed) => {
-          return delayed.opts.delay - differenceInMilliseconds(new Date(), new Date(delayed.data.updatedAt));
-        });
-
-      if (calcDelayDiffs?.length) {
-        for (const remainedDelay of calcDelayDiffs) {
-          if (Math.abs(remainedDelay - delay) < 1000) {
-            return delay + 1000;
-          }
-        }
-      }
-    }
-
-    return delay;
+    await this.queue.add(id, data, options);
   }
 }

--- a/apps/api/src/app/events/usecases/add-job/should-add-digest-job.usecase.ts
+++ b/apps/api/src/app/events/usecases/add-job/should-add-digest-job.usecase.ts
@@ -22,8 +22,9 @@ export class ShouldAddDigestJob {
       _templateId: data._templateId,
       _environmentId: data._environmentId,
     };
+
     const delayedDigest = await this.jobRepository.findOne(where);
 
-    return !!delayedDigest;
+    return !delayedDigest;
   }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix case of an extra digest created for delayed (regular or scheduled) that comes before digest 

- **Why was this change needed?** (You can also link to an open issue here)
WF:
<img width="734" alt="Screen Shot 2022-10-13 at 11 20 19" src="https://user-images.githubusercontent.com/7778680/195542382-acb730fa-d377-412a-a4de-b5b70ceeafd2.png">

Triggering twice resulted in :
![image](https://user-images.githubusercontent.com/7778680/195542087-70f55981-4cd2-45d1-ae1b-53f41f0e7978.png)

Now:
![image](https://user-images.githubusercontent.com/7778680/195542177-f60a801b-0a82-4c7c-8916-7178dd5a612b.png)

- **Other information**:

Also fixes the problem:
- that events that are delayed are added to a current digest, before their delay time completed.  
- events that have digest pending being sent twice 