### PR TITLE
feat: improve execution details for step filters

### DIFF
--- a/apps/api/src/app/events/usecases/trigger-event/filter-processing-details.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/filter-processing-details.ts
@@ -1,0 +1,35 @@
+import { StepFilter } from '@novu/dal';
+import { IFilterVariables } from './types';
+
+interface ICondition {
+  on: string;
+  field: string | string[];
+  expected: string;
+  actual: string;
+  operator: string;
+  passed: boolean;
+}
+
+export class FilterProcessingDetails {
+  private conditions: ICondition[] = [];
+  private filter: StepFilter;
+  private variables: IFilterVariables;
+
+  addFilter(filter: StepFilter, variables: IFilterVariables) {
+    this.filter = filter;
+    this.variables = variables;
+    this.conditions = [];
+  }
+
+  addCondition(condition: ICondition) {
+    this.conditions.push(condition);
+  }
+
+  toString() {
+    return JSON.stringify({
+      payload: this.variables,
+      filter: this.filter,
+      conditions: this.conditions,
+    });
+  }
+}

--- a/apps/api/src/app/events/usecases/trigger-event/types.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/types.ts
@@ -1,0 +1,8 @@
+import type { ITriggerPayload } from '@novu/node';
+import type { SubscriberEntity } from '@novu/dal';
+
+export interface IFilterVariables {
+  payload?: ITriggerPayload;
+  subscriber?: SubscriberEntity;
+  webhook?: Record<string, unknown>;
+}

--- a/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.command.ts
+++ b/apps/api/src/app/execution-details/usecases/create-execution-details/create-execution-details.command.ts
@@ -20,6 +20,7 @@ export enum DetailEnum {
   PROVIDER_ERROR = 'Unexpected provider error',
   START_SENDING = 'Start sending message',
   START_DIGESTING = 'Start digesting',
+  PROCESSING_STEP_FILTER = 'Processing step filter',
   FILTER_STEPS = 'Step was filtered based on steps filters',
   DIGESTED_EVENTS_PROVIDED = 'Steps to get digest events found',
   DIGEST_TRIGGERED_EVENTS = 'Digest triggered events',

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -25,7 +25,7 @@ const subscriberSchema = new Schema(
     channels: [Schema.Types.Mixed],
     isOnline: {
       type: Schema.Types.Boolean,
-      default: false,
+      required: false,
     },
     lastOnlineAt: Schema.Types.Date,
   },


### PR DESCRIPTION
### What change does this PR introduce?

Improve execution details for the step filters.

I'm not sure how it would be better to display the condition for the `isOnlineInLast`, for the condition check we do use two fields on the subscriber entity `isOnline, lastSeenAt`. When the subscriber `isOnline: true` the condition `actual: 'true'`, but when `isOnline: false` we will calculate based on `lastSeenAt`, and then the `actual: '10'` will be a time difference.
So generally speaking I don't like that the `actual` might be `true` or `10`.

### Why was this change needed?

This is a part of the "Is Online Filters" project.

### Other information (Screenshots)

![Screenshot 2023-01-13 at 16 31 31](https://user-images.githubusercontent.com/2607232/212370775-6b1b2e8f-e08c-44fc-99fe-c4e033768734.png)

![Screenshot 2023-01-13 at 16 31 23](https://user-images.githubusercontent.com/2607232/212370786-cb2dfcb4-0d95-4447-9a14-66052b67dfd3.png)


