### PR TITLE
Remove redundant usage of "undefinded" on an optional param

### DIFF
--- a/apps/web/src/design-system/input/Input.tsx
+++ b/apps/web/src/design-system/input/Input.tsx
@@ -15,8 +15,8 @@ interface IInputProps extends SpacingProps {
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   rightSection?: React.ReactNode;
   type?: 'text' | 'password' | 'email' | 'search' | 'tel' | 'url' | 'number';
-  min?: string | number | undefined;
-  max?: string | number | undefined;
+  min?: string | number;
+  max?: string | number;
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
 }
 

--- a/apps/web/src/design-system/template-button/ChannelButton.tsx
+++ b/apps/web/src/design-system/template-button/ChannelButton.tsx
@@ -30,7 +30,7 @@ interface ITemplateButtonProps {
   changeTab?: (string) => void;
   errors?: boolean | string;
   showDots?: boolean;
-  id?: string | undefined;
+  id?: string;
   onDelete?: (id: string) => void;
   dragging?: boolean;
   setActivePage?: (string) => void;


### PR DESCRIPTION
<!--
Thank you for sending the PR! 
Please fill the applicable details below
Happy contributing!
-->

### What change does this PR introduce? 

Introduces removal of  having an 'undefined' type in the union of an optional property as it is redundant 

### Why was this change needed?

An Optional Param implicitly adds an 'undefined' property so explicitly adding it is pointless

### Other information (Screenshots)


