### PR TITLE
docs: Fix `receiver` spelling from `reciever`

### DIFF
--- a/docs/src/usage-examples.md
+++ b/docs/src/usage-examples.md
@@ -2,11 +2,13 @@
 sidebar_position: 1
 ---
 
+```typescript
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 import FAQ from '@site/src/components/FAQ';
 import FAQItem from '@site/src/components/FAQItem';
+```
 
 # Introduction Example
 

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -50,7 +50,7 @@ export class UserService {
 
   async triggerEvent() {
     await this.novu.trigger('password-reset', {
-      $email: 'reciever@mail.com',
+      $email: 'receiver@mail.com',
       $user_id: 'id'
     });
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update (Typo)

- **Why was this change needed?** (You can also link to an open issue here)
The spelling of `receiver` was written as `reciever`. It was a typo.

- **Other information**:
