### PR TITLE
feat(api): add use case to get a topic subscribers entity

### DIFF
--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -19,6 +19,7 @@ import {
   FeedRepository,
   SubscriberPreferenceRepository,
   TopicRepository,
+  TopicSubscribersRepository,
 } from '@novu/dal';
 import { AnalyticsService } from './services/analytics/analytics.service';
 import { QueueService } from './services/queue';
@@ -48,6 +49,7 @@ const DAL_MODELS = [
   FeedRepository,
   SubscriberPreferenceRepository,
   TopicRepository,
+  TopicSubscribersRepository,
 ];
 
 function getStorageServiceClass() {

--- a/apps/api/src/app/topics/dtos/index.ts
+++ b/apps/api/src/app/topics/dtos/index.ts
@@ -1,3 +1,5 @@
 export * from './create-topic.dto';
 export * from './filter-topics.dto';
 export * from './get-topic.dto';
+export * from './topic.dto';
+export * from './topic-subscribers.dto';

--- a/apps/api/src/app/topics/dtos/topic-subscribers.dto.ts
+++ b/apps/api/src/app/topics/dtos/topic-subscribers.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { EnvironmentId, OrganizationId, TopicId, UserId } from '../types';
+
+export class TopicSubscribersDto {
+  @ApiProperty()
+  _organizationId: OrganizationId;
+
+  @ApiProperty()
+  _environmentId: EnvironmentId;
+
+  @ApiProperty()
+  _topicId: TopicId;
+
+  @ApiProperty()
+  _userId: UserId;
+
+  @ApiProperty()
+  subscribers: string[];
+}

--- a/apps/api/src/app/topics/e2e/create-topic.e2e.ts
+++ b/apps/api/src/app/topics/e2e/create-topic.e2e.ts
@@ -5,7 +5,7 @@ import { IJwtPayload, MemberRoleEnum } from '@novu/shared';
 
 const URL = '/v1/topics';
 
-describe('Topic creation - /topics (POST)', async () => {
+describe.only('Topic creation - /topics (POST)', async () => {
   let session: UserSession;
 
   before(async () => {
@@ -62,7 +62,8 @@ describe('Topic creation - /topics (POST)', async () => {
     });
 
     expect(conflictResponse.statusCode).to.eql(409);
-    expect(conflictResponse.message).to.eql(
+    expect(conflictResponse.body.error).to.eql('Conflict');
+    expect(conflictResponse.body.message).to.eql(
       `There is already a topic with the key ${topicKey} for user ${session.user._id}`
     );
   });

--- a/apps/api/src/app/topics/e2e/filter-topics.e2e.ts
+++ b/apps/api/src/app/topics/e2e/filter-topics.e2e.ts
@@ -10,7 +10,7 @@ const createNewTopic = async (session: UserSession, topicKey: string) => {
   });
 };
 
-describe.only('Filter topics - /topics (GET)', async () => {
+describe('Filter topics - /topics (GET)', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/topics/use-cases/get-topic-subscribers/get-topic-subscribers.command.ts
+++ b/apps/api/src/app/topics/use-cases/get-topic-subscribers/get-topic-subscribers.command.ts
@@ -1,0 +1,9 @@
+import { IsDefined, IsString } from 'class-validator';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class GetTopicSubscribersCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsDefined()
+  topicId: string;
+}

--- a/apps/api/src/app/topics/use-cases/get-topic-subscribers/get-topic-subscribers.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/get-topic-subscribers/get-topic-subscribers.use-case.ts
@@ -1,0 +1,43 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { TopicSubscribersEntity, TopicSubscribersRepository } from '@novu/dal';
+
+import { GetTopicSubscribersCommand } from './get-topic-subscribers.command';
+
+import { TopicSubscribersDto } from '../../dtos/topic-subscribers.dto';
+
+@Injectable()
+export class GetTopicSubscribersUseCase {
+  constructor(private topicSubscribersRepository: TopicSubscribersRepository) {}
+
+  async execute(command: GetTopicSubscribersCommand) {
+    const entity = this.mapToEntity(command);
+    const topicSubscribers = await this.topicSubscribersRepository.findOne(entity);
+
+    if (!topicSubscribers) {
+      throw new NotFoundException(
+        `Topic id ${command.topicId} for the user ${command.userId} has no entity with subscribers`
+      );
+    }
+
+    return this.mapFromEntity(topicSubscribers);
+  }
+
+  private mapToEntity(domainEntity: GetTopicSubscribersCommand): Omit<TopicSubscribersEntity, 'subscribers'> {
+    return {
+      _environmentId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.environmentId),
+      _topicId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.topicId),
+      _organizationId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.organizationId),
+      _userId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.userId),
+    };
+  }
+
+  private mapFromEntity(topicSubscribers: TopicSubscribersEntity): TopicSubscribersDto {
+    return {
+      ...topicSubscribers,
+      _topicId: TopicSubscribersRepository.convertObjectIdToString(topicSubscribers._topicId),
+      _organizationId: TopicSubscribersRepository.convertObjectIdToString(topicSubscribers._organizationId),
+      _environmentId: TopicSubscribersRepository.convertObjectIdToString(topicSubscribers._environmentId),
+      _userId: TopicSubscribersRepository.convertObjectIdToString(topicSubscribers._userId),
+    };
+  }
+}

--- a/apps/api/src/app/topics/use-cases/get-topic-subscribers/index.ts
+++ b/apps/api/src/app/topics/use-cases/get-topic-subscribers/index.ts
@@ -1,0 +1,2 @@
+export * from './get-topic-subscribers.command';
+export * from './get-topic-subscribers.use-case';

--- a/apps/api/src/app/topics/use-cases/index.ts
+++ b/apps/api/src/app/topics/use-cases/index.ts
@@ -1,9 +1,11 @@
 import { CreateTopicUseCase } from './create-topic/create-topic.use-case';
 import { FilterTopicsUseCase } from './filter-topics/filter-topics.use-case';
 import { GetTopicUseCase } from './get-topic/get-topic.use-case';
+import { GetTopicSubscribersUseCase } from './get-topic-subscribers/get-topic-subscribers.use-case';
 
 export * from './create-topic';
 export * from './filter-topics';
 export * from './get-topic';
+export * from './get-topic-subscribers';
 
-export const USE_CASES = [CreateTopicUseCase, FilterTopicsUseCase, GetTopicUseCase];
+export const USE_CASES = [CreateTopicUseCase, FilterTopicsUseCase, GetTopicUseCase, GetTopicSubscribersUseCase];

--- a/libs/dal/src/repositories/topic/topic-subscribers.entity.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.entity.ts
@@ -6,6 +6,6 @@ export class TopicSubscribersEntity {
   _environmentId: EnvironmentId;
   _organizationId: OrganizationId;
   _userId: UserId;
-  topicId: TopicId;
-  subscribers: [SubscriberId];
+  _topicId: TopicId;
+  subscribers: SubscriberId[];
 }

--- a/libs/dal/src/repositories/topic/topic-subscribers.schema.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.schema.ts
@@ -25,6 +25,12 @@ const topicSubscribersSchema = new Schema(
       index: true,
       required: true,
     },
+    _topicId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Topic',
+      index: true,
+      required: true,
+    },
     subscribers: [{ type: Schema.Types.ObjectId, ref: 'Subscriber', required: true }],
   },
   schemaOptions

--- a/scripts/dev-environment-setup.sh
+++ b/scripts/dev-environment-setup.sh
@@ -418,7 +418,7 @@ install_databases () {
         fi
     else
         skip_message "Databases"
-        echo $SKIP
+        echo "$SKIP"
     fi
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Adds the use case to retrieve the relationship between a topic and its subscribers.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
It is a previous step needed to be able to add and remove subscribers from a topic.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
