### PR TITLE
Nv 1212 feature create topicsubscribers schema

### DIFF
--- a/libs/dal/src/repositories/subscriber/subscriber.entity.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.entity.ts
@@ -1,7 +1,9 @@
 import { ChatProviderIdEnum, PushProviderIdEnum } from '@novu/shared';
 
+export type SubscriberId = string;
+
 export class SubscriberEntity {
-  _id?: string;
+  _id?: SubscriberId;
 
   firstName: string;
 

--- a/libs/dal/src/repositories/topic/index.ts
+++ b/libs/dal/src/repositories/topic/index.ts
@@ -1,1 +1,2 @@
 export * from './topic.entity';
+export * from './topic-subscribers.entity';

--- a/libs/dal/src/repositories/topic/topic-subscribers.entity.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.entity.ts
@@ -1,0 +1,13 @@
+import { Types } from 'mongoose';
+
+import { EnvironmentId, OrganizationId, TopicId, UserId } from './topic.entity';
+
+import { SubscriberId } from '../subscriber/subscriber.entity';
+
+export class TopicSubscribersEntity {
+  _environmentId: EnvironmentId;
+  _organizationId: OrganizationId;
+  _userId: UserId;
+  topicId: TopicId;
+  subscribers: [SubscriberId];
+}

--- a/libs/dal/src/repositories/topic/topic-subscribers.schema.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.schema.ts
@@ -1,0 +1,35 @@
+import * as mongoose from 'mongoose';
+import { Schema } from 'mongoose';
+
+import { TopicSubscribersEntity } from './topic-subscribers.entity';
+
+import { schemaOptions } from '../schema-default.options';
+
+const topicSubscribersSchema = new Schema(
+  {
+    _environmentId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Environment',
+      index: true,
+      required: true,
+    },
+    _organizationId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Organization',
+      index: true,
+      required: true,
+    },
+    _userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      index: true,
+      required: true,
+    },
+    subscribers: [{ type: Schema.Types.ObjectId, ref: 'Subscriber', required: true }],
+  },
+  schemaOptions
+);
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const TopicSubscribers =
+  mongoose.models.Topic || mongoose.model<TopicSubscribersEntity>('TopicSubscribers', topicSubscribersSchema);

--- a/libs/dal/src/repositories/topic/topic.entity.ts
+++ b/libs/dal/src/repositories/topic/topic.entity.ts
@@ -1,10 +1,10 @@
 import { Types } from 'mongoose';
 
-type EnvironmentId = Types.ObjectId;
-type OrganizationId = Types.ObjectId;
-type TopicId = Types.ObjectId;
+export type EnvironmentId = Types.ObjectId;
+export type OrganizationId = Types.ObjectId;
+export type TopicId = Types.ObjectId;
 type TopicKey = string;
-type UserId = Types.ObjectId;
+export type UserId = Types.ObjectId;
 
 export class TopicEntity {
   _id: TopicId;


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Creates the schema and entity to gather the subscribers that will be associated to a topic.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
A topic is a way to know to which subscribers will be needed to send a notification in one shot. We need to store those relationships in the database so then users will be able to manage the topic subscribers with different functionalities.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
