### PR TITLE
fix: adds color to link in modal

### DIFF
--- a/apps/web/src/pages/integrations/components/ConnectIntegrationForm.tsx
+++ b/apps/web/src/pages/integrations/components/ConnectIntegrationForm.tsx
@@ -190,7 +190,7 @@ export function ConnectIntegrationForm({
 
         <InlineDiv>
           <span>Read our guide on where to get the credentials </span>
-          <a href={provider?.docReference} target="_blank" rel="noreferrer">
+          <a href={provider?.docReference} target="_blank" rel="noreferrer" style={{ color: '#DD2476 ' }}>
             here.
           </a>
         </InlineDiv>


### PR DESCRIPTION
### What change does this PR introduce? 

It changes the color for the text **Here**, in the modal which is shown when we connect to the provider.

### Why was this change needed?

#2268 

### Other information (Screenshots)
![image](https://user-images.githubusercontent.com/27822551/207370466-3d5f180b-f2f7-44d6-849b-e19dcf70a85a.png)

![image](https://user-images.githubusercontent.com/27822551/207370695-ca5f00fb-b88f-4634-b046-a86edd7ce3db.png)

