### PR TITLE
docs: added provider documentation link

### DIFF
--- a/docs/docs/channels/push/index.md
+++ b/docs/docs/channels/push/index.md
@@ -1,5 +1,11 @@
 # Push Notifications
 
-Novu can be used to deliver push notifications to your customers devices. Both Mobile and Web push notifications are supported.
+Novu can be used to deliver push notifications to your customers using a unified delivery API. Both Mobile and Web push notifications are supported.
 
 You can save a user's notification/device identifiers using [Subscriber Credentials](/platform/subscribers#updating-subscriber-credentials).
+
+You can easily integrate your favorite delivery provider using the built-in [integration store](https://web.novu.co/integrations).
+
+To read a provider specific documentation:
+- [Expo Push]([url](/channels/push/expo))
+- [Firebase Cloud Messages](/channels/push/fcm) 

--- a/docs/docs/channels/push/index.md
+++ b/docs/docs/channels/push/index.md
@@ -1,6 +1,6 @@
 # Push Notifications
 
-Novu can be used to deliver push notifications to your customers using a unified delivery API. Both Mobile and Web push notifications are supported.
+Novu can be used to deliver push notifications to your customers devices using a unified delivery API. Both Mobile and Web push notifications are supported.
 
 You can save a user's notification/device identifiers using [Subscriber Credentials](/platform/subscribers#updating-subscriber-credentials).
 

--- a/docs/docs/channels/push/index.md
+++ b/docs/docs/channels/push/index.md
@@ -7,5 +7,5 @@ You can save a user's notification/device identifiers using [Subscriber Credenti
 You can easily integrate your favorite delivery provider using the built-in [integration store](https://web.novu.co/integrations).
 
 To read a provider specific documentation:
-- [Expo Push]([url](/channels/push/expo))
+- [Expo Push](/channels/push/expo)
 - [Firebase Cloud Messages](/channels/push/fcm) 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Added Expo Push and Firebase Cloud Messages documentation link to [index.md](https://github.com/novuhq/novu/blob/e0d8e42a6319b7e39be82c8c5dd0d28ea581c915/docs/docs/channels/push/index.md).
- **Why was this change needed?** (You can also link to an open issue here)
    - As the documentation of providers should be enlisted in [index.md](https://github.com/novuhq/novu/blob/e0d8e42a6319b7e39be82c8c5dd0d28ea581c915/docs/docs/channels/push/index.md)
- **Other information**:
_NA_