### PR TITLE
feat(api): filter layouts endpoint

### DIFF
--- a/apps/api/src/app/layouts/dtos/filter-layouts.dto.ts
+++ b/apps/api/src/app/layouts/dtos/filter-layouts.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+import { LayoutDto } from './layout.dto';
+
+export class FilterLayoutsRequestDto {
+  @Transform(({ value }) => Number(value))
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @ApiPropertyOptional({ type: Number })
+  public page?: number;
+
+  @Transform(({ value }) => Number(value))
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @ApiPropertyOptional({ type: Number })
+  public pageSize?: number;
+}
+
+export class FilterLayoutsResponseDto {
+  @ApiProperty({
+    type: Array,
+  })
+  data: LayoutDto[];
+
+  @ApiProperty({
+    type: Number,
+  })
+  page: number;
+
+  @ApiProperty({
+    type: Number,
+  })
+  pageSize: number;
+
+  @ApiProperty({
+    type: Number,
+  })
+  totalCount: number;
+}

--- a/apps/api/src/app/layouts/dtos/index.ts
+++ b/apps/api/src/app/layouts/dtos/index.ts
@@ -1,3 +1,4 @@
 export * from './create-layout.dto';
+export * from './filter-layouts.dto';
 export * from './get-layout.dto';
 export * from './layout.dto';

--- a/apps/api/src/app/layouts/e2e/filter-layouts.e2e.ts
+++ b/apps/api/src/app/layouts/e2e/filter-layouts.e2e.ts
@@ -1,0 +1,174 @@
+import { UserSession } from '@novu/testing';
+import { LayoutRepository } from '@novu/dal';
+import { LayoutName, TemplateVariableTypeEnum } from '@novu/shared';
+import { expect } from 'chai';
+
+import { CreateLayoutResponseDto } from '../dtos';
+
+const BASE_PATH = '/v1/layouts';
+
+describe('Filter layouts - /layouts (GET)', async () => {
+  let session: UserSession;
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    await createNewLayout(session, 'layout-name-1');
+    await createNewLayout(session, 'layout-name-2');
+    await createNewLayout(session, 'layout-name-3');
+  });
+
+  it('should return a validation error if the params provided are not in the right type', async () => {
+    const url = `${BASE_PATH}?page=first&pageSize=big`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(400);
+    expect(response.body.error).to.eql('Bad Request');
+    expect(response.body.message).to.eql([
+      'page must not be less than 0',
+      'page must be an integer number',
+      'pageSize must not be less than 0',
+      'pageSize must be an integer number',
+    ]);
+  });
+
+  it('should return a validation error if the expected params provided are not integers', async () => {
+    const url = `${BASE_PATH}?page=1.5&pageSize=1.5`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(400);
+    expect(response.body.error).to.eql('Bad Request');
+    expect(response.body.message).to.eql(['page must be an integer number', 'pageSize must be an integer number']);
+  });
+
+  it('should return a validation error if the expected params provided are negative integers', async () => {
+    const url = `${BASE_PATH}?page=-1&pageSize=-1`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(400);
+    expect(response.body.error).to.eql('Bad Request');
+    expect(response.body.message).to.eql(['page must not be less than 0', 'pageSize must not be less than 0']);
+  });
+
+  it('should return a Bad Request error if the page size requested is bigger than the default one (10)', async () => {
+    const url = `${BASE_PATH}?page=1&pageSize=101`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(400);
+    expect(response.body.error).to.eql('Bad Request');
+    expect(response.body.message).to.eql('Page size can not be larger then 10');
+  });
+
+  it('should retrieve all the layouts that exist in the database for the environment if not query params provided', async () => {
+    const url = `${BASE_PATH}`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(200);
+
+    const { data, totalCount, page, pageSize } = response.body;
+
+    expect(data.length).to.eql(3);
+    expect(totalCount).to.eql(3);
+    expect(page).to.eql(0);
+    expect(pageSize).to.eql(10);
+  });
+
+  it('should retrieve two layouts from the database for the environment if pageSize is set to 2 and page 0 selected', async () => {
+    const url = `${BASE_PATH}?page=0&pageSize=2`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(200);
+
+    const { data, totalCount, page, pageSize } = response.body;
+
+    expect(data.length).to.eql(2);
+    expect(totalCount).to.eql(3);
+    expect(page).to.eql(0);
+    expect(pageSize).to.eql(2);
+
+    expect(data[0].name).to.eql('layout-name-1');
+    expect(data[1].name).to.eql('layout-name-2');
+  });
+
+  it('should retrieve one layout from the database for the environment if pageSize is set to 2 and page 1 selected', async () => {
+    const url = `${BASE_PATH}?page=1&pageSize=2`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(200);
+
+    const { data, totalCount, page, pageSize } = response.body;
+
+    expect(data.length).to.eql(1);
+    expect(totalCount).to.eql(3);
+    expect(page).to.eql(1);
+    expect(pageSize).to.eql(2);
+
+    expect(data[0].name).to.eql('layout-name-3');
+  });
+
+  it('should retrieve zero layouts from the database for the environment if pageSize is set to 2 and page 2 selected', async () => {
+    const url = `${BASE_PATH}?page=2&pageSize=2`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(200);
+
+    const { data, totalCount, page, pageSize } = response.body;
+
+    expect(data.length).to.eql(0);
+    expect(totalCount).to.eql(3);
+    expect(page).to.eql(2);
+    expect(pageSize).to.eql(2);
+  });
+
+  it('should ignore other query params and return all the layouts that belong to the environment', async () => {
+    const url = `${BASE_PATH}?unsupportedParam=whatever`;
+    const response = await session.testAgent.get(url);
+
+    expect(response.statusCode).to.eql(200);
+
+    const { data, totalCount, page, pageSize } = response.body;
+
+    expect(data.length).to.eql(3);
+    expect(totalCount).to.eql(3);
+    expect(page).to.eql(0);
+    expect(pageSize).to.eql(10);
+  });
+});
+
+const createNewLayout = async (session: UserSession, layoutName: LayoutName): Promise<CreateLayoutResponseDto> => {
+  const content = [
+    {
+      type: 'text',
+      content: 'This are the text contents of the template for {{firstName}}',
+    },
+    {
+      type: 'button',
+      content: 'SIGN UP',
+      url: 'https://url-of-app.com/{{urlVariable}}',
+    },
+  ];
+  const variables = [
+    { name: 'firstName', type: TemplateVariableTypeEnum.STRING, defaultValue: 'John', required: false },
+  ];
+  const isDefault = true;
+
+  const result = await session.testAgent
+    .post(BASE_PATH)
+    .send({
+      name: layoutName,
+      content,
+      variables,
+      isDefault,
+    })
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/);
+
+  expect(result.status).to.eql(201);
+
+  const { _id } = result.body.data;
+
+  return {
+    _id,
+  };
+};

--- a/apps/api/src/app/layouts/use-cases/filter-layouts/filter-layouts.command.ts
+++ b/apps/api/src/app/layouts/use-cases/filter-layouts/filter-layouts.command.ts
@@ -1,0 +1,13 @@
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+import { EnvironmentCommand } from '../../../shared/commands/project.command';
+
+export class FilterLayoutsCommand extends EnvironmentCommand {
+  @IsNumber()
+  @IsOptional()
+  page?: number;
+
+  @IsNumber()
+  @IsOptional()
+  pageSize?: number;
+}

--- a/apps/api/src/app/layouts/use-cases/filter-layouts/filter-layouts.use-case.ts
+++ b/apps/api/src/app/layouts/use-cases/filter-layouts/filter-layouts.use-case.ts
@@ -1,0 +1,59 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { EnvironmentId, OrganizationId, LayoutEntity, LayoutRepository } from '@novu/dal';
+
+import { FilterLayoutsCommand } from './filter-layouts.command';
+
+import { LayoutDto } from '../../dtos/layout.dto';
+
+const DEFAULT_LAYOUT_LIMIT = 10;
+
+@Injectable()
+export class FilterLayoutsUseCase {
+  constructor(private layoutRepository: LayoutRepository) {}
+
+  async execute(command: FilterLayoutsCommand) {
+    const { pageSize = DEFAULT_LAYOUT_LIMIT, page = 0 } = command;
+
+    if (pageSize > DEFAULT_LAYOUT_LIMIT) {
+      throw new BadRequestException(`Page size can not be larger then ${DEFAULT_LAYOUT_LIMIT}`);
+    }
+
+    const query = this.mapFromCommandToEntity(command);
+
+    const totalCount = await this.layoutRepository.count(query);
+
+    const skipTimes = page <= 0 ? 0 : page;
+    const pagination = {
+      limit: pageSize,
+      skip: skipTimes * pageSize,
+    };
+
+    const filteredLayouts = await this.layoutRepository.filterLayouts(query, pagination);
+
+    return {
+      page,
+      totalCount,
+      pageSize,
+      data: filteredLayouts.map(this.mapFromEntityToDto),
+    };
+  }
+
+  private mapFromCommandToEntity(
+    command: FilterLayoutsCommand
+  ): Pick<LayoutEntity, '_environmentId' | '_organizationId'> {
+    return {
+      _environmentId: LayoutRepository.convertStringToObjectId(command.environmentId),
+      _organizationId: LayoutRepository.convertStringToObjectId(command.organizationId),
+    } as Pick<LayoutEntity, '_environmentId' | '_organizationId'>;
+  }
+
+  private mapFromEntityToDto(layout: LayoutEntity): LayoutDto {
+    return {
+      ...layout,
+      _id: LayoutRepository.convertObjectIdToString(layout._id),
+      _organizationId: LayoutRepository.convertObjectIdToString(layout._organizationId),
+      _environmentId: LayoutRepository.convertObjectIdToString(layout._environmentId),
+      isDeleted: layout.deleted,
+    };
+  }
+}

--- a/apps/api/src/app/layouts/use-cases/filter-layouts/index.ts
+++ b/apps/api/src/app/layouts/use-cases/filter-layouts/index.ts
@@ -1,0 +1,2 @@
+export * from './filter-layouts.command';
+export * from './filter-layouts.use-case';

--- a/apps/api/src/app/layouts/use-cases/index.ts
+++ b/apps/api/src/app/layouts/use-cases/index.ts
@@ -1,7 +1,9 @@
 import { CreateLayoutUseCase } from './create-layout/create-layout.use-case';
+import { FilterLayoutsUseCase } from './filter-layouts/filter-layouts.use-case';
 import { GetLayoutUseCase } from './get-layout/get-layout.use-case';
 
 export * from './create-layout';
+export * from './filter-layouts';
 export * from './get-layout';
 
-export const USE_CASES = [CreateLayoutUseCase, GetLayoutUseCase];
+export const USE_CASES = [CreateLayoutUseCase, FilterLayoutsUseCase, GetLayoutUseCase];

--- a/libs/dal/src/repositories/layout/layout.repository.ts
+++ b/libs/dal/src/repositories/layout/layout.repository.ts
@@ -70,10 +70,10 @@ export class LayoutRepository extends BaseRepository<EnforceEnvironmentQuery, La
         },
       },
       {
-        $limit: pagination.limit,
+        $skip: pagination.skip,
       },
       {
-        $skip: pagination.skip,
+        $limit: pagination.limit,
       },
     ]);
 


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Adds endpoint to filter layouts by environment.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
UI needs a layout manager to list all the layouts an organization has in certain environment. For that this endpoint will be needed to show and paginate all the layouts.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
