### PR TITLE
feat: ensure one default layout

### DIFF
--- a/apps/api/src/app/layouts/usecases/delete-layout/delete-layout.use-case.ts
+++ b/apps/api/src/app/layouts/usecases/delete-layout/delete-layout.use-case.ts
@@ -35,7 +35,9 @@ export class DeleteLayoutUseCase {
     }
 
     if (layout.isDefault) {
-      throw new ConflictException(`Layout is being used as your default layout, so it can not be deleted`);
+      throw new ConflictException(
+        `Layout with id ${command.layoutId} is being used as your default layout, so it can not be deleted`
+      );
     }
 
     await this.layoutRepository.deleteLayout(command.layoutId, layout._environmentId, layout._organizationId);

--- a/apps/api/src/app/layouts/usecases/delete-layout/delete-layout.use-case.ts
+++ b/apps/api/src/app/layouts/usecases/delete-layout/delete-layout.use-case.ts
@@ -1,5 +1,5 @@
 import { ConflictException, Injectable } from '@nestjs/common';
-import { LayoutEntity, LayoutRepository } from '@novu/dal';
+import { LayoutRepository } from '@novu/dal';
 
 import { DeleteLayoutCommand } from './delete-layout.command';
 
@@ -34,14 +34,11 @@ export class DeleteLayoutUseCase {
       throw new ConflictException(`Layout with id ${command.layoutId} is being used so it can not be deleted`);
     }
 
-    await this.layoutRepository.deleteLayout(command.layoutId, layout._environmentId, layout._organizationId);
+    if (layout.isDefault) {
+      throw new ConflictException(`Layout is being used as your default layout, so it can not be deleted`);
+    }
 
-    const createLayoutChangeCommand = CreateLayoutChangeCommand.create({
-      environmentId: command.environmentId,
-      layoutId: command.layoutId,
-      organizationId: command.organizationId,
-      userId: command.userId,
-    });
+    await this.layoutRepository.deleteLayout(command.layoutId, layout._environmentId, layout._organizationId);
 
     await this.createChange(command);
   }

--- a/apps/api/src/app/layouts/usecases/find-deleted-layout/find-deleted-layout.spec.ts
+++ b/apps/api/src/app/layouts/usecases/find-deleted-layout/find-deleted-layout.spec.ts
@@ -9,7 +9,6 @@ import { FindDeletedLayoutCommand } from './find-deleted-layout.command';
 
 import { CreateLayoutUseCase, CreateLayoutCommand } from '../create-layout';
 import { DeleteLayoutUseCase, DeleteLayoutCommand } from '../delete-layout';
-import { LayoutId } from '../../types';
 
 import { SharedModule } from '../../../shared/shared.module';
 import { ChangeModule } from '../../../change/change.module';
@@ -68,7 +67,7 @@ describe('Find Deleted Layout Usecase', function () {
     const variables = [
       { name: 'organizationName', type: TemplateVariableTypeEnum.STRING, defaultValue: 'Company', required: false },
     ];
-    const isDefault = true;
+    const isDefault = false;
 
     const createCommand = CreateLayoutCommand.create({
       content,

--- a/apps/api/src/app/layouts/usecases/set-default-layout/set-default-layout.use-case.ts
+++ b/apps/api/src/app/layouts/usecases/set-default-layout/set-default-layout.use-case.ts
@@ -1,6 +1,5 @@
 import { LayoutEntity, LayoutRepository } from '@novu/dal';
 import { Injectable, Logger } from '@nestjs/common';
-import { LayoutDto } from '@novu/shared';
 
 import { SetDefaultLayoutCommand } from './set-default-layout.command';
 
@@ -85,6 +84,6 @@ export class SetDefaultLayoutUseCase {
     organizationId: OrganizationId,
     isDefault: boolean
   ): Promise<void> {
-    this.layoutRepository.updateIsDefault(layoutId, environmentId, organizationId, isDefault);
+    await this.layoutRepository.updateIsDefault(layoutId, environmentId, organizationId, isDefault);
   }
 }

--- a/apps/api/src/app/layouts/usecases/update-layout/update-layout.use-case.ts
+++ b/apps/api/src/app/layouts/usecases/update-layout/update-layout.use-case.ts
@@ -1,5 +1,5 @@
 import { LayoutEntity, LayoutRepository } from '@novu/dal';
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable } from '@nestjs/common';
 
 import { UpdateLayoutCommand } from './update-layout.command';
 
@@ -25,6 +25,10 @@ export class UpdateLayoutUseCase {
       organizationId: command.organizationId,
     });
     const databaseEntity = await this.getLayoutUseCase.execute(getLayoutCommand);
+
+    if (!command.isDefault && databaseEntity.isDefault) {
+      throw new ConflictException(`One default layout is required`);
+    }
 
     const patchedEntity = this.applyUpdatesToEntity(this.mapToEntity(databaseEntity), command);
     const hasBody = patchedEntity.content.includes('{{{body}}}');

--- a/apps/api/src/app/layouts/usecases/update-layout/update-layout.use-case.ts
+++ b/apps/api/src/app/layouts/usecases/update-layout/update-layout.use-case.ts
@@ -26,7 +26,7 @@ export class UpdateLayoutUseCase {
     });
     const databaseEntity = await this.getLayoutUseCase.execute(getLayoutCommand);
 
-    if (!command.isDefault && databaseEntity.isDefault) {
+    if (typeof command.isDefault === 'boolean' && !command.isDefault && databaseEntity.isDefault) {
       throw new ConflictException(`One default layout is required`);
     }
 


### PR DESCRIPTION
### What change does this PR introduce?

 We need to make sure user can not remove the only default layout - I see two usecases that could happen : 

In web - unchecking the default 

When deleting a layout, we disallow delete of an assigned layout, but it could be unassigned and the default. 


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
