### PR TITLE
fix: so subject are parsed for preview as well

### DIFF
--- a/apps/api/src/app/content-templates/content-templates.controller.ts
+++ b/apps/api/src/app/content-templates/content-templates.controller.ts
@@ -15,7 +15,8 @@ export class ContentTemplatesController {
     @UserSession() user: IJwtPayload,
     @Body('content') content: string | IEmailBlock[],
     @Body('contentType') contentType: MessageTemplateContentType,
-    @Body('payload') payload: any
+    @Body('payload') payload: any,
+    @Body('subject') subject: string
   ) {
     return this.previewEmailUsecase.execute(
       PreviewEmailCommand.create({
@@ -25,6 +26,7 @@ export class ContentTemplatesController {
         content,
         contentType,
         payload,
+        subject,
       })
     );
   }

--- a/apps/api/src/app/content-templates/e2e/preview-email.e2e.ts
+++ b/apps/api/src/app/content-templates/e2e/preview-email.e2e.ts
@@ -11,14 +11,16 @@ describe('Preview email - /v1/content-templates/preview/email (POST)', function 
   it('should generate preview html email', async function () {
     const {
       body: {
-        data: { html },
+        data: { html, subject },
       },
     } = await session.testAgent.post(`/v1/content-templates/preview/email`).send({
       contentType: 'editor',
       content: [{ type: 'text', content: 'test {{test}} test' }],
       payload: JSON.stringify({ test: 'test' }),
+      subject: 'test {{test}} test',
     });
 
     expect(html.includes('test test test')).true;
+    expect(subject.includes('test test test')).true;
   });
 });

--- a/apps/api/src/app/content-templates/usecases/parse-preview/preview-email.command.ts
+++ b/apps/api/src/app/content-templates/usecases/parse-preview/preview-email.command.ts
@@ -12,4 +12,7 @@ export class PreviewEmailCommand extends EnvironmentWithUserCommand {
 
   @IsDefined()
   payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  @IsString()
+  subject: string;
 }

--- a/apps/api/src/app/content-templates/usecases/parse-preview/preview-email.usecase.ts
+++ b/apps/api/src/app/content-templates/usecases/parse-preview/preview-email.usecase.ts
@@ -19,6 +19,8 @@ export class PreviewEmail {
       this.getContent(isEditorMode, command.content, payload),
     ]);
 
+    const subject = await this.renderContent(command.subject, payload);
+
     const html = await this.compileTemplate.execute(
       CompileTemplateCommand.create({
         templateId: isEditorMode ? 'basic' : 'custom',
@@ -34,7 +36,7 @@ export class PreviewEmail {
       })
     );
 
-    return { html };
+    return { html, subject };
   }
 
   private async getContent(

--- a/apps/api/src/app/content-templates/usecases/parse-preview/preview-email.usecase.ts
+++ b/apps/api/src/app/content-templates/usecases/parse-preview/preview-email.usecase.ts
@@ -48,7 +48,6 @@ export class PreviewEmail {
       content = [...content] as IEmailBlock[];
       for (const block of content) {
         block.content = await this.renderContent(block.content, payload);
-        block.content = block.content.trim();
         block.url = await this.renderContent(block.url || '', payload);
       }
 
@@ -59,7 +58,7 @@ export class PreviewEmail {
   }
 
   private async renderContent(content: string, payload: any) {
-    return await this.compileTemplate.execute(
+    const renderedContent = await this.compileTemplate.execute(
       CompileTemplateCommand.create({
         templateId: 'custom',
         customTemplate: content,
@@ -68,5 +67,7 @@ export class PreviewEmail {
         },
       })
     );
+
+    return renderedContent.trim();
   }
 }

--- a/apps/web/src/api/content-templates.ts
+++ b/apps/web/src/api/content-templates.ts
@@ -5,10 +5,12 @@ export async function previewEmail({
   content,
   contentType,
   payload,
+  subject,
 }: {
   content: string | IEmailBlock[];
   contentType: MessageTemplateContentType;
   payload: string;
+  subject: string;
 }) {
-  return api.post('/v1/content-templates/preview/email', { content, contentType, payload });
+  return api.post('/v1/content-templates/preview/email', { content, contentType, payload, subject });
 }

--- a/apps/web/src/pages/templates/editor/Preview.tsx
+++ b/apps/web/src/pages/templates/editor/Preview.tsx
@@ -39,6 +39,7 @@ export const Preview = ({ activeStep, view }: { activeStep: number; view: string
 
   const { integrations = [] } = useIntegrations();
   const [integration, setIntegration]: any = useState(null);
+  const [parsedSubject, setParsedSubject] = useState(subject);
   const [content, setContent] = useState<string>('<html><head></head><body><div></div></body></html>');
   const { isLoading, mutateAsync } = useMutation(previewEmail);
   const processedVariables = useProcessVariables(variables);
@@ -53,8 +54,12 @@ export const Preview = ({ activeStep, view }: { activeStep: number; view: string
     content: string | IEmailBlock[];
     payload: any;
   }) => {
-    mutateAsync(args).then((result: { html: string }) => {
+    mutateAsync({
+      ...args,
+      subject,
+    }).then((result: { html: string; subject: string }) => {
       setContent(result.html);
+      setParsedSubject(result.subject);
 
       return result;
     });
@@ -85,12 +90,12 @@ export const Preview = ({ activeStep, view }: { activeStep: number; view: string
       <Grid>
         <Grid.Col span={9}>
           <When truthy={view === 'web'}>
-            <PreviewWeb subject={subject} content={content} integration={integration} />
+            <PreviewWeb subject={parsedSubject} content={content} integration={integration} />
           </When>
           <When truthy={view === 'mobile'}>
             <Grid>
               <Grid.Col span={12}>
-                <PreviewMobile subject={subject} content={content} integration={integration} />
+                <PreviewMobile subject={parsedSubject} content={content} integration={integration} />
               </Grid.Col>
             </Grid>
           </When>


### PR DESCRIPTION
### What change does this PR introduce? 
So subject are parsed in backend with email content to be rendered in preview

### Other information (Screenshots)
<img width="1512" alt="Screenshot 2022-12-04 at 08 38 51" src="https://user-images.githubusercontent.com/2233092/205479737-9e841b4a-7535-4f69-912a-519fd839e657.png">
