### PR TITLE
fix: so date is visible on hover in dark mode

### DIFF
--- a/apps/web/src/components/activity/ExecutionDetailsStepHeader.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailsStepHeader.tsx
@@ -26,7 +26,7 @@ const StepDetails = styled(Text)<{ theme: string }>`
 `;
 
 const StepDate = styled(Text)<{ theme: string }>`
-  color: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.B30 : colors.B60)};
+  color: ${colors.B60};
   font-size: 12px;
   line-height: 16px;
   padding: 3px 0 0;


### PR DESCRIPTION
### What kind of change does this PR introduce? 
- [x] Bug
- [ ] Feature
- [ ] Docs
- [ ] Other(s)

### Why was this change needed?
https://linear.app/novu/issue/NV-1109/hover-and-time-color-identical-in-dark-mode

### Other information (Screenshots)
<img width="1512" alt="Screenshot 2022-10-31 at 06 37 46" src="https://user-images.githubusercontent.com/2233092/198939308-59d8424c-689a-46e6-bd00-a6082ee4259b.png">
<img width="1512" alt="Screenshot 2022-10-31 at 06 37 53" src="https://user-images.githubusercontent.com/2233092/198939312-37da5032-fa2e-4850-8d44-0dc913b09ce9.png">

