### PR TITLE
docs: Remove link to provider-template

### DIFF
--- a/docs/docs/community/create-provider.md
+++ b/docs/docs/community/create-provider.md
@@ -153,8 +153,6 @@ export class TwilioSmsProvider implements ISmsProvider {
 }
 ```
 
-[GitHub Template](https://github.com/novuhq/provider-template)
-
 ## Add provider logos
 
 In order to present the provider in the Integration store we need logos in dark and light mode,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs Update: Removed broken link to provider-template from create-provider.md doc
Close #1760 

- **Why was this change needed?** (You can also link to an open issue here)
The link wasn't working and was supposed to be removed from the doc.
- **Other information**:
