### PR TITLE
fix: fix subscriber variables in trigger snippet not being updated

### DIFF
--- a/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.usecase.ts
@@ -106,7 +106,7 @@ export class UpdateNotificationTemplate {
 
       const subscribersVariables = contentService.extractSubscriberMessageVariables(command.steps);
 
-      updatePayload['triggers.0.subscribersVariables'] = subscribersVariables.map((i) => {
+      updatePayload['triggers.0.subscriberVariables'] = subscribersVariables.map((i) => {
         return {
           name: i,
         };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
- **Why was this change needed?** (You can also link to an open issue here)
On update of template - trigger snippet was not updated with the new subscriber variables. 
For example : adding an email step and updating an existing template will not add 'email:....' to trigger snippet
- **Other information**:
