### PR TITLE
Removed duplicate ISubscriberPayload in subscriber.interface

### DIFF
--- a/packages/node/src/lib/subscribers/subscriber.interface.ts
+++ b/packages/node/src/lib/subscribers/subscriber.interface.ts
@@ -47,16 +47,6 @@ export interface IUpdateSubscriberPreferencePayload {
 
   enabled?: boolean;
 }
-
-export interface IUpdateSubscriberPreferencePayload {
-  channel?: {
-    type: ChannelTypeEnum;
-    enabled: boolean;
-  };
-
-  enabled?: boolean;
-}
-
 export interface IGetSubscriberNotificationFeedParams {
   page?: number;
   feedIdentifier: string;


### PR DESCRIPTION
### What change does this PR introduce? 

Duplicate identical IUpdateSubscriberPreferencePayload inside subscriber.interface.ts. 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 

### Why was this change needed?

While trying to investigate how Novu works, we stumbled upon this. Found by @milanarif

### Other information (Screenshots)

![image](https://user-images.githubusercontent.com/722315/205305675-db2aa472-67a1-4bf3-be60-8d8e58d26191.png)
