### PR TITLE
NV-1588 - Execution Details modal Should include Template name

### DIFF
--- a/apps/web/src/components/activity/ExecutionDetailsModal.tsx
+++ b/apps/web/src/components/activity/ExecutionDetailsModal.tsx
@@ -64,7 +64,7 @@ export function ExecutionDetailsModal({
           paddingInline: '8px',
         },
       }}
-      title={<Title size={2}>Execution details</Title>}
+      title={<Title size={2}>Execution Details for {template.name ?? ''}</Title>}
       sx={{ backdropFilter: 'blur(10px)' }}
       shadow={theme.colorScheme === 'dark' ? shadows.dark : shadows.medium}
       radius="md"


### PR DESCRIPTION
### What change does this PR introduce?
Updates the  `Execution Details` Modal  title to `Execution Details for <TEMPLATE_NAME>`

### Why was this change needed?
Closes https://github.com/novuhq/novu/issues/2716

### Other information (Screenshots)
<img width="1410" alt="Screenshot 2023-02-14 at 9 23 31 PM" src="https://user-images.githubusercontent.com/34602861/218825462-d95ab577-a075-48d0-8b3d-0c65bc738665.png">
