### PR TITLE
feat(api): integrate set default layout in creation and update flows

### DIFF
--- a/apps/api/src/app/layouts/e2e/get-layout.e2e.ts
+++ b/apps/api/src/app/layouts/e2e/get-layout.e2e.ts
@@ -9,8 +9,8 @@ import { TemplateVariableTypeEnum } from '../types';
 const BASE_PATH = '/v1/layouts';
 
 describe('Get a layout - /layouts/:layoutId (GET)', async () => {
-  const layoutName = 'layout-name-creation';
-  const isDefault = true;
+  const layoutName = 'layout-name-retrieval';
+  const isDefault = false;
   let session: UserSession;
   let createdLayout: LayoutDto;
 
@@ -55,7 +55,7 @@ describe('Get a layout - /layouts/:layoutId (GET)', async () => {
     expect(layout.content).to.eql(expectedContent);
     expect(layout.variables).to.eql(expectedVariables);
     expect(layout.contentType).to.eql('customHtml');
-    expect(layout.isDefault).to.eql(true);
+    expect(layout.isDefault).to.eql(false);
     expect(layout.isDeleted).to.eql(false);
     expect(layout.createdAt).to.be.ok;
     expect(layout.updatedAt).to.be.ok;

--- a/apps/api/src/app/layouts/e2e/update-layout.e2e.ts
+++ b/apps/api/src/app/layouts/e2e/update-layout.e2e.ts
@@ -72,4 +72,32 @@ describe('Layout update - /layouts (PATCH)', async () => {
     expect(updatedBody.createdAt).to.be.ok;
     expect(updatedBody.updatedAt).to.be.ok;
   });
+
+  it('if the layout updated is assigned as default it should set as non default the existing default layout', async () => {
+    const firstLayout = await createLayout(session, 'layout-name-update-first-created', true);
+    const secondLayout = await createLayout(session, 'layout-name-update-second-created', false);
+
+    const firstLayoutUrl = `${BASE_PATH}/${firstLayout._id}`;
+    const firstLayoutResponse = await session.testAgent.get(firstLayoutUrl);
+    expect(firstLayoutResponse.body.data._id).to.eql(firstLayout._id);
+    expect(firstLayoutResponse.body.data.isDefault).to.eql(true);
+
+    const secondLayoutUrl = `${BASE_PATH}/${secondLayout._id}`;
+    const secondLayoutResponse = await session.testAgent.get(secondLayoutUrl);
+    expect(secondLayoutResponse.body.data._id).to.eql(secondLayout._id);
+    expect(secondLayoutResponse.body.data.isDefault).to.eql(false);
+
+    // We proceed to set the second layout as default by update
+    const updateResponse = await session.testAgent.patch(secondLayoutUrl).send({
+      isDefault: true,
+    });
+
+    const firstLayoutNonDefaultResponse = await session.testAgent.get(firstLayoutUrl);
+    expect(firstLayoutNonDefaultResponse.body.data._id).to.eql(firstLayout._id);
+    expect(firstLayoutNonDefaultResponse.body.data.isDefault).to.eql(false);
+
+    const secondLayoutDefaultResponse = await session.testAgent.get(secondLayoutUrl);
+    expect(secondLayoutDefaultResponse.body.data._id).to.eql(secondLayout._id);
+    expect(secondLayoutDefaultResponse.body.data.isDefault).to.eql(true);
+  });
 });


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Integrates the set default layout use case in the create layout and update layout use case for when the command property is default is set to true, to proceed to set the chosen layout as default and to set to non default any existing default layout in the environment.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
We just want to have a default layout by environment so when users decide to choose one layout as default either when creating it or updating it, we had to add that case, because if not we would face a situation of having multiple default layouts.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
