### PR TITLE
fix: add Redis optional configurable password

### DIFF
--- a/apps/api/src/app/events/services/workflow.queue.service.ts
+++ b/apps/api/src/app/events/services/workflow.queue.service.ts
@@ -12,6 +12,7 @@ export class WorkflowQueueService {
       db: Number(process.env.REDIS_DB_INDEX),
       port: Number(process.env.REDIS_PORT),
       host: process.env.REDIS_HOST,
+      password: process.env.REDIS_PASSWORD,
       connectTimeout: 50000,
       keepAlive: 30000,
       family: 4,

--- a/apps/api/src/app/shared/services/queue/queue.service.ts
+++ b/apps/api/src/app/shared/services/queue/queue.service.ts
@@ -14,6 +14,7 @@ export class QueueService {
       db: Number(process.env.REDIS_DB_INDEX),
       port: Number(process.env.REDIS_PORT),
       host: process.env.REDIS_HOST,
+      password: process.env.REDIS_PASSWORD,
       connectTimeout: 50000,
       keepAlive: 30000,
       family: 4,

--- a/apps/api/src/config/env-validator.ts
+++ b/apps/api/src/config/env-validator.ts
@@ -27,6 +27,7 @@ const validators: { [K in keyof any]: ValidatorSpec<any[K]> } = {
   }),
   REDIS_HOST: str(),
   REDIS_PORT: port(),
+  REDIS_PASSWORD: str(),
   JWT_SECRET: str(),
   SENDGRID_API_KEY: str({
     default: '',

--- a/apps/api/src/config/env-validator.ts
+++ b/apps/api/src/config/env-validator.ts
@@ -27,7 +27,6 @@ const validators: { [K in keyof any]: ValidatorSpec<any[K]> } = {
   }),
   REDIS_HOST: str(),
   REDIS_PORT: port(),
-  REDIS_PASSWORD: str(),
   JWT_SECRET: str(),
   SENDGRID_API_KEY: str({
     default: '',

--- a/apps/ws/src/shared/framework/redis.adapter.ts
+++ b/apps/ws/src/shared/framework/redis.adapter.ts
@@ -9,6 +9,7 @@ export class RedisIoAdapter extends IoAdapter {
     const redisAdapter = redisIoAdapter({
       host: process.env.REDIS_HOST,
       port: process.env.REDIS_PORT,
+      password: process.env.REDIS_PASSWORD,
       prefix: () => {
         // if custom prefix is empty ensure that the default prefix is set
         let prefix = 'socket.io';

--- a/apps/ws/src/shared/queue/queue.service.ts
+++ b/apps/ws/src/shared/queue/queue.service.ts
@@ -14,6 +14,7 @@ export class QueueService {
       db: Number(process.env.REDIS_DB_INDEX),
       port: Number(process.env.REDIS_PORT),
       host: process.env.REDIS_HOST,
+      password: process.env.REDIS_PASSWORD,
       connectTimeout: 50000,
       keepAlive: 30000,
       family: 4,

--- a/docs/docs/community/run-locally.md
+++ b/docs/docs/community/run-locally.md
@@ -57,6 +57,7 @@ If you want to test certain parts of Novu or run it in production mode though, s
         <li><code>DISABLE_USER_REGISTRATION</code> (default: false)<br />If users should not be able to create new accounts. Possible values are: true, false</li>
         <li><code>REDIS_HOST</code><br />The domain / IP of your redis instance</li>
         <li><code>REDIS_PORT</code><br />The port of your redis instance</li>
+        <li><code>REDIS_PASSWORD</code><br />Optional password of your redis instance</li>
         <li><code>JWT_SECRET</code><br />The secret keybase which is used to encrypt / verify the tokens issued for authentication</li>
         <li><code>SENDGRID_API_KEY</code><br />The api key of the Sendgrid account used to send various emails</li>
         <li><code>MONGO_URL</code><br />The URL of your MongoDB instance</li>
@@ -75,6 +76,7 @@ If you want to test certain parts of Novu or run it in production mode though, s
         <li><code>REDIS_HOST</code><br />The domain / IP of your redis instance</li>
         <li><code>REDIS_PORT</code><br />The port of your redis instance</li>
         <li><code>REDIS_DB_INDEX</code><br />The database index of your redis instance</li>
+        <li><code>REDIS_PASSWORD</code><br />Optional password of your redis instance</li>
         <li><code>JWT_SECRET</code><br />The secret keybase which is used to encrypt / verify the tokens issued for authentication</li>
         <li><code>MONGO_URL</code><br />The URL of your MongoDB instance</li>
         <li><code>PORT</code><br />The port on which the WebSocket service should listen on</li>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
   Added a password option to the redis instance

- **Why was this change needed?** (You can also link to an open issue here)
  Currently it's not possible to connect with an external redis instance

- **Other information**:
  Related to: https://github.com/novuhq/novu/issues/1863 
