### PR TITLE
fix: missing indexes for count query

### DIFF
--- a/apps/api/src/app/events/e2e/delay-events.e2e.ts
+++ b/apps/api/src/app/events/e2e/delay-events.e2e.ts
@@ -199,7 +199,7 @@ describe('Trigger event - Delay triggered events - /v1/events/trigger (POST)', f
     const diff = differenceInMilliseconds(new Date(delayedJob.payload.sendAt), new Date(delayedJob?.updatedAt));
 
     const delay = await workflowQueueService.queue.getDelayed();
-    expect(delay[0].opts.delay).to.approximately(diff, 500);
+    expect(delay[0].opts.delay).to.approximately(diff, 1000);
   });
 
   it('should not include delayed event in digested sent message', async function () {

--- a/apps/api/src/app/integrations/usecases/calculate-limit-novu-integration/calculate-limit-novu-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/calculate-limit-novu-integration/calculate-limit-novu-integration.usecase.ts
@@ -21,12 +21,16 @@ export class CalculateLimitNovuIntegration {
       return;
     }
 
-    const messagesCount = await this.messageRepository.count({
-      channel: command.channelType,
-      _organizationId: command.organizationId,
-      providerId,
-      createdAt: { $gte: startOfMonth(new Date()), $lte: endOfMonth(new Date()) },
-    });
+    const messagesCount = await this.messageRepository.count(
+      {
+        channel: command.channelType,
+        _organizationId: command.organizationId,
+        _environmentId: command.environmentId,
+        providerId,
+        createdAt: { $gte: startOfMonth(new Date()), $lte: endOfMonth(new Date()) },
+      },
+      CalculateLimitNovuIntegration.MAX_NOVU_INTEGRATION_MAIL_REQUESTS
+    );
 
     return {
       limit: CalculateLimitNovuIntegration.MAX_NOVU_INTEGRATION_MAIL_REQUESTS,

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ClassConstructor, plainToInstance } from 'class-transformer';
-import { Document, Model, Query, Types, ProjectionType } from 'mongoose';
+import { Document, Model, Query, Types, ProjectionType, FilterQuery } from 'mongoose';
 
 export class BaseRepository<T_Query, T_Response> {
   public _model: Model<any & Document>;
@@ -21,8 +21,10 @@ export class BaseRepository<T_Query, T_Response> {
     return new Types.ObjectId(value);
   }
 
-  async count(query: T_Query): Promise<number> {
-    return await this.MongooseModel.countDocuments(query);
+  async count(query: FilterQuery<T_Query>, limit?: number): Promise<number> {
+    return this.MongooseModel.countDocuments(query, {
+      limit,
+    });
   }
 
   async aggregate(query: any[]): Promise<any> {


### PR DESCRIPTION
### What change does this PR introduce?

Add environmentId to the query to avoid collections scans on it and limited the amount of objects scanned until reached limit

### Why was this change needed?

The current query is not utilizing indexes properly since an index on organizationId does not exists

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
