### PR TITLE
feat: Add navigation to team members in command palette

### DIFF
--- a/apps/web/src/components/utils/Spotlight.tsx
+++ b/apps/web/src/components/utils/Spotlight.tsx
@@ -1,7 +1,7 @@
 import { SpotlightProvider } from '@mantine/spotlight';
 import { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Activity, Bolt, Box, Settings, Repeat } from '../../design-system/icons';
+import { Activity, Bolt, Box, Settings, Repeat, Team } from '../../design-system/icons';
 import { SpotlightContext } from '../../store/spotlightContext';
 
 export const SpotLight = ({ children }) => {
@@ -39,6 +39,12 @@ export const SpotLight = ({ children }) => {
         title: 'Go to Activities',
         onTrigger: () => navigate('/activities'),
         icon: <Activity />,
+      },
+      {
+        id: 'navigate-team-members',
+        title: 'Go to Team Members',
+        onTrigger: () => navigate('/team'),
+        icon: <Team />,
       },
       {
         id: 'navigate-docs',


### PR DESCRIPTION
Introduces ability to navigate to team members in command palette

fixes #1342 

What kind of change does this PR introduce?
Feature:Add navigation to team members in command palette as described in [NV-937]

Why was this change needed? To fix #1342 