### PR TITLE
feat(api): remove subscribers endpoint, use case and test

### DIFF
--- a/apps/api/src/app/topics/dtos/index.ts
+++ b/apps/api/src/app/topics/dtos/index.ts
@@ -2,5 +2,6 @@ export * from './add-subscribers.dto';
 export * from './create-topic.dto';
 export * from './filter-topics.dto';
 export * from './get-topic.dto';
+export * from './remove-subscribers.dto';
 export * from './topic.dto';
 export * from './topic-subscribers.dto';

--- a/apps/api/src/app/topics/dtos/remove-subscribers.dto.ts
+++ b/apps/api/src/app/topics/dtos/remove-subscribers.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsDefined } from 'class-validator';
+
+import { SubscriberId } from '../types';
+
+export class RemoveSubscribersRequestDto {
+  @ApiProperty({
+    description: 'List of subscriber identifiers that will be removed to the topic',
+  })
+  @IsArray()
+  @IsDefined()
+  subscribers: SubscriberId[];
+}

--- a/apps/api/src/app/topics/e2e/remove-subscribers.e2e.ts
+++ b/apps/api/src/app/topics/e2e/remove-subscribers.e2e.ts
@@ -1,0 +1,120 @@
+import { SubscriberEntity } from '@novu/dal';
+import { SubscribersService, UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+import { CreateTopicResponseDto } from '../dtos';
+
+describe('Remove subscribers to topic - /topics/:topicId/subscribers/removal (POST)', async () => {
+  const topicKey = 'topic-key-remove-subscribers';
+  const topicName = 'topic-name';
+  const URL = '/v1/topics';
+
+  let session: UserSession;
+  let subscriberService: SubscribersService;
+  let subscriber: SubscriberEntity;
+  let secondSubscriber: SubscriberEntity;
+  let thirdSubscriber: SubscriberEntity;
+  let topicId: string;
+  let getTopicUrl: string;
+  let removeSubscribersUrl: string;
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+    subscriber = await subscriberService.createSubscriber();
+    secondSubscriber = await subscriberService.createSubscriber();
+    thirdSubscriber = await subscriberService.createSubscriber();
+
+    const response = await session.testAgent.post(URL).send({
+      key: topicKey,
+      name: topicName,
+    });
+    expect(response.statusCode).to.eql(201);
+    topicId = response.body.data._id;
+    expect(topicId).to.exist;
+
+    getTopicUrl = `${URL}/${topicId}`;
+    const addSubscribersUrl = `${getTopicUrl}/subscribers`;
+    removeSubscribersUrl = `${addSubscribersUrl}/removal`;
+
+    // We prefill the data to work with
+    await session.testAgent
+      .post(addSubscribersUrl)
+      .send({ subscribers: [subscriber._id, secondSubscriber._id, thirdSubscriber._id] });
+  });
+
+  it('should throw validation error for missing request payload information', async () => {
+    const { body } = await session.testAgent.post(removeSubscribersUrl).send({});
+
+    expect(body.statusCode).to.eql(400);
+    expect(body.message).to.eql(['subscribers should not be null or undefined', 'subscribers must be an array']);
+  });
+
+  it('should remove subscriber from the topic', async () => {
+    const subscribers = [subscriber._id];
+
+    const response = await session.testAgent.post(removeSubscribersUrl).send({ subscribers });
+
+    expect(response.statusCode).to.eql(204);
+    expect(response.body).to.be.empty;
+
+    const getResponse = await session.testAgent.get(getTopicUrl);
+    expect(getResponse.statusCode).to.eql(200);
+
+    const getResponseTopic = getResponse.body.data;
+
+    expect(getResponseTopic._id).to.eql(topicId);
+    expect(getResponseTopic._userId).to.eql(session.user._id);
+    expect(getResponseTopic._environmentId).to.eql(session.environment._id);
+    expect(getResponseTopic._organizationId).to.eql(session.organization._id);
+    expect(getResponseTopic.key).to.eql(topicKey);
+    expect(getResponseTopic.name).to.eql(topicName);
+    expect(getResponseTopic.subscribers).to.eql([secondSubscriber._id, thirdSubscriber._id]);
+  });
+
+  it('should keep the same when trying to remove a subscriber already removed from the topic', async () => {
+    const subscribers = [subscriber._id];
+
+    const response = await session.testAgent.post(removeSubscribersUrl).send({ subscribers });
+
+    expect(response.statusCode).to.eql(204);
+    expect(response.body).to.be.empty;
+
+    const getResponse = await session.testAgent.get(getTopicUrl);
+    expect(getResponse.statusCode).to.eql(200);
+
+    const getResponseTopic = getResponse.body.data;
+
+    expect(getResponseTopic._id).to.eql(topicId);
+    expect(getResponseTopic._userId).to.eql(session.user._id);
+    expect(getResponseTopic._environmentId).to.eql(session.environment._id);
+    expect(getResponseTopic._organizationId).to.eql(session.organization._id);
+    expect(getResponseTopic.key).to.eql(topicKey);
+    expect(getResponseTopic.name).to.eql(topicName);
+    expect(getResponseTopic.subscribers).to.eql([secondSubscriber._id, thirdSubscriber._id]);
+  });
+
+  it('should remove multiple subscribers from the topic', async () => {
+    const subscribers = [secondSubscriber._id, thirdSubscriber._id];
+
+    const response = await session.testAgent.post(removeSubscribersUrl).send({ subscribers });
+
+    expect(response.statusCode).to.eql(204);
+    expect(response.body).to.be.empty;
+
+    const getResponse = await session.testAgent.get(getTopicUrl);
+    expect(getResponse.statusCode).to.eql(200);
+
+    const getResponseTopic = getResponse.body.data;
+
+    expect(getResponseTopic._id).to.eql(topicId);
+    expect(getResponseTopic._userId).to.eql(session.user._id);
+    expect(getResponseTopic._environmentId).to.eql(session.environment._id);
+    expect(getResponseTopic._organizationId).to.eql(session.organization._id);
+    expect(getResponseTopic.key).to.eql(topicKey);
+    expect(getResponseTopic.name).to.eql(topicName);
+    expect(getResponseTopic.subscribers).to.eql([]);
+  });
+});

--- a/apps/api/src/app/topics/topics.controller.ts
+++ b/apps/api/src/app/topics/topics.controller.ts
@@ -16,6 +16,7 @@ import {
   FilterTopicsRequestDto,
   FilterTopicsResponseDto,
   GetTopicResponseDto,
+  RemoveSubscribersRequestDto,
 } from './dtos';
 import {
   AddSubscribersCommand,
@@ -26,6 +27,8 @@ import {
   FilterTopicsUseCase,
   GetTopicCommand,
   GetTopicUseCase,
+  RemoveSubscribersCommand,
+  RemoveSubscribersUseCase,
 } from './use-cases';
 
 import { JwtAuthGuard } from '../auth/framework/auth.guard';
@@ -43,6 +46,7 @@ export class TopicsController {
     private createTopicUseCase: CreateTopicUseCase,
     private filterTopicsUseCase: FilterTopicsUseCase,
     private getTopicUseCase: GetTopicUseCase,
+    private removeSubscribersUseCase: RemoveSubscribersUseCase,
     @Inject(ANALYTICS_SERVICE) private analyticsService: AnalyticsService
   ) {}
 
@@ -81,6 +85,26 @@ export class TopicsController {
   ): Promise<void> {
     await this.addSubscribersUseCase.execute(
       AddSubscribersCommand.create({
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        subscribers: body.subscribers,
+        topicId,
+        userId: user._id,
+      })
+    );
+  }
+
+  @ExternalApiAccessible()
+  @ApiNoContentResponse()
+  @Post(':topicId/subscribers/removal')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeSubscribers(
+    @UserSession() user: IJwtPayload,
+    @Param('topicId') topicId: string,
+    @Body() body: RemoveSubscribersRequestDto
+  ): Promise<void> {
+    await this.removeSubscribersUseCase.execute(
+      RemoveSubscribersCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         subscribers: body.subscribers,

--- a/apps/api/src/app/topics/use-cases/index.ts
+++ b/apps/api/src/app/topics/use-cases/index.ts
@@ -4,12 +4,14 @@ import { CreateTopicSubscribersUseCase } from './create-topic-subscribers/create
 import { FilterTopicsUseCase } from './filter-topics/filter-topics.use-case';
 import { GetTopicUseCase } from './get-topic/get-topic.use-case';
 import { GetTopicSubscribersUseCase } from './get-topic-subscribers/get-topic-subscribers.use-case';
+import { RemoveSubscribersUseCase } from './remove-subscribers/remove-subscribers.use-case';
 
 export * from './add-subscribers';
 export * from './create-topic';
 export * from './filter-topics';
 export * from './get-topic';
 export * from './get-topic-subscribers';
+export * from './remove-subscribers';
 
 export const USE_CASES = [
   AddSubscribersUseCase,
@@ -18,4 +20,5 @@ export const USE_CASES = [
   FilterTopicsUseCase,
   GetTopicUseCase,
   GetTopicSubscribersUseCase,
+  RemoveSubscribersUseCase,
 ];

--- a/apps/api/src/app/topics/use-cases/remove-subscribers/index.ts
+++ b/apps/api/src/app/topics/use-cases/remove-subscribers/index.ts
@@ -1,0 +1,2 @@
+export * from './remove-subscribers.command';
+export * from './remove-subscribers.use-case';

--- a/apps/api/src/app/topics/use-cases/remove-subscribers/remove-subscribers.command.ts
+++ b/apps/api/src/app/topics/use-cases/remove-subscribers/remove-subscribers.command.ts
@@ -1,0 +1,15 @@
+import { IsArray, IsDefined, IsString } from 'class-validator';
+
+import { TopicId, SubscriberId } from '../../types';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class RemoveSubscribersCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsDefined()
+  topicId: TopicId;
+
+  @IsArray()
+  @IsDefined()
+  subscribers: SubscriberId[];
+}

--- a/apps/api/src/app/topics/use-cases/remove-subscribers/remove-subscribers.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/remove-subscribers/remove-subscribers.use-case.ts
@@ -1,0 +1,27 @@
+import { TopicSubscribersEntity, TopicSubscribersRepository } from '@novu/dal';
+import { ConflictException, Injectable } from '@nestjs/common';
+
+import { RemoveSubscribersCommand } from './remove-subscribers.command';
+
+@Injectable()
+export class RemoveSubscribersUseCase {
+  constructor(private topicSubscribersRepository: TopicSubscribersRepository) {}
+
+  async execute(command: RemoveSubscribersCommand) {
+    const entity = this.mapToEntity(command);
+
+    await this.topicSubscribersRepository.removeSubscribers(entity);
+
+    return undefined;
+  }
+
+  private mapToEntity(domainEntity: RemoveSubscribersCommand): TopicSubscribersEntity {
+    return {
+      _environmentId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.environmentId),
+      _organizationId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.organizationId),
+      _topicId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.topicId),
+      _userId: TopicSubscribersRepository.convertStringToObjectId(domainEntity.userId),
+      subscribers: domainEntity.subscribers,
+    };
+  }
+}

--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -31,7 +31,21 @@ export class TopicSubscribersRepository extends BaseRepository<EnforceEnvironmen
         $addToSet: { subscribers },
       }
     );
+  }
 
-    return undefined;
+  async removeSubscribers(entity: TopicSubscribersEntity): Promise<void> {
+    const { _environmentId, _organizationId, _topicId, _userId, subscribers } = entity;
+
+    await this.update(
+      {
+        _environmentId,
+        _organizationId,
+        _topicId,
+        _userId,
+      },
+      {
+        $pullAll: { subscribers },
+      }
+    );
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
Adds the endpoint to remove subscribers from a topic.


### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
With this endpoint users can create their topics and fully assign and remove the subscribers they choose to that topic in order to be able to send a notification to that topic and therefore, those subscribed to the topic receiving said notification. The functionality to send a notification to a topic is yet to be done.


### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
