### PR TITLE
fix: copy bell theme instead of using merge

### DIFF
--- a/packages/notification-center/src/hooks/use-default-theme.hook.ts
+++ b/packages/notification-center/src/hooks/use-default-theme.hook.ts
@@ -42,8 +42,8 @@ export function useDefaultBellColors(props: IDefaultBellColors): { bellColors: I
 
   const bellColors =
     colorScheme === 'light'
-      ? merge(defaultNotificationBellLightTheme, props?.bellColors)
-      : merge(defaultNotificationBellDarkTheme, props?.bellColors);
+      ? { ...defaultNotificationBellLightTheme, bellColors: props?.bellColors }
+      : { ...defaultNotificationBellDarkTheme, bellColors: props?.bellColors };
 
   return {
     bellColors,


### PR DESCRIPTION
### What change does this PR introduce? 

Fixes an issue where the notification center would break whenever the useDefaultBellColors was used. This was due to `defaultNotificationTheme` being a frozen object and attempting to use `merge` to update properties on it. This PR simply replaces the use of merge with copying the object using the spread operator.

### Why was this change needed?
Closes #2004 
