### PR TITLE
fix(web): make step hover border round

### DIFF
--- a/apps/web/src/components/activity/ExecutionDetailsAccordion.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailsAccordion.tsx
@@ -16,6 +16,9 @@ const useStyles = createStyles((theme) => ({
     paddingLeft: '25px',
     paddingRight: '25px',
     paddingTop: '15px',
+    '&:hover': {
+      borderRadius: '7px',
+    },
   },
   item: {
     border: `1px solid ${theme.colorScheme === 'dark' ? colors.B30 : colors.B85}`,


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What kind of change does this PR introduce? 
<!-- Mark All The Applicable Boxes and add some information -->

- [X] Bug
- [ ] Feature
- [ ] Docs
- [ ] Other(s)

Make the border radius round for the steps in the execution details modal when hovered.

### Why was this change needed?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
The border radius of the steps in the execution details modal when hovered where square.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->


### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
BEFORE
<img width="227" alt="Screenshot 2022-11-01 at 16 44 41" src="https://user-images.githubusercontent.com/18152036/199299931-e5ee867a-cf71-4003-a7d2-de34d124f4fd.png">

AFTER
<img width="294" alt="Screenshot 2022-11-01 at 17 28 25" src="https://user-images.githubusercontent.com/18152036/199299970-16adacfb-a8a8-4c7b-b3c2-6a9455b7963b.png">
