### PR TITLE
fix: so no global style are applied

### DIFF
--- a/packages/notification-center/src/components/notification-center/components/AppContent.tsx
+++ b/packages/notification-center/src/components/notification-center/components/AppContent.tsx
@@ -19,7 +19,7 @@ export function AppContent() {
   };
 
   return (
-    <MantineProvider withNormalizeCSS theme={themeConfig}>
+    <MantineProvider theme={themeConfig}>
       <div className={wrapperClassName(primaryColor, fontFamily, dir)}>
         <Layout />
       </div>


### PR DESCRIPTION
### What change does this PR introduce?
Removing the usage of normalize css for our notification center

### Why was this change needed?
So the normalize css are not applied to our users websites

### Other information (Screenshots)
<img width="522" alt="Screenshot 2023-02-02 at 14 15 09" src="https://user-images.githubusercontent.com/2233092/216336066-44a03eb5-f784-4aa5-80ad-08b2a8cf522f.png">
<img width="522" alt="Screenshot 2023-02-02 at 14 15 15" src="https://user-images.githubusercontent.com/2233092/216336077-dc24646d-22a7-40b9-9c17-033b2680fafc.png">
<img width="522" alt="Screenshot 2023-02-02 at 14 15 22" src="https://user-images.githubusercontent.com/2233092/216336082-6545a480-e2e5-4197-9e34-c808d05bf8ee.png">
<img width="522" alt="Screenshot 2023-02-02 at 14 15 31" src="https://user-images.githubusercontent.com/2233092/216336088-efd2497c-028e-43e9-9593-bdfe8ee0b245.png">
<img width="522" alt="Screenshot 2023-02-02 at 14 15 47" src="https://user-images.githubusercontent.com/2233092/216336096-48ba6a20-b697-4473-83db-7d9559dee348.png">
<img width="522" alt="Screenshot 2023-02-02 at 14 15 54" src="https://user-images.githubusercontent.com/2233092/216336098-4b4016a5-0fe4-46b6-895b-4b523efb8ad2.png">

