### PR TITLE
fix: copy when there is no email integration active

### DIFF
--- a/apps/web/src/components/templates/LackIntegrationError.tsx
+++ b/apps/web/src/components/templates/LackIntegrationError.tsx
@@ -4,14 +4,16 @@ import { Text } from '../../design-system';
 import { DoubleArrowRight } from '../../design-system/icons/arrows/CircleArrowRight';
 import { useNavigate } from 'react-router-dom';
 
-export function LackIntegrationError({ channelType }: { channelType: string }) {
+export function LackIntegrationError({ channelType, text }: { channelType: string; text?: string }) {
   const navigate = useNavigate();
 
   return (
     <>
       <WarningMessage>
         <Text>
-          {`Looks like you haven’t configured your ${channelType} provider yet, this channel will be disabled until you configure it.`}
+          {text
+            ? text
+            : `Looks like you haven’t configured your ${channelType} provider yet, this channel will be disabled until you configure it.`}
         </Text>
         <DoubleArrowRight onClick={() => navigate('/integrations')} />
       </WarningMessage>

--- a/apps/web/src/components/templates/email-editor/EmailContentCard.tsx
+++ b/apps/web/src/components/templates/email-editor/EmailContentCard.tsx
@@ -85,7 +85,12 @@ export function EmailContentCard({
 
   return (
     <>
-      {!isIntegrationActive ? <LackIntegrationError channelType="E-Mail" /> : null}
+      {!isIntegrationActive ? (
+        <LackIntegrationError
+          channelType="E-Mail"
+          text="Looks like you haven’t configured your E-Mail provider yet, visit the integrations page to configure."
+        />
+      ) : null}
       <div
         style={{
           fontWeight: 'bolder',

--- a/apps/web/src/components/templates/email-editor/EmailContentCard.tsx
+++ b/apps/web/src/components/templates/email-editor/EmailContentCard.tsx
@@ -8,7 +8,9 @@ import { EmailCustomCodeEditor } from './EmailCustomCodeEditor';
 import { LackIntegrationError } from '../LackIntegrationError';
 import { useEnvController } from '../../../store/use-env-controller';
 import { useActiveIntegrations } from '../../../api/hooks';
+import { ChannelTypeEnum } from '@novu/shared';
 import { EmailInboxContent } from './EmailInboxContent';
+import { useIntegrationLimit } from '../../../api/hooks/integrations/use-integration-limit';
 
 const EDITOR = 'Editor';
 const CUSTOM_CODE = 'Custom Code';
@@ -28,6 +30,8 @@ export function EmailContentCard({
   const [activeTab, setActiveTab] = useState<string | null>(EDITOR);
   const { integrations = [] } = useActiveIntegrations();
   const [integration, setIntegration]: any = useState(null);
+
+  const { enabled } = useIntegrationLimit(ChannelTypeEnum.EMAIL);
 
   useEffect(() => {
     if (integrations.length === 0) {
@@ -88,7 +92,11 @@ export function EmailContentCard({
       {!isIntegrationActive ? (
         <LackIntegrationError
           channelType="E-Mail"
-          text="Looks like you haven’t configured your E-Mail provider yet, visit the integrations page to configure."
+          text={
+            enabled
+              ? 'Looks like you haven’t configured your E-Mail provider yet, visit the integrations page to configure.'
+              : undefined
+          }
         />
       ) : null}
       <div


### PR DESCRIPTION
### What change does this PR introduce?
Change copy for when no email integration is active.

### Why was this change needed?
For it to not be misleading with the new predefined provider.
