### PR TITLE
NV-538 - Change Z-index for user profile dropdown to overlay the loader in notification template screen

### DIFF
--- a/apps/web/src/design-system/table/Table.tsx
+++ b/apps/web/src/design-system/table/Table.tsx
@@ -101,6 +101,7 @@ export function Table({
     <div style={{ position: 'relative', minHeight: 500, display: 'flex', flexDirection: 'column' }}>
       <LoadingOverlay
         visible={loading}
+        zIndex={1}
         overlayColor={theme.colorScheme === 'dark' ? colors.B30 : colors.B98}
         loaderProps={{
           color: colors.error,


### PR DESCRIPTION
### What change does this PR introduce?
Mends the Notification Listing Table's `Loader's` `zIndex` value to less than of `Notification bar` and `User Dropdown`.

### Why was this change needed?
Closes https://github.com/novuhq/novu/issues/2198

### Other Information:

After Fix:
[Templates _ Novu Manage Platform (1).webm](https://user-images.githubusercontent.com/58044533/218698551-65398784-5e78-41a6-b2e5-4a8ea03f9441.webm)

Before Fix:
[Templates _ Novu Manage Platform.webm](https://user-images.githubusercontent.com/58044533/218665613-d43dec87-4fe1-4b33-bb75-ec1380e7c56e.webm)







