### PR TITLE
feat(api): add endpoint to filter topics with pagination

### DIFF
--- a/apps/api/src/app/topics/dtos/filter-topics.dto.ts
+++ b/apps/api/src/app/topics/dtos/filter-topics.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsPositive, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+import { TopicDto } from './topic.dto';
+
+import { TopicKey } from '../types';
+
+export class FilterTopicsRequestDto {
+  @Transform(({ value }) => Number(value))
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  @ApiPropertyOptional({ type: Number })
+  public page?: number;
+
+  @Transform(({ value }) => Number(value))
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  @ApiPropertyOptional({ type: Number })
+  public pageSize?: number;
+
+  @IsString()
+  @IsOptional()
+  @ApiPropertyOptional({ type: String })
+  public key?: TopicKey;
+}
+
+export class FilterTopicsResponseDto {
+  @ApiProperty({
+    type: Array,
+  })
+  data: TopicDto[];
+
+  @ApiProperty({
+    type: Number,
+  })
+  page: number;
+
+  @ApiProperty({
+    type: Number,
+  })
+  pageSize: number;
+
+  @ApiProperty({
+    type: Number,
+  })
+  totalCount: number;
+}

--- a/apps/api/src/app/topics/dtos/index.ts
+++ b/apps/api/src/app/topics/dtos/index.ts
@@ -1,2 +1,3 @@
 export * from './create-topic.dto';
+export * from './filter-topics.dto';
 export * from './get-topic.dto';

--- a/apps/api/src/app/topics/dtos/topic.dto.ts
+++ b/apps/api/src/app/topics/dtos/topic.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { EnvironmentId, OrganizationId, TopicId, TopicKey, TopicName, UserId } from '../types';
 
 export class TopicDto {
-  @ApiProperty()
+  @ApiPropertyOptional()
   _id?: TopicId;
 
   @ApiProperty()

--- a/apps/api/src/app/topics/e2e/filter-topics.e2e.ts
+++ b/apps/api/src/app/topics/e2e/filter-topics.e2e.ts
@@ -1,0 +1,130 @@
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+const BASE_PATH = '/v1/topics';
+
+const createNewTopic = async (session: UserSession, topicKey: string) => {
+  return await session.testAgent.post(BASE_PATH).send({
+    key: topicKey,
+    name: `${topicKey}-name`,
+  });
+};
+
+describe.only('Filter topics - /topics (GET)', async () => {
+  let session: UserSession;
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    await createNewTopic(session, 'topic-key-1');
+    await createNewTopic(session, 'topic-key-2');
+    await createNewTopic(session, 'topic-key-3');
+  });
+
+  it('should return a validation error if the params provided are not in the right type', async () => {
+    const url = `${BASE_PATH}?page=first&pageSize=big`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(400);
+    expect(response.body.error).to.eql('Bad Request');
+    expect(response.body.message).to.eql([
+      'page must be a positive number',
+      'page must be an integer number',
+      'pageSize must be a positive number',
+      'pageSize must be an integer number',
+    ]);
+  });
+
+  it('should return a validation error if the expected params provided are not integers', async () => {
+    const url = `${BASE_PATH}?page=1.5&pageSize=1.5`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(400);
+    expect(response.body.error).to.eql('Bad Request');
+    expect(response.body.message).to.eql(['page must be an integer number', 'pageSize must be an integer number']);
+  });
+
+  it('should return a validation error if the expected params provided are negative integers', async () => {
+    const url = `${BASE_PATH}?page=-1&pageSize=-1`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(400);
+    expect(response.body.error).to.eql('Bad Request');
+    expect(response.body.message).to.eql(['page must be a positive number', 'pageSize must be a positive number']);
+  });
+
+  it('should return a Bad Request error if the page size requested is bigger than the default one (100)', async () => {
+    const url = `${BASE_PATH}?page=1&pageSize=101`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(400);
+    expect(response.body.error).to.eql('Bad Request');
+    expect(response.body.message).to.eql('Page size can not be larger then 100');
+  });
+
+  it('should retrieve all the topics that exist in the database for the user if not query params provided', async () => {
+    const url = `${BASE_PATH}`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(200);
+
+    const { data, totalCount, page, pageSize } = response.body;
+
+    expect(data.length).to.eql(3);
+    expect(totalCount).to.eql(3);
+    expect(page).to.eql(0);
+    expect(pageSize).to.eql(100);
+  });
+
+  it('should retrieve the topic filtered by the query param key for the user', async () => {
+    const topicKey = 'topic-key-2';
+    const url = `${BASE_PATH}?key=${topicKey}`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(200);
+
+    const { data, totalCount, page, pageSize } = response.body;
+    const [topic] = data;
+
+    expect(data.length).to.eql(1);
+    expect(totalCount).to.eql(1);
+    expect(page).to.eql(0);
+    expect(pageSize).to.eql(100);
+    expect(topic._userId).to.eql(session.user._id);
+    expect(topic._environmentId).to.eql(session.environment._id);
+    expect(topic._organizationId).to.eql(session.organization._id);
+    expect(topic.key).to.eql(topicKey);
+    expect(topic.createdAt).to.exist;
+    expect(topic.updatedAt).to.exist;
+  });
+
+  it('should retrieve an empty response if filtering by a key that is not in the database for the user', async () => {
+    const topicKey = 'topic-key-not-existing';
+    const url = `${BASE_PATH}?key=${topicKey}`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(200);
+
+    const { data, totalCount, page, pageSize } = response.body;
+
+    expect(data.length).to.eql(0);
+    expect(totalCount).to.eql(0);
+    expect(page).to.eql(0);
+    expect(pageSize).to.eql(100);
+  });
+
+  it('should ignore other query params and return all the topics that belong the user', async () => {
+    const url = `${BASE_PATH}?unsupportedParam=whatever`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(200);
+
+    const { data, totalCount, page, pageSize } = response.body;
+
+    expect(data.length).to.eql(3);
+    expect(totalCount).to.eql(3);
+    expect(page).to.eql(0);
+    expect(pageSize).to.eql(100);
+  });
+});

--- a/apps/api/src/app/topics/e2e/get-topic.e2e.ts
+++ b/apps/api/src/app/topics/e2e/get-topic.e2e.ts
@@ -11,14 +11,6 @@ describe('Get a topic - /topics/:topicId (GET)', async () => {
     await session.initialize();
   });
 
-  it('should throw route not found 404 error for missing param in the path', async () => {
-    const { body } = await session.testAgent.get(`${BASE_PATH}/`);
-
-    expect(body.statusCode).to.equal(404);
-    expect(body.message).to.eql('Cannot GET /v1/topics/');
-    expect(body.error).to.eql('Not Found');
-  });
-
   it('should retrieve the requested topic successfully if exists in the database for that user', async () => {
     const topicKey = 'topic-key';
     const topicName = 'topic-name';

--- a/apps/api/src/app/topics/topics.controller.ts
+++ b/apps/api/src/app/topics/topics.controller.ts
@@ -1,9 +1,22 @@
-import { Body, Controller, Get, Inject, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiExcludeController, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Inject, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiExcludeController, ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { IJwtPayload } from '@novu/shared';
 
-import { CreateTopicRequestDto, CreateTopicResponseDto, GetTopicResponseDto } from './dtos';
-import { CreateTopicCommand, CreateTopicUseCase, GetTopicCommand, GetTopicUseCase } from './use-cases';
+import {
+  CreateTopicRequestDto,
+  CreateTopicResponseDto,
+  FilterTopicsRequestDto,
+  FilterTopicsResponseDto,
+  GetTopicResponseDto,
+} from './dtos';
+import {
+  CreateTopicCommand,
+  CreateTopicUseCase,
+  FilterTopicsCommand,
+  FilterTopicsUseCase,
+  GetTopicCommand,
+  GetTopicUseCase,
+} from './use-cases';
 
 import { JwtAuthGuard } from '../auth/framework/auth.guard';
 import { ExternalApiAccessible } from '../auth/framework/external-api.decorator';
@@ -17,6 +30,7 @@ import { ANALYTICS_SERVICE } from '../shared/shared.module';
 export class TopicsController {
   constructor(
     private createTopicUseCase: CreateTopicUseCase,
+    private filterTopicsUseCase: FilterTopicsUseCase,
     private getTopicUseCase: GetTopicUseCase,
     @Inject(ANALYTICS_SERVICE) private analyticsService: AnalyticsService
   ) {}
@@ -46,7 +60,45 @@ export class TopicsController {
   }
 
   @ExternalApiAccessible()
-  @UseGuards(JwtAuthGuard)
+  @ApiQuery({
+    name: 'key',
+    type: String,
+    description: 'Topic key',
+    required: false,
+  })
+  @ApiQuery({
+    name: 'page',
+    type: Number,
+    description: 'Number of page for the pagination',
+    required: false,
+  })
+  @ApiQuery({
+    name: 'pageSize',
+    type: Number,
+    description: 'Size of page for the pagination',
+    required: false,
+  })
+  @ApiOkResponse({
+    type: FilterTopicsResponseDto,
+  })
+  @Get('')
+  async filterTopics(
+    @UserSession() user: IJwtPayload,
+    @Query() query?: FilterTopicsRequestDto
+  ): Promise<FilterTopicsResponseDto> {
+    return await this.filterTopicsUseCase.execute(
+      FilterTopicsCommand.create({
+        environmentId: user.environmentId,
+        key: query?.key,
+        organizationId: user.organizationId,
+        page: query?.page,
+        pageSize: query?.pageSize,
+        userId: user._id,
+      })
+    );
+  }
+
+  @ExternalApiAccessible()
   @ApiOkResponse({
     type: GetTopicResponseDto,
   })

--- a/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.command.ts
+++ b/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.command.ts
@@ -1,0 +1,19 @@
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+import { TopicKey } from '../../types';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class FilterTopicsCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsOptional()
+  key?: TopicKey;
+
+  @IsNumber()
+  @IsOptional()
+  page?: number;
+
+  @IsNumber()
+  @IsOptional()
+  pageSize?: number;
+}

--- a/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.use-case.ts
@@ -1,0 +1,54 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { EnvironmentId, OrganizationId, TopicEntity, TopicRepository, UserId } from '@novu/dal';
+
+import { FilterTopicsCommand } from './filter-topics.command';
+
+import { TopicDto } from '../../dtos/topic.dto';
+
+const DEFAULT_TOPIC_LIMIT = 100;
+
+const mapFromCommandToEntity = (
+  command: FilterTopicsCommand
+): Pick<TopicEntity, '_environmentId' | 'key' | '_organizationId' | '_userId'> => ({
+  _environmentId: command.environmentId as unknown as EnvironmentId,
+  _organizationId: command.organizationId as unknown as OrganizationId,
+  _userId: command.userId as unknown as UserId,
+  ...(command.key && { key: command.key }),
+});
+
+const mapFromEntityToDto = (topic: TopicEntity): TopicDto => ({
+  ...topic,
+  _id: topic._id as unknown as string,
+  _organizationId: topic._organizationId as unknown as string,
+  _environmentId: topic._environmentId as unknown as string,
+  _userId: topic._userId as unknown as string,
+});
+
+@Injectable()
+export class FilterTopicsUseCase {
+  constructor(private topicRepository: TopicRepository) {}
+
+  async execute(command: FilterTopicsCommand) {
+    const { pageSize = DEFAULT_TOPIC_LIMIT, page = 0 } = command;
+
+    if (pageSize > DEFAULT_TOPIC_LIMIT) {
+      throw new BadRequestException(`Page size can not be larger then ${DEFAULT_TOPIC_LIMIT}`);
+    }
+
+    const query = mapFromCommandToEntity(command);
+
+    const totalCount = await this.topicRepository.count(query);
+
+    const data = await this.topicRepository.find(query, '', {
+      limit: pageSize,
+      skip: page * pageSize,
+    });
+
+    return {
+      page,
+      totalCount,
+      pageSize,
+      data: data.map(mapFromEntityToDto),
+    };
+  }
+}

--- a/apps/api/src/app/topics/use-cases/filter-topics/index.ts
+++ b/apps/api/src/app/topics/use-cases/filter-topics/index.ts
@@ -1,0 +1,2 @@
+export * from './filter-topics.command';
+export * from './filter-topics.use-case';

--- a/apps/api/src/app/topics/use-cases/index.ts
+++ b/apps/api/src/app/topics/use-cases/index.ts
@@ -1,7 +1,9 @@
 import { CreateTopicUseCase } from './create-topic/create-topic.use-case';
+import { FilterTopicsUseCase } from './filter-topics/filter-topics.use-case';
 import { GetTopicUseCase } from './get-topic/get-topic.use-case';
 
 export * from './create-topic';
+export * from './filter-topics';
 export * from './get-topic';
 
-export const USE_CASES = [CreateTopicUseCase, GetTopicUseCase];
+export const USE_CASES = [CreateTopicUseCase, FilterTopicsUseCase, GetTopicUseCase];


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Adds an endpoint to be able to filter the topics by key (only for now) with pagination, besides its use case and tests.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
This endpoint will allow us to implement the functionality that users will be able to find a topic they created based on the custom topic key they assigned to it.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
