### PR TITLE
fix(web): remove back link and fix layout footer of exec-det

### DIFF
--- a/apps/web/src/components/activity/ExecutionDetailsFooter.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailsFooter.tsx
@@ -1,50 +1,21 @@
-import { Grid } from '@mantine/core';
-import { Link } from 'react-router-dom';
+import { Group } from '@mantine/core';
 import styled from 'styled-components';
 
 import { GotAQuestionButton } from '../utils/GotAQuestionButton';
-import { colors, Text } from '../../design-system';
-import { ArrowLeft } from '../../design-system/icons';
+import { colors, Container, Text } from '../../design-system';
 
-const LinkWrapper = styled.div`
-  display: flex;
-  justify-content: start;
-  padding-top: 35px;
-`;
-
-const LinkText = styled(Text)`
-  color: ${colors.B60};
-  font-size: 14px;
-  line-height: 17px;
-  padding-left: 5px;
-  padding-top: 3px;
-`;
-
-const ActionsWrapper = styled(LinkWrapper)`
+const ActionsWrapper = styled(Container)`
   margin: 0;
   padding: 0;
 `;
 
-export const ExecutionDetailsFooter = ({ onClose, origin }) => {
-  // TODO: Might be a good idea pass the name of the origin rather than the location path
-  const linkText = `Back to ${origin.replace('/', '')}`;
-
+export const ExecutionDetailsFooter = () => {
   return (
-    <Grid gutter={10}>
-      <Grid.Col span={3}>
-        <LinkWrapper>
-          <ArrowLeft height={24} width={24} color={colors.B60} />
-          <Link to={origin} onClick={onClose}>
-            <LinkText>{linkText}</LinkText>
-          </Link>
-        </LinkWrapper>
-      </Grid.Col>
-      <Grid.Col span={2} offset={7}>
-        <ActionsWrapper>
-          {/* TODO: Button has a margin top that's not possible to overload */}
-          <GotAQuestionButton mt={30} size="md" />
-        </ActionsWrapper>
-      </Grid.Col>
-    </Grid>
+    <Group position="right">
+      <ActionsWrapper>
+        {/* TODO: Button has a margin top that's not possible to overload */}
+        <GotAQuestionButton mt={30} size="md" />
+      </ActionsWrapper>
+    </Group>
   );
 };

--- a/apps/web/src/components/activity/ExecutionDetailsModal.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailsModal.tsx
@@ -10,13 +10,11 @@ import { colors, shadows, Title } from '../../design-system';
 export function ExecutionDetailsModal({
   notificationId,
   modalVisibility,
-  origin,
   onClose,
 }: {
   notificationId: string;
   modalVisibility: boolean;
   onClose: () => void;
-  origin: string;
 }) {
   const theme = useMantineTheme();
   const { data: response, isLoading } = useQuery(['activity', notificationId], () => getNotification(notificationId), {
@@ -59,7 +57,7 @@ export function ExecutionDetailsModal({
         data-test-id="execution-details-modal-loading-overlay"
       />
       <ExecutionDetailsAccordion steps={jobs} />
-      <ExecutionDetailsFooter onClose={onClose} origin={origin} />
+      <ExecutionDetailsFooter />
     </Modal>
   );
 }

--- a/apps/web/src/components/templates/ExecutionDetailsModalWrapper.tsx
+++ b/apps/web/src/components/templates/ExecutionDetailsModalWrapper.tsx
@@ -30,12 +30,7 @@ export const ExecutionDetailsModalWrapper = ({ transactionId, isOpen, onClose }:
         }}
       />
       {notification?.data?.length && (
-        <ExecutionDetailsModal
-          notificationId={notification?.data[0]._id}
-          modalVisibility={isOpen}
-          onClose={onClose}
-          origin={location.pathname}
-        />
+        <ExecutionDetailsModal notificationId={notification?.data[0]._id} modalVisibility={isOpen} onClose={onClose} />
       )}
     </>
   );

--- a/apps/web/src/pages/activities/ActivitiesPage.tsx
+++ b/apps/web/src/pages/activities/ActivitiesPage.tsx
@@ -130,12 +130,7 @@ export function ActivitiesPage() {
           onPageChange: handleTableChange,
         }}
       />
-      <ExecutionDetailsModal
-        notificationId={notificationId}
-        modalVisibility={isModalOpen}
-        onClose={onModalClose}
-        origin={location.pathname}
-      />
+      <ExecutionDetailsModal notificationId={notificationId} modalVisibility={isModalOpen} onClose={onModalClose} />
     </PageContainer>
   );
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix)

Removes the link back where the execution details modal has been opened from and fixes the footer layout at the same time.

- **Why was this change needed?** (You can also link to an open issue here)
UI fixes.

- **Other information**:

BEFORE
<img width="1503" alt="Screenshot 2022-10-28 at 15 22 49" src="https://user-images.githubusercontent.com/18152036/198647478-f4174a77-2e3f-4fdf-8f78-ac8c109708fe.png">

AFTER
<img width="1571" alt="Screenshot 2022-10-28 at 15 28 42" src="https://user-images.githubusercontent.com/18152036/198647562-0dd923bf-a42a-47e6-a1ad-49dc7af340b3.png">
