### PR TITLE
fix: add backwards compatability for auth header

### DIFF
--- a/apps/ws/src/socket/ws.gateway.ts
+++ b/apps/ws/src/socket/ws.gateway.ts
@@ -11,7 +11,7 @@ export class WSGateway implements OnGatewayConnection {
   server: Server;
 
   async handleConnection(connection: Socket) {
-    const { token } = connection.handshake.auth;
+    const token = connection.handshake.auth?.token || connection.handshake.query?.token;
 
     if (!token || token === 'null') {
       return this.disconnect(connection);


### PR DESCRIPTION
### What change does this PR introduce?

For old notification center clients that still use the old query method for authentication.

### Why was this change needed?

Old clients would break, unless upgraded to 0.10.0.

### Other information (Screenshots)

Might be also related to: #2392 
