### PR TITLE
feat: added share feedback to open github issue through command palette

### DIFF
--- a/apps/web/src/components/utils/Spotlight.tsx
+++ b/apps/web/src/components/utils/Spotlight.tsx
@@ -66,6 +66,13 @@ export const SpotLight = ({ children }) => {
           window?.open('https://discord.com/invite/novu', '_blank')?.focus();
         },
       },
+      {
+        id: 'navigate-share-feedback',
+        title: 'Share Feedback',
+        onTrigger: () => {
+          window?.open('https://github.com/novuhq/novu/issues/new/choose', '_blank')?.focus();
+        },
+      },
     ]);
   }, []);
 

--- a/apps/web/src/components/utils/Spotlight.tsx
+++ b/apps/web/src/components/utils/Spotlight.tsx
@@ -1,7 +1,7 @@
 import { SpotlightProvider } from '@mantine/spotlight';
 import { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Activity, Bolt, Box, Settings, Repeat, Team, Brand } from '../../design-system/icons';
+import { Activity, Bolt, Box, Settings, Repeat, Team, Brand, Chat } from '../../design-system/icons';
 import { SpotlightContext } from '../../store/spotlightContext';
 
 export const SpotLight = ({ children }) => {
@@ -72,6 +72,7 @@ export const SpotLight = ({ children }) => {
         onTrigger: () => {
           window?.open('https://github.com/novuhq/novu/issues/new/choose', '_blank')?.focus();
         },
+        icon: <Chat />,
       },
     ]);
   }, []);


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- Added `Share Feedback` as one of the item for the command palette, which will open the github issue page when accessed.
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/29251776/217785769-d5f07fea-438a-451e-aa52-bf84f1f918d4.png">

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
