### PR TITLE
fix: color of digest icon if no explicit color is passed 

### DIFF
--- a/apps/web/src/design-system/icons/general/Digest.tsx
+++ b/apps/web/src/design-system/icons/general/Digest.tsx
@@ -6,7 +6,7 @@ export function Digest(props: React.ComponentPropsWithoutRef<'svg'>) {
     <svg xmlns="http://www.w3.org/2000/svg" viewBox={`0 0 ${props.width} ${props.height}`} fill="none" {...props}>
       <path
         d="M1 19L12 25L23 19M1 13L12 19L23 13M12 1L1 7L12 13L23 7L12 1Z"
-        stroke={props.color}
+        stroke={props.color ? props.color : 'currentColor'}
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What kind of change does this PR introduce? 
<!-- Mark All The Applicable Boxes and add some information -->

- [x] Bug
- [ ] Feature
- [ ] Docs
- [ ] Other(s)


### Why was this change needed?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
<img width="1549" alt="Screen Shot 2022-10-31 at 19 35 52" src="https://user-images.githubusercontent.com/7778680/199074524-269f2c3e-1ef9-4e21-9380-4afdb577be53.png"><!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
after:
<img width="1635" alt="Screen Shot 2022-10-31 at 19 39 28" src="https://user-images.githubusercontent.com/7778680/199074557-150f6951-0e1b-49f2-b4e4-ef86583cfb7e.png">


### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
