### PR TITLE
feat(providers): add tls options to nodemailer

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -396,7 +396,9 @@
     "redlock",
     "axios",
     "ioredis",
-    "newrelic"
+    "newrelic",
+    "nodemailer",
+    "emailjs"
   ],
   "flagWords": [],
   "patterns": [

--- a/apps/api/src/app/events/services/mail-service/handlers/nodemailer.handler.ts
+++ b/apps/api/src/app/events/services/mail-service/handlers/nodemailer.handler.ts
@@ -1,6 +1,8 @@
 import { ChannelTypeEnum } from '@novu/shared';
 import { ICredentials } from '@novu/dal';
 import { NodemailerProvider } from '@novu/nodemailer';
+import { ConnectionOptions } from 'tls';
+
 import { BaseHandler } from './base.handler';
 
 export class NodemailerHandler extends BaseHandler {
@@ -15,6 +17,9 @@ export class NodemailerHandler extends BaseHandler {
       secure?: boolean;
       user: string;
       password: string;
+      requireTls: boolean;
+      ignoreTls: boolean;
+      tlsOptions: ConnectionOptions;
       dkim: {
         domainName: string;
         keySelector: string;
@@ -27,6 +32,9 @@ export class NodemailerHandler extends BaseHandler {
       secure: credentials.secure as boolean,
       user: credentials.user as string,
       password: credentials.password as string,
+      requireTls: credentials.requireTls as boolean,
+      ignoreTls: credentials.ignoreTls as boolean,
+      tlsOptions: credentials.tlsOptions as ConnectionOptions,
       dkim: {
         domainName: credentials.domain as string,
         keySelector: credentials.accountSid as string,

--- a/apps/web/cypress/tests/integration-store.spec.ts
+++ b/apps/web/cypress/tests/integration-store.spec.ts
@@ -5,38 +5,76 @@ describe('Integration store page', function () {
     cy.initializeSession().as('session');
   });
 
-  it('should display email available for connection', function () {
-    cy.visit('/integrations');
-    cy.location('pathname').should('equal', '/integrations');
+  describe('Sendgrid', () => {
+    it('should display email available for connection', function () {
+      cy.visit('/integrations');
+      cy.location('pathname').should('equal', '/integrations');
 
-    getFirstIntegrationCard().get('button').contains('Connect');
+      getFirstIntegrationCard().get('button').contains('Connect');
+    });
+
+    it('should display integrated sendgrid provider', function () {
+      interceptSendgridIntegration(true);
+
+      cy.visit('/integrations');
+
+      getFirstIntegrationCard().getByTestId('card-status-bar-active').contains('Active');
+    });
+
+    it('should display not integrated sendgrid provider', function () {
+      interceptSendgridIntegration(false);
+
+      cy.visit('/integrations');
+
+      getFirstIntegrationCard().getByTestId('card-status-bar-active').contains('Not Active');
+    });
+
+    it('should display use credentials on settings modal', function () {
+      interceptSendgridIntegration(true);
+
+      cy.visit('/integrations');
+
+      getFirstIntegrationCard().getByTestId('provider-card-settings-svg').click();
+
+      cy.getByTestId('apiKey').should('have.value', '123');
+      cy.getByTestId('from').should('have.value', 'cypress');
+    });
   });
 
-  it('should display integrated sendgrid provider', function () {
-    interceptIntegration(true);
+  describe('Nodemailer', () => {
+    it('should display email available for connection', function () {
+      cy.visit('/integrations');
+      cy.location('pathname').should('equal', '/integrations');
 
-    cy.visit('/integrations');
+      getFirstIntegrationCard().get('button').contains('Connect');
+    });
 
-    getFirstIntegrationCard().getByTestId('card-status-bar-active').contains('Active');
-  });
+    it('should display integrated nodemailer provider', function () {
+      interceptNodemailerIntegration(true);
 
-  it('should display not integrated sendgrid provider', function () {
-    interceptIntegration(false);
+      cy.visit('/integrations');
 
-    cy.visit('/integrations');
+      getFirstIntegrationCard().getByTestId('card-status-bar-active').contains('Active');
+    });
 
-    getFirstIntegrationCard().getByTestId('card-status-bar-active').contains('Not Active');
-  });
+    it('should display not integrated sendgrid provider', function () {
+      interceptNodemailerIntegration(false);
 
-  it('should display use credentials on settings modal', function () {
-    interceptIntegration(true);
+      cy.visit('/integrations');
 
-    cy.visit('/integrations');
+      getFirstIntegrationCard().getByTestId('card-status-bar-active').contains('Not Active');
+    });
 
-    getFirstIntegrationCard().getByTestId('provider-card-settings-svg').click();
+    it('should display use credentials on settings modal', function () {
+      interceptNodemailerIntegration(true);
 
-    cy.getByTestId('apiKey').should('have.value', '123');
-    cy.getByTestId('from').should('have.value', 'cypress');
+      cy.visit('/integrations');
+
+      getFirstIntegrationCard().getByTestId('provider-card-settings-svg').click();
+
+      cy.getByTestId('apiKey').should('have.value', '123');
+      cy.getByTestId('from').should('have.value', 'cypress');
+    });
   });
 });
 
@@ -44,7 +82,7 @@ function getFirstIntegrationCard() {
   return cy.getByTestId('integration-group-email').getByTestId('integration-provider-card-sendgrid').eq(0);
 }
 
-function interceptIntegration(isActive: boolean) {
+function interceptSendgridIntegration(isActive: boolean) {
   cy.intercept('*/integrations', {
     data: [
       {
@@ -52,6 +90,28 @@ function interceptIntegration(isActive: boolean) {
         providerId: 'sendgrid',
         active: isActive,
         credentials: { apiKey: '123', from: 'cypress' },
+      },
+    ],
+  });
+}
+
+function interceptNodemailerIntegration(isActive: boolean) {
+  cy.intercept('*/integrations', {
+    data: [
+      {
+        channel: ChannelTypeEnum.EMAIL,
+        providerId: 'nodemailer',
+        active: isActive,
+        credentials: {
+          from: 'cypress',
+          senderName: 'Novu',
+          host: 'localhost.novu.co',
+          port: 587,
+          secure: true,
+          requireTls: true,
+          ignoreTls: false,
+          tlsOptions: { requireUnauthorized: false },
+        },
       },
     ],
   });

--- a/libs/dal/src/repositories/integration/integration.entity.ts
+++ b/libs/dal/src/repositories/integration/integration.entity.ts
@@ -21,6 +21,9 @@ export interface ICredentials {
   serviceAccount?: string;
   baseUrl?: string;
   ipPoolName?: string;
+  requireTls?: boolean;
+  ignoreTls?: boolean;
+  tlsOptions?: Record<string, unknown>;
 }
 
 export class IntegrationEntity {

--- a/libs/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/libs/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -146,6 +146,24 @@ export const nodemailerConfig: IConfigCredentials[] = [
     required: false,
   },
   {
+    key: CredentialsKeyEnum.RequireTls,
+    displayName: 'Require TLS',
+    type: 'boolean',
+    required: false,
+  },
+  {
+    key: CredentialsKeyEnum.IgnoreTls,
+    displayName: 'Ignore TLS',
+    type: 'boolean',
+    required: false,
+  },
+  {
+    key: CredentialsKeyEnum.TlsOptions,
+    displayName: 'TLS options',
+    type: 'object',
+    required: false,
+  },
+  {
     key: CredentialsKeyEnum.Domain,
     displayName: 'DKIM: Domain name',
     type: 'string',

--- a/libs/shared/src/consts/providers/provider.enum.ts
+++ b/libs/shared/src/consts/providers/provider.enum.ts
@@ -21,6 +21,9 @@ export enum CredentialsKeyEnum {
   ServiceAccount = 'serviceAccount',
   BaseUrl = 'baseUrl',
   WebhookUrl = 'webhookUrl',
+  RequireTls = 'requireTls',
+  IgnoreTls = 'ignoreTls',
+  TlsOptions = 'tlsOptions',
 }
 
 export enum EmailProviderIdEnum {

--- a/libs/shared/src/dto/integration/construct-integration.interface.ts
+++ b/libs/shared/src/dto/integration/construct-integration.interface.ts
@@ -14,6 +14,9 @@ export interface ICredentialsDto {
   from?: string;
   senderName?: string;
   projectName?: string;
+  requireTls?: boolean;
+  ignoreTls?: boolean;
+  tlsOptions?: Record<string, unknown>;
 }
 export interface IConstructIntegrationDto {
   credentials: ICredentialsDto;

--- a/packages/application-generic/src/factories/mail/handlers/nodemailer.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/nodemailer.handler.ts
@@ -2,6 +2,7 @@ import { ChannelTypeEnum } from '@novu/shared';
 import { ICredentials } from '@novu/dal';
 import { NodemailerProvider } from '@novu/nodemailer';
 import { BaseHandler } from './base.handler';
+import { ConnectionOptions } from 'tls';
 
 export class NodemailerHandler extends BaseHandler {
   constructor() {
@@ -15,6 +16,9 @@ export class NodemailerHandler extends BaseHandler {
       secure?: boolean;
       user?: string;
       password?: string;
+      requireTls: boolean;
+      ignoreTls: boolean;
+      tlsOptions: ConnectionOptions;
       dkim?: {
         domainName: string;
         keySelector: string;
@@ -27,10 +31,13 @@ export class NodemailerHandler extends BaseHandler {
       secure: credentials.secure,
       user: credentials.user,
       password: credentials.password,
+      requireTls: credentials.requireTls,
+      ignoreTls: credentials.ignoreTls,
+      tlsOptions: credentials.tlsOptions,
       dkim: {
-        domainName: credentials.domain as string,
-        keySelector: credentials.accountSid as string,
-        privateKey: credentials.secretKey as string,
+        domainName: credentials.domain,
+        keySelector: credentials.accountSid,
+        privateKey: credentials.secretKey,
       },
     };
 

--- a/providers/nodemailer/README.md
+++ b/providers/nodemailer/README.md
@@ -22,18 +22,21 @@ const provider = new NodemailerProvider({
 To take advantage of the different advanced configurations of TLS options you can set up the following properties with their corresponding environment variable:
 
 - ignoreTls: NODEMAILER_IGNORE_TLS -> Boolean
+
 ```sh
 # .env
 NODEMAILER_IGNORE_TLS=true
 ```
 
 - requireTls: NODEMAILER_REQUIRE_TLS -> Boolean
+
 ```sh
 # .env
 NODEMAILER_REQUIRE_TLS=true
 ```
 
 - tlsOptions: NODEMAILER_TLS_OPTIONS -> JSON
+
 ```sh
 # .env
 NODEMAILER_TLS_OPTIONS={"rejectUnauthorized":false}

--- a/providers/nodemailer/README.md
+++ b/providers/nodemailer/README.md
@@ -16,3 +16,43 @@ const provider = new NodemailerProvider({
   secure: process.env.NODEMAILER_SECURE,
 });
 ```
+
+## Advanced configuration
+
+To take advantage of the different advanced configurations of TLS options you can set up the following properties with their corresponding environment variable:
+
+- ignoreTls: NODEMAILER_IGNORE_TLS -> Boolean
+```sh
+# .env
+NODEMAILER_IGNORE_TLS=true
+```
+
+- requireTls: NODEMAILER_REQUIRE_TLS -> Boolean
+```sh
+# .env
+NODEMAILER_REQUIRE_TLS=true
+```
+
+- tlsOptions: NODEMAILER_TLS_OPTIONS -> JSON
+```sh
+# .env
+NODEMAILER_TLS_OPTIONS={"rejectUnauthorized":false}
+```
+
+```javascript
+import { NodemailerProvider } from '@novu/nodemailer';
+
+const provider = new NodemailerProvider({
+  from: process.env.NODEMAILER_FROM_EMAIL,
+  host: process.env.NODEMAILER_HOST,
+  user: process.env.NODEMAILER_USERNAME,
+  password: process.env.NODEMAILER_PASSWORD,
+  port: process.env.NODEMAILER_PORT,
+  secure: process.env.NODEMAILER_SECURE,
+  ignoreTls: process.env.NODEMAILER_IGNORE_TLS,
+  requireTls: process.env.NODEMAILER_REQUIRE_TLS,
+  tlsOptions: process.env.NODEMAILER_TLS_OPTIONS,
+});
+```
+
+You can read more details of the different possible configurations in [Nodemailer documentation](https://nodemailer.com/smtp/#tls-options)

--- a/providers/nodemailer/src/lib/nodemailer.provider.ts
+++ b/providers/nodemailer/src/lib/nodemailer.provider.ts
@@ -18,7 +18,7 @@ interface INodemailerConfig {
   secure?: boolean;
   user?: string;
   password?: string;
-  dkim?: DKIM.SingleKeyOptions | undefined;
+  dkim?: DKIM.SingleKeyOptions;
   ignoreTls?: boolean;
   requireTls?: boolean;
   tlsOptions?: ConnectionOptions;

--- a/providers/nodemailer/src/lib/nodemailer.provider.ts
+++ b/providers/nodemailer/src/lib/nodemailer.provider.ts
@@ -8,6 +8,21 @@ import {
 } from '@novu/stateless';
 import nodemailer, { SendMailOptions, Transporter } from 'nodemailer';
 import DKIM from 'nodemailer/lib/dkim';
+import SMTPTransport from 'nodemailer/lib/smtp-transport';
+import { ConnectionOptions } from 'tls';
+
+interface INodemailerConfig {
+  from: string;
+  host: string;
+  port: number;
+  secure?: boolean;
+  user?: string;
+  password?: string;
+  dkim?: DKIM.SingleKeyOptions | undefined;
+  ignoreTls?: boolean;
+  requireTls?: boolean;
+  tlsOptions?: ConnectionOptions;
+}
 
 export class NodemailerProvider implements IEmailProvider {
   id = 'nodemailer';
@@ -16,17 +31,7 @@ export class NodemailerProvider implements IEmailProvider {
 
   private transports: Transporter;
 
-  constructor(
-    private config: {
-      from: string;
-      host: string;
-      port: number;
-      secure?: boolean;
-      user?: string;
-      password?: string;
-      dkim?: DKIM.SingleKeyOptions | undefined;
-    }
-  ) {
+  constructor(private config: INodemailerConfig) {
     let dkim = this.config.dkim;
 
     if (!dkim?.domainName || !dkim?.privateKey || !dkim?.keySelector) {
@@ -35,7 +40,9 @@ export class NodemailerProvider implements IEmailProvider {
 
     const authEnabled = this.config.user && this.config.password;
 
-    this.transports = nodemailer.createTransport({
+    const tls: ConnectionOptions = this.getTlsOptions();
+
+    const smtpTransportOptions: SMTPTransport.Options = {
       host: this.config.host,
       port: this.config.port,
       secure: this.config.secure,
@@ -46,12 +53,37 @@ export class NodemailerProvider implements IEmailProvider {
           }
         : undefined,
       dkim,
-      tls: authEnabled
-        ? undefined
-        : {
-            rejectUnauthorized: false,
-          },
-    });
+      ignoreTLS: this.config.ignoreTls,
+      requireTLS: this.config.requireTls,
+      ...(tls && { tls }),
+    };
+
+    this.transports = nodemailer.createTransport(smtpTransportOptions);
+  }
+
+  getTlsOptions(): ConnectionOptions | undefined {
+    /**
+     * Only render TLS options if secure is enabled to true.
+     * Reference: https://nodemailer.com/smtp/#tls-options
+     *
+     */
+    if (this.config.secure && !!this.config.tlsOptions) {
+      this.validateTlsOptions();
+
+      return this.config.tlsOptions;
+    }
+
+    return undefined;
+  }
+
+  validateTlsOptions(): void {
+    try {
+      JSON.parse(JSON.stringify(this.config.tlsOptions));
+    } catch {
+      throw new Error(
+        'TLS options is not a valid JSON. Check again the value set for NODEMAILER_TLS_OPTIONS'
+      );
+    }
   }
 
   async sendMessage(


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Introduces the ability for the users to override and set up TLS configurations.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
To give configuration power to SMTP providers for our users and be able to integrate Novu.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
