### PR TITLE
Fix link in monorepo-structure.md

### DIFF
--- a/docs/docs/community/monorepo-structure.md
+++ b/docs/docs/community/monorepo-structure.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 In this guide, we will explore the Novu mono-repo structure and high-level structure of the different libraries and services we use.
 
-![Monorepo outline of packages and services](/img/monorepo-structure.jpeg)
+![Monorepo outline of packages and services](/docs/static/img/monorepo-structure.jpeg)
 
 ## Setting up the monorepo
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix the link to monorepo.jpeg in monorepo-structure.md

Close #1743

- **Why was this change needed?** (You can also link to an open issue here)
The link to image was leading to 404 page which was unintended.

- **Other information**:
