### PR TITLE
fix: so nodemailer can be used without user and password

### DIFF
--- a/providers/nodemailer/src/lib/nodemailer.provider.spec.ts
+++ b/providers/nodemailer/src/lib/nodemailer.provider.spec.ts
@@ -75,7 +75,8 @@ test('should trigger nodemailer without auth with rejectUnauthorized as false', 
     user: undefined,
     password: undefined,
   };
-  new NodemailerProvider(config);
+  const provider = new NodemailerProvider(config);
+  await provider.sendMessage(mockNovuMessage);
 
   expect(nodemailer.createTransport).toHaveBeenCalled();
   expect(nodemailer.createTransport).toHaveBeenCalledWith({

--- a/providers/nodemailer/src/lib/nodemailer.provider.spec.ts
+++ b/providers/nodemailer/src/lib/nodemailer.provider.spec.ts
@@ -14,6 +14,8 @@ jest.mock('nodemailer', () => {
   };
 });
 
+import nodemailer from 'nodemailer';
+
 const mockConfig = {
   host: 'test.test.email',
   port: 587,
@@ -48,6 +50,43 @@ test('should trigger nodemailer correctly', async () => {
         filename: 'test.txt',
       },
     ],
+  });
+
+  expect(nodemailer.createTransport).toHaveBeenCalled();
+  expect(nodemailer.createTransport).toHaveBeenCalledWith({
+    host: mockConfig.host,
+    port: mockConfig.port,
+    secure: mockConfig.secure,
+    auth: {
+      user: mockConfig.user,
+      pass: mockConfig.password,
+    },
+    dkim: undefined,
+    tls: undefined,
+  });
+});
+
+test('should trigger nodemailer without auth with rejectUnauthorized as false', async () => {
+  const config = {
+    host: 'test.test.email',
+    port: 587,
+    secure: false,
+    from: 'test@test.com',
+    user: undefined,
+    password: undefined,
+  };
+  new NodemailerProvider(config);
+
+  expect(nodemailer.createTransport).toHaveBeenCalled();
+  expect(nodemailer.createTransport).toHaveBeenCalledWith({
+    host: config.host,
+    port: config.port,
+    secure: config.secure,
+    auth: undefined,
+    dkim: undefined,
+    tls: {
+      rejectUnauthorized: false,
+    },
   });
 });
 

--- a/providers/nodemailer/src/lib/nodemailer.provider.ts
+++ b/providers/nodemailer/src/lib/nodemailer.provider.ts
@@ -33,18 +33,24 @@ export class NodemailerProvider implements IEmailProvider {
       dkim = undefined;
     }
 
+    const authEnabled = this.config.user && this.config.password;
+
     this.transports = nodemailer.createTransport({
       host: this.config.host,
       port: this.config.port,
       secure: this.config.secure,
-      auth:
-        this.config.user && this.config.password
-          ? {
-              user: this.config.user,
-              pass: this.config.password,
-            }
-          : undefined,
+      auth: authEnabled
+        ? {
+            user: this.config.user,
+            pass: this.config.password,
+          }
+        : undefined,
       dkim,
+      tls: authEnabled
+        ? undefined
+        : {
+            rejectUnauthorized: false,
+          },
     });
   }
 

--- a/providers/nodemailer/src/lib/nodemailer.provider.ts
+++ b/providers/nodemailer/src/lib/nodemailer.provider.ts
@@ -37,10 +37,13 @@ export class NodemailerProvider implements IEmailProvider {
       host: this.config.host,
       port: this.config.port,
       secure: this.config.secure,
-      auth: {
-        user: this.config.user,
-        pass: this.config.password,
-      },
+      auth:
+        this.config.user && this.config.password
+          ? {
+              user: this.config.user,
+              pass: this.config.password,
+            }
+          : undefined,
       dkim,
     });
   }


### PR DESCRIPTION
### What change does this PR introduce? 
Make user and password optional for nodemailer so it can be used for internal smtp servers.
