### PR TITLE
chore(notification-center-vue): fix rollup issue for the external libraries

### DIFF
--- a/packages/notification-center-vue/package.json
+++ b/packages/notification-center-vue/package.json
@@ -38,9 +38,9 @@
   "devDependencies": {
     "@types/node": "^18.7.14",
     "@vitejs/plugin-vue": "^2.3.4",
-    "rollup-plugin-typescript2": "^0.33.0",
-    "rollup": "^3.3.0",
     "rimraf": "^3.0.2",
+    "rollup": "^3.3.0",
+    "rollup-plugin-typescript2": "^0.33.0",
     "typescript": "^4.5.4",
     "vite": "^2.9.15",
     "vue-tsc": "^0.40.5"

--- a/packages/notification-center-vue/vite.config.js
+++ b/packages/notification-center-vue/vite.config.js
@@ -35,7 +35,7 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
-      external: ['vue'],
+      external: ['vue', 'react', 'react-dom'],
       output: {
         exports: 'named',
         globals: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31662,7 +31662,7 @@ packages:
     resolution: {integrity: sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==}
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   /concat-stream/1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -55634,7 +55634,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 5.0.1
       source-map: 0.6.1
-      terser: 5.15.1
+      terser: 5.12.1
       webpack: 4.46.0
       webpack-sources: 1.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
### What change does this PR introduce? 

Fixes the issue for the Vite/Rollup build configuration with the external libraries.
I've solved it with ChatGPT, which is amazing 🤯 

### Why was this change needed?

Because on the `next` branch `notification-center-vue` package is failing to build.

### Other information (Screenshots)

![Screenshot 2022-12-06 at 22 19 06](https://user-images.githubusercontent.com/2607232/206025619-73c4846b-85b6-4079-8f06-5584e3269834.png)
![Screenshot 2022-12-06 at 22 20 38](https://user-images.githubusercontent.com/2607232/206025633-f5ba2afb-61aa-4405-99be-da2f8e477a74.png)


