### PR TITLE
fix(infra): remove standard-version package as being unused

### DIFF
--- a/_templates/provider/new/package.ejs.t
+++ b/_templates/provider/new/package.ejs.t
@@ -51,7 +51,6 @@
     "nyc": "^15.1.0",
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/packages/application-generic/package.json
+++ b/packages/application-generic/package.json
@@ -83,7 +83,6 @@
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
     "sinon": "^9.2.4",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -51,7 +51,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,7 +1449,6 @@ importers:
       prettier: ^2.1.1
       rimraf: ^3.0.2
       sinon: ^9.2.4
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -1503,7 +1502,6 @@ importers:
       prettier: 2.7.1
       rimraf: 3.0.2
       sinon: 9.2.4
-      standard-version: 9.3.2
       ts-jest: 27.1.4_vqlr6pm7mnv5rngd46vdqt4eby
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -1630,7 +1628,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -1651,7 +1648,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_e7edjj3qv32mdmmvbihk7iemnq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -1967,7 +1963,6 @@ importers:
       nyc: ^15.1.0
       open-cli: ^6.0.1
       prettier: ^2.1.1
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -1987,7 +1982,6 @@ importers:
       nyc: 15.1.0
       open-cli: 6.0.1
       prettier: 2.7.1
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2010,7 +2004,6 @@ importers:
       prettier: ^2.1.1
       qs: ^6.11.0
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2033,7 +2026,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2056,7 +2048,6 @@ importers:
       nyc: ^15.1.0
       open-cli: ^6.0.1
       prettier: ^2.1.1
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2076,7 +2067,6 @@ importers:
       nyc: 15.1.0
       open-cli: 6.0.1
       prettier: 2.7.1
-      standard-version: 9.3.2
       ts-jest: 27.1.4_qp56subiksolyncig76b27lvdu
       ts-node: 9.1.1_typescript@4.0.8
       typedoc: 0.19.2_typescript@4.0.8
@@ -2097,7 +2087,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2118,7 +2107,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2140,7 +2128,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: 9.5.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2161,7 +2148,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.5.0
       ts-jest: 27.1.4_umhwpvuqw4p7q7gqrua2jbjayq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2183,7 +2169,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2204,7 +2189,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2229,7 +2213,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2253,7 +2236,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2278,7 +2260,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2302,7 +2283,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2325,7 +2305,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2347,7 +2326,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.2
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2369,7 +2347,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2390,7 +2367,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2412,7 +2388,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2433,7 +2408,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2457,7 +2431,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: 9.5.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2480,7 +2453,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.5.0
       ts-jest: 27.1.4_umhwpvuqw4p7q7gqrua2jbjayq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2503,7 +2475,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2525,7 +2496,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_e7edjj3qv32mdmmvbihk7iemnq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2549,7 +2519,6 @@ importers:
       open-cli: ^6.0.1
       prettier: 2.4.1
       rimraf: ^3.0.2
-      standard-version: 9.5.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2572,7 +2541,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.4.1
       rimraf: 3.0.2
-      standard-version: 9.5.0
       ts-jest: 27.1.4_umhwpvuqw4p7q7gqrua2jbjayq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2594,7 +2562,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2616,7 +2583,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2639,7 +2605,6 @@ importers:
       pepipost: ^5.0.0
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: 9.5.0
       ts-jest: ^27.0.7
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2660,7 +2625,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.5.0
       ts-jest: 27.1.4_umhwpvuqw4p7q7gqrua2jbjayq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2682,7 +2646,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2703,7 +2666,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_e7edjj3qv32mdmmvbihk7iemnq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2726,7 +2688,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: 9.5.0
       ts-jest: ^27.0.7
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2748,7 +2709,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.5.0
       ts-jest: 27.1.4_umhwpvuqw4p7q7gqrua2jbjayq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2770,7 +2730,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2791,7 +2750,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2813,7 +2771,6 @@ importers:
       plivo: ^4.22.4
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: 9.5.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2834,8 +2791,7 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.5.0
-      ts-jest: 27.1.4_mjytj3422l35p4lu22eg53ghni
+      ts-jest: 27.1.4_umhwpvuqw4p7q7gqrua2jbjayq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
       typescript: 4.6.2
@@ -2856,7 +2812,6 @@ importers:
       postmark: ^2.7.8
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: 9.5.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2877,7 +2832,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.5.0
       ts-jest: 27.1.4_umhwpvuqw4p7q7gqrua2jbjayq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2899,7 +2853,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: 9.5.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2920,7 +2873,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.5.0
       ts-jest: 27.1.4_umhwpvuqw4p7q7gqrua2jbjayq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2943,7 +2895,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -2965,7 +2916,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_e7edjj3qv32mdmmvbihk7iemnq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -2988,7 +2938,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -3010,7 +2959,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_gxxm7iira7qywlxitjbf2xjjqa
       ts-node: 9.1.1_typescript@4.6.3
       typedoc: 0.19.2_typescript@4.6.3
@@ -3033,7 +2981,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -3055,7 +3002,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_t4ldjoaolo4tjxxklyv3omdwf4
       ts-node: 9.1.1_typescript@4.3.5
       typedoc: 0.19.2_typescript@4.3.5
@@ -3079,7 +3025,6 @@ importers:
       prettier: ^2.1.1
       rimraf: ^3.0.2
       sms77-client: ^2.14.0
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -3102,7 +3047,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_e7edjj3qv32mdmmvbihk7iemnq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -3124,7 +3068,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -3145,7 +3088,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_e7edjj3qv32mdmmvbihk7iemnq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -3168,7 +3110,6 @@ importers:
       prettier: ^2.1.1
       rimraf: ^3.0.2
       sparkpost: ^2.1.4
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -3190,7 +3131,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -3211,7 +3151,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       telnyx: ^1.23.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
@@ -3233,7 +3172,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -3256,7 +3194,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: ^9.0.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       typedoc: ^0.19.0
@@ -3278,7 +3215,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.2
       rimraf: 3.0.2
-      standard-version: 9.3.2
       ts-jest: 27.1.4_pyeptv4an376ndai4k5axbgzye
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -3299,7 +3235,6 @@ importers:
       open-cli: ^6.0.1
       prettier: ^2.1.1
       rimraf: ^3.0.2
-      standard-version: 9.5.0
       ts-jest: ^27.0.5
       ts-node: ^9.0.0
       twilio: ^3.67.2
@@ -3321,7 +3256,6 @@ importers:
       open-cli: 6.0.1
       prettier: 2.6.1
       rimraf: 3.0.2
-      standard-version: 9.5.0
       ts-jest: 27.1.4_umhwpvuqw4p7q7gqrua2jbjayq
       ts-node: 9.1.1_typescript@4.6.2
       typedoc: 0.19.2_typescript@4.6.2
@@ -34986,7 +34920,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -36348,42 +36282,6 @@ packages:
       q: 1.5.1
     dev: true
 
-  /conventional-changelog-atom/2.0.8:
-    resolution: {integrity: sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==}
-    engines: {node: '>=10'}
-    dependencies:
-      q: 1.5.1
-    dev: true
-
-  /conventional-changelog-codemirror/2.0.8:
-    resolution: {integrity: sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==}
-    engines: {node: '>=10'}
-    dependencies:
-      q: 1.5.1
-    dev: true
-
-  /conventional-changelog-config-spec/2.1.0:
-    resolution: {integrity: sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ==}
-    dev: true
-
-  /conventional-changelog-conventionalcommits/4.6.1:
-    resolution: {integrity: sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==}
-    engines: {node: '>=10'}
-    dependencies:
-      compare-func: 2.0.0
-      lodash: 4.17.21
-      q: 1.5.1
-    dev: true
-
-  /conventional-changelog-conventionalcommits/4.6.3:
-    resolution: {integrity: sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==}
-    engines: {node: '>=10'}
-    dependencies:
-      compare-func: 2.0.0
-      lodash: 4.17.21
-      q: 1.5.1
-    dev: true
-
   /conventional-changelog-conventionalcommits/5.0.0:
     resolution: {integrity: sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==}
     engines: {node: '>=10'}
@@ -36413,42 +36311,6 @@ packages:
       through2: 4.0.2
     dev: true
 
-  /conventional-changelog-ember/2.0.9:
-    resolution: {integrity: sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==}
-    engines: {node: '>=10'}
-    dependencies:
-      q: 1.5.1
-    dev: true
-
-  /conventional-changelog-eslint/3.0.9:
-    resolution: {integrity: sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==}
-    engines: {node: '>=10'}
-    dependencies:
-      q: 1.5.1
-    dev: true
-
-  /conventional-changelog-express/2.0.6:
-    resolution: {integrity: sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      q: 1.5.1
-    dev: true
-
-  /conventional-changelog-jquery/3.0.11:
-    resolution: {integrity: sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==}
-    engines: {node: '>=10'}
-    dependencies:
-      q: 1.5.1
-    dev: true
-
-  /conventional-changelog-jshint/2.0.9:
-    resolution: {integrity: sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==}
-    engines: {node: '>=10'}
-    dependencies:
-      compare-func: 2.0.0
-      q: 1.5.1
-    dev: true
-
   /conventional-changelog-preset-loader/2.3.4:
     resolution: {integrity: sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==}
     engines: {node: '>=10'}
@@ -36468,40 +36330,6 @@ packages:
       semver: 6.3.0
       split: 1.0.1
       through2: 4.0.2
-    dev: true
-
-  /conventional-changelog/3.1.24:
-    resolution: {integrity: sha512-ed6k8PO00UVvhExYohroVPXcOJ/K1N0/drJHx/faTH37OIZthlecuLIRX/T6uOp682CAoVoFpu+sSEaeuH6Asg==}
-    engines: {node: '>=10'}
-    dependencies:
-      conventional-changelog-angular: 5.0.13
-      conventional-changelog-atom: 2.0.8
-      conventional-changelog-codemirror: 2.0.8
-      conventional-changelog-conventionalcommits: 4.6.1
-      conventional-changelog-core: 4.2.4
-      conventional-changelog-ember: 2.0.9
-      conventional-changelog-eslint: 3.0.9
-      conventional-changelog-express: 2.0.6
-      conventional-changelog-jquery: 3.0.11
-      conventional-changelog-jshint: 2.0.9
-      conventional-changelog-preset-loader: 2.3.4
-    dev: true
-
-  /conventional-changelog/3.1.25:
-    resolution: {integrity: sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      conventional-changelog-angular: 5.0.13
-      conventional-changelog-atom: 2.0.8
-      conventional-changelog-codemirror: 2.0.8
-      conventional-changelog-conventionalcommits: 4.6.3
-      conventional-changelog-core: 4.2.4
-      conventional-changelog-ember: 2.0.9
-      conventional-changelog-eslint: 3.0.9
-      conventional-changelog-express: 2.0.6
-      conventional-changelog-jquery: 3.0.11
-      conventional-changelog-jshint: 2.0.9
-      conventional-changelog-preset-loader: 2.3.4
     dev: true
 
   /conventional-commit-types/2.3.0:
@@ -39104,14 +38932,6 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
-  /dotgitignore/2.1.0:
-    resolution: {integrity: sha512-sCm11ak2oY6DglEPpCB8TixLjWAxd3kJTs6UIcSasNYxXdFPV+YKlye92c8H4kKFqV5qYMIh7d+cYecEg0dIkA==}
-    engines: {node: '>=6'}
-    dependencies:
-      find-up: 3.0.0
-      minimatch: 3.1.2
-    dev: true
-
   /downshift/6.1.7_react@17.0.2:
     resolution: {integrity: sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==}
     peerDependencies:
@@ -40410,7 +40230,6 @@ packages:
     dependencies:
       eslint: 7.32.0
       globals: 11.12.0
-    dev: false
 
   /eslint-plugin-cypress/2.12.1_eslint@8.30.0:
     resolution: {integrity: sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==}
@@ -42921,13 +42740,6 @@ packages:
     resolution: {integrity: sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==}
     dependencies:
       js-yaml: 3.14.1
-    dev: true
-
-  /fs-access/1.0.1:
-    resolution: {integrity: sha512-05cXDIwNbFaoFWaz5gNHlUTbH5whiss/hr/ibzPd4MH3cR4w0ZKeIPiVdbyJurg3O5r/Bjpvn9KOb1/rPMf3nA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      null-check: 1.0.0
     dev: true
 
   /fs-capacitor/2.0.4:
@@ -52030,11 +51842,6 @@ packages:
     dependencies:
       boolbase: 1.0.0
 
-  /null-check/1.0.0:
-    resolution: {integrity: sha512-j8ZNHg19TyIQOWCGeeQJBuu6xZYIEurf8M1Qsfd8mFrGEfIZytbw18YjKWg+LcO25NowXGZXZpKAx+Ui3TFfDw==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /num2fraction/1.2.2:
     resolution: {integrity: sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=}
 
@@ -53405,7 +53212,7 @@ packages:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.3.5
+      ts-pnp: 1.2.0_typescript@4.5.4
     transitivePeerDependencies:
       - typescript
 
@@ -53430,7 +53237,7 @@ packages:
     resolution: {integrity: sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.3.5
+      ts-pnp: 1.2.0_typescript@4.5.4
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -55506,16 +55313,6 @@ packages:
       bluebird:
         optional: true
 
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
-
   /promise-limit/2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
     dev: false
@@ -57159,7 +56956,7 @@ packages:
       semver: 7.3.2
       style-loader: 1.3.0_webpack@4.44.2
       terser-webpack-plugin: 4.2.3_webpack@4.44.2
-      ts-pnp: 1.2.0_typescript@4.3.5
+      ts-pnp: 1.2.0_typescript@4.5.4
       typescript: 4.3.5
       url-loader: 4.1.1_7hroj2mdu577asu2zyhaasbvae
       webpack: 4.44.2
@@ -60043,50 +59840,6 @@ packages:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
     dev: false
 
-  /standard-version/9.3.2:
-    resolution: {integrity: sha512-u1rfKP4o4ew7Yjbfycv80aNMN2feTiqseAhUhrrx2XtdQGmu7gucpziXe68Z4YfHVqlxVEzo4aUA0Iu3VQOTgQ==}
-    engines: {node: '>=10'}
-    deprecated: standard-version is deprecated. If you're a GitHub user, I recommend https://github.com/googleapis/release-please as an alternative.
-    hasBin: true
-    dependencies:
-      chalk: 2.4.2
-      conventional-changelog: 3.1.24
-      conventional-changelog-config-spec: 2.1.0
-      conventional-changelog-conventionalcommits: 4.6.1
-      conventional-recommended-bump: 6.1.0
-      detect-indent: 6.1.0
-      detect-newline: 3.1.0
-      dotgitignore: 2.1.0
-      figures: 3.2.0
-      find-up: 5.0.0
-      fs-access: 1.0.1
-      git-semver-tags: 4.1.1
-      semver: 7.3.8
-      stringify-package: 1.0.1
-      yargs: 16.2.0
-    dev: true
-
-  /standard-version/9.5.0:
-    resolution: {integrity: sha512-3zWJ/mmZQsOaO+fOlsa0+QK90pwhNd042qEcw6hKFNoLFs7peGyvPffpEBbK/DSGPbyOvli0mUIFv5A4qTjh2Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      chalk: 2.4.2
-      conventional-changelog: 3.1.25
-      conventional-changelog-config-spec: 2.1.0
-      conventional-changelog-conventionalcommits: 4.6.3
-      conventional-recommended-bump: 6.1.0
-      detect-indent: 6.1.0
-      detect-newline: 3.1.0
-      dotgitignore: 2.1.0
-      figures: 3.2.0
-      find-up: 5.0.0
-      git-semver-tags: 4.1.1
-      semver: 7.3.8
-      stringify-package: 1.0.1
-      yargs: 16.2.0
-    dev: true
-
   /start-server-and-test/1.15.3:
     resolution: {integrity: sha512-4GqkqghvUR9cJ8buvtgkyT0AHgVwCJ5EN8eDEhe9grTChGwWUxGm2nqfSeE9+0PZkLRdFqcwTwxVHe1y3ViutQ==}
     engines: {node: '>=6'}
@@ -60403,11 +60156,6 @@ packages:
       get-own-enumerable-property-symbols: 3.0.2
       is-obj: 1.0.1
       is-regexp: 1.0.0
-
-  /stringify-package/1.0.1:
-    resolution: {integrity: sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==}
-    deprecated: This module is not used anymore, and has been replaced by @npmcli/package-json
-    dev: true
 
   /strip-ansi/3.0.1:
     resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
@@ -62068,40 +61816,6 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest/27.1.4_mjytj3422l35p4lu22eg53ghni:
-    resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: '*'
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@types/jest': 27.4.0
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.4.7_ts-node@9.1.1
-      jest-util: 27.5.1
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.8
-      typescript: 4.6.2
-      yargs-parser: 20.2.9
-    dev: true
-
   /ts-jest/27.1.4_n57wun5nltbvzis3zgtotiy72e:
     resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -62621,17 +62335,6 @@ packages:
       typescript: 4.6.3
       yn: 3.1.1
     dev: true
-
-  /ts-pnp/1.2.0_typescript@4.3.5:
-    resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      typescript: 4.3.5
 
   /ts-pnp/1.2.0_typescript@4.5.4:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}

--- a/providers/apns/package.json
+++ b/providers/apns/package.json
@@ -46,7 +46,6 @@
     "nyc": "^15.1.0",
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/burst-sms/package.json
+++ b/providers/burst-sms/package.json
@@ -49,7 +49,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/clickatell/package.json
+++ b/providers/clickatell/package.json
@@ -47,7 +47,6 @@
     "nyc": "^15.1.0",
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0"

--- a/providers/discord/package.json
+++ b/providers/discord/package.json
@@ -48,7 +48,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/emailjs/package.json
+++ b/providers/emailjs/package.json
@@ -61,7 +61,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "9.5.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/expo/package.json
+++ b/providers/expo/package.json
@@ -48,7 +48,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/fcm/package.json
+++ b/providers/fcm/package.json
@@ -51,7 +51,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/firetext/package.json
+++ b/providers/firetext/package.json
@@ -51,7 +51,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/gupshup/package.json
+++ b/providers/gupshup/package.json
@@ -49,7 +49,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/infobip/package.json
+++ b/providers/infobip/package.json
@@ -48,7 +48,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/mailersend/package.json
+++ b/providers/mailersend/package.json
@@ -48,7 +48,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/mailgun/package.json
+++ b/providers/mailgun/package.json
@@ -62,7 +62,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "9.5.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/mailjet/package.json
+++ b/providers/mailjet/package.json
@@ -49,7 +49,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/mandrill/package.json
+++ b/providers/mandrill/package.json
@@ -58,7 +58,6 @@
     "open-cli": "^6.0.1",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "standard-version": "9.5.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/ms-teams/package.json
+++ b/providers/ms-teams/package.json
@@ -48,7 +48,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/netcore/package.json
+++ b/providers/netcore/package.json
@@ -61,7 +61,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "9.5.0",
     "ts-jest": "^27.0.7",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/nexmo/package.json
+++ b/providers/nexmo/package.json
@@ -48,7 +48,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/nodemailer/package.json
+++ b/providers/nodemailer/package.json
@@ -62,7 +62,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "9.5.0",
     "ts-jest": "^27.0.7",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/outlook365/package.json
+++ b/providers/outlook365/package.json
@@ -48,7 +48,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/plivo/package.json
+++ b/providers/plivo/package.json
@@ -60,7 +60,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "9.5.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/postmark/package.json
+++ b/providers/postmark/package.json
@@ -61,7 +61,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "9.5.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/sendgrid/package.json
+++ b/providers/sendgrid/package.json
@@ -61,7 +61,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "9.5.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/sendinblue/package.json
+++ b/providers/sendinblue/package.json
@@ -49,7 +49,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/ses/package.json
+++ b/providers/ses/package.json
@@ -49,7 +49,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/slack/package.json
+++ b/providers/slack/package.json
@@ -49,7 +49,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/sms77/package.json
+++ b/providers/sms77/package.json
@@ -50,7 +50,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/sns/package.json
+++ b/providers/sns/package.json
@@ -48,7 +48,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/sparkpost/package.json
+++ b/providers/sparkpost/package.json
@@ -49,7 +49,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/telnyx/package.json
+++ b/providers/telnyx/package.json
@@ -48,7 +48,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/termii/package.json
+++ b/providers/termii/package.json
@@ -49,7 +49,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",

--- a/providers/twilio/package.json
+++ b/providers/twilio/package.json
@@ -60,7 +60,6 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "standard-version": "9.5.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.0",


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Self explanatory.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Unused dependency. Also it is deprecated. From security and development perspective is a good thing to do.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
