### PR TITLE
feat: remove pii from sentry reports

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -70,7 +70,7 @@ if (process.env.SENTRY_DSN) {
          */
         { type: HttpException, filter: (exception: HttpException) => exception.getStatus() < 500 },
       ],
-      user: ['_id', 'firstName', 'lastName', 'email', 'organizationId', 'environmentId', 'roles'],
+      user: ['_id', 'firstName', 'organizationId', 'environmentId', 'roles', 'domain'],
     }),
   });
 }

--- a/apps/api/src/app/shared/framework/user.decorator.ts
+++ b/apps/api/src/app/shared/framework/user.decorator.ts
@@ -15,7 +15,8 @@ export const UserSession = createParamDecorator((data, ctx) => {
      * This helps with sentry and other tools that need to know who the user is based on `id` property.
      */
     req.user.id = req.user._id;
-    req.user.username = ((req.user.firstName || '') + ' ' + (req.user.lastName || '')).trim();
+    req.user.username = (req.user.firstName || '').trim();
+    req.user.domain = req.user.email?.split('@')[1];
 
     return req.user;
   }


### PR DESCRIPTION
### What change does this PR introduce? 

Remove PII from sentry request breadcrumbs

### Why was this change needed?

No actual need for storing it there, request could be identified by and id

