### PR TITLE
[NV-924] - Add cypress component test to ActivityStatistics component

### DIFF
--- a/apps/web/src/pages/activities/components/ActivityStatistics.cy.tsx
+++ b/apps/web/src/pages/activities/components/ActivityStatistics.cy.tsx
@@ -1,0 +1,37 @@
+import { ActivityStatistics } from './ActivityStatistics';
+import { TestWrapper } from '../../../testing';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+describe('Activity Statistics Component Test', () => {
+  const activityStatisticsComponentSelector = '[data-test-id="activity-stats-weekly-sent"]';
+  const queryClient = new QueryClient();
+
+  it('should Render the Activity Statistics Component', () => {
+    cy.mount(
+      <TestWrapper>
+        <QueryClientProvider client={queryClient}>
+          <ActivityStatistics></ActivityStatistics>
+        </QueryClientProvider>
+      </TestWrapper>
+    );
+  });
+
+  it('should get the activity-stats-weekly-sent data test id', () => {
+    cy.mount(
+      <TestWrapper>
+        <QueryClientProvider client={queryClient}>
+          <ActivityStatistics></ActivityStatistics>
+        </QueryClientProvider>
+      </TestWrapper>
+    );
+    cy.intercept('GET', '/v1/activity', {
+      body: {
+        yearlySent: 1,
+        monthlySent: 12,
+        weeklySent: 52,
+      },
+    }).as('activityStatistics');
+
+    cy.get(activityStatisticsComponentSelector);
+  });
+});


### PR DESCRIPTION
## Why?

To help increase our test coverage within the `novu/web` project, we can add the newly released [cypress component tests](https://docs.cypress.io/guides/component-testing/testing-react).

## How?

A new component test file should be added located near the original source file(see example at `apps/web/src/design-system/button/button.cy.tsx` and could be run after running `npm run start` from the root of the monorepo and specifying "Run Tests" and "Open Cypress", after which select the "Component testing" in the cypress screen.

Write the new test and make sure it passes all assertions.

The component is located at: `apps/web/src/pages/activities/components/ActivityStatistics.tsx `