### PR TITLE
style: Fix UI issues in settings page

### DIFF
--- a/apps/web/src/design-system/color-input/ColorInput.tsx
+++ b/apps/web/src/design-system/color-input/ColorInput.tsx
@@ -21,6 +21,7 @@ interface IColorInputProps extends SpacingProps {
   placeholder?: string;
   value?: string;
   description?: string;
+  disallowInput?: boolean;
   onChange?: (color: string) => void;
 }
 

--- a/apps/web/src/pages/settings/tabs/BrandingForm.tsx
+++ b/apps/web/src/pages/settings/tabs/BrandingForm.tsx
@@ -162,6 +162,7 @@ export function BrandingForm({
                   label="Brand Color"
                   description="Will be used to style emails and inbox experience"
                   data-test-id="color-picker"
+                  disallowInput={false}
                   {...field}
                 />
               )}
@@ -199,7 +200,12 @@ export const dropzoneChildren = (status: DropzoneStatus, image) => (
     {!image ? (
       <Upload style={{ width: 80, height: 80, color: colors.B60 }} />
     ) : (
-      <img data-test-id="logo-image-wrapper" src={image} style={{ width: '100%', height: 80 }} alt="avatar" />
+      <img
+        data-test-id="logo-image-wrapper"
+        src={image}
+        style={{ width: 100, height: 100, objectFit: 'contain' }}
+        alt="avatar"
+      />
     )}
   </Group>
 );


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes #840

- Updated image size to be 100x100 with `object-fit: contain` so that they always maintain the original aspect ratio if not square
- Makes it possible to input custom values in color picker; helpful especially when the required color is just too specific

## Why was this change needed?
This PR was introduced to fixes issue and introduce requested feature in the Setting page.

## Other information
As per the discussion over at Discord with @scopsy the issue with the font Select component is left as it.
This is because the mantine version used on the web is slightly older version. (Needs #1346)
