### PR TITLE
feat(api): promote changes of layouts

### DIFF
--- a/apps/api/src/app/change/usecases/index.ts
+++ b/apps/api/src/app/change/usecases/index.ts
@@ -9,6 +9,7 @@ import { CountChanges } from './count-changes/count-changes.usecase';
 import { PromoteNotificationGroupChange } from './promote-notification-group-change/promote-notification-group-change';
 import { UpdateChange } from './update-change/update-change';
 import { PromoteFeedChange } from './promote-feed-change/promote-feed-change';
+import { PromoteLayoutChange } from './promote-layout-change/promote-layout-change.use-case';
 
 export * from './apply-change';
 export * from './create-change';
@@ -19,6 +20,7 @@ export const USE_CASES = [
   CreateChange,
   PromoteChangeToEnvironment,
   PromoteFeedChange,
+  PromoteLayoutChange,
   PromoteNotificationGroupChange,
   PromoteNotificationTemplateChange,
   PromoteMessageTemplateChange,

--- a/apps/api/src/app/change/usecases/promote-change-to-environment/promote-change-to-environment.usecase.ts
+++ b/apps/api/src/app/change/usecases/promote-change-to-environment/promote-change-to-environment.usecase.ts
@@ -59,6 +59,7 @@ export class PromoteChangeToEnvironment {
         break;
       case ChangeEntityTypeEnum.LAYOUT:
         await this.promoteLayoutChange.execute(typeCommand);
+        break;
       default:
         Logger.error(`Change with type ${command.type} could not be enabled from environment ${command.environmentId}`);
     }

--- a/apps/api/src/app/change/usecases/promote-change-to-environment/promote-change-to-environment.usecase.ts
+++ b/apps/api/src/app/change/usecases/promote-change-to-environment/promote-change-to-environment.usecase.ts
@@ -1,12 +1,14 @@
 import { forwardRef, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { ChangeRepository, EnvironmentRepository } from '@novu/dal';
 import { ChangeEntityTypeEnum } from '@novu/shared';
+import { applyDiff } from 'recursive-diff';
+
 import { PromoteChangeToEnvironmentCommand } from './promote-change-to-environment.command';
 import { PromoteTypeChangeCommand } from '../promote-type-change.command';
+import { PromoteLayoutChange } from '../promote-layout-change';
 import { PromoteNotificationTemplateChange } from '../promote-notification-template-change';
 import { PromoteMessageTemplateChange } from '../promote-message-template-change/promote-message-template-change';
 import { PromoteNotificationGroupChange } from '../promote-notification-group-change/promote-notification-group-change';
-import { applyDiff } from 'recursive-diff';
 import { PromoteFeedChange } from '../promote-feed-change/promote-feed-change';
 
 @Injectable()
@@ -14,6 +16,7 @@ export class PromoteChangeToEnvironment {
   constructor(
     private changeRepository: ChangeRepository,
     private environmentRepository: EnvironmentRepository,
+    private promoteLayoutChange: PromoteLayoutChange,
     @Inject(forwardRef(() => PromoteNotificationTemplateChange))
     private promoteNotificationTemplateChange: PromoteNotificationTemplateChange,
     private promoteMessageTemplateChange: PromoteMessageTemplateChange,
@@ -54,6 +57,8 @@ export class PromoteChangeToEnvironment {
       case ChangeEntityTypeEnum.FEED:
         await this.promoteFeedChange.execute(typeCommand);
         break;
+      case ChangeEntityTypeEnum.LAYOUT:
+        await this.promoteLayoutChange.execute(typeCommand);
       default:
         Logger.error(`Change with type ${command.type} could not be enabled from environment ${command.environmentId}`);
     }

--- a/apps/api/src/app/change/usecases/promote-layout-change/index.ts
+++ b/apps/api/src/app/change/usecases/promote-layout-change/index.ts
@@ -1,0 +1,1 @@
+export * from './promote-layout-change.use-case';

--- a/apps/api/src/app/change/usecases/promote-layout-change/promote-layout-change.use-case.ts
+++ b/apps/api/src/app/change/usecases/promote-layout-change/promote-layout-change.use-case.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { LayoutEntity, LayoutRepository } from '@novu/dal';
+
+import { PromoteTypeChangeCommand } from '../promote-type-change.command';
+
+@Injectable()
+export class PromoteLayoutChange {
+  constructor(private layoutRepository: LayoutRepository) {}
+
+  async execute(command: PromoteTypeChangeCommand) {
+    const item = await this.layoutRepository.findOne({
+      _environmentId: command.environmentId,
+      _id: command.item._id,
+    });
+
+    const newItem = command.item as LayoutEntity;
+
+    if (!item) {
+      const layoutEntity = {
+        ...newItem,
+        _creatorId: command.userId,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      };
+
+      return this.layoutRepository.createLayout(layoutEntity);
+    }
+
+    return this.layoutRepository.update(
+      {
+        _environmentId: command.environmentId,
+        _id: item._id,
+      },
+      {
+        name: newItem.name,
+        content: newItem.content,
+        contentType: newItem.contentType,
+        variables: newItem.variables,
+      }
+    );
+  }
+}

--- a/apps/api/src/app/change/usecases/promote-message-template-change/promote-message-template-change.ts
+++ b/apps/api/src/app/change/usecases/promote-message-template-change/promote-message-template-change.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { PromoteTypeChangeCommand } from '../promote-type-change.command';
-import { MessageTemplateEntity, MessageTemplateRepository, FeedRepository } from '@novu/dal';
+import { MessageTemplateEntity, LayoutRepository, MessageTemplateRepository, FeedRepository } from '@novu/dal';
 
 @Injectable()
 export class PromoteMessageTemplateChange {
-  constructor(private messageTemplateRepository: MessageTemplateRepository, private feedRepository: FeedRepository) {}
+  constructor(
+    private messageTemplateRepository: MessageTemplateRepository,
+    private feedRepository: FeedRepository,
+    private layoutRepository: LayoutRepository
+  ) {}
 
   async execute(command: PromoteTypeChangeCommand) {
     const item = await this.messageTemplateRepository.findOne({
@@ -24,6 +28,12 @@ export class PromoteMessageTemplateChange {
       identifier: feedDev?.identifier,
     });
 
+    const layout = await this.layoutRepository.findOne({
+      _environmentId: command.environmentId,
+      _organizationId: command.organizationId,
+      _parentId: newItem._layoutId,
+    });
+
     if (!item) {
       return this.messageTemplateRepository.create({
         type: newItem.type,
@@ -36,6 +46,7 @@ export class PromoteMessageTemplateChange {
         active: newItem.active,
         _parentId: newItem._id,
         _feedId: feed?._id,
+        _layoutId: layout?._id,
         _environmentId: command.environmentId,
         _creatorId: command.userId,
         _organizationId: command.organizationId,
@@ -57,6 +68,7 @@ export class PromoteMessageTemplateChange {
         cta: newItem.cta,
         active: newItem.active,
         _feedId: feed?._id,
+        _layoutId: layout?._id,
       }
     );
   }

--- a/apps/api/src/app/layouts/dtos/layout.dto.ts
+++ b/apps/api/src/app/layouts/dtos/layout.dto.ts
@@ -52,4 +52,7 @@ export class LayoutDto {
 
   @ApiPropertyOptional()
   updatedAt?: string;
+
+  @ApiPropertyOptional()
+  _parentId?: string;
 }

--- a/apps/api/src/app/layouts/usecases/create-layout-change/create-layout-change.use-case.ts
+++ b/apps/api/src/app/layouts/usecases/create-layout-change/create-layout-change.use-case.ts
@@ -6,8 +6,6 @@ import { CreateLayoutChangeCommand } from './create-layout-change.command';
 
 import { FindDeletedLayoutCommand, FindDeletedLayoutUseCase } from '../find-deleted-layout';
 
-import { LayoutDto } from '../../dtos/layout.dto';
-import { ChannelTypeEnum, IEmailBlock } from '../../types';
 import { CreateChange, CreateChangeCommand } from '../../../change/usecases';
 
 @Injectable()
@@ -21,7 +19,11 @@ export class CreateLayoutChangeUseCase {
   async execute(command: CreateLayoutChangeCommand, isDeleteChange = false): Promise<void> {
     const item = isDeleteChange
       ? await this.findDeletedLayout.execute(FindDeletedLayoutCommand.create(command))
-      : await this.layoutRepository.findById(command.layoutId, command.environmentId);
+      : await this.layoutRepository.findOne({
+          _id: command.layoutId,
+          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
+        });
 
     if (item) {
       const changeId = LayoutRepository.createObjectId();

--- a/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.usecase.ts
+++ b/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.usecase.ts
@@ -61,6 +61,19 @@ export class CreateMessageTemplate {
       );
     }
 
+    if (command.layoutId) {
+      await this.updateChange.execute(
+        UpdateChangeCommand.create({
+          _entityId: command.layoutId,
+          type: ChangeEntityTypeEnum.LAYOUT,
+          parentChangeId: command.parentChangeId,
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          userId: command.userId,
+        })
+      );
+    }
+
     return item;
   }
 }

--- a/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.usecase.ts
+++ b/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.usecase.ts
@@ -136,6 +136,19 @@ export class UpdateMessageTemplate {
       );
     }
 
+    if (command.layoutId) {
+      await this.updateChange.execute(
+        UpdateChangeCommand.create({
+          _entityId: command.layoutId,
+          type: ChangeEntityTypeEnum.LAYOUT,
+          parentChangeId: command.parentChangeId,
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          userId: command.userId,
+        })
+      );
+    }
+
     return item;
   }
 }

--- a/apps/web/src/components/templates/email-editor/EmailInboxContent.tsx
+++ b/apps/web/src/components/templates/email-editor/EmailInboxContent.tsx
@@ -121,6 +121,7 @@ export const EmailInboxContent = ({
               label="Layouts"
               data-test-id="templates-layout"
               loading={isLoading}
+              disabled={readonly}
               required
               error={errors?.steps ? errors?.steps[index]?.template?.layoutId?.message : undefined}
               searchable

--- a/apps/web/src/pages/brand/tabs/LayoutEditor.tsx
+++ b/apps/web/src/pages/brand/tabs/LayoutEditor.tsx
@@ -211,7 +211,6 @@ export function LayoutEditor({
                   checked={field.value === true}
                   disabled={readonly}
                   onChange={field.onChange}
-                  // mt={30}
                   data-test-id="is-default-layout"
                   label="Set as Default"
                 />
@@ -219,7 +218,7 @@ export function LayoutEditor({
             }}
           />
 
-          <Button submit data-test-id="submit-layout">
+          <Button disabled={readonly} submit data-test-id="submit-layout">
             {editMode ? 'Update' : 'Create'}
           </Button>
         </Group>

--- a/apps/web/src/pages/brand/tabs/LayoutsListPage.tsx
+++ b/apps/web/src/pages/brand/tabs/LayoutsListPage.tsx
@@ -13,6 +13,7 @@ import { useLayouts } from '../../../api/hooks/use-layouts';
 import { useMutation } from '@tanstack/react-query';
 import { deleteLayoutById } from '../../../api/layouts';
 import { errorMessage, successMessage } from '../../../utils/notifications';
+import { useEnvController } from '../../../store/use-env-controller';
 
 const enum ActivePageEnum {
   LAYOUTS_LIST = 'layouts_list',
@@ -22,6 +23,7 @@ const enum ActivePageEnum {
 
 export function LayoutsListPage() {
   const theme = useMantineTheme();
+  const { readonly } = useEnvController();
   const [page, setPage] = useState<number>(0);
   const [editId, setEditId] = useState('');
   const [activeScreen, setActiveScreen] = useState(ActivePageEnum.LAYOUTS_LIST);
@@ -101,15 +103,17 @@ export function LayoutsListPage() {
               color={theme.colorScheme === 'dark' ? colors.B40 : colors.B80}
             />
           </ActionIcon>
-          <ActionIcon
-            variant="transparent"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete(_id);
-            }}
-          >
-            <Trash color={theme.colorScheme === 'dark' ? colors.B40 : colors.B80} />
-          </ActionIcon>
+          {!readonly && (
+            <ActionIcon
+              variant="transparent"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(_id);
+              }}
+            >
+              <Trash color={theme.colorScheme === 'dark' ? colors.B40 : colors.B80} />
+            </ActionIcon>
+          )}
         </ActionButtonWrapper>
       ),
     },
@@ -135,8 +139,10 @@ export function LayoutsListPage() {
               marginBottom: '10px',
             }}
           >
-            <UnstyledButton onClick={() => setActiveScreen(ActivePageEnum.CREATE_LAYOUT)}>
-              <Text gradient>+ Create New Layout</Text>
+            <UnstyledButton disabled={readonly} onClick={() => setActiveScreen(ActivePageEnum.CREATE_LAYOUT)}>
+              <Text gradient={!readonly} color={colors.B60}>
+                + Create New Layout
+              </Text>
             </UnstyledButton>
           </div>
 

--- a/libs/dal/src/repositories/layout/layout.entity.ts
+++ b/libs/dal/src/repositories/layout/layout.entity.ts
@@ -14,6 +14,7 @@ export class LayoutEntity {
   _environmentId: EnvironmentId;
   _organizationId: OrganizationId;
   _creatorId: UserId;
+  _parentId?: LayoutId;
   name: LayoutName;
   description?: LayoutDescription;
   variables?: ITemplateVariable[];

--- a/libs/dal/src/repositories/layout/layout.schema.ts
+++ b/libs/dal/src/repositories/layout/layout.schema.ts
@@ -20,6 +20,10 @@ const layoutSchema = new Schema(
       type: Schema.Types.ObjectId,
       ref: 'User',
     },
+    _parentId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Layout',
+    },
     name: Schema.Types.String,
     description: Schema.Types.String,
     variables: [

--- a/libs/shared/src/dto/layout/layout.dto.ts
+++ b/libs/shared/src/dto/layout/layout.dto.ts
@@ -15,6 +15,7 @@ export class LayoutDto {
   _organizationId: OrganizationId;
   _environmentId: EnvironmentId;
   _creatorId: UserId;
+  _parentId?: LayoutId;
   name: LayoutName;
   description?: LayoutDescription;
   channel: ChannelTypeEnum;

--- a/libs/shared/src/entities/change/change.interface.ts
+++ b/libs/shared/src/entities/change/change.interface.ts
@@ -1,5 +1,5 @@
 export enum ChangeEntityTypeEnum {
-  FEED = 'FEED',
+  FEED = 'Feed',
   MESSAGE_TEMPLATE = 'MessageTemplate',
   LAYOUT = 'Layout',
   NOTIFICATION_TEMPLATE = 'NotificationTemplate',

--- a/libs/shared/src/entities/layout/layout.interface.ts
+++ b/libs/shared/src/entities/layout/layout.interface.ts
@@ -14,6 +14,7 @@ export interface ILayoutEntity {
   _organizationId: OrganizationId;
   _environmentId: EnvironmentId;
   _creatorId: UserId;
+  _parentId?: LayoutId;
   name: LayoutName;
   channel: ChannelTypeEnum;
   content: string;


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Adds use case to be able to promote existing changes between environments in layouts.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
To keep aligned our users' environments after they create and test their email notification layouts.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
