### PR TITLE
fix: unhandled no template steps scenario

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -663,6 +663,29 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     expect(block.content).to.equal('Hello John Doe, Welcome to Umbrella Corp');
   });
 
+  it('should handle empty workflow scenario', async function () {
+    template = await session.createTemplate({
+      steps: [],
+    });
+
+    const response = await session.testAgent
+      .post(`/v1/events/trigger`)
+      .send({
+        name: template.triggers[0].identifier,
+        to: subscriber.subscriberId,
+        payload: {
+          myUser: {
+            lastName: 'Test',
+          },
+        },
+      })
+      .expect(201);
+
+    const { status, acknowledged } = response.body.data;
+    expect(status).to.equal('no_workflow_steps_defined');
+    expect(acknowledged).to.equal(true);
+  });
+
   it('should trigger with given required variables', async function () {
     template = await session.createTemplate({
       steps: [

--- a/apps/api/src/app/events/usecases/trigger-event/trigger-event.usecase.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/trigger-event.usecase.ts
@@ -74,6 +74,13 @@ export class TriggerEvent {
       return this.logTemplateNotActive(command, template);
     }
 
+    if (!template.steps?.length) {
+      return {
+        acknowledged: true,
+        status: 'no_workflow_steps_defined',
+      };
+    }
+
     // Modify Attachment Key Name, Upload attachments to Storage Provider and Remove file from payload
     if (command.payload && Array.isArray(command.payload.attachments)) {
       this.modifyAttachments(command);


### PR DESCRIPTION
### What change does this PR introduce? 

Properly handle no steps usecase when event is triggered

### Why was this change needed?

The lack of handling caused an unhandled exception of 500 to be thrown for the API user. 

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
