### PR TITLE
fix: test send email with nouv email integration

### DIFF
--- a/apps/web/src/components/templates/email-editor/TestSendEmail.tsx
+++ b/apps/web/src/components/templates/email-editor/TestSendEmail.tsx
@@ -4,7 +4,7 @@ import { useClipboard } from '@mantine/hooks';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useFormContext, useWatch } from 'react-hook-form';
 import styled from '@emotion/styled';
-import { MemberStatusEnum } from '@novu/shared';
+import { ChannelTypeEnum, MemberStatusEnum } from '@novu/shared';
 
 import { Button, Text, colors, Tooltip } from '../../../design-system';
 import { testSendEmailMessage } from '../../../api/templates';
@@ -15,6 +15,7 @@ import { inputStyles } from '../../../design-system/config/inputs.styles';
 import useStyles from '../../../design-system/select/Select.styles';
 import { getOrganizationMembers } from '../../../api/organization';
 import { useProcessVariables } from '../../../hooks/use-process-variables';
+import { useIntegrationLimit } from '../../../api/hooks/integrations/use-integration-limit';
 
 export function TestSendEmail({ index, isIntegrationActive }: { index: number; isIntegrationActive: boolean }) {
   const { currentUser } = useContext(AuthContext);
@@ -30,6 +31,7 @@ export function TestSendEmail({ index, isIntegrationActive }: { index: number; i
   });
 
   const { data: organizationMembers } = useQuery<any[]>(['getOrganizationMembers'], getOrganizationMembers);
+  const { enabled } = useIntegrationLimit(ChannelTypeEnum.EMAIL);
 
   const [sendTo, setSendTo] = useState<string[]>(currentUser?.email ? [currentUser?.email] : []);
   const [membersEmails, setMembersEmails] = useState<string[]>([currentUser?.email || '']);
@@ -130,7 +132,7 @@ export function TestSendEmail({ index, isIntegrationActive }: { index: number; i
           loading={isLoading}
           icon={<Invite />}
           data-test-id="test-send-email-btn"
-          disabled={!isIntegrationActive}
+          disabled={!isIntegrationActive && !enabled}
           onClick={() => onTestEmail()}
         >
           Send Test Email


### PR DESCRIPTION
### What change does this PR introduce?

So sending test email can be done with Novu email provider

### Other information (Screenshots)
<img width="1512" alt="Screenshot 2023-01-29 at 14 35 36" src="https://user-images.githubusercontent.com/2233092/215329780-5a52121f-1f3f-45c4-a53d-1b4abd39a0b0.png">


