### PR TITLE
feat(api): integrate the map trigger recipients use case in events controller

### DIFF
--- a/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
@@ -1,6 +1,7 @@
 import { IsDefined, IsObject, IsOptional, IsString } from 'class-validator';
 import { ApiExtraModels, ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
-import { TriggerRecipientsSubscriber, TriggerRecipientsSubscribers } from '@novu/node';
+import { TriggerRecipientSubscriber, TriggerRecipients } from '@novu/node';
+import { TopicId, TriggerRecipientsTypeEnum } from '@novu/shared';
 
 export class SubscriberPayloadDto {
   @ApiProperty()
@@ -15,7 +16,15 @@ export class SubscriberPayloadDto {
   avatar?: string;
 }
 
+export class TopicPayloadDto {
+  @ApiProperty()
+  id: TopicId;
+  @ApiProperty()
+  type: TriggerRecipientsTypeEnum;
+}
+
 @ApiExtraModels(SubscriberPayloadDto)
+@ApiExtraModels(TopicPayloadDto)
 export class TriggerEventRequestDto {
   @ApiProperty({
     description:
@@ -67,10 +76,17 @@ export class TriggerEventRequestDto {
         type: '[string]',
         description: 'List of subscriber identifiers',
       },
+      {
+        $ref: getSchemaPath(TopicPayloadDto),
+      },
+      {
+        type: '[TopicPayloadDto]',
+        description: 'List of topics',
+      },
     ],
   })
   @IsDefined()
-  to: TriggerRecipientsSubscribers;
+  to: TriggerRecipients;
 
   @ApiProperty({
     description: 'A unique identifier for this transaction, we will generated a UUID if not provided.',
@@ -89,5 +105,5 @@ export class TriggerEventRequestDto {
     ],
   })
   @IsOptional()
-  actor?: TriggerRecipientsSubscriber;
+  actor?: TriggerRecipientSubscriber;
 }

--- a/apps/api/src/app/events/dtos/trigger-event-to-all-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-to-all-request.dto.ts
@@ -1,6 +1,6 @@
 import { IsDefined, IsObject, IsOptional, IsString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
-import { TriggerRecipientsSubscriber } from '@novu/node';
+import { TriggerRecipientSubscriber } from '@novu/node';
 
 import { SubscriberPayloadDto } from './trigger-event-request.dto';
 
@@ -55,5 +55,5 @@ export class TriggerEventToAllRequestDto {
     ],
   })
   @IsOptional()
-  actor?: TriggerRecipientsSubscriber;
+  actor?: TriggerRecipientSubscriber;
 }

--- a/apps/api/src/app/events/usecases/map-trigger-recipients/map-trigger-recipients.use-case.ts
+++ b/apps/api/src/app/events/usecases/map-trigger-recipients/map-trigger-recipients.use-case.ts
@@ -66,33 +66,41 @@ export class MapTriggerRecipients {
     userId: UserId,
     recipients: TriggerRecipients
   ): Promise<ISubscribersDefine[]> {
-    const topics = this.findTopics(recipients);
+    /*
+     * TODO: We should manage the env variables from the config and not process.env
+     * https://github.com/motdotla/dotenv/issues/51
+     */
+    if (process.env.FF_IS_TOPIC_NOTIFICATION_ENABLED === 'true') {
+      const topics = this.findTopics(recipients);
 
-    const topicSubscribers: ISubscribersDefine[] = [];
+      const topicSubscribers: ISubscribersDefine[] = [];
 
-    for (const topic of topics) {
-      try {
-        const getTopicSubscribersCommand = GetTopicSubscribersCommand.create({
-          environmentId,
-          topicId: topic?.topicId || '',
-          organizationId,
-          userId,
-        });
-        const { subscribers } = await this.getTopicSubscribers.execute(getTopicSubscribersCommand);
+      for (const topic of topics) {
+        try {
+          const getTopicSubscribersCommand = GetTopicSubscribersCommand.create({
+            environmentId,
+            topicId: topic?.topicId || '',
+            organizationId,
+            userId,
+          });
+          const { subscribers } = await this.getTopicSubscribers.execute(getTopicSubscribersCommand);
 
-        subscribers?.forEach((subscriber: SubscriberId) => topicSubscribers.push({ subscriberId: subscriber }));
-      } catch (error) {
-        this.logTopicSubscribersError({
-          environmentId,
-          organizationId,
-          topicId: topic?.topicId || '',
-          transactionId,
-          userId,
-        });
+          subscribers?.forEach((subscriber: SubscriberId) => topicSubscribers.push({ subscriberId: subscriber }));
+        } catch (error) {
+          this.logTopicSubscribersError({
+            environmentId,
+            organizationId,
+            topicId: topic?.topicId || '',
+            transactionId,
+            userId,
+          });
+        }
       }
+
+      return topicSubscribers;
     }
 
-    return topicSubscribers;
+    return [];
   }
 
   public mapSubscriber(subscriber: TriggerRecipientSubscriber): ISubscribersDefine {

--- a/apps/api/src/config/env-validator.ts
+++ b/apps/api/src/config/env-validator.ts
@@ -1,4 +1,4 @@
-import { makeValidator, port, str, url, ValidatorSpec } from 'envalid';
+import { bool, makeValidator, port, str, url, ValidatorSpec } from 'envalid';
 import * as envalid from 'envalid';
 
 const str32 = makeValidator((variable) => {
@@ -45,9 +45,10 @@ const validators: { [K in keyof any]: ValidatorSpec<any[K]> } = {
   NEW_RELIC_LICENSE_KEY: str({
     default: '',
   }),
-  FF_IS_TOPIC_NOTIFICATION_ENABLED: str({
-    choices: ['false', 'true'],
-    default: 'false',
+  FF_IS_TOPIC_NOTIFICATION_ENABLED: bool({
+    desc: 'This is the environment variables used to enable the feature to send notifications to a topic',
+    default: false,
+    choices: [false, true],
   }),
 };
 

--- a/packages/node/src/lib/events/events.interface.ts
+++ b/packages/node/src/lib/events/events.interface.ts
@@ -4,44 +4,26 @@ import { IAttachmentOptions } from '../novu.interface';
 import { ITopic } from '../topics/topic.interface';
 import { ISubscribersDefine } from '../subscribers/subscriber.interface';
 
-/**
- * RETRO COMPATIBLE TYPES
- * TODO
- */
-export type TriggerRecipientsSubscriber = string | ISubscribersDefine;
-export type TriggerRecipientsSubscriberMany = TriggerRecipientsSubscriber[];
-export type TriggerRecipientsSubscribers =
-  | TriggerRecipientsSubscriber
-  | TriggerRecipientsSubscriberMany;
-export type TriggerRecipientsTopics = ITopic | ITopic[];
-
-export type TriggerRecipientsType =
-  | TriggerRecipientsSubscribers
-  | TriggerRecipientsTopics;
-
-export interface ITriggerPayloadOptions extends IBroadcastPayloadOptions {
-  to: TriggerRecipientsSubscribers;
-  actor?: TriggerRecipientsSubscriber;
-}
-////////
-
-/**
- * NEW INTEGRATION TYPES
- * TODO
- */
 export type TriggerRecipientSubscriber = string | ISubscribersDefine;
 export type TriggerRecipientTopics = ITopic[];
+
 export type TriggerRecipient = TriggerRecipientSubscriber | ITopic;
+
 export type TriggerRecipients = TriggerRecipient[];
-// string | ISubscribersDefine | string[] | ISubscribersDefine[] | ITopic[]
+
+// string | ISubscribersDefine | (string | ISubscribersDefine | ITopic)[]
 export type TriggerRecipientsPayload =
   | TriggerRecipientSubscriber
   | TriggerRecipients;
-//////////////////
 
 export interface IBroadcastPayloadOptions {
   payload: ITriggerPayload;
   overrides?: ITriggerOverrides;
+}
+
+export interface ITriggerPayloadOptions extends IBroadcastPayloadOptions {
+  to: TriggerRecipientsPayload;
+  actor?: TriggerRecipientSubscriber;
 }
 
 export interface ITriggerPayload {


### PR DESCRIPTION

<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. --> 
We finally integrate the new functionality that maps properly all the recipients (subscriberIds, subscriber payload and topics) into the Trigger event endpoint. The integration is controlled by the feature flag that is disabled by default to not interfere with the current working order of the endpoint until the release 0.10.0 if we find proper the state of the feature to get released.
It also cleans the old typings for the new ones in the subscriber interface, that I consider handle the typing a bit better and clearer.
Finally integration tests for the enablement/disablement of the feature are added.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
The full integration allows now to test the feature in isolation and double check if the trigger event endpoint functionality is not affected and the results provided from sending a notification to a topic are the expected ones. Next PRs will handle mostly E2E testing the different flows in the trigger event endpoint for payloads with or without topics to check  that downstream nothing is affected by the new feature.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
