### PR TITLE
fix: added functionality to override subscriber preference for system critical messages

### DIFF
--- a/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
+++ b/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
@@ -1,4 +1,10 @@
-import { NotificationTemplateEntity, SubscriberEntity, MessageRepository, SubscriberRepository } from '@novu/dal';
+import {
+  NotificationTemplateEntity,
+  SubscriberEntity,
+  MessageRepository,
+  SubscriberRepository,
+  NotificationTemplateRepository,
+} from '@novu/dal';
 import { UserSession, SubscribersService } from '@novu/testing';
 import { expect } from 'chai';
 import axios from 'axios';
@@ -16,6 +22,7 @@ describe('Trigger event - process subscriber /v1/events/trigger (POST)', functio
 
   const subscriberRepository = new SubscriberRepository();
   const messageRepository = new MessageRepository();
+  const notificationTemplateRepository = new NotificationTemplateRepository();
 
   beforeEach(async () => {
     session = new UserSession();
@@ -139,6 +146,63 @@ describe('Trigger event - process subscriber /v1/events/trigger (POST)', functio
     });
 
     expect(message.length).to.equal(3);
+  });
+
+  it('should ignore subscruber preference and send all triggers for System critical template', async function () {
+    const payload: ISubscribersDefine = {
+      subscriberId: session.subscriberId,
+      firstName: 'New Test Name',
+      lastName: 'New Last of name',
+      email: 'newtest@email.novu',
+    };
+
+    await triggerEvent(session, template, payload);
+
+    await session.awaitRunningJobs(template._id);
+
+    const widgetSubscriber = await subscriberRepository.findBySubscriberId(
+      session.environment._id,
+      session.subscriberId
+    );
+
+    let message = await messageRepository.find({
+      _environmentId: session.environment._id,
+      _templateId: template._id,
+      _subscriberId: widgetSubscriber._id,
+    });
+
+    expect(message.length).to.equal(2);
+
+    const updateData = {
+      channel: {
+        type: ChannelTypeEnum.IN_APP,
+        enabled: false,
+      },
+    };
+
+    await updateSubscriberPreference(updateData, session.subscriberToken, template._id);
+
+    await notificationTemplateRepository.update(
+      {
+        _id: template._id,
+        _organizationId: session.organization._id,
+      },
+      {
+        critical: true,
+      }
+    );
+
+    await triggerEvent(session, template, payload);
+
+    await session.awaitRunningJobs(template._id);
+
+    message = await messageRepository.find({
+      _environmentId: session.environment._id,
+      _templateId: template._id,
+      _subscriberId: widgetSubscriber._id,
+    });
+
+    expect(message.length).to.equal(4);
   });
 });
 

--- a/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
+++ b/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
@@ -148,7 +148,7 @@ describe('Trigger event - process subscriber /v1/events/trigger (POST)', functio
     expect(message.length).to.equal(3);
   });
 
-  it('should ignore subscruber preference and send all triggers for System critical template', async function () {
+  it('should ignore subscriber preference and send all triggers for system critical template', async function () {
     const payload: ISubscribersDefine = {
       subscriberId: session.subscriberId,
       firstName: 'New Test Name',

--- a/apps/api/src/app/events/usecases/send-message/send-message.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message.usecase.ts
@@ -146,7 +146,7 @@ export class SendMessage {
 
     const result = this.isActionStep(job) || this.stepPreferred(preference, job);
 
-    if (!result) {
+    if (!result && !template.critical) {
       await this.createExecutionDetails.execute(
         CreateExecutionDetailsCommand.create({
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
@@ -160,7 +160,7 @@ export class SendMessage {
       );
     }
 
-    return result;
+    return result || template.critical;
   }
 
   private stepPreferred(preference: { enabled: boolean; channels: IPreferenceChannels }, job: JobEntity) {

--- a/libs/dal/src/repositories/notification-template/notification-template.schema.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.schema.ts
@@ -18,7 +18,7 @@ const notificationTemplateSchema = new Schema(
     },
     critical: {
       type: Schema.Types.Boolean,
-      default: true,
+      default: false,
     },
     _notificationGroupId: {
       type: Schema.Types.ObjectId,


### PR DESCRIPTION

<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Allows system critical message to pass through even if subscriber has opt-out from preferences

