### PR TITLE
removed duplicate entry and corrected alphabetical order

### DIFF
--- a/packages/notification-center/src/i18n/lang.ts
+++ b/packages/notification-center/src/i18n/lang.ts
@@ -1,69 +1,71 @@
-import { EN } from './languages/en';
-import { FI } from './languages/fi';
-import { FR } from './languages/fr';
-import { HI } from './languages/hi';
-import { ID } from './languages/id';
-import { IT } from './languages/it';
-import { KA } from './languages/ka';
-import { MR } from './languages/mr';
-import { MS } from './languages/ms';
-import { RU } from './languages/ru';
-import { UK } from './languages/uk';
-import { ES } from './languages/es';
-import { GL } from './languages/gl';
-import { FA } from './languages/fa';
+import { AF } from './languages/af';
 import { AR } from './languages/ar';
-import { GU } from './languages/gu';
-import { DE } from './languages/de';
-import { BN } from './languages/bn';
-import { ML } from './languages/ml';
-import { ZH } from './languages/zh';
-import { HR } from './languages/hr';
-import { OR } from './languages/or';
-import { SA } from './languages/sa';
-import { NE } from './languages/ne';
-import { UR } from './languages/ur';
-import { PL } from './languages/pl';
-import { CS } from './languages/cs';
-import { PA } from './languages/pa';
-import { TA } from './languages/ta';
-import { SD } from './languages/sd';
-import { CA } from './languages/ca';
-import { IG } from './languages/ig';
-import { KO } from './languages/ko';
-import { KU } from './languages/ku';
-import { EL } from './languages/el';
-import { JA } from './languages/ja';
-import { HU } from './languages/hu';
-import { BG } from './languages/bg';
-import { DA } from './languages/da';
 import { AS } from './languages/as';
 import { AZ } from './languages/az';
-import { SI } from './languages/si';
-import { NO } from './languages/no';
-import { PT } from './languages/pt';
-import { SV } from './languages/sv';
-import { TR } from './languages/tr';
-import { TE } from './languages/te';
-import { LO } from './languages/lo';
-import { RO } from './languages/ro';
-import { VI } from './languages/vi';
-import { ZU } from './languages/zu';
-import { NL } from './languages/nl';
-import { UZ } from './languages/uz';
-import { TH } from './languages/th';
-import { HE } from './languages/he';
-import { KM } from './languages/km';
-import { GA } from './languages/ga';
-import { HY } from './languages/hy';
-import { KK } from './languages/kk';
-import { TL } from './languages/tl';
-import { EU } from './languages/eu';
-import { AF } from './languages/af';
 import { BE } from './languages/be';
-import { SQ } from './languages/sq';
+import { BG } from './languages/bg';
+import { BH } from './languages/bh';
+import { BN } from './languages/bn';
+import { CA } from './languages/ca';
+import { CS } from './languages/cs';
+import { DA } from './languages/da';
+import { DE } from './languages/de';
+import { EL } from './languages/el';
+import { EN } from './languages/en';
+import { ES } from './languages/es';
+import { EU } from './languages/eu';
+import { FA } from './languages/fa';
+import { FI } from './languages/fi';
+import { FR } from './languages/fr';
+import { GA } from './languages/ga';
+import { GL } from './languages/gl';
+import { GU } from './languages/gu';
+import { HE } from './languages/he';
+import { HI } from './languages/hi';
+import { HR } from './languages/hr';
+import { HU } from './languages/hu';
+import { HY } from './languages/hy';
+import { ID } from './languages/id';
+import { IG } from './languages/ig';
+import { IT } from './languages/it';
+import { JA } from './languages/ja';
+import { KA } from './languages/ka';
+import { KK } from './languages/kk';
+import { KM } from './languages/km';
+import { KO } from './languages/ko';
+import { KU } from './languages/ku';
+import { LO } from './languages/lo';
 import { LT } from './languages/lt';
 import { LV } from './languages/lv';
+import { ML } from './languages/ml';
+import { MR } from './languages/mr';
+import { MS } from './languages/ms';
+import { NE } from './languages/ne';
+import { NL } from './languages/nl';
+import { NO } from './languages/no';
+import { OR } from './languages/or';
+import { PA } from './languages/pa';
+import { PL } from './languages/pl';
+import { PT } from './languages/pt';
+import { RO } from './languages/ro';
+import { RU } from './languages/ru';
+import { SA } from './languages/sa';
+import { SD } from './languages/sd';
+import { SI } from './languages/si';
+import { SQ } from './languages/sq';
+import { SV } from './languages/sv';
+import { TA } from './languages/ta';
+import { TE } from './languages/te';
+import { TH } from './languages/th';
+import { TL } from './languages/tl';
+import { TR } from './languages/tr';
+import { UK } from './languages/uk';
+import { UR } from './languages/ur';
+import { UZ } from './languages/uz';
+import { VI } from './languages/vi';
+import { ZH } from './languages/zh';
+import { ZU } from './languages/zu';
+
 
 export interface ITranslationContent {
   readonly notifications: string;
@@ -78,72 +80,73 @@ export interface ITranslationEntry {
 }
 
 export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
-  en: EN,
-  ro: RO,
-  fi: FI,
-  hi: HI,
-  fr: FR,
-  gu: GU,
-  ru: RU,
-  es: ES,
-  gl: GL,
-  id: ID,
-  it: IT,
-  ka: KA,
-  ig: IG,
-  mr: MR,
-  ms: MS,
+  af: AF,
   ar: AR,
-  fa: FA,
-  uk: UK,
-  de: DE,
-  bn: BN,
-  ml: ML,
-  zh: ZH,
-  hr: HR,
-  or: OR,
-  sa: SA,
-  ur: UR,
-  ne: NE,
-  pl: PL,
-  cs: CS,
-  pa: PA,
-  ta: TA,
-  sd: SD,
-  ca: CA,
-  ko: KO,
-  ku: KU,
-  el: EL,
-  ja: JA,
-  sv: SV,
-  hu: HU,
-  bg: BG,
-  da: DA,
   as: AS,
   az: AZ,
-  si: SI,
-  no: NO,
-  pt: PT,
-  tr: TR,
-  te: TE,
-  lo: LO,
-  vi: VI,
-  zu: ZU,
-  nl: NL,
-  uz: UZ,
-  th: TH,
-  he: HE,
-  km: KM,
-  ga: GA,
-  hy: HY,
-  kk: KK,
-  tl: TL,
-  eu: EU,
-  af: AF,
   be: BE,
-  sq: SQ,
+  bg: BG,
+  bh: BH,
+  bn: BN,
+  ca: CA,
+  cs: CS,
+  da: DA,
+  de: DE,
+  el: EL,
+  en: EN,
+  es: ES,
+  eu: EU,
+  fa: FA,
+  fi: FI,
+  fr: FR,
+  ga: GA,
+  gl: GL,
+  gu: GU,
+  he: HE,
+  hi: HI,
+  hr: HR,
+  hu: HU,
+  hy: HY,
+  id: ID,
+  ig: IG,
+  it: IT,
+  ja: JA,
+  ka: KA,
+  kk: KK,
+  km: KM,
+  ko: KO,
+  ku: KU,
+  lo: LO,
   lt: LT,
   lv: LV,
+  ml: ML,
+  mr: MR,
+  ms: MS,
+  ne: NE,
+  nl: NL,
+  no: NO,
+  or: OR,
+  pa: PA,
+  pl: PL,
+  pt: PT,
+  ro: RO,
+  ru: RU,
+  sa: SA,
+  sd: SD,
+  si: SI,
+  sq: SQ,
+  sv: SV,
+  ta: TA,
+  te: TE,
+  th: TH,
+  tl: TL,
+  tr: TR,
+  uk: UK,
+  ur: UR,
+  uz: UZ,
+  vi: VI,
+  zh: ZH,
+  zu: ZU,
 };
 
 /**
@@ -158,70 +161,70 @@ export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
  * https://docs.novu.co/notification-center/react-components#customize-the-ui-language
  */
 export type I18NLanguage =
-  | 'en'
-  | 'ro'
-  | 'fi'
-  | 'hi'
-  | 'id'
-  | 'it'
-  | 'ka'
-  | 'gu'
-  | 'mr'
-  | 'ms'
-  | 'ru'
-  | 'uk'
-  | 'es'
-  | 'gl'
+  | 'af'
   | 'ar'
-  | 'fa'
-  | 'fr'
-  | 'de'
-  | 'ig'
-  | 'bn'
-  | 'ml'
-  | 'zh'
-  | 'hr'
-  | 'or'
-  | 'sa'
-  | 'ur'
-  | 'ne'
-  | 'pl'
-  | 'cs'
-  | 'sv'
-  | 'sd'
-  | 'ca'
-  | 'pa'
-  | 'ta'
-  | 'ko'
-  | 'bg'
-  | 'ku'
-  | 'el'
-  | 'ja'
-  | 'hu'
-  | 'da'
-  | 'si'
-  | 'pt'
-  | 'tr'
   | 'as'
   | 'az'
-  | 'no'
-  | 'te'
+  | 'be'
+  | 'bg'
+  | 'bh'
+  | 'bn'
+  | 'ca'
+  | 'cs'
   | 'da'
-  | 'vi'
-  | 'zu'
-  | 'nl'
-  | 'uz'
-  | 'lo'
-  | 'th'
-  | 'he'
+  | 'de'
+  | 'el'
+  | 'en'
+  | 'es'
+  | 'eu'
+  | 'fa'
+  | 'fi'
+  | 'fr'
   | 'ga'
+  | 'gl'
+  | 'gu'
+  | 'he'
+  | 'hi'
+  | 'hr'
+  | 'hu'
   | 'hy'
+  | 'id'
+  | 'ig'
+  | 'it'
+  | 'ja'
+  | 'ka'
   | 'kk'
   | 'km'
-  | 'tl'
-  | 'af'
-  | 'be'
-  | 'sq'
+  | 'ko'
+  | 'ku'
+  | 'lo'
   | 'lt'
   | 'lv'
-  | 'eu';
+  | 'ml'
+  | 'mr'
+  | 'ms'
+  | 'ne'
+  | 'nl'
+  | 'no'
+  | 'or'
+  | 'pa'
+  | 'pl'
+  | 'pt'
+  | 'ro'
+  | 'ru'
+  | 'sa'
+  | 'sd'
+  | 'si'
+  | 'sq'
+  | 'sv'
+  | 'ta'
+  | 'te'
+  | 'th'
+  | 'tl'
+  | 'tr'
+  | 'uk'
+  | 'ur'
+  | 'uz'
+  | 'vi'
+  | 'zh'
+  | 'zu';


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
made all language codes alphabetically correct.
also removed the duplicate entry of language code da from line number 201 and 209.

- **Why was this change needed?** (You can also link to an open issue here)
While all language codes were placed randomly it was possible for an duplicate entry.
its not a big issue to have duplicate entry but it is good practice to avoid it. so removed duplicate entry of da.
