### PR TITLE
feat(api): add subscribers endpoint, use case and tests

### DIFF
--- a/apps/api/src/app/topics/dtos/add-subscribers.dto.ts
+++ b/apps/api/src/app/topics/dtos/add-subscribers.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsDefined } from 'class-validator';
+
+import { SubscriberId } from '../types';
+
+export class AddSubscribersRequestDto {
+  @ApiProperty({
+    description: 'List of subscriber identifiers that will be associated to the topic',
+  })
+  @IsArray()
+  @IsDefined()
+  subscribers: SubscriberId[];
+}

--- a/apps/api/src/app/topics/dtos/index.ts
+++ b/apps/api/src/app/topics/dtos/index.ts
@@ -1,3 +1,4 @@
+export * from './add-subscribers.dto';
 export * from './create-topic.dto';
 export * from './filter-topics.dto';
 export * from './get-topic.dto';

--- a/apps/api/src/app/topics/e2e/add-subscribers.e2e.ts
+++ b/apps/api/src/app/topics/e2e/add-subscribers.e2e.ts
@@ -1,0 +1,116 @@
+import { SubscriberEntity } from '@novu/dal';
+import { SubscribersService, UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+import { CreateTopicResponseDto } from '../dtos';
+
+describe('Add subscribers to topic - /topics/:topicId/subscribers (POST)', async () => {
+  const topicKey = 'topic-key-add-subscribers';
+  const topicName = 'topic-name';
+  const URL = '/v1/topics';
+
+  let session: UserSession;
+  let subscriberService: SubscribersService;
+  let subscriber: SubscriberEntity;
+  let secondSubscriber: SubscriberEntity;
+  let thirdSubscriber: SubscriberEntity;
+  let topicId: string;
+  let getTopicUrl: string;
+  let addSubscribersUrl: string;
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+    subscriber = await subscriberService.createSubscriber();
+    secondSubscriber = await subscriberService.createSubscriber();
+    thirdSubscriber = await subscriberService.createSubscriber();
+
+    const response = await session.testAgent.post(URL).send({
+      key: topicKey,
+      name: topicName,
+    });
+
+    expect(response.statusCode).to.eql(201);
+    topicId = response.body.data._id;
+    expect(topicId).to.exist;
+    getTopicUrl = `${URL}/${topicId}`;
+    addSubscribersUrl = `${getTopicUrl}/subscribers`;
+  });
+
+  it('should throw validation error for missing request payload information', async () => {
+    const { body } = await session.testAgent.post(addSubscribersUrl).send({});
+
+    expect(body.statusCode).to.eql(400);
+    expect(body.message).to.eql(['subscribers should not be null or undefined', 'subscribers must be an array']);
+  });
+
+  it('should add subscriber to topic', async () => {
+    const subscribers = [subscriber._id];
+
+    const response = await session.testAgent.post(addSubscribersUrl).send({ subscribers });
+
+    expect(response.statusCode).to.eql(204);
+    expect(response.body).to.be.empty;
+
+    const getResponse = await session.testAgent.get(getTopicUrl);
+    expect(getResponse.statusCode).to.eql(200);
+
+    const getResponseTopic = getResponse.body.data;
+
+    expect(getResponseTopic._id).to.eql(topicId);
+    expect(getResponseTopic._userId).to.eql(session.user._id);
+    expect(getResponseTopic._environmentId).to.eql(session.environment._id);
+    expect(getResponseTopic._organizationId).to.eql(session.organization._id);
+    expect(getResponseTopic.key).to.eql(topicKey);
+    expect(getResponseTopic.name).to.eql(topicName);
+    expect(getResponseTopic.subscribers).to.eql([subscriber._id]);
+  });
+
+  it('should not duplicate subscribers if adding a subscriber already added to topic', async () => {
+    const preconditionResponse = await session.testAgent.get(getTopicUrl);
+    expect(preconditionResponse.statusCode).to.eql(200);
+    expect(preconditionResponse.body.data.subscribers).to.eql([subscriber._id]);
+
+    const subscribers = [subscriber._id];
+
+    const response = await session.testAgent.post(addSubscribersUrl).send({ subscribers });
+
+    expect(response.statusCode).to.eql(204);
+
+    const getResponse = await session.testAgent.get(getTopicUrl);
+    expect(getResponse.statusCode).to.eql(200);
+
+    const getResponseTopic = getResponse.body.data;
+
+    expect(getResponseTopic._id).to.eql(topicId);
+    expect(getResponseTopic._userId).to.eql(session.user._id);
+    expect(getResponseTopic._environmentId).to.eql(session.environment._id);
+    expect(getResponseTopic._organizationId).to.eql(session.organization._id);
+    expect(getResponseTopic.key).to.eql(topicKey);
+    expect(getResponseTopic.name).to.eql(topicName);
+    expect(getResponseTopic.subscribers).to.eql([subscriber._id]);
+  });
+
+  it('should add multiple subscribers to topic', async () => {
+    const subscribers = [secondSubscriber._id, thirdSubscriber._id];
+
+    const response = await session.testAgent.post(addSubscribersUrl).send({ subscribers });
+
+    expect(response.statusCode).to.eql(204);
+
+    const getResponse = await session.testAgent.get(getTopicUrl);
+    expect(getResponse.statusCode).to.eql(200);
+
+    const getResponseTopic = getResponse.body.data;
+
+    expect(getResponseTopic._id).to.eql(topicId);
+    expect(getResponseTopic._userId).to.eql(session.user._id);
+    expect(getResponseTopic._environmentId).to.eql(session.environment._id);
+    expect(getResponseTopic._organizationId).to.eql(session.organization._id);
+    expect(getResponseTopic.key).to.eql(topicKey);
+    expect(getResponseTopic.name).to.eql(topicName);
+    expect(getResponseTopic.subscribers).to.eql([subscriber._id, secondSubscriber._id, thirdSubscriber._id]);
+  });
+});

--- a/apps/api/src/app/topics/use-cases/add-subscribers/add-subscribers.command.ts
+++ b/apps/api/src/app/topics/use-cases/add-subscribers/add-subscribers.command.ts
@@ -1,0 +1,15 @@
+import { IsArray, IsDefined, IsString } from 'class-validator';
+
+import { TopicId, SubscriberId } from '../../types';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class AddSubscribersCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsDefined()
+  topicId: TopicId;
+
+  @IsArray()
+  @IsDefined()
+  subscribers: SubscriberId[];
+}

--- a/apps/api/src/app/topics/use-cases/add-subscribers/add-subscribers.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/add-subscribers/add-subscribers.use-case.ts
@@ -1,0 +1,27 @@
+import { TopicSubscribersEntity, TopicSubscribersRepository } from '@novu/dal';
+import { ConflictException, Injectable } from '@nestjs/common';
+
+import { AddSubscribersCommand } from './add-subscribers.command';
+
+@Injectable()
+export class AddSubscribersUseCase {
+  constructor(private topicSubscribersRepository: TopicSubscribersRepository) {}
+
+  async execute(command: AddSubscribersCommand) {
+    const entity = this.mapToEntity(command);
+
+    await this.topicSubscribersRepository.addSubscribers(entity);
+
+    return undefined;
+  }
+
+  private mapToEntity(domainEntity: AddSubscribersCommand): TopicSubscribersEntity {
+    return {
+      _environmentId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.environmentId),
+      _organizationId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.organizationId),
+      _topicId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.topicId),
+      _userId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.userId),
+      subscribers: domainEntity.subscribers,
+    };
+  }
+}

--- a/apps/api/src/app/topics/use-cases/add-subscribers/index.ts
+++ b/apps/api/src/app/topics/use-cases/add-subscribers/index.ts
@@ -1,0 +1,2 @@
+export * from './add-subscribers.command';
+export * from './add-subscribers.use-case';

--- a/apps/api/src/app/topics/use-cases/index.ts
+++ b/apps/api/src/app/topics/use-cases/index.ts
@@ -1,15 +1,18 @@
+import { AddSubscribersUseCase } from './add-subscribers/add-subscribers.use-case';
 import { CreateTopicUseCase } from './create-topic/create-topic.use-case';
 import { CreateTopicSubscribersUseCase } from './create-topic-subscribers/create-topic-subscribers.use-case';
 import { FilterTopicsUseCase } from './filter-topics/filter-topics.use-case';
 import { GetTopicUseCase } from './get-topic/get-topic.use-case';
 import { GetTopicSubscribersUseCase } from './get-topic-subscribers/get-topic-subscribers.use-case';
 
+export * from './add-subscribers';
 export * from './create-topic';
 export * from './filter-topics';
 export * from './get-topic';
 export * from './get-topic-subscribers';
 
 export const USE_CASES = [
+  AddSubscribersUseCase,
   CreateTopicUseCase,
   CreateTopicSubscribersUseCase,
   FilterTopicsUseCase,

--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -16,4 +16,22 @@ export class TopicSubscribersRepository extends BaseRepository<EnforceEnvironmen
   constructor() {
     super(TopicSubscribers, TopicSubscribersEntity);
   }
+
+  async addSubscribers(entity: TopicSubscribersEntity): Promise<void> {
+    const { _environmentId, _organizationId, _topicId, _userId, subscribers } = entity;
+
+    await this.update(
+      {
+        _environmentId,
+        _organizationId,
+        _topicId,
+        _userId,
+      },
+      {
+        $addToSet: { subscribers },
+      }
+    );
+
+    return undefined;
+  }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Adds the endpoint to add subscribers to a topic.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
With this endpoint users can create their topics and assign the subscribers they choose to that topic in order to be able to send a notification to that topic and therefore, those subscribed to the topic receiving said notification. The functionality to send a notification to a topic is yet to be done.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
