### PR TITLE
fix: validate mongo object id

### DIFF
--- a/apps/api/src/app/messages/messages.controller.ts
+++ b/apps/api/src/app/messages/messages.controller.ts
@@ -9,6 +9,7 @@ import { DeleteMessageResponseDto } from './dtos/delete-message-response.dto';
 import { ActivitiesResponseDto } from '../notifications/dtos/activities-response.dto';
 import { GetMessages, GetMessagesCommand } from './usecases/get-messages';
 import { MessagesResponseDto } from '../widgets/dtos/message-response.dto';
+import { DeleteMessageParams } from './params/delete-message.param';
 
 @Controller('/messages')
 @ApiTags('Messages')
@@ -75,7 +76,7 @@ export class MessagesController {
   })
   async deleteMessage(
     @UserSession() user: IJwtPayload,
-    @Param('messageId') messageId: string
+    @Param() { messageId }: DeleteMessageParams
   ): Promise<DeleteMessageResponseDto> {
     return await this.removeMessage.execute(
       RemoveMessageCommand.create({

--- a/apps/api/src/app/messages/params/delete-message.param.ts
+++ b/apps/api/src/app/messages/params/delete-message.param.ts
@@ -1,0 +1,6 @@
+import { IsMongoId } from 'class-validator';
+
+export class DeleteMessageParams {
+  @IsMongoId()
+  messageId: string;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

Fix "Internal server error" on request with an invalid mongo object id.
 
Error:
Cast to ObjectId failed for value "MESSAGE_ID" at path "_id" for model "Message".

Solves:
https://sentry.io/organizations/novu-r9/issues/3738921566/?alert_rule_id=10492815&alert_timestamp=1668417571510&alert_type=email&environment=dev&project=6248811&referrer=alert_email


### Why was this change needed?

Without the validation, the response from the server will be 
{
    "statusCode": 500,
    "message": "Internal server error"
}

After the change:
{
    "statusCode": 400,
    "message": [
        "messageId must be a mongodb id"
    ],
    "error": "Bad Request"
}


### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
