### PR TITLE
Grammar fix for sms77

### DIFF
--- a/docs/docs/channels/sms/SMS77.md
+++ b/docs/docs/channels/sms/SMS77.md
@@ -1,19 +1,19 @@
 # SMS77
 
-You can use the [SMS77](https://www.sms77.io/en) provider to send SMS messages to your customers using the Novu Platform with a single API to create multi-channel experiences.
+It is possible to use the [SMS77](https://www.sms77.io/en) provider to send SMS messages to the customers using the Novu Platform with a single API to create multi-channel experiences.
 
 ## Getting Started
 
-To use the SMS77 channel, you will need to create a SMS77 account and add your API key to the SMS77 integration on the Novu platform.
+To use the SMS77 channel, the first step is to create a SMS77 account and add the personal API key to the SMS77 integration on the Novu platform.
 
 ## Find the API key
 
-To find your SMS77 API key, log into your SMS77 account and navigate to the API Keys page by clicking on the 'Developer' tab present at the end of the sidebar. It is suggested that you create a new API key for use with Novu. Copy the newly created API key. 
+To find the SMS77 API key, log into the personal SMS77 account and navigate to the API Keys page by clicking on the 'Developer' tab present at the end of the sidebar. It is suggested to create a new API key for use with Novu. Copy the newly created API key. 
     
 ## Create a AWS SNS integration with Novu
 
 - Visit the [Integrations](https://web.novu.co/integrations) page on Novu.
 - Locate **SMS77** under SMS section and click on the **Connect** button.
-- Enter your `API key`.
+- Enter the `API key`.
 - Click on the **Save** button.
-- You should now be able to send SMS notifications using **SMS77** in Novu.
+- Now it is possible to send SMS notifications using **SMS77** in Novu.

--- a/packages/notification-center/src/i18n/languages/it.ts
+++ b/packages/notification-center/src/i18n/languages/it.ts
@@ -5,7 +5,6 @@ export const IT: ITranslationEntry = {
     notifications: 'Notifiche',
     markAllAsRead: 'Segna tutti come letti',
     poweredBy: 'Offerto da',
-    settings: 'Impostazioni',
   },
   lang: 'it',
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Documentation update
- **Why was this change needed?** (You can also link to an open issue here)
This pr fixes the use of "you" and "your" in the `SMS77` documentation.
In the documentation it is usually preferable to use a generic form.
