### PR TITLE
feat: add notification template find one caching

### DIFF
--- a/apps/api/src/app/change/e2e/promote-changes.e2e.ts
+++ b/apps/api/src/app/change/e2e/promote-changes.e2e.ts
@@ -84,7 +84,7 @@ describe('Promote changes', () => {
     const prodVersion = await notificationTemplateRepository.findOne({
       _environmentId: prodEnv._id,
       _parentId: notificationTemplateId,
-    });
+    } as any);
 
     expect(prodVersion._notificationGroupId).to.eq(prodGroup._id);
   });
@@ -144,7 +144,7 @@ describe('Promote changes', () => {
     const prodVersion = await notificationTemplateRepository.findOne({
       _environmentId: prodEnv._id,
       _parentId: notificationTemplateId,
-    });
+    } as any);
 
     expect(prodVersion.steps.length).to.eq(0);
   });
@@ -178,7 +178,7 @@ describe('Promote changes', () => {
       _organizationId: session.organization._id,
       _notificationId: prodEnv._id,
       _parentId: notificationTemplateId,
-    });
+    } as any);
 
     expect(prodVersion.active).to.eq(true);
   });

--- a/apps/api/src/app/change/usecases/get-changes/get-changes.usecase.ts
+++ b/apps/api/src/app/change/usecases/get-changes/get-changes.usecase.ts
@@ -76,10 +76,10 @@ export class GetChanges {
     const item = await this.notificationTemplateRepository.findOne({
       _environmentId: environmentId,
       'steps._templateId': entityId,
-    });
+    } as any);
 
     if (!item) {
-      Logger.error(`Could not find notification template for template id ${entityId}`);
+      Logger.error(`Could not find notification template for message template id ${entityId}`);
 
       return {};
     }

--- a/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.ts
+++ b/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.ts
@@ -26,7 +26,7 @@ export class PromoteNotificationTemplateChange {
     const item = await this.notificationTemplateRepository.findOne({
       _environmentId: command.environmentId,
       _parentId: command.item._id,
-    });
+    } as any);
 
     const newItem = command.item as NotificationTemplateEntity;
 

--- a/apps/api/src/app/events/usecases/process-subscriber/process-subscriber.usecase.ts
+++ b/apps/api/src/app/events/usecases/process-subscriber/process-subscriber.usecase.ts
@@ -31,7 +31,7 @@ export class ProcessSubscriber {
   ) {}
 
   public async execute(command: ProcessSubscriberCommand): Promise<JobEntity[]> {
-    const template = await this.notificationTemplateRepository.findById(command.templateId, command.organizationId);
+    const template = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
 
     const subscriber: SubscriberEntity = await this.getSubscriber(
       {

--- a/apps/api/src/app/events/usecases/send-message/send-message.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message.usecase.ts
@@ -134,7 +134,7 @@ export class SendMessage {
   }
 
   private async filterPreferredChannels(job: JobEntity): Promise<boolean> {
-    const template = await this.notificationTemplateRepository.findById(job._templateId, job._organizationId);
+    const template = await this.notificationTemplateRepository.findById(job._templateId, job._environmentId);
     const buildCommand = GetSubscriberTemplatePreferenceCommand.create({
       organizationId: job._organizationId,
       subscriberId: job._subscriberId,

--- a/apps/api/src/app/notification-template/e2e/change-template-status.e2e.ts
+++ b/apps/api/src/app/notification-template/e2e/change-template-status.e2e.ts
@@ -21,14 +21,14 @@ describe('Change template status by id - /notification-templates/:templateId/sta
       active: false,
       draft: true,
     });
-    const beforeChange = await notificationTemplateRepository.findById(template._id, template._organizationId);
+    const beforeChange = await notificationTemplateRepository.findById(template._id, template._environmentId);
 
     expect(beforeChange.active).to.equal(false);
     expect(beforeChange.draft).to.equal(true);
     const { body } = await session.testAgent.put(`/v1/notification-templates/${template._id}/status`).send({
       active: true,
     });
-    const found = await notificationTemplateRepository.findById(template._id, template._organizationId);
+    const found = await notificationTemplateRepository.findById(template._id, template._environmentId);
 
     expect(found.active).to.equal(true);
     expect(found.draft).to.equal(false);

--- a/apps/api/src/app/notification-template/e2e/create-notification-templates.e2e.ts
+++ b/apps/api/src/app/notification-template/e2e/create-notification-templates.e2e.ts
@@ -99,7 +99,7 @@ describe('Create Notification template - /notification-templates (POST)', async 
     const prodVersionNotification = await notificationTemplateRepository.findOne({
       _environmentId: prodEnv._id,
       _parentId: template._id,
-    });
+    } as any);
 
     expect(prodVersionNotification.tags[0]).to.equal(template.tags[0]);
     expect(prodVersionNotification.steps.length).to.equal(template.steps.length);

--- a/apps/api/src/app/notification-template/e2e/delete-notification-template.e2e.ts
+++ b/apps/api/src/app/notification-template/e2e/delete-notification-template.e2e.ts
@@ -62,7 +62,7 @@ describe('Delete notification template by id - /notification-templates/:template
     const isCreated = await notificationTemplateRepository.findOne({
       _environmentId: prodEvn._id,
       _parentId: notificationTemplateId,
-    });
+    } as any);
 
     expect(isCreated).to.exist;
 
@@ -81,7 +81,7 @@ describe('Delete notification template by id - /notification-templates/:template
     const isDeleted = await notificationTemplateRepository.findOne({
       _environmentId: prodEvn._id,
       _parentId: notificationTemplateId,
-    });
+    } as any);
 
     expect(!isDeleted).to.equal(true);
   });

--- a/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.usecase.ts
@@ -14,7 +14,7 @@ export class ChangeTemplateActiveStatus {
 
   async execute(command: ChangeTemplateActiveStatusCommand): Promise<NotificationTemplateEntity> {
     const foundTemplate = await this.notificationTemplateRepository.findOne({
-      _organizationId: command.organizationId,
+      _environmentId: command.environmentId,
       _id: command.templateId,
     });
     if (!foundTemplate) {
@@ -38,7 +38,7 @@ export class ChangeTemplateActiveStatus {
       }
     );
 
-    const item = await this.notificationTemplateRepository.findById(command.templateId, command.organizationId);
+    const item = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
     await this.createChange.execute(
       CreateChangeCommand.create({
         organizationId: command.organizationId,

--- a/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.usecase.ts
@@ -99,7 +99,7 @@ export class CreateNotificationTemplate {
       _notificationGroupId: command.notificationGroupId,
     });
 
-    const item = await this.notificationTemplateRepository.findById(savedTemplate._id, command.organizationId);
+    const item = await this.notificationTemplateRepository.findById(savedTemplate._id, command.environmentId);
 
     await this.createChange.execute(
       CreateChangeCommand.create({

--- a/apps/api/src/app/notification-template/usecases/get-notification-template/get-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/get-notification-template/get-notification-template.usecase.ts
@@ -7,7 +7,7 @@ export class GetNotificationTemplate {
   constructor(private notificationTemplateRepository: NotificationTemplateRepository) {}
 
   async execute(command: GetNotificationTemplateCommand): Promise<NotificationTemplateEntity> {
-    const template = await this.notificationTemplateRepository.findById(command.templateId, command.organizationId);
+    const template = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
     if (!template) {
       throw new NotFoundException(`Template with id ${command.templateId} not found`);
     }

--- a/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.usecase.ts
@@ -32,7 +32,7 @@ export class UpdateNotificationTemplate {
   async execute(command: UpdateNotificationTemplateCommand): Promise<NotificationTemplateEntity> {
     const existingTemplate = await this.notificationTemplateRepository.findById(
       command.templateId,
-      command.organizationId
+      command.environmentId
     );
     if (!existingTemplate) throw new NotFoundException(`Notification template with id ${command.templateId} not found`);
 
@@ -192,7 +192,7 @@ export class UpdateNotificationTemplate {
     await this.notificationTemplateRepository.update(
       {
         _id: command.templateId,
-        _organizationId: command.organizationId,
+        _environmentId: command.environmentId,
       },
       {
         $set: updatePayload,
@@ -223,6 +223,6 @@ export class UpdateNotificationTemplate {
       critical: command.critical,
     });
 
-    return await this.notificationTemplateRepository.findById(command.templateId, command.organizationId);
+    return await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
   }
 }

--- a/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
@@ -55,7 +55,7 @@ export class UpdateSubscriberPreference {
         channels: command.channel?.type ? channelObj : null,
       });
 
-      const template = await this.notificationTemplateRepository.findById(command.templateId, command.organizationId);
+      const template = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
 
       const getSubscriberPreferenceCommand = GetSubscriberTemplatePreferenceCommand.create({
         organizationId: command.organizationId,
@@ -93,7 +93,7 @@ export class UpdateSubscriberPreference {
       }
     );
 
-    const template = await this.notificationTemplateRepository.findById(command.templateId, command.organizationId);
+    const template = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
 
     const getSubscriberPreferenceCommand = GetSubscriberTemplatePreferenceCommand.create({
       organizationId: command.organizationId,

--- a/libs/dal/src/repositories/subscriber/subscriber.repository.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.repository.ts
@@ -6,9 +6,9 @@ import { Cached, DalException, ICacheService, InvalidateCache } from '../../shar
 import { Document, FilterQuery, ProjectionType } from 'mongoose';
 import { isStoreConnected } from '../../shared/interceptors/shared-cache.interceptor';
 
-class PartialIntegrationEntity extends Omit(SubscriberEntity, ['_environmentId', '_organizationId']) {}
+class PartialSubscriberEntity extends Omit(SubscriberEntity, ['_environmentId', '_organizationId']) {}
 
-type EnforceEnvironmentQuery = FilterQuery<PartialIntegrationEntity & Document> &
+type EnforceEnvironmentQuery = FilterQuery<PartialSubscriberEntity & Document> &
   ({ _environmentId: string } | { _organizationId: string });
 
 type EnforceIdentifierQuery = EnforceEnvironmentQuery & { _id: string };

--- a/libs/testing/src/notification-template.service.ts
+++ b/libs/testing/src/notification-template.service.ts
@@ -108,7 +108,7 @@ export class NotificationTemplateService {
 
     return await this.notificationTemplateRepository.findById(
       notificationTemplate._id,
-      notificationTemplate._organizationId
+      notificationTemplate._environmentId
     );
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

adds cached findOne and findbyId (findbyId is used on the trigger flow)

### Why was this change needed?

in order to cache the most used queries on the trigger flow.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
