### PR TITLE
fix(web): the email editor brand logo issue

### DIFF
--- a/apps/web/src/components/templates/email-editor/EmailMessageEditor.tsx
+++ b/apps/web/src/components/templates/email-editor/EmailMessageEditor.tsx
@@ -123,6 +123,9 @@ export function EmailMessageEditor({
         <div onClick={() => !branding?.logo && navigate(getBrandSettingsUrl())} role="link">
           <Dropzone
             styles={{
+              inner: {
+                height: '100%',
+              },
               root: {
                 borderRadius: '7px',
                 padding: '10px',


### PR DESCRIPTION
### What change does this PR introduce?

Fixes the email editor brand logo issue described here: #2385

### Why was this change needed?

To fix the issue.

### Other information (Screenshots)

![Screenshot 2022-12-29 at 00 33 46](https://user-images.githubusercontent.com/2607232/209885697-df663921-45ac-49f8-b922-21cf2ea9569c.png)
![Screenshot 2022-12-29 at 00 32 49](https://user-images.githubusercontent.com/2607232/209885701-7c3c99fb-7ea5-4e72-addf-cbfb6f8fa2dc.png)

