### PR TITLE
Test Mailjet connection

### DIFF
--- a/providers/mailjet/src/lib/mailjet.provider.spec.ts
+++ b/providers/mailjet/src/lib/mailjet.provider.spec.ts
@@ -47,28 +47,31 @@ jest.mock('node-mailjet', () => {
   };
 });
 
-test('should trigger mailjet library correctly and return proper response', async () => {
-  const provider = new MailjetEmailProvider({
-    apiKey: 'testApiKey',
-    apiSecret: 'testSecret',
-    from: 'testFrom@test.com',
-  });
+const mockConfig = {
+  apiKey: 'testApiKey',
+  apiSecret: 'testSecret',
+  from: 'testFrom@test.com',
+};
+const mockMessageConfig = {
+  to: 'testTo@test2.com',
+  subject: 'test subject',
+  html: '<div> Mail Content </div>',
+};
 
-  const messageResponse = await provider.sendMessage({
-    to: 'testTo@test2.com',
-    subject: 'test subject',
-    html: '<div> Mail Content </div>',
-  });
+test('should trigger mailjet library correctly and return proper response', async () => {
+  const provider = new MailjetEmailProvider(mockConfig);
+
+  const messageResponse = await provider.sendMessage(mockMessageConfig);
 
   expect(requestFn).toBeCalledTimes(1);
   expect(requestFn).toBeCalledWith({
     Messages: [
       {
-        From: { Email: 'testFrom@test.com' },
-        HTMLPart: '<div> Mail Content </div>',
-        Subject: 'test subject',
+        From: { Email: mockConfig.from },
+        HTMLPart: mockMessageConfig.html,
+        Subject: mockMessageConfig.subject,
         TextPart: undefined,
-        To: [{ Email: 'testTo@test2.com' }],
+        To: [{ Email: mockMessageConfig.to }],
       },
     ],
   });
@@ -76,4 +79,12 @@ test('should trigger mailjet library correctly and return proper response', asyn
     id: 'a9e7-437c-84f8-e2c2d5958014',
     date: 'Sun, 24 Oct 2021 15:56:29 GMT',
   });
+});
+
+test('should check provider integration correctly', async () => {
+  const provider = new MailjetEmailProvider(mockConfig);
+  const messageResponse = await provider.checkIntegration(mockMessageConfig);
+
+  expect(requestFn).toHaveBeenCalled();
+  expect(messageResponse.success).toBe(true);
 });

--- a/providers/mailjet/src/lib/mailjet.provider.ts
+++ b/providers/mailjet/src/lib/mailjet.provider.ts
@@ -34,7 +34,42 @@ export class MailjetEmailProvider implements IEmailProvider {
     const send = this.mailjetClient.post('send', {
       version: MAILJET_API_VERSION,
     });
-    const requestObject = {
+    const requestObject = this.createMailData(options);
+
+    const response = (await send.request(requestObject)) as MailjetResponse;
+
+    return {
+      id: response.response.header['x-mj-request-guid'],
+      date: response.response.header.date,
+    };
+  }
+
+  async checkIntegration(
+    options: IEmailOptions
+  ): Promise<ICheckIntegrationResponse> {
+    const send = this.mailjetClient.post('send', {
+      version: MAILJET_API_VERSION,
+    });
+    const requestObject = this.createMailData(options);
+    try {
+      await send.request(requestObject);
+
+      return {
+        success: true,
+        message: 'Integrated successfully!',
+        code: CheckIntegrationResponseEnum.SUCCESS,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: error.message,
+        code: CheckIntegrationResponseEnum.BAD_CREDENTIALS,
+      };
+    }
+  }
+
+  private createMailData(options: IEmailOptions) {
+    return {
       Messages: [
         {
           From: {
@@ -55,23 +90,6 @@ export class MailjetEmailProvider implements IEmailProvider {
           })),
         },
       ],
-    };
-
-    const response = (await send.request(requestObject)) as MailjetResponse;
-
-    return {
-      id: response.response.header['x-mj-request-guid'],
-      date: response.response.header.date,
-    };
-  }
-
-  async checkIntegration(
-    options: IEmailOptions
-  ): Promise<ICheckIntegrationResponse> {
-    return {
-      success: true,
-      message: 'Integrated successfully!',
-      code: CheckIntegrationResponseEnum.SUCCESS,
     };
   }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds implementation for the `checkIntegration` method in the `mailjet` provider to check integration while creating or updating it.

- **Why was this change needed?** (You can also link to an open issue here)
https://github.com/novuhq/novu/issues/1469

- **Other information**:
For Invalid credentials, It  shows the following message,
![image](https://user-images.githubusercontent.com/50201755/195965020-83570b24-6c60-4786-8b67-a314d2b80b96.png)

