### PR TITLE
fix: so empty state can be provided to popover notification center

### DIFF
--- a/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
+++ b/packages/notification-center/src/components/popover-notification-center/PopoverNotificationCenter.tsx
@@ -15,6 +15,7 @@ interface IPopoverNotificationCenterProps {
   children: (props: INotificationBellProps) => JSX.Element;
   header?: () => JSX.Element;
   footer?: () => JSX.Element;
+  emptyState?: () => JSX.Element;
   listItem?: ListItem;
   colorScheme: ColorScheme;
   theme?: INovuThemePopoverProvider;
@@ -58,6 +59,7 @@ export function PopoverNotificationCenter({ children, ...props }: IPopoverNotifi
         footer={props.footer}
         colorScheme={props.colorScheme}
         theme={props.theme}
+        emptyState={props.emptyState}
         onActionClick={props.onActionClick}
         actionsResultBlock={props.actionsResultBlock}
         listItem={props.listItem}


### PR DESCRIPTION
### What change does this PR introduce? 
Make empty state prop a prop on popover as well.

### Why was this change needed?
To be able to override the empty state in the popover notification center as well...