### PR TITLE
fix: long text overflows container

### DIFF
--- a/apps/web/src/components/templates/in-app-editor/content/Content.tsx
+++ b/apps/web/src/components/templates/in-app-editor/content/Content.tsx
@@ -37,6 +37,7 @@ export function Content(props: IContentProps) {
             width: '100%',
             outline: 'none',
             backgroundColor: 'transparent',
+            overflowWrap: 'anywhere',
             ...(props.readonly
               ? {
                   backgroundColor: props.theme?.colorScheme === 'dark' ? colors.B20 : colors.B98,

--- a/packages/notification-center/src/components/notification-center/components/notification-item/NotificationListItem.tsx
+++ b/packages/notification-center/src/components/notification-center/components/notification-item/NotificationListItem.tsx
@@ -258,6 +258,7 @@ const NotificationItemContainer = styled.div`
 
 const TextContent = styled.div`
   line-height: 16px;
+  overflow-wrap: anywhere;
 `;
 
 const SettingsActionWrapper = styled.div<{ novuTheme: INovuTheme }>`


### PR DESCRIPTION
### What change does this PR introduce?
fixes an issue with longer notification text overflowing the container
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
closes #2449
