### PR TITLE
fix: size of email content "too large" 

### DIFF
--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -20,6 +20,8 @@ import { RolesGuard } from './app/auth/framework/roles.guard';
 import { SubscriberRouteGuard } from './app/auth/framework/subscriber-route.guard';
 import { validateEnv } from './config/env-validator';
 
+const extendedBodySizeRoutes = ['/v1/events', '/v1/notification-templates', '/v1/layouts'];
+
 if (process.env.SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
@@ -67,8 +69,8 @@ export async function bootstrap(expressApp?): Promise<INestApplication> {
   app.useGlobalGuards(new RolesGuard(app.get(Reflector)));
   app.useGlobalGuards(new SubscriberRouteGuard(app.get(Reflector)));
 
-  app.use('/v1/events/trigger', bodyParser.json({ limit: '20mb' }));
-  app.use('/v1/events/trigger', bodyParser.urlencoded({ limit: '20mb', extended: true }));
+  app.use(extendedBodySizeRoutes, bodyParser.json({ limit: '20mb' }));
+  app.use(extendedBodySizeRoutes, bodyParser.urlencoded({ limit: '20mb', extended: true }));
 
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION


### What change does this PR introduce?

The 20mb was only applied to event trigger - not for the broadcast, test email or to save and update the email content.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
