### PR TITLE
fix: details icon to show failed and success icons

### DIFF
--- a/apps/web/src/components/activity/ExecutionDetail.tsx
+++ b/apps/web/src/components/activity/ExecutionDetail.tsx
@@ -3,7 +3,7 @@ import { format, parseISO } from 'date-fns';
 import styled from 'styled-components';
 
 import { ExecutionDetailShowRaw } from './ExecutionDetailShowRaw';
-import { getColorByStatus, getLogoByType, getCheckLogo } from './helpers';
+import { getColorByStatus, getLogoByType, getLogoByStatus } from './helpers';
 
 import { colors, Text } from '../../design-system';
 import { When } from '../utils/When';
@@ -33,7 +33,7 @@ const getExecutionDetailLogoByType = (type) => {
     return logo;
   }
 
-  return getCheckLogo();
+  return getLogoByStatus(type);
 };
 
 export const ExecutionDetail = ({

--- a/apps/web/src/components/activity/helpers.ts
+++ b/apps/web/src/components/activity/helpers.ts
@@ -1,22 +1,32 @@
-import { JobStatusEnum, StepTypeEnum } from '@novu/shared';
+import { ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
 import { MantineTheme } from '@mantine/core';
 
 import { colors } from '../../design-system';
-import { Chat, Check, Digest, InApp, Mail, Sms, Timer } from '../../design-system/icons';
+import { Chat, Check, CheckCircle, Digest, ErrorIcon, InApp, Mail, Sms, Timer } from '../../design-system/icons';
 
-export const getColorByStatus = (theme: MantineTheme, status: JobStatusEnum): string => {
-  if (status === JobStatusEnum.FAILED) {
+export const getColorByStatus = (theme: MantineTheme, status: ExecutionDetailsStatusEnum): string => {
+  if (status === ExecutionDetailsStatusEnum.FAILED) {
     return colors.error;
   }
 
-  if (status === JobStatusEnum.COMPLETED) {
+  if (status === ExecutionDetailsStatusEnum.SUCCESS) {
     return colors.success;
   }
 
   return theme.colorScheme === 'dark' ? colors.B60 : colors.B40;
 };
 
-export const getCheckLogo = (): React.FunctionComponent<React.ComponentPropsWithoutRef<'svg'>> => {
+export const getLogoByStatus = (
+  status: ExecutionDetailsStatusEnum
+): React.FunctionComponent<React.ComponentPropsWithoutRef<'svg'>> => {
+  if (status === ExecutionDetailsStatusEnum.SUCCESS) {
+    return CheckCircle;
+  }
+
+  if (status === ExecutionDetailsStatusEnum.FAILED) {
+    return ErrorIcon;
+  }
+
   return Check;
 };
 


### PR DESCRIPTION
### What kind of change does this PR introduce? 
- [x] Bug
- [ ] Feature
- [ ] Docs
- [ ] Other(s)

<img width="1349" alt="Screenshot 2022-11-08 at 11 28 52" src="https://user-images.githubusercontent.com/2233092/200541241-04d65949-847b-42d1-8e2f-8ee3f65fd090.png">
<img width="1349" alt="Screenshot 2022-11-08 at 11 28 58" src="https://user-images.githubusercontent.com/2233092/200541253-8743ca4e-2584-4e06-aca2-23f7e0c24843.png">
