### PR TITLE
fix: so previous change id is used on delete change for notification template

### DIFF
--- a/apps/api/src/app/notification-template/e2e/delete-notification-template.e2e.ts
+++ b/apps/api/src/app/notification-template/e2e/delete-notification-template.e2e.ts
@@ -86,6 +86,32 @@ describe('Delete notification template by id - /notification-templates/:template
     expect(!isDeleted).to.equal(true);
   });
 
+  it('should only make one change on delete', async function () {
+    const groups = await notificationGroupRepository.find({
+      _environmentId: session.environment._id,
+    });
+
+    const testTemplate = {
+      name: 'test email template',
+      description: 'This is a test description',
+      tags: ['test-tag'],
+      notificationGroupId: groups[0]._id,
+      steps: [],
+    };
+
+    const { body } = await session.testAgent.post(`/v1/notification-templates`).send(testTemplate);
+    const notificationTemplateId = body.data._id;
+
+    await session.testAgent.delete(`/v1/notification-templates/${notificationTemplateId}`).send();
+
+    const {
+      body: { data },
+    } = await session.testAgent.get(`/v1/changes?promoted=false`);
+
+    expect(data[0].templateName).to.eq(body.data.name);
+    expect(data.length).to.eq(1);
+  });
+
   it('should not display on listing notification templates', async function () {
     const notificationTemplateService = new NotificationTemplateService(
       session.user._id,

--- a/apps/api/src/app/notification-template/usecases/delete-notification-template/delete-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/delete-notification-template/delete-notification-template.usecase.ts
@@ -1,7 +1,7 @@
 // eslint-ignore max-len
 
 import { Injectable } from '@nestjs/common';
-import { NotificationTemplateRepository, DalException } from '@novu/dal';
+import { NotificationTemplateRepository, DalException, ChangeRepository } from '@novu/dal';
 import { ChangeEntityTypeEnum } from '@novu/shared';
 import { CreateChange, CreateChangeCommand } from '../../../change/usecases';
 import { ApiException } from '../../../shared/exceptions/api.exception';
@@ -12,7 +12,8 @@ import { GetNotificationTemplateCommand } from '../get-notification-template/get
 export class DeleteNotificationTemplate {
   constructor(
     private notificationTemplateRepository: NotificationTemplateRepository,
-    private createChange: CreateChange
+    private createChange: CreateChange,
+    private changeRepository: ChangeRepository
   ) {}
 
   async execute(command: GetNotificationTemplateCommand) {
@@ -25,6 +26,13 @@ export class DeleteNotificationTemplate {
         _environmentId: command.environmentId,
         _id: command.templateId,
       });
+
+      const parentChangeId: string = await this.changeRepository.getChangeId(
+        command.environmentId,
+        ChangeEntityTypeEnum.NOTIFICATION_TEMPLATE,
+        command.templateId
+      );
+
       await this.createChange.execute(
         CreateChangeCommand.create({
           organizationId: command.organizationId,
@@ -32,7 +40,7 @@ export class DeleteNotificationTemplate {
           userId: command.userId,
           item: items[0],
           type: ChangeEntityTypeEnum.NOTIFICATION_TEMPLATE,
-          changeId: NotificationTemplateRepository.createObjectId(),
+          changeId: parentChangeId,
         })
       );
     } catch (e) {


### PR DESCRIPTION
### What change does this PR introduce?
Same behaviour as on update notification template

### Why was this change needed?
To fix so template is deleted in prod env when using promote all
