### PR TITLE
feat(api): add endpoint to set a layout as default

### DIFF
--- a/apps/api/src/app/layouts/e2e/delete-layout.e2e.ts
+++ b/apps/api/src/app/layouts/e2e/delete-layout.e2e.ts
@@ -1,6 +1,8 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
+import { createLayout } from './helpers';
+
 import { TemplateVariableTypeEnum } from '../types';
 
 const BASE_PATH = '/v1/layouts';
@@ -15,38 +17,8 @@ describe('Delete a layout - /layouts/:layoutId (DELETE)', async () => {
 
   it('should soft delete the requested layout successfully if exists in the database for that user', async () => {
     const layoutName = 'layout-name-deletion';
-    const layoutDescription = 'Amazing new layout';
-    const content = [
-      {
-        type: 'text',
-        content: 'This are the text contents of the template for {{firstName}}',
-        styles: { textAlign: 'left' },
-      },
-      {
-        type: 'button',
-        content: 'SIGN UP',
-        url: 'https://url-of-app.com/{{urlVariable}}',
-      },
-    ];
-    const variables = [
-      { name: 'firstName', type: TemplateVariableTypeEnum.STRING, defaultValue: 'John', required: false },
-    ];
     const isDefault = true;
-    const response = await session.testAgent.post(BASE_PATH).send({
-      name: layoutName,
-      description: layoutDescription,
-      content,
-      variables,
-      isDefault,
-    });
-
-    expect(response.statusCode).to.eql(201);
-
-    const { body } = response;
-    const createdLayout = body.data;
-    expect(createdLayout._id).to.exist;
-    expect(createdLayout._id).to.be.string;
-
+    const createdLayout = await createLayout(session, layoutName, isDefault);
     const url = `${BASE_PATH}/${createdLayout._id}`;
     const getResponse = await session.testAgent.delete(url);
 

--- a/apps/api/src/app/layouts/e2e/filter-layouts.e2e.ts
+++ b/apps/api/src/app/layouts/e2e/filter-layouts.e2e.ts
@@ -3,7 +3,7 @@ import { LayoutRepository } from '@novu/dal';
 import { LayoutName, TemplateVariableTypeEnum } from '@novu/shared';
 import { expect } from 'chai';
 
-import { CreateLayoutResponseDto } from '../dtos';
+import { createLayout } from './helpers';
 
 const BASE_PATH = '/v1/layouts';
 
@@ -14,9 +14,9 @@ describe('Filter layouts - /layouts (GET)', async () => {
     session = new UserSession();
     await session.initialize();
 
-    await createNewLayout(session, 'layout-name-1');
-    await createNewLayout(session, 'layout-name-2');
-    await createNewLayout(session, 'layout-name-3');
+    await createLayout(session, 'layout-name-1', false);
+    await createLayout(session, 'layout-name-2', false);
+    await createLayout(session, 'layout-name-3', false);
   });
 
   it('should return a validation error if the params provided are not in the right type', async () => {
@@ -135,42 +135,3 @@ describe('Filter layouts - /layouts (GET)', async () => {
     expect(pageSize).to.eql(10);
   });
 });
-
-const createNewLayout = async (session: UserSession, layoutName: LayoutName): Promise<CreateLayoutResponseDto> => {
-  const description = 'Amazing new layout';
-  const content = [
-    {
-      type: 'text',
-      content: 'This are the text contents of the template for {{firstName}}',
-    },
-    {
-      type: 'button',
-      content: 'SIGN UP',
-      url: 'https://url-of-app.com/{{urlVariable}}',
-    },
-  ];
-  const variables = [
-    { name: 'firstName', type: TemplateVariableTypeEnum.STRING, defaultValue: 'John', required: false },
-  ];
-  const isDefault = true;
-
-  const result = await session.testAgent
-    .post(BASE_PATH)
-    .send({
-      name: layoutName,
-      description,
-      content,
-      variables,
-      isDefault,
-    })
-    .set('Accept', 'application/json')
-    .expect('Content-Type', /json/);
-
-  expect(result.status).to.eql(201);
-
-  const { _id } = result.body.data;
-
-  return {
-    _id,
-  };
-};

--- a/apps/api/src/app/layouts/e2e/get-layout.e2e.ts
+++ b/apps/api/src/app/layouts/e2e/get-layout.e2e.ts
@@ -1,22 +1,28 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
+import { createLayout } from './helpers';
+
+import { LayoutDto } from '../dtos';
 import { TemplateVariableTypeEnum } from '../types';
 
 const BASE_PATH = '/v1/layouts';
 
 describe('Get a layout - /layouts/:layoutId (GET)', async () => {
+  const layoutName = 'layout-name-creation';
+  const isDefault = true;
   let session: UserSession;
+  let createdLayout: LayoutDto;
 
   before(async () => {
     session = new UserSession();
     await session.initialize();
+    createdLayout = await createLayout(session, layoutName, isDefault);
   });
 
   it('should retrieve the requested layout successfully if exists in the database for that user', async () => {
-    const layoutName = 'layout-name-creation';
-    const description = 'Amazing new layout';
-    const content = [
+    const expectedDescription = 'Amazing new layout';
+    const expectedContent = [
       {
         type: 'text',
         content: 'This are the text contents of the template for {{firstName}}',
@@ -28,24 +34,10 @@ describe('Get a layout - /layouts/:layoutId (GET)', async () => {
         url: 'https://url-of-app.com/{{urlVariable}}',
       },
     ];
-    const variables = [
+
+    const expectedVariables = [
       { name: 'firstName', type: TemplateVariableTypeEnum.STRING, defaultValue: 'John', required: false },
     ];
-    const isDefault = true;
-    const response = await session.testAgent.post(BASE_PATH).send({
-      name: layoutName,
-      description,
-      content,
-      variables,
-      isDefault,
-    });
-
-    expect(response.statusCode).to.eql(201);
-
-    const { body } = response;
-    const createdLayout = body.data;
-    expect(createdLayout._id).to.exist;
-    expect(createdLayout._id).to.be.string;
 
     const url = `${BASE_PATH}/${createdLayout._id}`;
     const getResponse = await session.testAgent.get(url);
@@ -59,9 +51,9 @@ describe('Get a layout - /layouts/:layoutId (GET)', async () => {
     expect(layout._organizationId).to.eql(session.organization._id);
     expect(layout._creatorId).to.eql(session.user._id);
     expect(layout.name).to.eql(layoutName);
-    expect(layout.description).to.eql(description);
-    expect(layout.content).to.eql(content);
-    expect(layout.variables).to.eql(variables);
+    expect(layout.description).to.eql(expectedDescription);
+    expect(layout.content).to.eql(expectedContent);
+    expect(layout.variables).to.eql(expectedVariables);
     expect(layout.contentType).to.eql('customHtml');
     expect(layout.isDefault).to.eql(true);
     expect(layout.isDeleted).to.eql(false);

--- a/apps/api/src/app/layouts/e2e/helpers/index.ts
+++ b/apps/api/src/app/layouts/e2e/helpers/index.ts
@@ -1,0 +1,46 @@
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+import { LayoutDto } from '../../dtos';
+import { LayoutName, TemplateVariableTypeEnum } from '../../types';
+
+const BASE_PATH = '/v1/layouts';
+
+export const createLayout = async (session: UserSession, name: LayoutName, isDefault: boolean): Promise<LayoutDto> => {
+  const description = 'Amazing new layout';
+  const content = [
+    {
+      type: 'text',
+      content: 'This are the text contents of the template for {{firstName}}',
+      styles: { textAlign: 'left' },
+    },
+    {
+      type: 'button',
+      content: 'SIGN UP',
+      url: 'https://url-of-app.com/{{urlVariable}}',
+    },
+  ];
+  const variables = [
+    { name: 'firstName', type: TemplateVariableTypeEnum.STRING, defaultValue: 'John', required: false },
+  ];
+  const response = await session.testAgent.post(BASE_PATH).send({
+    name,
+    description,
+    content,
+    variables,
+    isDefault,
+  });
+
+  expect(response.statusCode).to.eql(201);
+
+  const { body } = response;
+  const createdLayout = body.data;
+  expect(createdLayout._id).to.exist;
+  expect(createdLayout._id).to.be.string;
+
+  const url = `${BASE_PATH}/${createdLayout._id}`;
+  const getResponse = await session.testAgent.get(url);
+  expect(getResponse.status).to.eql(200);
+
+  return getResponse.body.data;
+};

--- a/apps/api/src/app/layouts/e2e/set-default-layout.e2e.ts
+++ b/apps/api/src/app/layouts/e2e/set-default-layout.e2e.ts
@@ -1,0 +1,56 @@
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+import { createLayout } from './helpers';
+
+import { LayoutDto } from '../dtos';
+import { TemplateVariableTypeEnum } from '../types';
+
+const BASE_PATH = '/v1/layouts';
+
+describe('Set layout as default - /layouts/:layoutId/default (POST)', async () => {
+  const layoutName = 'layout-name-set-default';
+  const isDefault = false;
+  let session: UserSession;
+  let createdLayout: LayoutDto;
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+    createdLayout = await createLayout(session, layoutName, isDefault);
+  });
+
+  it('should set the chosen layout as default', async () => {
+    expect(createdLayout.isDefault).to.eql(false);
+
+    const url = `${BASE_PATH}/${createdLayout._id}/default`;
+    const updateResponse = await session.testAgent.post(url);
+    expect(updateResponse.status).to.eql(204);
+
+    const getUrl = `${BASE_PATH}/${createdLayout._id}`;
+    const getResponse = await session.testAgent.get(getUrl);
+    expect(getResponse.status).to.eql(200);
+    expect(getResponse.body.data.isDefault).to.eql(true);
+  });
+
+  it('should set the chosen layout as default and the previous default layout is non default anymore', async () => {
+    const secondLayoutName = 'layout-name-set-default-2';
+    const secondLayout = await createLayout(session, secondLayoutName, false);
+    expect(secondLayout.isDefault).to.eql(false);
+
+    const firstLayoutUrl = `${BASE_PATH}/${createdLayout._id}`;
+    const firstLayoutResponse = await session.testAgent.get(firstLayoutUrl);
+    expect(firstLayoutResponse.body.data.isDefault).to.eql(true);
+
+    const url = `${BASE_PATH}/${secondLayout._id}/default`;
+    const updateResponse = await session.testAgent.post(url);
+    expect(updateResponse.status).to.eql(204);
+
+    const updatedFirstLayoutResponse = await session.testAgent.get(firstLayoutUrl);
+    expect(updatedFirstLayoutResponse.body.data.isDefault).to.eql(false);
+
+    const secondLayoutUrl = `${BASE_PATH}/${secondLayout._id}`;
+    const updatedSecondLayoutResponse = await session.testAgent.get(secondLayoutUrl);
+    expect(updatedSecondLayoutResponse.body.data.isDefault).to.eql(true);
+  });
+});

--- a/apps/api/src/app/layouts/e2e/update-layout.e2e.ts
+++ b/apps/api/src/app/layouts/e2e/update-layout.e2e.ts
@@ -1,6 +1,8 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
+import { createLayout } from './helpers';
+
 import { LayoutDto } from '../dtos';
 import { TemplateVariableTypeEnum } from '../types';
 
@@ -13,7 +15,7 @@ describe('Layout update - /layouts (PATCH)', async () => {
   before(async () => {
     session = new UserSession();
     await session.initialize();
-    createdLayout = await createLayout(session);
+    createdLayout = await createLayout(session, 'layout-name-update', true);
   });
 
   it('should throw validation error for empty payload when not sending a body', async () => {
@@ -71,42 +73,3 @@ describe('Layout update - /layouts (PATCH)', async () => {
     expect(updatedBody.updatedAt).to.be.ok;
   });
 });
-
-const createLayout = async (session: UserSession): Promise<LayoutDto> => {
-  const layoutName = 'layout-name-creation';
-  const description = 'Amazing new layout';
-  const content = [
-    {
-      type: 'text',
-      content: 'This are the text contents of the template for {{firstName}}',
-    },
-    {
-      type: 'button',
-      content: 'SIGN UP',
-      url: 'https://url-of-app.com/{{urlVariable}}',
-    },
-  ];
-  const variables = [
-    { name: 'firstName', type: TemplateVariableTypeEnum.STRING, defaultValue: 'John', required: false },
-  ];
-  const isDefault = true;
-  const response = await session.testAgent.post(BASE_PATH).send({
-    name: layoutName,
-    description,
-    content,
-    variables,
-    isDefault,
-  });
-
-  expect(response.statusCode).to.eql(201);
-
-  const { body } = response;
-  const createdLayout = body.data;
-  expect(createdLayout._id).to.exist;
-  expect(createdLayout._id).to.be.string;
-
-  const url = `${BASE_PATH}/${createdLayout._id}`;
-  const getResponse = await session.testAgent.get(url);
-
-  return getResponse.body.data;
-};

--- a/apps/api/src/app/layouts/layouts.controller.ts
+++ b/apps/api/src/app/layouts/layouts.controller.ts
@@ -41,6 +41,8 @@ import {
   FilterLayoutsUseCase,
   GetLayoutCommand,
   GetLayoutUseCase,
+  SetDefaultLayoutCommand,
+  SetDefaultLayoutUseCase,
   UpdateLayoutCommand,
   UpdateLayoutUseCase,
 } from './use-cases';
@@ -61,6 +63,7 @@ export class LayoutsController {
     private deleteLayoutUseCase: DeleteLayoutUseCase,
     private filterLayoutsUseCase: FilterLayoutsUseCase,
     private getLayoutUseCase: GetLayoutUseCase,
+    private setDefaultLayoutUseCase: SetDefaultLayoutUseCase,
     private updateLayoutUseCase: UpdateLayoutUseCase,
     @Inject(ANALYTICS_SERVICE) private analyticsService: AnalyticsService
   ) {}
@@ -191,6 +194,26 @@ export class LayoutsController {
         content: body.content,
         variables: body.variables,
         isDefault: body.isDefault,
+      })
+    );
+  }
+
+  @Post('/:layoutId/default')
+  @ExternalApiAccessible()
+  @ApiNoContentResponse()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Set default layout',
+    description:
+      'Sets the default layout for the environment and updates to non default to the existing default layout (if any).',
+  })
+  async setDefaultLayout(@UserSession() user: IJwtPayload, @Param('layoutId') layoutId: LayoutId): Promise<void> {
+    await this.setDefaultLayoutUseCase.execute(
+      SetDefaultLayoutCommand.create({
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        userId: user._id,
+        layoutId,
       })
     );
   }

--- a/apps/api/src/app/layouts/use-cases/index.ts
+++ b/apps/api/src/app/layouts/use-cases/index.ts
@@ -2,12 +2,14 @@ import { CreateLayoutUseCase } from './create-layout/create-layout.use-case';
 import { DeleteLayoutUseCase } from './delete-layout/delete-layout.use-case';
 import { FilterLayoutsUseCase } from './filter-layouts/filter-layouts.use-case';
 import { GetLayoutUseCase } from './get-layout/get-layout.use-case';
+import { SetDefaultLayoutUseCase } from './set-default-layout/set-default-layout.use-case';
 import { UpdateLayoutUseCase } from './update-layout/update-layout.use-case';
 
 export * from './create-layout';
 export * from './delete-layout';
 export * from './filter-layouts';
 export * from './get-layout';
+export * from './set-default-layout';
 export * from './update-layout';
 
 export const USE_CASES = [
@@ -15,5 +17,6 @@ export const USE_CASES = [
   DeleteLayoutUseCase,
   FilterLayoutsUseCase,
   GetLayoutUseCase,
+  SetDefaultLayoutUseCase,
   UpdateLayoutUseCase,
 ];

--- a/apps/api/src/app/layouts/use-cases/set-default-layout/index.ts
+++ b/apps/api/src/app/layouts/use-cases/set-default-layout/index.ts
@@ -1,0 +1,2 @@
+export * from './set-default-layout.command';
+export * from './set-default-layout.use-case';

--- a/apps/api/src/app/layouts/use-cases/set-default-layout/set-default-layout.command.ts
+++ b/apps/api/src/app/layouts/use-cases/set-default-layout/set-default-layout.command.ts
@@ -1,0 +1,11 @@
+import { IsDefined, IsString } from 'class-validator';
+
+import { LayoutId } from '../../types';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class SetDefaultLayoutCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsDefined()
+  layoutId: LayoutId;
+}

--- a/apps/api/src/app/layouts/use-cases/set-default-layout/set-default-layout.use-case.ts
+++ b/apps/api/src/app/layouts/use-cases/set-default-layout/set-default-layout.use-case.ts
@@ -1,0 +1,68 @@
+import { LayoutEntity, LayoutRepository } from '@novu/dal';
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SetDefaultLayoutCommand } from './set-default-layout.command';
+
+import { LayoutDto } from '../../dtos/layout.dto';
+import { EnvironmentId, LayoutId, OrganizationId } from '../../types';
+
+@Injectable()
+export class SetDefaultLayoutUseCase {
+  constructor(private layoutRepository: LayoutRepository) {}
+
+  async execute(command: SetDefaultLayoutCommand) {
+    const defaultLayoutId = await this.findDefaultLayoutId(command.environmentId, command.organizationId);
+
+    try {
+      if (defaultLayoutId) {
+        await this.setIsDefaultForLayout(defaultLayoutId, command.environmentId, command.organizationId, false);
+      }
+
+      await this.setIsDefaultForLayout(command.layoutId, command.environmentId, command.organizationId, true);
+    } catch (error) {
+      Logger.error(error);
+      // TODO: Rollback through transactions
+    }
+  }
+
+  private mapToEntity(
+    domainEntity: SetDefaultLayoutCommand
+  ): Pick<LayoutEntity, '_id' | '_environmentId' | '_organizationId' | '_creatorId'> {
+    return {
+      _id: LayoutRepository.convertStringToObjectId(domainEntity.userId),
+      _environmentId: LayoutRepository.convertStringToObjectId(domainEntity.environmentId),
+      _organizationId: LayoutRepository.convertStringToObjectId(domainEntity.organizationId),
+      _creatorId: domainEntity.userId,
+    };
+  }
+
+  private async findDefaultLayoutId(
+    environmentId: EnvironmentId,
+    organizationId: OrganizationId
+  ): Promise<LayoutId | undefined> {
+    const defaultLayout = await this.layoutRepository.findDefault(
+      LayoutRepository.convertStringToObjectId(environmentId),
+      LayoutRepository.convertStringToObjectId(organizationId)
+    );
+
+    if (!defaultLayout) {
+      return undefined;
+    }
+
+    return LayoutRepository.convertObjectIdToString(defaultLayout._id);
+  }
+
+  private async setIsDefaultForLayout(
+    layoutId: LayoutId,
+    environmentId: EnvironmentId,
+    organizationId: OrganizationId,
+    isDefault: boolean
+  ): Promise<void> {
+    this.layoutRepository.updateIsDefault(
+      LayoutRepository.convertStringToObjectId(layoutId),
+      LayoutRepository.convertStringToObjectId(environmentId),
+      LayoutRepository.convertStringToObjectId(organizationId),
+      isDefault
+    );
+  }
+}

--- a/libs/dal/src/repositories/layout/layout.repository.ts
+++ b/libs/dal/src/repositories/layout/layout.repository.ts
@@ -66,6 +66,10 @@ export class LayoutRepository extends BaseRepository<EnforceEnvironmentQuery, La
     }
   }
 
+  async findDefault(_environmentId: EnvironmentId, _organizationId: OrganizationId): Promise<LayoutEntity | null> {
+    return await this.findOne({ _environmentId, _organizationId, isDefault: true });
+  }
+
   async filterLayouts(
     query: EnforceEnvironmentQuery,
     pagination: { limit: number; skip: number }
@@ -87,21 +91,28 @@ export class LayoutRepository extends BaseRepository<EnforceEnvironmentQuery, La
     return data;
   }
 
-  async setLayoutAsDefault(
+  async updateIsDefault(
     _id: LayoutId,
     _environmentId: EnvironmentId,
-    _organizationId: OrganizationId
+    _organizationId: OrganizationId,
+    isDefault: boolean
   ): Promise<void> {
-    await this.update(
+    const updated = await this.update(
       {
         _id,
         _environmentId,
         _organizationId,
       },
       {
-        isDefault: true,
+        isDefault,
       }
     );
+
+    if (updated.matched === 0 || updated.modified === 0) {
+      throw new DalException(
+        `Update of layout ${_id} in environment ${_environmentId} was not performed properly. Not able to set 'isDefault' to ${isDefault}`
+      );
+    }
   }
 
   async updateLayout(entity: LayoutEntity): Promise<LayoutEntity> {


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Adds endpoint and use case to set a layout as default. If there is an existing default layout in the same environment, it will set it to non default while setting as default the chosen one.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
The endpoint is probably not going to be used but the use case will be reused in the creation and update endpoints when the `isDefault` property is sent as true. As we can only have one default template per environment we need this functionality.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
