### PR TITLE
fix: allow step filtering by nested payload/subscriber data

### DIFF
--- a/apps/api/src/app/events/usecases/trigger-event/message-matcher.service.spec.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/message-matcher.service.spec.ts
@@ -252,17 +252,25 @@ describe('Message filter matcher', function () {
           {
             operator: 'EQUAL',
             value: 'nestedValue',
-            field: 'data.nestedKey.childKey',
+            field: 'data.nestedKey',
             on: FilterPartTypeEnum.SUBSCRIBER,
           },
         ]),
       }),
       {
         subscriber: {
+          firstName: '',
+          lastName: '',
+          email: '',
+          subscriberId: '',
+          deleted: false,
+          createdAt: '',
+          updatedAt: '',
+          _id: '',
+          _organizationId: '',
+          _environmentId: '',
           data: {
-            nestedKey: {
-              childKey: 'nestedValue',
-            },
+            nestedKey: 'nestedValue',
           },
         },
       }
@@ -279,12 +287,12 @@ describe('Message filter matcher', function () {
             operator: 'EQUAL',
             value: 'nestedValue',
             field: 'data.nestedKey.doesNotExist',
-            on: FilterPartTypeEnum.SUBSCRIBER,
+            on: FilterPartTypeEnum.PAYLOAD,
           },
         ]),
       }),
       {
-        subscriber: {
+        payload: {
           data: {
             nestedKey: {
               childKey: 'nestedValue',

--- a/apps/api/src/app/events/usecases/trigger-event/message-matcher.service.spec.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/message-matcher.service.spec.ts
@@ -245,6 +245,58 @@ describe('Message filter matcher', function () {
     expect(matchedMessage.passed).to.equal(true);
   });
 
+  it('should get nested custom subscriber data', async function () {
+    const matchedMessage = await messageMatcher.filter(
+      sendMessageCommand({
+        step: makeStep('Correct Match', 'OR', [
+          {
+            operator: 'EQUAL',
+            value: 'nestedValue',
+            field: 'data.nestedKey.childKey',
+            on: FilterPartTypeEnum.SUBSCRIBER,
+          },
+        ]),
+      }),
+      {
+        subscriber: {
+          data: {
+            nestedKey: {
+              childKey: 'nestedValue',
+            },
+          },
+        },
+      }
+    );
+
+    expect(matchedMessage.passed).to.equal(true);
+  });
+
+  it("should return false with nested data that doesn't exist", async function () {
+    const matchedMessage = await messageMatcher.filter(
+      sendMessageCommand({
+        step: makeStep('Correct Match', 'OR', [
+          {
+            operator: 'EQUAL',
+            value: 'nestedValue',
+            field: 'data.nestedKey.doesNotExist',
+            on: FilterPartTypeEnum.SUBSCRIBER,
+          },
+        ]),
+      }),
+      {
+        subscriber: {
+          data: {
+            nestedKey: {
+              childKey: 'nestedValue',
+            },
+          },
+        },
+      }
+    );
+
+    expect(matchedMessage.passed).to.equal(false);
+  });
+
   it('should get smaller or equal payload var then filter value', async function () {
     let matchedMessage = await messageMatcher.filter(
       sendMessageCommand({

--- a/apps/api/src/app/events/usecases/trigger-event/message-matcher.service.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/message-matcher.service.ts
@@ -288,7 +288,7 @@ export class MessageMatcher {
     fieldFilter: IBaseFieldFilterPart,
     filterProcessingDetails: FilterProcessingDetails
   ): boolean {
-    const actualValue = _.get(variables, [fieldFilter.on, fieldFilter.field]);
+    const actualValue = _.get(variables, `${fieldFilter.on}.${fieldFilter.field}`);
     const filterValue = this.parseValue(actualValue, fieldFilter.value);
     let result = false;
 


### PR DESCRIPTION
### What change does this PR introduce?

This change passes a string to lodash.get() instead of an array so that it is able to access nested data. For example, instead of calling `_.get(obj, ['subscriber', 'data.myKey'])`, we now call `_.get(obj, 'subscriber.data.myKey')`. 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

Closes #2756, fixing a bug to allow filter steps to filter by nested data.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

In the following screenshot, you can see that the notification has a step filter of (`subscriber.data.customKey`, `EQUALS`, `"customValue"`) and there is a user with custom data `{customKey: 'customValue'}`. When the notification is triggered, the user receives the notification. 

<img width="2260" alt="Screenshot 2023-02-15 at 12 44 04 PM" src="https://user-images.githubusercontent.com/37708620/219152264-2058dd98-8c50-4f1e-903c-36060e330260.png">

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
