### PR TITLE
feat: added user lockout mechanism

### DIFF
--- a/apps/api/src/app/auth/e2e/login.e2e.ts
+++ b/apps/api/src/app/auth/e2e/login.e2e.ts
@@ -135,7 +135,7 @@ describe('User login - /auth/login (POST)', async () => {
       }
     );
 
-    for (let i = 0; i < MAX_LOGIN_ATTEMPTS; i++) {
+    for (let i = 0; i < MAX_LOGIN_ATTEMPTS - 1; i++) {
       const { body } = await session.testAgent.post('/v1/auth/login').send({
         email: session.user.email,
         password: 'wrong-password',
@@ -144,5 +144,13 @@ describe('User login - /auth/login (POST)', async () => {
       expect(body.message).to.contain('Wrong credentials provided');
       expect(body.statusCode).to.equal(400);
     }
+
+    const { body } = await session.testAgent.post('/v1/auth/login').send({
+      email: userCredentials.email,
+      password: userCredentials.password,
+    });
+
+    expect(body.statusCode).to.equal(401);
+    expect(body.message).to.contain('Account blocked');
   });
 });

--- a/apps/api/src/app/auth/e2e/login.e2e.ts
+++ b/apps/api/src/app/auth/e2e/login.e2e.ts
@@ -2,9 +2,11 @@ import { UserSession } from '@novu/testing';
 import * as jwt from 'jsonwebtoken';
 import { expect } from 'chai';
 import { IJwtPayload } from '@novu/shared';
+import { UserRepository } from '@novu/dal';
 
 describe('User login - /auth/login (POST)', async () => {
   let session: UserSession;
+  const userRepository = new UserRepository();
   const userCredentials = {
     email: 'Testy.test22@gmail.com',
     password: '123456789',
@@ -108,5 +110,46 @@ describe('User login - /auth/login (POST)', async () => {
 
     expect(body.statusCode).to.equal(401);
     expect(body.message).to.contain('Account blocked');
+  });
+
+  it('should reset the account blocked error after 5 minutes and allow for more 5 failed attempts', async () => {
+    await userRepository.update(
+      { _id: session.user._id },
+      {
+        $set: {
+          'failedLogin.times': 0,
+        },
+      }
+    );
+
+    const MAX_LOGIN_ATTEMPTS = 5;
+    const BLOCKED_PERIOD_IN_MILLISECONDS = 5 * 60 * 1000;
+
+    for (let i = 0; i < MAX_LOGIN_ATTEMPTS; i++) {
+      await session.testAgent.post('/v1/auth/login').send({
+        email: userCredentials.email,
+        password: 'wrong-password',
+      });
+    }
+
+    const { body } = await session.testAgent.post('/v1/auth/login').send({
+      email: userCredentials.email,
+      password: userCredentials.password,
+    });
+
+    expect(body.statusCode).to.equal(401);
+    expect(body.message).to.contain('Account blocked');
+
+    await new Promise((resolve) => setTimeout(resolve, BLOCKED_PERIOD_IN_MILLISECONDS));
+
+    for (let i = 0; i < MAX_LOGIN_ATTEMPTS; i++) {
+      const { body: response } = await session.testAgent.post('/v1/auth/login').send({
+        email: userCredentials.email,
+        password: 'wrong-password',
+      });
+
+      expect(response.statusCode).to.equal(400);
+      expect(response.message).to.contain('Wrong credentials provided');
+    }
   });
 });

--- a/apps/api/src/app/auth/e2e/login.e2e.ts
+++ b/apps/api/src/app/auth/e2e/login.e2e.ts
@@ -60,4 +60,53 @@ describe('User login - /auth/login (POST)', async () => {
     expect(body.statusCode).to.equal(400);
     expect(body.message).to.contain('Wrong credentials provided');
   });
+
+  it('should allow user to log in and reset the failed attempts counter after less than 5 failed attempts within 5 minutes', async () => {
+    const SAFE_FAILED_LOGIN_ATTEMPTS = 3;
+
+    for (let i = 0; i < SAFE_FAILED_LOGIN_ATTEMPTS; i++) {
+      await session.testAgent.post('/v1/auth/login').send({
+        email: userCredentials.email,
+        password: 'wrong-password',
+      });
+    }
+
+    const { body } = await session.testAgent.post('/v1/auth/login').send({
+      email: userCredentials.email,
+      password: userCredentials.password,
+    });
+
+    const jwtContent = (await jwt.decode(body.data.token)) as IJwtPayload;
+
+    expect(jwtContent.firstName).to.equal('test');
+    expect(jwtContent.lastName).to.equal('user');
+    expect(jwtContent.email).to.equal('testytest22@gmail.com');
+
+    const { body: wrongCredsBody } = await session.testAgent.post('/v1/auth/login').send({
+      email: userCredentials.email,
+      password: 'wrong-password',
+    });
+
+    expect(wrongCredsBody.statusCode).to.equal(400);
+    expect(wrongCredsBody.message).to.contain('Wrong credentials provided');
+  });
+
+  it('should block the user account after 5 unsuccessful attempts within 5 minutes', async () => {
+    const MAX_LOGIN_ATTEMPTS = 5;
+
+    for (let i = 0; i < MAX_LOGIN_ATTEMPTS; i++) {
+      await session.testAgent.post('/v1/auth/login').send({
+        email: userCredentials.email,
+        password: 'wrong-password',
+      });
+    }
+
+    const { body } = await session.testAgent.post('/v1/auth/login').send({
+      email: userCredentials.email,
+      password: userCredentials.password,
+    });
+
+    expect(body.statusCode).to.equal(401);
+    expect(body.message).to.contain('Account blocked');
+  });
 });

--- a/apps/api/src/app/auth/usecases/login/login.usecase.ts
+++ b/apps/api/src/app/auth/usecases/login/login.usecase.ts
@@ -55,9 +55,7 @@ export class Login {
     const lastFailedAttempt = user?.failedLogin?.lastFailedAttempt;
     if (!lastFailedAttempt) return false;
 
-    const now = Date.now();
-    const formattedLastAttempt = parseISO(lastFailedAttempt);
-    const diff = differenceInMinutes(now, formattedLastAttempt);
+    const diff = this.getTimeDiffForAttempt(lastFailedAttempt);
 
     return user?.failedLogin?.times >= this.MAX_LOGIN_ATTEMPTS && diff <= this.BLOCKED_PERIOD_IN_MINUTES;
   }
@@ -68,9 +66,8 @@ export class Login {
     const lastFailedAttempt = user?.failedLogin?.lastFailedAttempt;
 
     if (lastFailedAttempt) {
-      const formattedLastAttempt = parseISO(lastFailedAttempt);
-      const diff = differenceInMinutes(formattedLastAttempt, now);
-      times = diff <= this.BLOCKED_PERIOD_IN_MINUTES ? times + 1 : times;
+      const diff = this.getTimeDiffForAttempt(lastFailedAttempt);
+      times = diff <= this.BLOCKED_PERIOD_IN_MINUTES ? times + 1 : 1;
     }
 
     await this.userRepository.update(
@@ -99,5 +96,13 @@ export class Login {
         },
       }
     );
+  }
+
+  private getTimeDiffForAttempt(lastFailedAttempt: string) {
+    const now = Date.now();
+    const formattedLastAttempt = parseISO(lastFailedAttempt);
+    const diff = differenceInMinutes(now, formattedLastAttempt);
+
+    return diff;
   }
 }

--- a/apps/api/src/app/auth/usecases/login/login.usecase.ts
+++ b/apps/api/src/app/auth/usecases/login/login.usecase.ts
@@ -1,6 +1,7 @@
 import * as bcrypt from 'bcrypt';
 import { Inject, Injectable } from '@nestjs/common';
-import { UserRepository } from '@novu/dal';
+import { differenceInMinutes, parseISO } from 'date-fns';
+import { UserRepository, UserEntity } from '@novu/dal';
 import { LoginCommand } from './login.command';
 import { ApiException } from '../../../shared/exceptions/api.exception';
 
@@ -21,15 +22,77 @@ export class Login {
     const email = normalizeEmail(command.email);
     const user = await this.userRepository.findByEmail(email);
     if (!user) throw new ApiException('User not found');
+
+    if (this.isAccountBlocked(user)) {
+      throw new ApiException('Account blocked, Please try again after 5 minutes');
+    }
+
     if (!user.password) throw new ApiException('OAuth user login attempt');
 
     const isMatching = await bcrypt.compare(command.password, user.password);
-    if (!isMatching) throw new ApiException('Wrong credentials provided');
+    if (!isMatching) {
+      await this.updateFailedAttempts(user);
+      throw new ApiException('Wrong credentials provided');
+    }
 
     this.analyticsService.upsertUser(user, user._id);
+
+    if (user?.failedLogin?.times > 0) {
+      await this.resetFailedAttempts(user);
+    }
 
     return {
       token: await this.authService.generateUserToken(user),
     };
+  }
+
+  private isAccountBlocked(user: UserEntity) {
+    const lastFailedAttempt = user?.failedLogin?.lastFailedAttempt;
+    if (!lastFailedAttempt) return false;
+
+    const now = Date.now();
+    const formattedLastAttempt = parseISO(lastFailedAttempt);
+    const diff = differenceInMinutes(now, formattedLastAttempt);
+
+    return user?.failedLogin?.times >= 5 && diff <= 5;
+  }
+
+  private async updateFailedAttempts(user: UserEntity) {
+    const now = Date.now();
+    let times = user?.failedLogin?.times ?? 1;
+    const lastFailedAttempt = user?.failedLogin?.lastFailedAttempt;
+
+    if (lastFailedAttempt) {
+      const formattedLastAttempt = parseISO(lastFailedAttempt);
+      const diff = differenceInMinutes(formattedLastAttempt, now);
+      times = diff <= 5 ? times + 1 : times;
+    }
+
+    await this.userRepository.update(
+      {
+        _id: user._id,
+      },
+      {
+        $set: {
+          failedLogin: {
+            times,
+            lastFailedAttempt: now,
+          },
+        },
+      }
+    );
+  }
+
+  private async resetFailedAttempts(user: UserEntity) {
+    await this.userRepository.update(
+      {
+        _id: user._id,
+      },
+      {
+        $set: {
+          'failedLogin.times': 0,
+        },
+      }
+    );
   }
 }

--- a/apps/api/src/app/auth/usecases/login/login.usecase.ts
+++ b/apps/api/src/app/auth/usecases/login/login.usecase.ts
@@ -57,17 +57,17 @@ export class Login {
 
     const diff = this.getTimeDiffForAttempt(lastFailedAttempt);
 
-    return user?.failedLogin?.times >= this.MAX_LOGIN_ATTEMPTS && diff <= this.BLOCKED_PERIOD_IN_MINUTES;
+    return user?.failedLogin?.times >= this.MAX_LOGIN_ATTEMPTS && diff < this.BLOCKED_PERIOD_IN_MINUTES;
   }
 
   private async updateFailedAttempts(user: UserEntity) {
-    const now = Date.now();
+    const now = new Date();
     let times = user?.failedLogin?.times ?? 1;
     const lastFailedAttempt = user?.failedLogin?.lastFailedAttempt;
 
     if (lastFailedAttempt) {
       const diff = this.getTimeDiffForAttempt(lastFailedAttempt);
-      times = diff <= this.BLOCKED_PERIOD_IN_MINUTES ? times + 1 : 1;
+      times = diff < this.BLOCKED_PERIOD_IN_MINUTES ? times + 1 : 1;
     }
 
     await this.userRepository.update(
@@ -99,7 +99,7 @@ export class Login {
   }
 
   private getTimeDiffForAttempt(lastFailedAttempt: string) {
-    const now = Date.now();
+    const now = new Date();
     const formattedLastAttempt = parseISO(lastFailedAttempt);
     const diff = differenceInMinutes(now, formattedLastAttempt);
 

--- a/libs/dal/src/repositories/user/user.entity.ts
+++ b/libs/dal/src/repositories/user/user.entity.ts
@@ -40,4 +40,9 @@ export class UserEntity {
   createdAt: string;
 
   showOnBoarding?: boolean;
+
+  failedLogin?: {
+    times: number;
+    lastFailedAttempt: string;
+  };
 }

--- a/libs/dal/src/repositories/user/user.schema.ts
+++ b/libs/dal/src/repositories/user/user.schema.ts
@@ -27,6 +27,10 @@ const userSchema = new Schema(
       },
     ],
     password: Schema.Types.String,
+    failedLogin: {
+      times: Schema.Types.Number,
+      lastFailedAttempt: Schema.Types.Date,
+    },
   },
   schemaOptions
 );


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 
Adds a lockout mechanism for accounts after consecutive unsuccessful login attempts.
An user account will be blocked for 5 minutes, if it makes 5 unsuccessful login attempts within 5 minutes.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 

### Why was this change needed?
Without a lockout mechanism, one can do a brute force attack to guess the password of an user
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
