### PR TITLE
refactor: auth pages improvements

### DIFF
--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -87,7 +87,7 @@ export function LoginForm({}: Props) {
             leftIcon={<Github />}
             sx={{ color: colors.B40, fontSize: '16px', fontWeight: 700, height: '50px' }}
           >
-            Sign In with Github
+            Sign In with GitHub
           </GithubButton>
           <Divider label={<Text color={colors.B40}>Or</Text>} color={colors.B30} labelPosition="center" my="md" />
         </>

--- a/apps/web/src/components/layout/components/AuthContainer.tsx
+++ b/apps/web/src/components/layout/components/AuthContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { colors, Text, Title, Container } from '../../../design-system';
+import PageMeta from './PageMeta';
 
 export default function AuthContainer({
   title,
@@ -14,19 +15,17 @@ export default function AuthContainer({
 }) {
   return (
     <Container
-      size={600}
       sx={{
-        marginRight: '20%',
-        paddingTop: '5%',
-        '@media (max-width: 1500px)': {
-          marginRight: '10%',
-        },
+        display: 'flex',
+        alignItems: 'center',
+        margin: 0,
         '@media (max-width: 1100px)': {
-          marginRight: 'auto',
+          justifyContent: 'center',
         },
       }}
     >
-      <div style={{ marginTop: '30px' }}>
+      <PageMeta title={title} />
+      <div style={{ margin: '30px 0', width: '100%', maxWidth: 550 }}>
         <Title>{title}</Title>
         {customDescription || (
           <Text size="lg" color={colors.B60} mb={60} mt={20}>

--- a/apps/web/src/components/layout/components/AuthLayout.tsx
+++ b/apps/web/src/components/layout/components/AuthLayout.tsx
@@ -7,20 +7,20 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <ThemeProvider>
-      <div style={{ minHeight: 950 }}>
-        <div className={classes.wrapper}>
+      <div className={classes.wrapper}>
+        <div className={classes.bg}>
           <img
             src="/static/images/logo-formerly-dark-bg.png"
             alt="logo"
-            style={{ maxWidth: 150, marginTop: 5, marginLeft: 5 }}
+            style={{ alignSelf: 'flex-start', maxWidth: 150, marginTop: 5, marginLeft: 5 }}
           />
           <Box
             sx={{
               position: 'absolute',
+              right: '50%',
               display: 'flex',
               flexDirection: 'column',
-              left: 120,
-              top: 'calc(50% - 165px)',
+              transform: 'translate(35%, 7%)',
               '@media (max-width: 1200px)': {
                 display: 'none',
               },
@@ -47,14 +47,18 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
 
 const useStyles = createStyles((theme) => ({
   wrapper: {
-    height: '100%',
-    minHeight: 950,
-    position: 'absolute',
-    width: '100%',
-    zIndex: -1,
-    left: '0px',
-    top: '0px',
-    backgroundSize: 'contain',
+    display: 'grid',
+    gridAutoFlow: 'column',
+    gridAutoColumns: '1fr',
+    columnGap: 25,
+    minHeight: '100vh',
+  },
+  bg: {
+    display: 'flex',
+    alignItems: 'center',
+    position: 'relative',
+    minWidth: 600,
+    backgroundSize: '70% 100%',
     backgroundRepeat: 'no-repeat',
     backgroundImage: `url('/static/images/signin_bg.png')`,
     '@media (max-width: 1100px)': {

--- a/apps/web/src/design-system/password-input/PasswordInput.tsx
+++ b/apps/web/src/design-system/password-input/PasswordInput.tsx
@@ -46,8 +46,4 @@ const StyledPassword = styled(MantinePasswordInput)<{ error?: any }>`
   input {
     height: 100%;
   }
-
-  input::placeholder {
-    color: ${colors.B40};
-  }
 `;

--- a/apps/web/src/pages/auth/InvitationPage.tsx
+++ b/apps/web/src/pages/auth/InvitationPage.tsx
@@ -80,16 +80,14 @@ export default function InvitationPage() {
             </Center>
           }
         >
-          <div style={{ position: 'relative', minHeight: 'inherit' }}>
-            <LoadingOverlay
-              visible={isLoading}
-              overlayColor={colors.B30}
-              loaderProps={{
-                color: colors.error,
-              }}
-            />
-            {!isLoading && <SignUpForm email={data?.email} token={tokenParam} />}
-          </div>
+          <LoadingOverlay
+            visible={isLoading}
+            overlayColor={colors.B30}
+            loaderProps={{
+              color: colors.error,
+            }}
+          />
+          {!isLoading && <SignUpForm email={data?.email} token={tokenParam} />}
         </AuthContainer>
       )}
     </AuthLayout>

--- a/apps/web/src/pages/auth/InvitationPage.tsx
+++ b/apps/web/src/pages/auth/InvitationPage.tsx
@@ -23,6 +23,8 @@ export default function InvitationPage() {
       enabled: !!tokenParam,
     }
   );
+  const inviterFirstName = data?.inviter?.firstName || '';
+  const organizationName = data?.organization.name || '';
 
   const logoutWhenActiveSession = () => {
     logout();
@@ -61,23 +63,25 @@ export default function InvitationPage() {
         <AuthContainer
           title="Get Started"
           customDescription={
-            <Center inline mb={60} mt={20}>
-              <Text size="lg" mr={4} color={colors.B60}>
-                You've been invited by
-              </Text>
-              <Text size="lg" weight="bold" mr={4}>
-                {data?.inviter?.firstName || ''}
-              </Text>
-              <Text size="lg" mr={4} color={colors.B60}>
-                to join
-              </Text>
-              <Text size="lg" weight="bold">
-                {data?.organization.name || ''}
-              </Text>
-              <Text size="lg" color={colors.B60}>
-                .
-              </Text>
-            </Center>
+            inviterFirstName && organizationName ? (
+              <Center inline mb={60} mt={20}>
+                <Text size="lg" mr={4} color={colors.B60}>
+                  You've been invited by
+                </Text>
+                <Text size="lg" weight="bold" mr={4}>
+                  {inviterFirstName[0].toUpperCase() + inviterFirstName.slice(1)}
+                </Text>
+                <Text size="lg" mr={4} color={colors.B60}>
+                  to join
+                </Text>
+                <Text size="lg" weight="bold">
+                  {organizationName}
+                </Text>
+                <Text size="lg" color={colors.B60}>
+                  .
+                </Text>
+              </Center>
+            ) : undefined
           }
         >
           <LoadingOverlay


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Various improvements for auth pages

- **Why was this change needed?** (You can also link to an open issue here)

- First of all, preventing vertical scrolling (due setting of min-width) when it is not needed, see current behavior:

| Desktop   | Mobile    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/198245616-35771eed-e82d-46fc-8133-8588db1b62f2.png) | ![image](https://user-images.githubusercontent.com/4408379/198245738-6321488e-a81c-4517-be78-a8aaeff6f1b5.png) |



- Align content of the auth pages in center looks more neat:

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/198246486-8cddd5d1-9442-4339-a06a-b26cd96756ef.png) | ![image](https://user-images.githubusercontent.com/4408379/198246399-364aa541-9fa9-4179-a2cd-7addb5eb2eea.png) |

- Make placeholder color text equal for both inputs

- Providing meta title for each of auth page

- Fix proper naming of GitHub

- Capitalize inviter name on Invitation page




- **Other information**:
