### PR TITLE
fix: fix errors of reading undefined in var manager

### DIFF
--- a/apps/web/src/hooks/use-variables-manager.ts
+++ b/apps/web/src/hooks/use-variables-manager.ts
@@ -35,7 +35,7 @@ export const useVariablesManager = (index: number, contents: string[]) => {
   function gatherTextContent(template = {}) {
     setTextContent(
       contents
-        .map((con) => con.split('.').reduce((a, b) => a[b], template))
+        .map((con) => con.split('.').reduce((a, b) => a && a[b], template))
         .map((con) => (Array.isArray(con) ? con.map((innerCon) => innerCon.content).join(' ') : con))
         .join(' ')
     );


### PR DESCRIPTION
### What change does this PR introduce?

Fix to these sentry errors: [1](https://sentry.io/organizations/novu-r9/issues/3585039175/?project=6250907&query=is%3Aunresolved&referrer=issue-stream) [2](https://sentry.io/organizations/novu-r9/issues/3836606905/?project=6250907&query=is%3Aunresolved&referrer=issue-stream)

`Cannot read properties of undefined (reading '0')`
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

It was caused after a user removed action buttons in in-app editor. 
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
