### PR TITLE
feat: notify about security changes on settings page

### DIFF
--- a/apps/web/src/pages/settings/tabs/components/Security.tsx
+++ b/apps/web/src/pages/settings/tabs/components/Security.tsx
@@ -2,6 +2,7 @@ import { Button, colors, Switch, Text } from '../../../../design-system';
 import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { ColorScheme, InputWrapper, useMantineTheme } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
 import { inputStyles } from '../../../../design-system/config/inputs.styles';
 import { useForm } from 'react-hook-form';
 import { useMutation } from 'react-query';
@@ -35,6 +36,11 @@ export const Security = () => {
 
     await updateWidgetSettingsMutation(data);
     await refetchEnvironment();
+
+    showNotification({
+      message: 'Security info updated successfully',
+      color: 'green',
+    });
   }
 
   const { handleSubmit } = useForm({


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small feature improvement

- **Why was this change needed?** (You can also link to an open issue here)

Changing the "Enable HMAC encryption" option and then clicking by "Update" button has no UI effect. As a user, I expect to see confirmation that the change I just made has been saved on server. 

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/197337393-7cd0ce37-6b7a-4abf-b686-dec277be0c3d.png) | ![image](https://user-images.githubusercontent.com/4408379/197337488-2e5f5fa6-7d82-4551-8a7b-a2859da18248.png) |





- **Other information**:
