### PR TITLE
fix: duplicate preference rows on update

### DIFF
--- a/packages/notification-center/src/components/notification-center/components/user-preference/SubscriberPreference.tsx
+++ b/packages/notification-center/src/components/notification-center/components/user-preference/SubscriberPreference.tsx
@@ -81,7 +81,7 @@ export function SubscriberPreference() {
 
             const handleUpdateChannelPreference = async (type: string, checked: boolean) => {
               setLoadingUpdate(true);
-              await updatePreference(item, type, checked, index);
+              await updatePreference(item, type, checked);
               setLoadingUpdate(false);
             };
 

--- a/packages/notification-center/src/hooks/use-subscriber-preference.hook.ts
+++ b/packages/notification-center/src/hooks/use-subscriber-preference.hook.ts
@@ -22,17 +22,12 @@ export function useSubscriberPreference() {
     setLoading(false);
   }
 
-  async function updatePreference(
-    preferenceItem: IUserPreferenceSettings,
-    channelType: string,
-    checked: boolean,
-    preferenceIndex: number
-  ) {
+  async function updatePreference(preferenceItem: IUserPreferenceSettings, channelType: string, checked: boolean) {
     const result = await api.updateSubscriberPreference(preferenceItem.template._id, channelType, checked);
 
     setPreferences((prev) => {
-      return prev.map((workflow, i) => {
-        if (i === preferenceIndex) {
+      return prev.map((workflow) => {
+        if (workflow.template._id === result.template._id) {
           return result;
         }
 


### PR DESCRIPTION


### What change does this PR introduce?
After update the search by index was not identical - it would override a different record.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

Closes: #2436 
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
