### PR TITLE
fix(api): is online filters - skip processing old subscribers

### DIFF
--- a/apps/api/src/app/events/usecases/trigger-event/message-matcher.service.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/message-matcher.service.ts
@@ -142,6 +142,13 @@ export class MessageMatcher {
       _environmentId: command.environmentId,
     });
 
+    const hasNoOnlineFieldsSet =
+      typeof subscriber?.isOnline === 'undefined' && typeof subscriber?.lastOnlineAt === 'undefined';
+    // the old subscriber created before the is online functionality should not be processed
+    if (hasNoOnlineFieldsSet) {
+      return false;
+    }
+
     const isOnlineMatch = subscriber?.isOnline === filter.value;
     if (filter.on === 'isOnline') {
       return isOnlineMatch;
@@ -151,7 +158,7 @@ export class MessageMatcher {
     const lastOnlineAt = subscriber?.lastOnlineAt ? parseISO(subscriber?.lastOnlineAt) : new Date();
     const diff = differenceIn(currentDate, lastOnlineAt, filter.timeOperator);
 
-    return subscriber?.isOnline || (!subscriber?.isOnline && diff <= filter.value);
+    return subscriber?.isOnline || (!subscriber?.isOnline && diff >= 0 && diff <= filter.value);
   }
 
   private processFilterEquality(variables: IFilterVariables, fieldFilter: IBaseFieldFilterPart) {

--- a/libs/dal/src/repositories/subscriber/subscriber.entity.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.entity.ts
@@ -32,7 +32,7 @@ export class SubscriberEntity {
 
   __v?: number;
 
-  isOnline: boolean;
+  isOnline?: boolean;
 
   lastOnlineAt?: string;
 }


### PR DESCRIPTION
### What change does this PR introduce?

Skip processing the subscribers that don't have "online" fields set.

### Why was this change needed?

Part of the "Is Online Filters" feature.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
