### PR TITLE
feat(web): temporarily hide webhook feedback from ui

### DIFF
--- a/apps/web/src/components/activity/ExecutionDetailsStepHeader.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailsStepHeader.tsx
@@ -1,12 +1,13 @@
-import { Container, Grid, Group, useMantineColorScheme } from '@mantine/core';
+import { Container, Grid, useMantineColorScheme } from '@mantine/core';
 import { ChannelTypeEnum, ExecutionDetailsStatusEnum, StepTypeEnum, DelayTypeEnum } from '@novu/shared';
 import { format, parseISO } from 'date-fns';
 import styled from 'styled-components';
 
+import { ExecutionDetailsWebhookFeedback } from './ExecutionDetailsWebhookFeedback';
 import { getLogoByType } from './helpers';
 
 import { colors, Text } from '../../design-system';
-import { CheckCircle, Clicked, ErrorIcon, Read, Received, Seen, Sent } from '../../design-system/icons';
+import { CheckCircle, ErrorIcon } from '../../design-system/icons';
 
 const StepName = styled(Text)<{ theme: string }>`
   color: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.white : colors.B40)};
@@ -44,22 +45,6 @@ const LogoWrapper = styled(Container)`
   max-width: 50px;
   padding: 10px 10px 0 0;
   position: relative;
-`;
-
-const StepActionOutcomeWrapper = styled(Container)`
-  align-items: center;
-  display: flex;
-  flex-flow: column;
-  justify-content: center;
-  margin: 0;
-  padding: 15px 0 0;
-`;
-
-const StepActionOutcomeName = styled(Text)`
-  color: ${colors.B60};
-  font-size: 12px;
-  line-height: 16px;
-  padding-top: 5px;
 `;
 
 const getLogoStyledComponentByStepStatus = (status, type) => {
@@ -157,30 +142,6 @@ const StepOutcome = ({ createdAt, name, detail, status }) => {
   );
 };
 
-const StepActionOutcome = ({ icon, text }) => {
-  const Icon = icon;
-
-  return (
-    <StepActionOutcomeWrapper>
-      <Icon height="15px" width="15px" />
-      <StepActionOutcomeName>{text}</StepActionOutcomeName>
-    </StepActionOutcomeWrapper>
-  );
-};
-
-// TODO: Render based on API response. So far we do placeholders.
-const StepActionOutcomes = () => {
-  return (
-    <Group position="right" spacing="xs">
-      <StepActionOutcome icon={Sent} text="Sent" />
-      <StepActionOutcome icon={Received} text="Received" />
-      <StepActionOutcome icon={Read} text="Read" />
-      <StepActionOutcome icon={Seen} text="Seen" />
-      <StepActionOutcome icon={Clicked} text="Clicked" />
-    </Group>
-  );
-};
-
 export const ExecutionDetailsStepHeader = ({ step }) => {
   const { status } = step?.executionDetails.at(-1) || {};
   const generatedDetail = generateDetailByStepAndStatus(status, step);
@@ -194,7 +155,7 @@ export const ExecutionDetailsStepHeader = ({ step }) => {
         <StepOutcome createdAt={step?.createdAt} name={step?.type} detail={generatedDetail} status={status} />
       </Grid.Col>
       <Grid.Col span={4}>
-        <StepActionOutcomes />
+        <ExecutionDetailsWebhookFeedback show={false} />
       </Grid.Col>
     </Grid>
   );

--- a/apps/web/src/components/activity/ExecutionDetailsWebhookFeedback.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailsWebhookFeedback.tsx
@@ -1,0 +1,49 @@
+import { Group } from '@mantine/core';
+import styled from 'styled-components';
+
+import { colors, Container, Text } from '../../design-system';
+import { Clicked, Read, Received, Seen, Sent } from '../../design-system/icons';
+
+const WebhookFeedbackWrapper = styled(Container)`
+  align-items: center;
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
+  margin: 0;
+  padding: 15px 0 0;
+`;
+
+const WebhookFeedbackTitle = styled(Text)`
+  color: ${colors.B60};
+  font-size: 12px;
+  line-height: 16px;
+  padding-top: 5px;
+`;
+
+const WebhookFeedback = ({ icon, text }) => {
+  const Icon = icon;
+
+  return (
+    <WebhookFeedbackWrapper>
+      <Icon height="15px" width="15px" />
+      <WebhookFeedbackTitle>{text}</WebhookFeedbackTitle>
+    </WebhookFeedbackWrapper>
+  );
+};
+
+// TODO: Render based on API response. So far we do placeholders.
+export const ExecutionDetailsWebhookFeedback = ({ show }) => {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <Group position="right" spacing="xs">
+      <WebhookFeedback icon={Sent} text="Sent" />
+      <WebhookFeedback icon={Received} text="Received" />
+      <WebhookFeedback icon={Read} text="Read" />
+      <WebhookFeedback icon={Seen} text="Seen" />
+      <WebhookFeedback icon={Clicked} text="Clicked" />
+    </Group>
+  );
+};


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What kind of change does this PR introduce? 
<!-- Mark All The Applicable Boxes and add some information -->

- [ ] Bug
- [X] Feature
- [ ] Docs
- [ ] Other(s)


### Why was this change needed?
This bit is not implemented yet in the API so we will hide it for now.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->


### Other information (Screenshots)
<img width="1467" alt="Screenshot 2022-10-31 at 10 21 43" src="https://user-images.githubusercontent.com/18152036/198989407-5609c3c3-6607-4853-97ea-562942c306b0.png">

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
