### PR TITLE
feat: add footer link for home

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -113,6 +113,10 @@ const codeTheme = require('./src/utils/prism');
             {
               items: [
                 {
+                  label: 'Home',
+                  href: 'https://novu.co',
+                },
+                {
                   label: 'Documentation',
                   to: '/',
                 },


### PR DESCRIPTION
### What change does this PR introduce?

Add a new link in footer as `Home` which will open `novu.co` in a new tab.

### Why was this change needed?

Closes #978

### Other information (Screenshots)

![image](https://user-images.githubusercontent.com/22377238/213292009-9909228e-ffc7-490c-835c-3f12233bdc32.png)
