### PR TITLE
fix(api): if no webhookurl provided there is a typeerror

### DIFF
--- a/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.command.ts
+++ b/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.command.ts
@@ -4,6 +4,7 @@ import { EnvironmentWithSubscriber } from '../../../shared/commands/project.comm
 import { JobEntity } from '@novu/dal';
 
 export enum DetailEnum {
+  CHAT_WEBHOOK_URL_MISSING = 'Webhook URL for the chat channel is missing',
   STEP_CREATED = 'Step created',
   STEP_QUEUED = 'Step queued',
   STEP_DELAYED = 'Step delayed',


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Fixes a potential TypeError if no webhookUrl is provided either in the payload or in the subscriber credentials.
Also adds a new execution detail when trying to send a Chat notification and the webhookUrl is not provided to help debug errors to users.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
We got contacted by a user that was confused about why Chat notification wasn't working. Investigating we found the internal error.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
WHAT USER SAW BEFORE
<img width="1443" alt="Screenshot 2022-11-18 at 12 29 32" src="https://user-images.githubusercontent.com/18152036/202706903-fa1b1560-8ba4-474c-9ac9-738eb6a08f5c.png">

WHAT USER SHOULD SEE NOW
<img width="1540" alt="Screenshot 2022-11-18 at 12 34 46" src="https://user-images.githubusercontent.com/18152036/202707049-106849bc-9959-4cc8-926c-d5784e65aea7.png">
