### PR TITLE
fix(web): avoid execution details modal to break when no subscriber vars

### DIFF
--- a/apps/web/src/components/activity/ExecutionDetailTrigger.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailTrigger.tsx
@@ -16,12 +16,14 @@ const buildTrigger = (identifier, subscriberVariables, payload): INotificationTr
     type: TriggerTypeEnum.EVENT,
     identifier,
     variables: payload ? Object.entries(payload).map(([name, value]) => ({ name, value })) : [],
-    subscriberVariables: Object.keys(subscriberVariables).map((key) => {
-      return {
-        name: key,
-        value: subscriberVariables[key],
-      };
-    }),
+    subscriberVariables: subscriberVariables
+      ? Object.keys(subscriberVariables).map((key) => {
+          return {
+            name: key,
+            value: subscriberVariables[key],
+          };
+        })
+      : [],
   };
 };
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What kind of change does this PR introduce? 
<!-- Mark All The Applicable Boxes and add some information -->

- [X] Bug
- [ ] Feature
- [ ] Docs
- [ ] Other(s)

Prevent in code missing subscriber variables to be parsed.

### Why was this change needed?
When the notification has no subscriber variables the execution details modal breaks.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->


### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
