### PR TITLE
feat: add link to github issue to sidebar

### DIFF
--- a/apps/web/cypress/tests/layout/side-menu.spec.ts
+++ b/apps/web/cypress/tests/layout/side-menu.spec.ts
@@ -12,11 +12,15 @@ describe('Side Menu', function () {
     cy.getByTestId('side-nav-settings-link').should('have.attr', 'href').should('include', '/settings');
   });
 
-  it('should show bottom support and docs', function () {
+  it('should show bottom support, docs and share feedback', function () {
     cy.getByTestId('side-nav-bottom-links').scrollIntoView().should('be.visible');
     cy.getByTestId('side-nav-bottom-link-support').should('have.attr', 'href').should('eq', 'https://discord.novu.co');
     cy.getByTestId('side-nav-bottom-link-documentation')
       .should('have.attr', 'href')
       .should('eq', 'https://docs.novu.co');
+
+    cy.getByTestId('side-nav-bottom-link-share-feedback')
+      .should('have.attr', 'href')
+      .should('eq', 'https://github.com/novuhq/novu/issues/new/choose');
   });
 });

--- a/apps/web/src/components/layout/components/SideNav.tsx
+++ b/apps/web/src/components/layout/components/SideNav.tsx
@@ -177,27 +177,40 @@ export function SideNav({}: Props) {
         <Navbar.Section>
           <OrganizationSelect />
         </Navbar.Section>
-        <BottomNav dark={dark} data-test-id="side-nav-bottom-links">
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://discord.novu.co"
-            data-test-id="side-nav-bottom-link-support"
-          >
-            Support
-          </a>
-          <p>
-            <b>&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;</b>
-          </p>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://docs.novu.co"
-            data-test-id="side-nav-bottom-link-documentation"
-          >
-            Documentation
-          </a>
-        </BottomNav>
+        <Navbar.Section>
+          <BottomNav dark={dark} data-test-id="side-nav-bottom-links">
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://discord.novu.co"
+              data-test-id="side-nav-bottom-link-support"
+            >
+              Support
+            </a>
+            <p>
+              <b>&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;</b>
+            </p>
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://docs.novu.co"
+              data-test-id="side-nav-bottom-link-documentation"
+            >
+              Docs
+            </a>
+            <p>
+              <b>&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;</b>
+            </p>
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://github.com/novuhq/novu/issues/new/choose"
+              data-test-id="side-nav-bottom-link-share-feedback"
+            >
+              Share Feedback
+            </a>
+          </BottomNav>
+        </Navbar.Section>
       </Navbar.Section>
     </Navbar>
   );


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- Added a link to create github issue on the side nav.
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/29251776/217764666-c5219339-e160-4f43-9386-584ded941947.png">
<img width="325" alt="image" src="https://user-images.githubusercontent.com/29251776/217764732-be12c71e-3741-48ae-99d1-982c300c6617.png">

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
