### PR TITLE
fix: update ci pipelines to remove build before building docker image

### DIFF
--- a/.github/workflows/dev-deploy-embed.yml
+++ b/.github/workflows/dev-deploy-embed.yml
@@ -66,6 +66,10 @@ jobs:
           NETLIFY_SITE_ID: 22682666-3a8d-40be-af26-017bfadf5ae9
         timeout-minutes: 1
 
+      - name: Remove build outputs
+        working-directory: libs/embed
+        run: rm -rf dist
+
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:

--- a/.github/workflows/dev-deploy-web.yml
+++ b/.github/workflows/dev-deploy-web.yml
@@ -112,6 +112,10 @@ jobs:
         with:
           oidc: true
 
+      - name: Remove build outputs
+        working-directory: apps/web
+        run: rm -rf build
+
       - name: Build, tag, and push image to ghcr.io
         id: build-image
         env:

--- a/.github/workflows/dev-deploy-widget.yml
+++ b/.github/workflows/dev-deploy-widget.yml
@@ -91,6 +91,10 @@ jobs:
           NETLIFY_SITE_ID: b9147448-b835-4eb1-a2f0-11102f611f5f
         timeout-minutes: 1
 
+      - name: Remove build outputs
+        working-directory: apps/widget
+        run: rm -rf build
+
       - name: Build, tag, and push image to ghcr.io
         id: build-image
         env:

--- a/.github/workflows/prod-deploy-embed.yml
+++ b/.github/workflows/prod-deploy-embed.yml
@@ -63,6 +63,10 @@ jobs:
           NETLIFY_SITE_ID: 0689c015-fca0-4940-a26d-3e33f561bc48
         timeout-minutes: 1
 
+      - name: Remove build outputs
+        working-directory: libs/embed
+        run: rm -rf dist
+
       - name: Build, tag, and push image to ghcr.io
         id: build-image
         env:

--- a/.github/workflows/prod-deploy-web.yml
+++ b/.github/workflows/prod-deploy-web.yml
@@ -110,6 +110,11 @@ jobs:
         with:
           oidc: true
 
+      - name: Remove build outputs
+        working-directory: apps/web
+        run: rm -rf build
+
+
       - name: Build, tag, and push image to ghcr.io
         id: build-image
         env:

--- a/.github/workflows/prod-deploy-widget.yml
+++ b/.github/workflows/prod-deploy-widget.yml
@@ -63,7 +63,7 @@ jobs:
           echo REACT_APP_WS_URL="https://ws.novu.co" >> .env
           echo REACT_APP_ENVIRONMENT=prod >> .env
 
-      - name: Envsetup  
+      - name: Envsetup
         working-directory: apps/widget
         run: npm run envsetup
 
@@ -91,6 +91,10 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: 6f927fd4-dcb0-4cf3-8c0b-8c5539d0d034
         timeout-minutes: 1
+
+      - name: Remove build outputs
+        working-directory: apps/widget
+        run: rm -rf build
 
       - name: Build, tag, and push image to ghcr.io
         id: build-image


### PR DESCRIPTION
### What change does this PR introduce?

Remove the build output of the ci before building the docker image 

### Why was this change needed?

Related to #2486

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
