### PR TITLE
[NV-928] - Add cypress component test to OrganizationSelect component

### DIFF
--- a/apps/web/src/components/layout/components/OrganizationSelect.cy.tsx
+++ b/apps/web/src/components/layout/components/OrganizationSelect.cy.tsx
@@ -1,0 +1,30 @@
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { TestWrapper } from '../../../testing';
+import OrganizationSelect from './OrganizationSelect';
+
+describe('Organization Select Component Test', () => {
+  const organizationSelectComponentSelector = '[data-test-id="organization-switch"]';
+  const queryClient = new QueryClient();
+
+  it('should Render the Organization Select Component', () => {
+    cy.mount(
+      <TestWrapper>
+        <QueryClientProvider client={queryClient}>
+          <OrganizationSelect />
+        </QueryClientProvider>
+      </TestWrapper>
+    );
+  });
+
+  it('should get the organization-switch data test id', () => {
+    cy.mount(
+      <TestWrapper>
+        <QueryClientProvider client={queryClient}>
+          <OrganizationSelect />
+        </QueryClientProvider>
+      </TestWrapper>
+    );
+
+    cy.get(organizationSelectComponentSelector);
+  });
+});


### PR DESCRIPTION
## Why?

To help increase our test coverage within the `novu/web` project, we can add the newly released [cypress component tests](https://docs.cypress.io/guides/component-testing/testing-react).

## How?

A new component test file should be added located near the original source file(see example at `apps/web/src/design-system/button/button.cy.tsx` and could be run after running `npm run start` from the root of the monorepo and specifying "Run Tests" and "Open Cypress", after which select the "Component testing" in the cypress screen.

Write the new test and make sure it passes all assertions.

The component is located at: apps/web/src/components/layout/components/OrganizationSelect.tsx