### PR TITLE
Updated the missing translation of 'Settings'

### DIFF
--- a/packages/notification-center/src/i18n/languages/it.ts
+++ b/packages/notification-center/src/i18n/languages/it.ts
@@ -5,6 +5,7 @@ export const IT: ITranslationEntry = {
     notifications: 'Notifiche',
     markAllAsRead: 'Segna tutti come letti',
     poweredBy: 'Offerto da',
+    settings: 'Impostazioni',
   },
   lang: 'it',
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a bug fix required for adding the settings translation within the _Italian_ translations file.

See Issue: #1539 
