### PR TITLE
fix: potential race condition on find query

### DIFF
--- a/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
+++ b/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
@@ -141,6 +141,9 @@ describe('Trigger event - process subscriber /v1/events/trigger (POST)', functio
 
     await session.awaitRunningJobs(template._id);
 
+    // fix potential race condition where trigger invalidate messages and the find query below
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
     message = await messageRepository.find({
       _environmentId: session.environment._id,
       _templateId: template._id,


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

add sleep after event trigger and messages query.

### Why was this change needed?

there could be a race condition of the invalidation of the messages while triggering new ones and the find messages query on the test.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
