### PR TITLE
feat: add transaction id filter to activity list

### DIFF
--- a/apps/web/src/pages/activities/ActivitiesPage.tsx
+++ b/apps/web/src/pages/activities/ActivitiesPage.tsx
@@ -108,6 +108,21 @@ export function ActivitiesPage() {
                 <Input
                   {...field}
                   error={fieldState.error?.message}
+                  label="Transaction ID"
+                  placeholder="Search by transaction id"
+                  value={field.value || ''}
+                />
+              )}
+              control={control}
+              name="transactionId"
+            />
+          </div>
+          <div style={{ minWidth: '250px' }}>
+            <Controller
+              render={({ field, fieldState }) => (
+                <Input
+                  {...field}
+                  error={fieldState.error?.message}
                   label="Search"
                   placeholder="Select Email or ID"
                   value={field.value || ''}

--- a/apps/web/src/pages/activities/components/ActivityItem.tsx
+++ b/apps/web/src/pages/activities/components/ActivityItem.tsx
@@ -123,6 +123,11 @@ export const ActivityItem = ({ item, onClick }) => {
                   <b>Subscriber id:</b> {item.subscriber.id}
                 </small>
               </div>
+              <div data-test-id="transaction-id">
+                <small>
+                  <b>Transaction id:</b> {item.transactionId}
+                </small>
+              </div>
             </div>
           </Grid.Col>
           <Grid.Col span={9}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What kind of change does this PR introduce? 
<!-- Mark All The Applicable Boxes and add some information -->

- [ ] Bug
- [x] Feature
- [ ] Docs
- [ ] Other(s)


### Why was this change needed?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->


### Other information (Screenshots)
It makes sense to me to also show the transaction id in an item, but maybe its too much information to show there
<img width="1294" alt="Screen Shot 2022-11-09 at 14 00 12" src="https://user-images.githubusercontent.com/7778680/200825056-5b75f73d-67e5-4769-9290-a52508505ca1.png">

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
