### PR TITLE
fix: so changes are aggregated into one

### DIFF
--- a/apps/api/src/app/layouts/usecases/create-layout-change/create-layout-change.use-case.ts
+++ b/apps/api/src/app/layouts/usecases/create-layout-change/create-layout-change.use-case.ts
@@ -18,12 +18,6 @@ export class CreateLayoutChangeUseCase {
   ) {}
 
   async execute(command: CreateLayoutChangeCommand, isDeleteChange = false): Promise<void> {
-    const parentChangeId: string = await this.changeRepository.getChangeId(
-      command.environmentId,
-      ChangeEntityTypeEnum.LAYOUT,
-      command.layoutId
-    );
-
     const item = isDeleteChange
       ? await this.findDeletedLayout.execute(FindDeletedLayoutCommand.create(command))
       : await this.layoutRepository.findOne({
@@ -33,6 +27,12 @@ export class CreateLayoutChangeUseCase {
         });
 
     if (item) {
+      const parentChangeId: string = await this.changeRepository.getChangeId(
+        command.environmentId,
+        ChangeEntityTypeEnum.LAYOUT,
+        command.layoutId
+      );
+
       await this.createChange.execute(
         CreateChangeCommand.create({
           organizationId: command.organizationId,

--- a/apps/inbound-mail/src/server/mailUtilities.ts
+++ b/apps/inbound-mail/src/server/mailUtilities.ts
@@ -1,4 +1,4 @@
-import child_process from 'child_process';
+import * as child_process from 'child_process';
 import * as shell from 'shelljs';
 import logger from './logger';
 import * as path from 'path';


### PR DESCRIPTION
### What change does this PR introduce?
After multiple updates in dev, there should be one row per layout in the changes table. Before, it shows all updates separately and they needed to be promoted individually (could cause unexpected behavior in the production if one change depends on another)

Now, all changes made to a layout will be aggregated into a single promotable change. 

* I still need to add tests. Will do in this pr
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
