### PR TITLE
fix(web): Remove .only flag

### DIFF
--- a/apps/widget/cypress/e2e/notifications-list.spec.ts
+++ b/apps/widget/cypress/e2e/notifications-list.spec.ts
@@ -84,7 +84,7 @@ describe('Notifications List', function () {
     cy.getByTestId('unseen-count-label').contains('4');
   });
 
-  it.only('count seen-unseen notification', function () {
+  it('count seen-unseen notification', function () {
     cy.getByTestId('unseen-count-label').contains('5');
     cy.intercept('**/notifications/feed?page=0').as('getNotifications');
     cy.getByTestId('notification-list-item').should('have.length', 5);


### PR DESCRIPTION
### What change does this PR introduce? 

Revert .only flag

### Why was this change needed?

It was restricting our test runs

