### PR TITLE
fix: catch compile errors in preview email and show error notification in ui

### DIFF
--- a/apps/api/src/app/content-templates/usecases/parse-preview/preview-email.usecase.ts
+++ b/apps/api/src/app/content-templates/usecases/parse-preview/preview-email.usecase.ts
@@ -3,6 +3,7 @@ import { IEmailBlock, OrganizationRepository, OrganizationEntity } from '@novu/d
 import { CompileTemplate } from '../compile-template/compile-template.usecase';
 import { CompileTemplateCommand } from '../compile-template/compile-template.command';
 import { PreviewEmailCommand } from './preview-email.command';
+import { ApiException } from '../../../shared/exceptions/api.exception';
 
 @Injectable()
 export class PreviewEmail {
@@ -17,12 +18,20 @@ export class PreviewEmail {
     }
 
     const isEditorMode = command.contentType === 'editor';
-    const [organization, content]: [OrganizationEntity, string | IEmailBlock[]] = await Promise.all([
-      this.organizationRepository.findById(command.organizationId),
-      this.getContent(isEditorMode, command.content, payload),
-    ]);
+    let subject = '';
+    let content: string | IEmailBlock[] = '';
+    let organization: OrganizationEntity;
 
-    const subject = await this.renderContent(command.subject, payload);
+    try {
+      [organization, content] = await Promise.all([
+        this.organizationRepository.findById(command.organizationId),
+        this.getContent(isEditorMode, command.content, payload),
+      ]);
+
+      subject = await this.renderContent(command.subject, payload);
+    } catch (e) {
+      throw new ApiException(e?.message || `Message content could not be generated`);
+    }
 
     const html = await this.compileTemplate.execute(
       CompileTemplateCommand.create({

--- a/apps/web/src/pages/templates/editor/Preview.tsx
+++ b/apps/web/src/pages/templates/editor/Preview.tsx
@@ -12,6 +12,7 @@ import { inputStyles } from '../../../design-system/config/inputs.styles';
 import { useProcessVariables } from '../../../hooks/use-process-variables';
 import { PreviewMobile } from './PreviewMobile';
 import { PreviewWeb } from './PreviewWeb';
+import { errorMessage } from '../../../utils/notifications';
 
 export const Preview = ({ activeStep, view }: { activeStep: number; view: string }) => {
   const { control } = useFormContext();
@@ -58,12 +59,16 @@ export const Preview = ({ activeStep, view }: { activeStep: number; view: string
     mutateAsync({
       ...args,
       subject: subject ? subject : '',
-    }).then((result: { html: string; subject: string }) => {
-      setContent(result.html);
-      setParsedSubject(result.subject);
+    })
+      .then((result: { html: string; subject: string }) => {
+        setContent(result.html);
+        setParsedSubject(result.subject);
 
-      return result;
-    });
+        return result;
+      })
+      .catch((e: any) => {
+        errorMessage(e?.message || 'Un-expected error occurred');
+      });
   };
 
   useEffect(() => {


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

There was no catch to errors thrown for compiling the preview. 
Might also help with the sentry with the errors we are getting on sentry. [example](https://sentry.io/organizations/novu-r9/issues/3844312241/?environment=prod&project=6248811&query=&referrer=issue-stream&statsPeriod=14d)
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
