### PR TITLE
Fixed the broken link to `workflow-photo` in digest.md

### DIFF
--- a/docs/docs/platform/digest.md
+++ b/docs/docs/platform/digest.md
@@ -12,7 +12,7 @@ This becomes useful when a user needs to be notified on a large amount of trigge
 
 After adding a digest node in the workflow editor, each node that will be below the digest node will be only triggered once in the specified digest interval. You can decide to send messages before adding a digest node and they will be triggered in real-time.
 
-![Workflow Photo](/img/digest-flow.png)
+![Workflow Photo](../../static/img/digest-flow.png)
 
 ### Node configurations
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes the broken link present in the digest.md file
- **Why was this change needed?** (You can also link to an open issue here)
Earlier the link wasn't working. Now it displays the image as expected.
- **Other information**:
- Resolves #1776
