### PR TITLE
fix(api): throw not found exception when subscriber not found before …

### DIFF
--- a/apps/api/src/app/subscribers/usecases/get-subscriber/get-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber/get-subscriber.usecase.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
+
 import { GetSubscriberCommand } from './get-subscriber.command';
 
 @Injectable()
@@ -7,6 +8,12 @@ export class GetSubscriber {
   constructor(private subscriberRepository: SubscriberRepository) {}
 
   async execute(command: GetSubscriberCommand): Promise<SubscriberEntity> {
-    return await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
+    const { environmentId, subscriberId } = command;
+    const subscriber = await this.subscriberRepository.findBySubscriberId(environmentId, subscriberId);
+    if (!subscriber) {
+      throw new NotFoundException(`Subscriber not found for id ${subscriberId}`);
+    }
+
+    return subscriber;
   }
 }

--- a/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.spec.ts
@@ -3,14 +3,14 @@ import { SubscribersService, UserSession } from '@novu/testing';
 import { NotFoundException } from '@nestjs/common';
 import { expect } from 'chai';
 
-import { GetSubscriber } from './get-subscriber.usecase';
-import { GetSubscriberCommand } from './get-subscriber.command';
+import { RemoveSubscriber } from './remove-subscriber.usecase';
+import { RemoveSubscriberCommand } from './remove-subscriber.command';
 
-import { SubscribersModule } from '../../subscribers.module';
 import { SharedModule } from '../../../shared/shared.module';
+import { SubscribersModule } from '../../subscribers.module';
 
-describe('Get Subscriber', function () {
-  let useCase: GetSubscriber;
+describe('Remove Subscriber', function () {
+  let useCase: RemoveSubscriber;
   let session: UserSession;
 
   beforeEach(async () => {
@@ -22,28 +22,30 @@ describe('Get Subscriber', function () {
     session = new UserSession();
     await session.initialize();
 
-    useCase = moduleRef.get<GetSubscriber>(GetSubscriber);
+    useCase = moduleRef.get<RemoveSubscriber>(RemoveSubscriber);
   });
 
-  it('should get a subscriber', async function () {
+  it('should remove a subscriber', async function () {
     const subscriberService = new SubscribersService(session.organization._id, session.environment._id);
     const subscriber = await subscriberService.createSubscriber();
+
     const res = await useCase.execute(
-      GetSubscriberCommand.create({
+      RemoveSubscriberCommand.create({
         subscriberId: subscriber.subscriberId,
         environmentId: session.environment._id,
         organizationId: session.organization._id,
       })
     );
-    expect(res.subscriberId).to.equal(subscriber.subscriberId);
+
+    expect(res).to.eql({ acknowledged: true, status: 'deleted' });
   });
 
-  it('should get a not found exception if subscriber does not exist', async () => {
+  it('should throw a not found exception if subscriber to remove does not exist', async () => {
     const subscriberService = new SubscribersService(session.organization._id, session.environment._id);
 
     try {
       await useCase.execute(
-        GetSubscriberCommand.create({
+        RemoveSubscriberCommand.create({
           subscriberId: 'invalid-subscriber-id',
           environmentId: session.environment._id,
           organizationId: session.organization._id,

--- a/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
@@ -1,17 +1,29 @@
 import { Injectable } from '@nestjs/common';
 import { SubscriberRepository, DalException } from '@novu/dal';
+
 import { RemoveSubscriberCommand } from './remove-subscriber.command';
+
+import { GetSubscriber } from '../get-subscriber/get-subscriber.usecase';
+
 import { ApiException } from '../../../shared/exceptions/api.exception';
 
 @Injectable()
 export class RemoveSubscriber {
-  constructor(private subscriberRepository: SubscriberRepository) {}
+  constructor(private subscriberRepository: SubscriberRepository, private getSubscriber: GetSubscriber) {}
 
   async execute(command: RemoveSubscriberCommand) {
     try {
+      const { environmentId: _environmentId, organizationId, subscriberId } = command;
+      const subscriber = await this.getSubscriber.execute({
+        environmentId: _environmentId,
+        organizationId,
+        subscriberId,
+      });
+
       await this.subscriberRepository.delete({
-        _environmentId: command.environmentId,
-        subscriberId: command.subscriberId,
+        _environmentId: subscriber._environmentId,
+        _organizationId: subscriber._organizationId,
+        subscriberId: subscriber.subscriberId,
       });
     } catch (e) {
       if (e instanceof DalException) {


### PR DESCRIPTION
…removal

<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Adds a throwing error when trying to get subscriber is not found and adds usecase to get the subscriber in the remove subscriber usecase to protect against the potential deletion of a user not existing in the database.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Better flow and better error management.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
