### PR TITLE
chore: Added unit test coverage for emailjs provider

### DIFF
--- a/providers/emailjs/src/lib/emailjs.provider.spec.ts
+++ b/providers/emailjs/src/lib/emailjs.provider.spec.ts
@@ -1,0 +1,66 @@
+import { CheckIntegrationResponseEnum, IEmailOptions } from '@novu/stateless';
+import { IEmailJsConfig } from './emailjs.config';
+import { EmailJsProvider } from './emailjs.provider';
+
+const mockConfig = {
+  from: 'test',
+} as IEmailJsConfig;
+
+const mockNovuMessage = {
+  to: ['test@test1.com', 'test@test2.com'],
+  subject: 'test subject',
+  html: '<div> Mail Content </div>',
+  text: 'Mail Cotent',
+  from: 'test@test.com',
+  attachments: [
+    { mime: 'text/plain', file: Buffer.from('dGVzdA=='), name: 'test.txt' },
+  ],
+} as IEmailOptions;
+
+test('should trigger emailjs with expected parameters', async () => {
+  const provider = new EmailJsProvider(mockConfig);
+  const spy = jest
+    .spyOn(provider, 'sendMessage')
+    .mockImplementation(async () => {
+      // eslint-disanyxt-line @typescript-eslint/no-explicit-any
+      return {} as any;
+    });
+
+  const response = await provider.sendMessage(mockNovuMessage);
+
+  expect(spy).toHaveBeenCalled();
+  expect(spy).toBeCalledWith({
+    to: mockNovuMessage.to,
+    subject: mockNovuMessage.subject,
+    html: mockNovuMessage.html,
+    text: mockNovuMessage.text,
+    from: mockNovuMessage.from,
+    attachments: [
+      {
+        mime: 'text/plain',
+        file: Buffer.from('dGVzdA=='),
+        name: 'test.txt',
+      },
+    ],
+  });
+});
+
+test('should trigger emailjs checkIntegration correctly', async () => {
+  const provider = new EmailJsProvider(mockConfig);
+  const spy = jest
+    .spyOn(provider, 'checkIntegration')
+    .mockImplementation(async () => {
+      return {
+        success: true,
+        message: 'Integrated successfully!',
+        code: CheckIntegrationResponseEnum.SUCCESS,
+      };
+    });
+
+  const response = await provider.checkIntegration(mockNovuMessage);
+
+  expect(spy).toHaveBeenCalled();
+  expect(response.success).toBeTruthy();
+  expect(response.message).toEqual('Integrated successfully!');
+  expect(response.code).toEqual(CheckIntegrationResponseEnum.SUCCESS);
+});

--- a/providers/emailjs/src/lib/emailjs.provider.spec.ts
+++ b/providers/emailjs/src/lib/emailjs.provider.spec.ts
@@ -1,4 +1,8 @@
-import { CheckIntegrationResponseEnum, IEmailOptions } from '@novu/stateless';
+import {
+  CheckIntegrationResponseEnum,
+  IEmailOptions,
+  ISendMessageSuccessResponse,
+} from '@novu/stateless';
 import { IEmailJsConfig } from './emailjs.config';
 import { EmailJsProvider } from './emailjs.provider';
 
@@ -10,7 +14,7 @@ const mockNovuMessage = {
   to: ['test@test1.com', 'test@test2.com'],
   subject: 'test subject',
   html: '<div> Mail Content </div>',
-  text: 'Mail Cotent',
+  text: 'Mail Content',
   from: 'test@test.com',
   attachments: [
     { mime: 'text/plain', file: Buffer.from('dGVzdA=='), name: 'test.txt' },
@@ -22,8 +26,10 @@ test('should trigger emailjs with expected parameters', async () => {
   const spy = jest
     .spyOn(provider, 'sendMessage')
     .mockImplementation(async () => {
-      // eslint-disanyxt-line @typescript-eslint/no-explicit-any
-      return {} as any;
+      return {
+        id: 'message-id',
+        date: '12/01/2020',
+      } as ISendMessageSuccessResponse;
     });
 
   const response = await provider.sendMessage(mockNovuMessage);
@@ -43,6 +49,9 @@ test('should trigger emailjs with expected parameters', async () => {
       },
     ],
   });
+  expect(response).not.toBeNull();
+  expect(response.date).toBe('12/01/2020');
+  expect(response.id).toBe('message-id');
 });
 
 test('should trigger emailjs checkIntegration correctly', async () => {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds unit test coverage for the emailjs provider.

- **Why was this change needed?** (You can also link to an open issue here)
There is currently no test coverage for this provider.

- **Other information**:

![image](https://user-images.githubusercontent.com/68904757/195549676-0378b8bf-9dc3-41a9-beda-a4db5f141020.png)

