### PR TITLE
fix: proper error handling for missing subscriber on preference update

### DIFF
--- a/apps/api/src/app/events/usecases/send-message/send-message.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message.usecase.ts
@@ -37,6 +37,7 @@ import { ANALYTICS_SERVICE } from '../../../shared/shared.module';
 import { Cached } from '../../../shared/interceptors';
 import { CacheKeyPrefixEnum } from '../../../shared/services/cache';
 import { MessageMatcher } from '../trigger-event/message-matcher.service';
+import { ApiException } from '../../../shared/exceptions/api.exception';
 
 @Injectable()
 export class SendMessage {
@@ -174,11 +175,15 @@ export class SendMessage {
       environmentId: job._environmentId,
     });
 
+    const subscriber = await this.subscriberRepository.findById(job._subscriberId);
+    if (!subscriber) throw new ApiException('Subscriber not found with id ' + job._subscriberId);
+
     const buildCommand = GetSubscriberTemplatePreferenceCommand.create({
       organizationId: job._organizationId,
-      subscriberId: job._subscriberId,
+      subscriberId: subscriber.subscriberId,
       environmentId: job._environmentId,
       template,
+      subscriber,
     });
 
     const { preference } = await this.getSubscriberTemplatePreferenceUsecase.execute(buildCommand);

--- a/apps/api/src/app/subscribers/e2e/get-preferences.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/get-preferences.e2e.ts
@@ -34,6 +34,6 @@ describe('Get Subscribers preferences - /subscribers/preferences/:subscriberId (
     }
 
     expect(error).to.be.ok;
-    expect(error?.response.data.message).to.contain('Subscriber not found');
+    expect(error?.response.data.message).to.contain('not found');
   });
 });

--- a/apps/api/src/app/subscribers/e2e/get-preferences.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/get-preferences.e2e.ts
@@ -24,4 +24,16 @@ describe('Get Subscribers preferences - /subscribers/preferences/:subscriberId (
     expect(data.preference.channels.email).to.equal(true);
     expect(data.preference.channels.in_app).to.equal(true);
   });
+
+  it('should handle un existing subscriberId', async function () {
+    let error;
+    try {
+      await getPreference(session, 'unexisting-subscriber-id');
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).to.be.ok;
+    expect(error?.response.data.message).to.contain('Subscriber not found');
+  });
 });

--- a/apps/api/src/app/subscribers/e2e/helpers/index.ts
+++ b/apps/api/src/app/subscribers/e2e/helpers/index.ts
@@ -27,12 +27,15 @@ export async function updateNotificationTemplate(
   });
 }
 
-export async function getPreference(session: UserSession) {
-  return await axiosInstance.get(`${session.serverUrl}/v1/subscribers/${session.subscriberId}/preferences`, {
-    headers: {
-      authorization: `ApiKey ${session.apiKey}`,
-    },
-  });
+export async function getPreference(session: UserSession, subscriberId?: string) {
+  return await axiosInstance.get(
+    `${session.serverUrl}/v1/subscribers/${subscriberId || session.subscriberId}/preferences`,
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
 }
 
 export async function updateSubscriberOnlineFlag(

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.command.ts
@@ -1,6 +1,8 @@
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
-import { NotificationTemplateEntity } from '@novu/dal';
+import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
 
 export class GetSubscriberTemplatePreferenceCommand extends EnvironmentWithSubscriber {
   template: NotificationTemplateEntity;
+
+  subscriber?: SubscriberEntity;
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -30,7 +30,7 @@ export class GetSubscriberTemplatePreference {
       command.subscriber ??
       (await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId));
     if (!subscriber) {
-      throw new ApiException('Subscriber not found');
+      throw new ApiException(`Subscriber ${command.subscriberId} not found`);
     }
 
     const subscriberPreference = await this.subscriberPreferenceRepository.findOne({

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -13,6 +13,7 @@ import {
   ISubscriberPreferenceResponse,
 } from '../get-subscriber-preference/get-subscriber-preference.usecase';
 import { GetSubscriberTemplatePreferenceCommand } from './get-subscriber-template-preference.command';
+import { ApiException } from '../../../shared/exceptions/api.exception';
 
 @Injectable()
 export class GetSubscriberTemplatePreference {
@@ -25,11 +26,16 @@ export class GetSubscriberTemplatePreference {
 
   async execute(command: GetSubscriberTemplatePreferenceCommand): Promise<ISubscriberPreferenceResponse> {
     const activeChannels = await this.queryActiveChannels(command);
-    const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
+    const subscriber =
+      command.subscriber ??
+      (await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId));
+    if (!subscriber) {
+      throw new ApiException('Subscriber not found');
+    }
 
     const subscriberPreference = await this.subscriberPreferenceRepository.findOne({
       _environmentId: command.environmentId,
-      _subscriberId: subscriber !== null ? subscriber._id : command.subscriberId,
+      _subscriberId: subscriber._id,
       _templateId: command.template._id,
     });
 


### PR DESCRIPTION
### What change does this PR introduce?

- Refactor usage of subscriberId and internal subscriber id on fetch preference
- Throw exception when subscriber not found
- Added missing change
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
### Why was this change needed?
NV-1459

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
