### PR TITLE
feat: make sender name an input field for email card

### DIFF
--- a/apps/api/src/app/events/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message-email.usecase.ts
@@ -362,14 +362,7 @@ export class SendMessageEmail extends SendMessageBase {
   ) {
     const mailFactory = new MailFactory();
     const mailHandler = mailFactory.getHandler(
-      {
-        ...integration,
-        credentials: {
-          ...integration.credentials,
-          senderName: senderName && senderName.length > 0 ? senderName : integration.credentials.senderName,
-        },
-        providerId: GetNovuIntegration.mapProviders(ChannelTypeEnum.EMAIL, integration.providerId),
-      },
+      SendMessageEmail.buildFactoryIntegration(integration, senderName),
       mailData.from
     );
 
@@ -428,6 +421,17 @@ export class SendMessageEmail extends SendMessageBase {
 
       return;
     }
+  }
+
+  public static buildFactoryIntegration(integration: IntegrationEntity, senderName?: string) {
+    return {
+      ...integration,
+      credentials: {
+        ...integration.credentials,
+        senderName: senderName && senderName.length > 0 ? senderName : integration.credentials.senderName,
+      },
+      providerId: GetNovuIntegration.mapProviders(ChannelTypeEnum.EMAIL, integration.providerId),
+    };
   }
 }
 

--- a/apps/api/src/app/events/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message-email.usecase.ts
@@ -361,10 +361,7 @@ export class SendMessageEmail extends SendMessageBase {
     senderName?: string
   ) {
     const mailFactory = new MailFactory();
-    const mailHandler = mailFactory.getHandler(
-      SendMessageEmail.buildFactoryIntegration(integration, senderName),
-      mailData.from
-    );
+    const mailHandler = mailFactory.getHandler(this.buildFactoryIntegration(integration, senderName), mailData.from);
 
     try {
       const result = await mailHandler.send(mailData);
@@ -423,7 +420,7 @@ export class SendMessageEmail extends SendMessageBase {
     }
   }
 
-  public static buildFactoryIntegration(integration: IntegrationEntity, senderName?: string) {
+  public buildFactoryIntegration(integration: IntegrationEntity, senderName?: string) {
     return {
       ...integration,
       credentials: {

--- a/apps/api/src/app/events/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message-email.usecase.ts
@@ -226,7 +226,14 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     if (email && integration) {
-      await this.sendMessage(integration, mailData, message, command, notification);
+      await this.sendMessage(
+        integration,
+        mailData,
+        message,
+        command,
+        notification,
+        emailChannel.template.senderName || overrides?.email?.senderName
+      );
 
       return;
     }
@@ -350,12 +357,17 @@ export class SendMessageEmail extends SendMessageBase {
     mailData: IEmailOptions,
     message: MessageEntity,
     command: SendMessageCommand,
-    notification: NotificationEntity
+    notification: NotificationEntity,
+    senderName?: string
   ) {
     const mailFactory = new MailFactory();
     const mailHandler = mailFactory.getHandler(
       {
         ...integration,
+        credentials: {
+          ...integration.credentials,
+          senderName: senderName && senderName.length > 0 ? senderName : integration.credentials.senderName,
+        },
         providerId: GetNovuIntegration.mapProviders(ChannelTypeEnum.EMAIL, integration.providerId),
       },
       mailData.from

--- a/apps/api/src/app/events/usecases/send-message/send-message.command.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message.command.ts
@@ -46,6 +46,7 @@ export class TestSendMessageCommand extends EnvironmentWithUserCommand {
   @IsString()
   subject: string;
   preheader?: string;
+  senderName?: string;
   @IsDefined()
   content: string | IEmailBlock[];
   @IsDefined()

--- a/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.command.ts
+++ b/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.command.ts
@@ -52,5 +52,9 @@ export class CreateMessageTemplateCommand extends EnvironmentWithUserCommand {
   preheader?: string;
 
   @IsOptional()
+  @IsString()
+  senderName?: string;
+
+  @IsOptional()
   actor?: IActor;
 }

--- a/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.usecase.ts
+++ b/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.usecase.ts
@@ -32,6 +32,7 @@ export class CreateMessageTemplate {
       _environmentId: command.environmentId,
       _creatorId: command.userId,
       preheader: command.preheader,
+      senderName: command.senderName,
       actor: command.actor,
     });
 

--- a/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.command.ts
+++ b/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.command.ts
@@ -53,5 +53,8 @@ export class UpdateMessageTemplateCommand extends EnvironmentWithUserCommand {
   preheader?: string;
 
   @IsOptional()
+  senderName?: string;
+
+  @IsOptional()
   actor?: IActor;
 }

--- a/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.usecase.ts
+++ b/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.usecase.ts
@@ -76,6 +76,10 @@ export class UpdateMessageTemplate {
       updatePayload.preheader = command.preheader;
     }
 
+    if (command.senderName !== undefined || command.senderName !== null) {
+      updatePayload.senderName = command.senderName;
+    }
+
     if (command.actor) {
       updatePayload.actor = command.actor;
     }

--- a/apps/api/src/app/notification-template/e2e/create-notification-templates.e2e.ts
+++ b/apps/api/src/app/notification-template/e2e/create-notification-templates.e2e.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { UserSession } from '@novu/testing';
+import { testServer, UserSession } from '@novu/testing';
 import {
   ChannelCTATypeEnum,
   ChannelTypeEnum,
@@ -331,7 +331,9 @@ describe('Create Notification template - /notification-templates (POST)', async 
   });
 
   it('should build factory integration', () => {
-    let result = SendMessageEmail.buildFactoryIntegration({
+    const instance = testServer.getService(SendMessageEmail);
+
+    let result = instance.buildFactoryIntegration({
       _environmentId: '',
       _organizationId: '',
       providerId: EmailProviderIdEnum.SendGrid,
@@ -347,7 +349,7 @@ describe('Create Notification template - /notification-templates (POST)', async 
 
     expect(result.credentials.senderName).to.equal('credentials');
 
-    result = SendMessageEmail.buildFactoryIntegration(
+    result = instance.buildFactoryIntegration(
       {
         _environmentId: '',
         _organizationId: '',
@@ -365,7 +367,7 @@ describe('Create Notification template - /notification-templates (POST)', async 
     );
     expect(result.credentials.senderName).to.equal('credentials');
 
-    result = SendMessageEmail.buildFactoryIntegration(
+    result = instance.buildFactoryIntegration(
       {
         _environmentId: '',
         _organizationId: '',

--- a/apps/api/src/app/notification-template/e2e/create-notification-templates.e2e.ts
+++ b/apps/api/src/app/notification-template/e2e/create-notification-templates.e2e.ts
@@ -9,6 +9,7 @@ import {
   TriggerTypeEnum,
   IFieldFilterPart,
   FilterPartTypeEnum,
+  EmailProviderIdEnum,
 } from '@novu/shared';
 import {
   ChangeRepository,
@@ -20,6 +21,7 @@ import { isSameDay } from 'date-fns';
 import { CreateNotificationTemplateRequestDto } from '../dto';
 
 import axios from 'axios';
+import { SendMessageEmail } from '../../events/usecases/send-message/send-message-email.usecase';
 
 describe('Create Notification template - /notification-templates (POST)', async () => {
   let session: UserSession;
@@ -295,6 +297,92 @@ describe('Create Notification template - /notification-templates (POST)', async 
     const steps = template.steps;
     expect(steps[0]._parentId).to.equal(null);
     expect(steps[0]._id).to.equal(steps[1]._parentId);
+  });
+
+  it('should use sender name in email template', async function () {
+    const testTemplate: Partial<CreateNotificationTemplateRequestDto> = {
+      name: 'test email template',
+      description: 'This is a test description',
+      tags: ['test-tag'],
+      notificationGroupId: session.notificationGroups[0]._id,
+      steps: [
+        {
+          template: {
+            name: 'Message Name',
+            subject: 'Test email subject',
+            preheader: 'Test email preheader',
+            senderName: 'test',
+            content: [{ type: EmailBlockTypeEnum.TEXT, content: 'This is a sample text block' }],
+            type: StepTypeEnum.EMAIL,
+          },
+          filters: [],
+        },
+      ],
+    };
+
+    const { body } = await session.testAgent.post(`/v1/notification-templates`).send(testTemplate);
+
+    expect(body.data).to.be.ok;
+    const template: INotificationTemplate = body.data;
+
+    expect(template._notificationGroupId).to.equal(testTemplate.notificationGroupId);
+    const message = template.steps[0];
+    expect(message.template?.senderName).to.equal('test');
+  });
+
+  it('should build factory integration', () => {
+    let result = SendMessageEmail.buildFactoryIntegration({
+      _environmentId: '',
+      _organizationId: '',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      credentials: {
+        senderName: 'credentials',
+      },
+      active: false,
+      deleted: false,
+      deletedAt: '',
+      deletedBy: '',
+    });
+
+    expect(result.credentials.senderName).to.equal('credentials');
+
+    result = SendMessageEmail.buildFactoryIntegration(
+      {
+        _environmentId: '',
+        _organizationId: '',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        credentials: {
+          senderName: 'credentials',
+        },
+        active: false,
+        deleted: false,
+        deletedAt: '',
+        deletedBy: '',
+      },
+      ''
+    );
+    expect(result.credentials.senderName).to.equal('credentials');
+
+    result = SendMessageEmail.buildFactoryIntegration(
+      {
+        _environmentId: '',
+        _organizationId: '',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        credentials: {
+          senderName: 'credentials',
+        },
+        active: false,
+        deleted: false,
+        deletedAt: '',
+        deletedBy: '',
+      },
+      'senderName'
+    );
+
+    expect(result.credentials.senderName).to.equal('senderName');
   });
 
   async function getProductionEnvironment() {

--- a/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.usecase.ts
@@ -74,6 +74,7 @@ export class CreateNotificationTemplate {
           feedId: message.template.feedId,
           layoutId: message.template.layoutId,
           preheader: message.template.preheader,
+          senderName: message.template.senderName,
           parentChangeId,
           actor: message.template.actor,
         })

--- a/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.usecase.ts
@@ -142,6 +142,7 @@ export class UpdateNotificationTemplate {
               subject: message.template.subject,
               title: message.template.title,
               preheader: message.template.preheader,
+              senderName: message.template.senderName,
               actor: message.template.actor,
               parentChangeId,
             })
@@ -166,6 +167,7 @@ export class UpdateNotificationTemplate {
               subject: message.template.subject,
               title: message.template.title,
               preheader: message.template.preheader,
+              senderName: message.template.senderName,
               parentChangeId,
             })
           );

--- a/apps/api/src/app/shared/dtos/message-template.ts
+++ b/apps/api/src/app/shared/dtos/message-template.ts
@@ -50,6 +50,10 @@ export class MessageTemplate {
   preheader?: string;
 
   @IsOptional()
+  @IsString()
+  senderName?: string;
+
+  @IsOptional()
   actor?: {
     type: ActorTypeEnum;
     data: string | null;

--- a/apps/web/src/components/templates/TemplateFormProvider.tsx
+++ b/apps/web/src/components/templates/TemplateFormProvider.tsx
@@ -47,6 +47,7 @@ const schema = z
                 subject: z.any(),
                 title: z.any(),
                 layoutId: z.any().optional(),
+                senderName: z.any().optional(),
               })
               .passthrough()
               .superRefine((template: any, ctx) => {

--- a/apps/web/src/components/templates/email-editor/EmailInboxContent.tsx
+++ b/apps/web/src/components/templates/email-editor/EmailInboxContent.tsx
@@ -2,7 +2,6 @@ import { Grid, useMantineTheme } from '@mantine/core';
 import { format } from 'date-fns';
 import { Controller, useFormContext } from 'react-hook-form';
 import { colors, Input, Select } from '../../../design-system';
-import { EmailIntegrationInfo } from '../../../pages/templates/editor/EmailIntegrationInfo';
 import { useLayouts } from '../../../api/hooks/useLayouts';
 import { useEffect } from 'react';
 
@@ -49,16 +48,23 @@ export const EmailInboxContent = ({
     >
       <Grid grow justify="center" align="stretch">
         <Grid.Col span={3}>
-          <div
-            style={{
-              padding: '15px',
-              borderRadius: '7px',
-              border: `1px solid ${theme.colorScheme === 'dark' ? colors.B30 : colors.B80}`,
-              margin: '5px 0px',
+          <Controller
+            name={`steps.${index}.template.senderName`}
+            control={control}
+            render={({ field }) => {
+              return (
+                <Input
+                  {...field}
+                  required
+                  error={errors?.steps ? errors.steps[index]?.template?.senderName?.message : undefined}
+                  disabled={readonly}
+                  value={field.value}
+                  placeholder={integration?.credentials?.senderName}
+                  data-test-id="emailSenderName"
+                />
+              );
             }}
-          >
-            <EmailIntegrationInfo integration={integration} field={'from'} />
-          </div>
+          />
         </Grid.Col>
         <Grid.Col span={4}>
           <div>

--- a/apps/web/src/components/templates/templateToFormMappers.ts
+++ b/apps/web/src/components/templates/templateToFormMappers.ts
@@ -15,6 +15,7 @@ const mapEmailStep = (item: IStepEntity): IStepEntity => ({
     ...item.template,
     layoutId: item.template._layoutId ?? '',
     preheader: item.template.preheader ?? '',
+    senderName: item.template.senderName ?? '',
     content: item.template.content,
     ...(item.template?.contentType === 'customHtml' && {
       htmlContent: item.template.content as string,

--- a/libs/dal/src/repositories/message-template/message-template.entity.ts
+++ b/libs/dal/src/repositories/message-template/message-template.entity.ts
@@ -32,6 +32,8 @@ export class MessageTemplateEntity {
 
   preheader?: string;
 
+  senderName?: string;
+
   _feedId?: string;
 
   cta?: IMessageCTA;

--- a/libs/dal/src/repositories/message-template/message-template.schema.ts
+++ b/libs/dal/src/repositories/message-template/message-template.schema.ts
@@ -39,6 +39,7 @@ const messageTemplateSchema = new Schema(
       action: Schema.Types.Mixed,
     },
     preheader: Schema.Types.String,
+    senderName: Schema.Types.String,
     _environmentId: {
       type: Schema.Types.ObjectId,
       ref: 'Environment',

--- a/libs/shared/src/entities/message-template/message-template.interface.ts
+++ b/libs/shared/src/entities/message-template/message-template.interface.ts
@@ -28,6 +28,7 @@ export interface IMessageTemplate {
   _layoutId?: string;
   active?: boolean;
   preheader?: string;
+  senderName?: string;
   actor?: {
     type: ActorTypeEnum;
     data: string | null;


### PR DESCRIPTION
### What change does this PR introduce?
So sender name can be changed from each email template if needed empty field uses default from integration.
