### PR TITLE
fix(api): improve `subscriberId` validation

### DIFF
--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -137,7 +137,7 @@ export class SubscribersController {
       CreateSubscriberCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
-        subscriberId: body.subscriberId.trim(),
+        subscriberId: body.subscriberId,
         firstName: body.firstName,
         lastName: body.lastName,
         email: body.email,

--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -137,7 +137,7 @@ export class SubscribersController {
       CreateSubscriberCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
-        subscriberId: body.subscriberId,
+        subscriberId: body.subscriberId.trim(),
         firstName: body.firstName,
         lastName: body.lastName,
         email: body.email,

--- a/apps/api/src/app/subscribers/usecases/create-subscriber/create-subscriber.command.ts
+++ b/apps/api/src/app/subscribers/usecases/create-subscriber/create-subscriber.command.ts
@@ -1,9 +1,9 @@
-import { IsDefined, IsEmail, IsOptional, IsString } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class CreateSubscriberCommand extends EnvironmentCommand {
   @IsString()
-  @IsDefined()
+  @IsNotEmpty()
   subscriberId: string;
 
   @IsEmail()

--- a/apps/api/src/app/subscribers/usecases/create-subscriber/create-subscriber.command.ts
+++ b/apps/api/src/app/subscribers/usecases/create-subscriber/create-subscriber.command.ts
@@ -1,9 +1,11 @@
 import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
+import { Transform } from 'class-transformer';
 
 export class CreateSubscriberCommand extends EnvironmentCommand {
   @IsString()
   @IsNotEmpty()
+  @Transform(({ value }) => value?.trim())
   subscriberId: string;
 
   @IsEmail()


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
small improvement to `subscriberId` validation on `/v1/subscribers/` `POST` request
now it throws an error if it receives `""` or `" "` for `subscriberId`
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
closes #2394 
