### PR TITLE
fix: remove blog.johnnyreilly.com Google Analytics tag

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -29,10 +29,7 @@ const codeTheme = require('./src/utils/prism');
             showLastUpdateAuthor: true,
             showLastUpdateTime: true,
           },
-          gtag: {
-            trackingID: 'G-226F0LR9KE',
-            anonymizeIP: true,
-          },
+
           theme: {
             customCss: require.resolve('./src/css/custom.scss'),
           },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -29,7 +29,10 @@ const codeTheme = require('./src/utils/prism');
             showLastUpdateAuthor: true,
             showLastUpdateTime: true,
           },
-
+          gtag: {
+            trackingID: 'G-ZC17SLMXRN',
+            anonymizeIP: true,
+          },
           theme: {
             customCss: require.resolve('./src/css/custom.scss'),
           },


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 

It will stop your docs site sending traffic data to Google Analytics against blog.johnnyreilly.com

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

You probably don't want to send traffic to my Google analytics property.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->

You can see me using it on my blog here: https://github.com/johnnyreilly/blog.johnnyreilly.com/blob/13e0433c32992592dfa59ff682c4443d8c62ef2c/blog-website/docusaurus.config.js#LL53C36-L53C36