### PR TITLE
fix: rearranged the order of statements inside the cleanup function

### DIFF
--- a/packages/notification-center/src/store/socket/use-socket-controller.ts
+++ b/packages/notification-center/src/store/socket/use-socket-controller.ts
@@ -29,8 +29,8 @@ export function useSocketController() {
     }
 
     return () => {
-      socket = null;
       socket?.disconnect();
+      socket = null;
     };
   }, [token]);
 


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
inside `use-socket-controller.ts` useEffect
 ```js
return () => {
      socket = null;
      socket?.disconnect();
 };
```
the order of statements were wrong
socket.disconnect should be invoked before setting it to null

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
