### PR TITLE
feat(api): ensure topic key is unique for same user, env and org

### DIFF
--- a/apps/api/src/app/topics/e2e/create-topic.e2e.ts
+++ b/apps/api/src/app/topics/e2e/create-topic.e2e.ts
@@ -41,4 +41,29 @@ describe('Topic creation - /topics (POST)', async () => {
     expect(body.data._id).to.exist;
     expect(body.data._id).to.be.string;
   });
+
+  it('should throw an error when trying to create a topic with a key already used', async () => {
+    const topicKey = 'topic-key-unique';
+    const topicName = 'topic-name';
+    const response = await session.testAgent.post(URL).send({
+      key: topicKey,
+      name: topicName,
+    });
+
+    expect(response.statusCode).to.eql(201);
+
+    const { body } = response;
+    expect(body.data._id).to.exist;
+    expect(body.data._id).to.be.string;
+
+    const conflictResponse = await session.testAgent.post(URL).send({
+      key: topicKey,
+      name: topicName,
+    });
+
+    expect(conflictResponse.statusCode).to.eql(409);
+    expect(conflictResponse.message).to.eql(
+      `There is already a topic with the key ${topicKey} for user ${session.user._id}`
+    );
+  });
 });

--- a/apps/api/src/app/topics/use-cases/create-topic/create-topic.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/create-topic/create-topic.use-case.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@nestjs/common';
 import { TopicEntity, TopicRepository } from '@novu/dal';
+import { ConflictException, Injectable } from '@nestjs/common';
 
 import { CreateTopicCommand } from './create-topic.command';
 
@@ -11,6 +11,18 @@ export class CreateTopicUseCase {
 
   async execute(command: CreateTopicCommand) {
     const entity = this.mapToEntity(command);
+
+    const topicExists = await this.topicRepository.findTopicByKey(
+      entity.key,
+      entity._userId,
+      entity._organizationId,
+      entity._environmentId
+    );
+
+    if (topicExists) {
+      throw new ConflictException(`There is already a topic with the key ${entity.key} for user ${entity._userId}`);
+    }
+
     const topic = await this.topicRepository.createTopic(entity);
 
     return this.mapFromEntity(topic);

--- a/libs/dal/src/repositories/topic/topic.repository.ts
+++ b/libs/dal/src/repositories/topic/topic.repository.ts
@@ -3,7 +3,7 @@ import { FilterQuery } from 'mongoose';
 
 import { TopicEntity } from './topic.entity';
 import { Topic } from './topic.schema';
-import { EnvironmentId, OrganizationId, TopicKey } from './types';
+import { EnvironmentId, OrganizationId, TopicKey, UserId } from './types';
 
 import { BaseRepository, Omit } from '../base-repository';
 
@@ -42,6 +42,7 @@ export class TopicRepository extends BaseRepository<EnforceEnvironmentQuery, Top
 
   async findTopicByKey(
     key: TopicKey,
+    userId: UserId,
     organizationId: OrganizationId,
     environmentId: EnvironmentId
   ): Promise<TopicEntity> {
@@ -49,6 +50,7 @@ export class TopicRepository extends BaseRepository<EnforceEnvironmentQuery, Top
       key,
       _organizationId: organizationId,
       _environmentId: environmentId,
+      _userId: userId,
     });
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Add the functionality to ensure the topic key is unique for an user in a certain organisation and environment.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Duplication of topics with the same key could be confusing and we want our users to have an easy way to identify their topics. So making the topic key they choose unique and avoiding creation duplication with same key helps to that.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
