### PR TITLE
update: fix typo in emailjs.md

### DIFF
--- a/docs/docs/channels/email/emailjs.md
+++ b/docs/docs/channels/email/emailjs.md
@@ -1,23 +1,23 @@
-# Emailjs
+# EmailJS
 
-[Emailjs](https://www.emailjs.com/) helps to send emails using client-side technologies only. No server is required – just connect Emailjs to one of the supported email services, create an email template, and use our Javascript library to trigger an email. You can use Emailjs to send the content of a form filled by your users directly to your email address, using a simple connection provided by Emailjs.
+[EmailJS](https://www.emailjs.com/) helps to send emails using client-side technologies only. No server is required – just connect EmailJS to one of the supported email services, create an email template, and use our Javascript library to trigger an email. You can use EmailJS to send the content of a form filled by your users directly to your email address, using a simple connection provided by EmailJS.
 
 ## Getting Started
 
-You have to simply create an account on emailjs and verify your email address after that you can use API or CDN provided by Emailjs to send a response of form to your email address.
+You have to simply create an account on EmailJS and verify your email address after that you can use API or CDN provided by EmailJS to send a response of form to your email address.
 
 ## How to connect a form to your email?
 
 - Create a simple HTML form.
-- Create an account on Emailjs and verify your email.
+- Create an account on EmailJS and verify your email.
 - Create a new service and do all the settings.
 - Create a connection using CDN or API.
 
-## Integrate Emailjs with Novu
+## Integrate EmailJS with Novu
 
 - Visit the [Integrations](https://web.novu.co/integrations) page on Novu.
-- Locate Emailjs and click on the **Connect** button.
-- Enter your Emailjs API Key.
+- Locate EmailJS and click on the **Connect** button.
+- Enter your EmailJS API Key.
 - Fill the `From email address` field using the authenticated email from the previous step.
 - Click on the **Save** button.
-- You should now be able to send notifications using Emailjs in Novu.
+- You should now be able to send notifications using EmailJS in Novu.


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Doc update - Changed every occurrence of Emailjs to **EmailJS** in [emailjs.md](https://github.com/novuhq/novu/blob/12af2340f8c77a482e8feb762b3eca9abd14e340/docs/docs/channels/email/emailjs.md).
    - Links and file name are untouched.
- **Why was this change needed?** (You can also link to an open issue here)
    - **'EmailJS'** is the official format. It's more suitable and looks better.
- **Other information**:
_NA_