### PR TITLE
Nv 1314 cache subscriberpreferences find one query

### DIFF
--- a/apps/api/src/app/subscribers/e2e/update-preference.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/update-preference.e2e.ts
@@ -27,6 +27,8 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
 
     await updatePreference(createData, session, template._id);
 
+    await sleepAfterUpdate(50);
+
     const updateDataEmailFalse = {
       channel: {
         type: ChannelTypeEnum.EMAIL,
@@ -35,6 +37,8 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     };
 
     await updatePreference(updateDataEmailFalse, session, template._id);
+
+    await sleepAfterUpdate(50);
 
     const response = (await getPreference(session)).data.data[0];
 
@@ -53,4 +57,14 @@ async function updatePreference(data: UpdateSubscriberPreferenceRequestDto, sess
       },
     }
   );
+}
+
+/**
+ * why this sleep needed?
+ * if no preference exist update request will cache null then create new preference while invalidate old cache.
+ * there is possible race condition with the next fetch with null value before it was invalidated.
+ * @param ms
+ */
+async function sleepAfterUpdate(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -40,14 +40,14 @@ export class GetSubscriberPreference {
   }
 
   async getTemplatePreference(template: NotificationTemplateEntity, command: GetSubscriberPreferenceCommand) {
-    const buildCommand = GetSubscriberTemplatePreferenceCommand.create({
-      organizationId: command.organizationId,
-      subscriberId: command.subscriberId,
-      environmentId: command.environmentId,
-      template,
-    });
-
-    return await this.getSubscriberTemplatePreferenceUsecase.execute(buildCommand);
+    return await this.getSubscriberTemplatePreferenceUsecase.execute(
+      GetSubscriberTemplatePreferenceCommand.create({
+        organizationId: command.organizationId,
+        subscriberId: command.subscriberId,
+        environmentId: command.environmentId,
+        template,
+      })
+    );
   }
 }
 

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.command.ts
@@ -3,4 +3,6 @@ import { NotificationTemplateEntity } from '@novu/dal';
 
 export class GetSubscriberTemplatePreferenceCommand extends EnvironmentWithSubscriber {
   template: NotificationTemplateEntity;
+
+  skipCache?: true;
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -27,11 +27,15 @@ export class GetSubscriberTemplatePreference {
     const activeChannels = await this.queryActiveChannels(command);
     const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
 
-    const subscriberPreference = await this.subscriberPreferenceRepository.findOne({
-      _environmentId: command.environmentId,
-      _subscriberId: subscriber !== null ? subscriber._id : command.subscriberId,
-      _templateId: command.template._id,
-    });
+    const subscriberPreference = await this.subscriberPreferenceRepository.findOne(
+      {
+        _environmentId: command.environmentId,
+        _subscriberId: subscriber !== null ? subscriber._id : command.subscriberId,
+        _templateId: command.template._id,
+      },
+      '',
+      { skipCache: command.skipCache }
+    );
 
     const responseTemplate = mapResponseTemplate(command.template);
     const subscriberPreferenceEnabled = subscriberPreference?.enabled ?? true;

--- a/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
@@ -19,8 +19,8 @@ import { AnalyticsService } from '../../../shared/services/analytics/analytics.s
 export class UpdateSubscriberPreference {
   constructor(
     private subscriberPreferenceRepository: SubscriberPreferenceRepository,
-    private getSubscriberTemplatePreference: GetSubscriberTemplatePreference,
     private notificationTemplateRepository: NotificationTemplateRepository,
+    private getSubscriberTemplatePreference: GetSubscriberTemplatePreference,
     @Inject(ANALYTICS_SERVICE) private analyticsService: AnalyticsService,
     private subscriberRepository: SubscriberRepository
   ) {}
@@ -42,6 +42,8 @@ export class UpdateSubscriberPreference {
       enabled: command.channel?.enabled,
     });
 
+    const template = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
+
     if (!userPreference) {
       const channelObj = {} as Record<'email' | 'sms' | 'in_app' | 'chat' | 'push', boolean>;
       channelObj[command.channel?.type] = command.channel?.enabled;
@@ -55,16 +57,15 @@ export class UpdateSubscriberPreference {
         channels: command.channel?.type ? channelObj : null,
       });
 
-      const template = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
-
-      const getSubscriberPreferenceCommand = GetSubscriberTemplatePreferenceCommand.create({
-        organizationId: command.organizationId,
-        subscriberId: command.subscriberId,
-        environmentId: command.environmentId,
-        template,
-      });
-
-      return await this.getSubscriberTemplatePreference.execute(getSubscriberPreferenceCommand);
+      return await this.getSubscriberTemplatePreference.execute(
+        GetSubscriberTemplatePreferenceCommand.create({
+          organizationId: command.organizationId,
+          subscriberId: command.subscriberId,
+          environmentId: command.environmentId,
+          template,
+          skipCache: true,
+        })
+      );
     }
 
     const updatePayload: Partial<SubscriberPreferenceEntity> = {};
@@ -93,15 +94,14 @@ export class UpdateSubscriberPreference {
       }
     );
 
-    const template = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
-
-    const getSubscriberPreferenceCommand = GetSubscriberTemplatePreferenceCommand.create({
-      organizationId: command.organizationId,
-      subscriberId: command.subscriberId,
-      environmentId: command.environmentId,
-      template,
-    });
-
-    return await this.getSubscriberTemplatePreference.execute(getSubscriberPreferenceCommand);
+    return await this.getSubscriberTemplatePreference.execute(
+      GetSubscriberTemplatePreferenceCommand.create({
+        organizationId: command.organizationId,
+        subscriberId: command.subscriberId,
+        environmentId: command.environmentId,
+        template,
+        skipCache: true,
+      })
+    );
   }
 }

--- a/apps/api/src/app/widgets/e2e/get-subscriber-preference.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/get-subscriber-preference.e2e.ts
@@ -2,7 +2,7 @@ import { NotificationTemplateEntity } from '@novu/dal';
 import { UserSession } from '@novu/testing';
 import axios from 'axios';
 import { expect } from 'chai';
-import { updateSubscriberPreference } from './update-subscriber-preference.e2e';
+import { sleepAfterUpdate, updateSubscriberPreference } from './update-subscriber-preference.e2e';
 import { ChannelTypeEnum } from '@novu/stateless';
 
 describe('GET /widget/preferences', function () {
@@ -54,6 +54,7 @@ describe('GET /widget/preferences', function () {
     };
 
     await updateSubscriberPreference(updateDataEmailFalse, session.subscriberToken, templateDefaultSettings._id);
+    await sleepAfterUpdate(50);
 
     const response = await getSubscriberPreference(session.subscriberToken);
 

--- a/apps/api/src/app/widgets/e2e/update-subscriber-preference.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/update-subscriber-preference.e2e.ts
@@ -27,6 +27,7 @@ describe('PATCH /widgets/preferences/:templateId', function () {
     };
 
     await updateSubscriberPreference(updateData, session.subscriberToken, template._id);
+    await sleepAfterUpdate(50);
 
     const response = await getSubscriberPreference(session.subscriberToken);
 
@@ -43,6 +44,8 @@ describe('PATCH /widgets/preferences/:templateId', function () {
     };
 
     await updateSubscriberPreference(createData, session.subscriberToken, template._id);
+
+    await sleepAfterUpdate(50);
 
     const updateDataEmailFalse = {
       channel: {
@@ -71,6 +74,8 @@ describe('PATCH /widgets/preferences/:templateId', function () {
       };
 
       await updateSubscriberPreference(createData, session.subscriberToken, template._id);
+
+      await sleepAfterUpdate(50);
 
       const updateDataEmailFalse = {
         channel: {},
@@ -120,4 +125,14 @@ export async function updateSubscriberPreference(
       Authorization: `Bearer ${subscriberToken}`,
     },
   });
+}
+
+/**
+ * why this sleep needed?
+ * if no preference exist update request will cache null then create new preference while invalidate old cache.
+ * there is possible race condition with the next fetch with null value before it was invalidated.
+ * @param ms
+ */
+export async function sleepAfterUpdate(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/libs/dal/src/repositories/subscriber-preference/subscriber-preference.repository.ts
+++ b/libs/dal/src/repositories/subscriber-preference/subscriber-preference.repository.ts
@@ -1,19 +1,53 @@
 import { BaseRepository, Omit } from '../base-repository';
 import { SubscriberPreferenceEntity } from './subscriber-preference.entity';
 import { SubscriberPreference } from './subscriber-preference.schema';
-import { Document, FilterQuery } from 'mongoose';
+import { Document, FilterQuery, ProjectionType } from 'mongoose';
+import { Cached, ICacheService, InvalidateCache } from '../../shared';
+import { ICacheConfig } from '../../shared/interceptors/shared-cache';
 
 class PartialIntegrationEntity extends Omit(SubscriberPreferenceEntity, ['_environmentId', '_organizationId']) {}
 
 type EnforceEnvironmentQuery = FilterQuery<PartialIntegrationEntity & Document> &
   ({ _environmentId: string } | { _organizationId: string });
 
+type EnforceIdentifierQuery = FilterQuery<PartialIntegrationEntity & Document> & {
+  _environmentId: string;
+} & {
+  _subscriberId: string;
+};
+
 export class SubscriberPreferenceRepository extends BaseRepository<
   EnforceEnvironmentQuery,
   SubscriberPreferenceEntity
 > {
-  constructor() {
-    super(SubscriberPreference, SubscriberPreferenceEntity);
+  constructor(cacheService?: ICacheService) {
+    super(SubscriberPreference, SubscriberPreferenceEntity, cacheService);
+  }
+
+  @InvalidateCache()
+  async update(
+    query: EnforceIdentifierQuery,
+    updateBody: any
+  ): Promise<{
+    matched: number;
+    modified: number;
+  }> {
+    return super.update(query, updateBody);
+  }
+
+  @InvalidateCache()
+  async create(data: EnforceEnvironmentQuery) {
+    return super.create(data);
+  }
+
+  @Cached()
+  async findOne(query: EnforceIdentifierQuery, select?: ProjectionType<any>, cacheConfig?: ICacheConfig) {
+    return super.findOne(query, select);
+  }
+
+  @InvalidateCache()
+  async delete(query: EnforceIdentifierQuery) {
+    return super.delete(query);
   }
 
   async findSubscriberPreferences(

--- a/libs/dal/src/shared/interceptors/shared-cache.spec.ts
+++ b/libs/dal/src/shared/interceptors/shared-cache.spec.ts
@@ -83,6 +83,32 @@ describe('shared cache', function () {
       expect(res[1]).to.be.equal(undefined);
     });
 
+    it('should retrieve identifier _subscriber from SubscriberPreference query', async function () {
+      const keyPrefix = 'SubscriberPreference';
+      let query: Record<string, unknown>;
+      let res: [string, string];
+
+      query = { _id: '123', _subscriberId: '456' };
+      res = getIdentifier(keyPrefix, query);
+      expect(res[1]).to.be.equal('456');
+
+      query = { _id: '123', subscriberId: '456' };
+      res = getIdentifier(keyPrefix, query);
+      expect(res[1]).to.be.equal('456');
+
+      query = { id: '123', _subscriberId: '456' };
+      res = getIdentifier(keyPrefix, query);
+      expect(res[1]).to.be.equal('456');
+
+      query = { id: '123', subscriberId: '456' };
+      res = getIdentifier(keyPrefix, query);
+      expect(res[1]).to.be.equal('456');
+
+      query = { dummyKey: '123' };
+      res = getIdentifier(keyPrefix, query);
+      expect(res[1]).to.be.equal(undefined);
+    });
+
     it('should retrieve identifier _id from not Message query', async function () {
       const keyPrefix = 'Subscriber';
       let query: Record<string, unknown>;

--- a/libs/dal/src/shared/interceptors/shared-cache.ts
+++ b/libs/dal/src/shared/interceptors/shared-cache.ts
@@ -11,6 +11,7 @@ export function validateCredentials(keyPrefix: string, credentials: string) {
  * @param keyConfig
  */
 export function getIdentifier(key: string, keyConfig: Record<string, unknown>): [string, string] {
+  const entitiesSubscriberPreferred = ['Message', 'SubscriberPreference'];
   const subscriberPreferredKeys = ['_subscriberId', 'subscriberId', '_id', 'id'];
   const idPreferredKeys = ['_id', 'id', '_subscriberId', 'subscriberId'];
 
@@ -20,7 +21,7 @@ export function getIdentifier(key: string, keyConfig: Record<string, unknown>): 
   const idPrefKey = idPreferredKeys.find((prefKey) => keyConfig[prefKey]);
   const idPreferred = [idPrefKey, keyConfig[idPrefKey] as string] as [string, string];
 
-  return key.startsWith('Message') ? subscriberPreferred : idPreferred;
+  return entitiesSubscriberPreferred.some((entity) => key.startsWith(entity)) ? subscriberPreferred : idPreferred;
 }
 
 export function getEnvironment(keyConfig: Record<string, unknown>): [string, string] {


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

adds 'subscriberpreferences' cached findOne.

### Why was this change needed?

in order to cache the most used queries on the trigger flow.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
