### PR TITLE
fix: ensure one default layout in set as default

### DIFF
--- a/apps/api/src/app/layouts/usecases/set-default-layout/set-default-layout.use-case.ts
+++ b/apps/api/src/app/layouts/usecases/set-default-layout/set-default-layout.use-case.ts
@@ -10,19 +10,19 @@ export class SetDefaultLayoutUseCase {
   constructor(private layoutRepository: LayoutRepository) {}
 
   async execute(command: SetDefaultLayoutCommand) {
-    const defaultLayoutId = await this.findExistingDefaultLayoutId(
+    const existingDefaultLayoutId = await this.findExistingDefaultLayoutId(
       command.layoutId,
       command.environmentId,
       command.organizationId
     );
 
-    if (!defaultLayoutId) {
+    if (!existingDefaultLayoutId) {
       return;
     }
 
     try {
-      if (defaultLayoutId) {
-        await this.setIsDefaultForLayout(defaultLayoutId, command.environmentId, command.organizationId, false);
+      if (existingDefaultLayoutId) {
+        await this.setIsDefaultForLayout(existingDefaultLayoutId, command.environmentId, command.organizationId, false);
       }
 
       await this.setIsDefaultForLayout(command.layoutId, command.environmentId, command.organizationId, true);


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
In update/create layout, because the db create/update of the new default happens before the SetDefaultLayoutUseCase, there are two at time. It is inconsistent which of them SetDefaultLayoutUseCase finds → so causes a state of two defaults at the same time. 
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
