### PR TITLE
Fix/unique infobip provider

### DIFF
--- a/libs/shared/src/consts/providers/channels/email.ts
+++ b/libs/shared/src/consts/providers/channels/email.ts
@@ -11,7 +11,7 @@ import {
   sendinblueConfig,
   sesConfig,
   outlook365Config,
-  infobipConfig,
+  infobipEmailConfig,
 } from '../credentials';
 import { IProviderConfig } from '../provider.interface';
 import { ChannelTypeEnum } from '../../../entities/message-template';
@@ -118,7 +118,7 @@ export const emailProviders: IProviderConfig[] = [
     id: EmailProviderIdEnum.Infobip,
     displayName: 'Infobip',
     channel: ChannelTypeEnum.EMAIL,
-    credentials: infobipConfig,
+    credentials: infobipEmailConfig,
     docReference: 'https://www.infobip.com/docs',
     logoFileName: { light: 'infobip.png', dark: 'infobip.png' },
   },

--- a/libs/shared/src/consts/providers/channels/sms.ts
+++ b/libs/shared/src/consts/providers/channels/sms.ts
@@ -9,7 +9,7 @@ import {
   telnyxConfig,
   twilioConfig,
   firetextConfig,
-  infobipConfig,
+  infobipSMSConfig,
   burstSmsConfig,
   clickatellConfig,
 } from '../credentials';
@@ -85,7 +85,7 @@ export const smsProviders: IProviderConfig[] = [
     id: SmsProviderIdEnum.Infobip,
     displayName: 'Infobip',
     channel: ChannelTypeEnum.SMS,
-    credentials: infobipConfig,
+    credentials: infobipSMSConfig,
     docReference: 'https://www.infobip.com/docs',
     logoFileName: { light: 'infobip.png', dark: 'infobip.png' },
   },

--- a/libs/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/libs/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -443,7 +443,7 @@ export const outlook365Config: IConfigCredentials[] = [
   ...mailConfigBase,
 ];
 
-export const infobipConfig: IConfigCredentials[] = [
+export const infobipSMSConfig: IConfigCredentials[] = [
   {
     key: CredentialsKeyEnum.ApiKey,
     displayName: 'API Key',
@@ -457,4 +457,20 @@ export const infobipConfig: IConfigCredentials[] = [
     required: true,
   },
   ...smsConfigBase,
+];
+
+export const infobipEmailConfig: IConfigCredentials[] = [
+  {
+    key: CredentialsKeyEnum.ApiKey,
+    displayName: 'API Key',
+    type: 'string',
+    required: true,
+  },
+  {
+    key: CredentialsKeyEnum.BaseUrl,
+    displayName: 'Base URL',
+    type: 'string',
+    required: true,
+  },
+  ...mailConfigBase,
 ];

--- a/libs/shared/src/consts/providers/provider.enum.ts
+++ b/libs/shared/src/consts/providers/provider.enum.ts
@@ -34,7 +34,7 @@ export enum EmailProviderIdEnum {
   Sendinblue = 'sendinblue',
   SES = 'ses',
   NetCore = 'netcore',
-  Infobip = 'infobip',
+  Infobip = 'infobip-email',
   MailerSend = 'mailersend',
   Clickatell = 'clickatell',
   Outlook365 = 'outlook365',
@@ -49,7 +49,7 @@ export enum SmsProviderIdEnum {
   Twilio = 'twilio',
   Gupshup = 'gupshup',
   Firetext = 'firetext',
-  Infobip = 'infobip',
+  Infobip = 'infobip-sms',
   BurstSms = 'burst-sms',
   Clickatell = 'clickatell',
 }

--- a/providers/infobip/src/lib/infobip.provider.ts
+++ b/providers/infobip/src/lib/infobip.provider.ts
@@ -10,9 +10,13 @@ import {
 } from '@novu/stateless';
 import { Infobip, AuthType } from '@infobip-api/sdk';
 
+const getProviderId = (channelType) => {
+  return `infobip-${channelType}`;
+};
+
 export class InfobipSmsProvider implements ISmsProvider {
-  id = 'infobip';
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
+  id = getProviderId(this.channelType);
 
   private infobipClient;
 
@@ -56,8 +60,8 @@ export class InfobipSmsProvider implements ISmsProvider {
 }
 
 export class InfobipEmailProvider implements IEmailProvider {
-  id = 'infobip';
   channelType = ChannelTypeEnum.EMAIL as ChannelTypeEnum.EMAIL;
+  id = getProviderId(this.channelType);
 
   private infobipClient;
 


### PR DESCRIPTION
### What change does this PR introduce? 

Breaks out the infobip config and ID so that the individual provider instances have unique configs within the database

### Why was this change needed?

Bug in the E-mail and SMS provider config being shared so the workflow doesn't recognise them separately 