### PR TITLE
docs(topic): Replace enum with string for simplified understanding

### DIFF
--- a/docs/docs/platform/topics.md
+++ b/docs/docs/platform/topics.md
@@ -114,7 +114,7 @@ To trigger a notification to all the subscribers of a topic, Novu's API allows i
 const topicKey = 'posts:comment:12345';
 
 await novu.trigger('<REPLACE_WITH_EVENT_NAME_FROM_ADMIN_PANEL>', {
-  to: [{ type: TriggerRecipientsTypeEnum.TOPIC, topicKey: topicKey }],
+  to: [{ type: 'topic', topicKey: topicKey }],
   payload: {},
 });
 ```
@@ -127,8 +127,8 @@ const topicKey = '<TOPIC-KEY-DEFINED-BY-THE-USER>';
 
 await novu.trigger('<REPLACE_WITH_EVENT_NAME_FROM_ADMIN_PANEL>', {
   to: [
-    { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: topicKey },
-    { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: 'Another Topic Key' },
+    { type: 'topic', topicKey: topicKey },
+    { type: 'topic', topicKey: 'Another Topic Key' },
   ],
   payload: {},
 });
@@ -142,7 +142,7 @@ To exclude the actor responsible for the action of a triggered topic event, you 
 const topicKey = 'posts:comment:12345';
 
 await novu.trigger('<REPLACE_WITH_EVENT_NAME_FROM_ADMIN_PANEL>', {
-  to: [{ type: TriggerRecipientsTypeEnum.TOPIC, topicKey: topicKey }],
+  to: [{ type: 'topic', topicKey: topicKey }],
   payload: {},
   actor: { subscriberId: '<SUBSCRIBER_ID_OF_ACTOR>' },
 });


### PR DESCRIPTION
### What change does this PR introduce?

Updates the Topic docs to do away with enums and simply use strings. 

### Why was this change needed?

This change is needed to simplify the understanding of developers trying to trigger notifications to topics. Before now, they need to go into the codebase to check the value of the enum. With this change, they can just copy and paste and trigger.

Furthermore, it makes it easy for non-JavaScript/non-Node developers to flow with the topics docs. 

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
