### PR TITLE
feat: add more integration fields for apns

### DIFF
--- a/apps/api/src/app/events/services/push-service/handlers/apns.handler.ts
+++ b/apps/api/src/app/events/services/push-service/handlers/apns.handler.ts
@@ -16,6 +16,8 @@ export class APNSHandler extends BasePushHandler {
       key: credentials.secretKey,
       keyId: credentials.apiKey,
       teamId: credentials.projectName,
+      bundleId: credentials.applicationId as string,
+      production: credentials.secure as boolean,
     });
   }
 }

--- a/apps/web/src/pages/integrations/components/IntegrationInput.tsx
+++ b/apps/web/src/pages/integrations/components/IntegrationInput.tsx
@@ -47,8 +47,6 @@ export function IntegrationInput({
   }
 
   if (credential.type === 'switch') {
-    console.log(field);
-
     return (
       <Switch
         styles={() => ({

--- a/apps/web/src/pages/integrations/components/IntegrationInput.tsx
+++ b/apps/web/src/pages/integrations/components/IntegrationInput.tsx
@@ -1,5 +1,5 @@
 import { CredentialsKeyEnum, IConfigCredentials, secureCredentials } from '@novu/shared';
-import { Input, PasswordInput, Textarea } from '../../../design-system';
+import { Input, PasswordInput, Switch, Textarea } from '../../../design-system';
 
 export function IntegrationInput({
   credential,
@@ -42,6 +42,30 @@ export function IntegrationInput({
         {...register(credential.key, {
           required: credential.required && `Please enter a ${credential.displayName.toLowerCase()}`,
         })}
+      />
+    );
+  }
+
+  if (credential.type === 'switch') {
+    console.log(field);
+
+    return (
+      <Switch
+        styles={() => ({
+          root: {
+            display: 'block !important',
+            maxWidth: '100% !important',
+          },
+        })}
+        label={credential.displayName}
+        required={credential.required}
+        placeholder={credential.displayName}
+        description={credential.description ?? ''}
+        data-test-id={credential.key}
+        error={errors[credential.key]?.message}
+        {...register(credential.key)}
+        checked={field.value === 'true'}
+        onChange={field.onChange}
       />
     );
   }

--- a/libs/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/libs/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -411,6 +411,19 @@ export const apnsConfig: IConfigCredentials[] = [
     type: 'text',
     required: true,
   },
+  {
+    key: CredentialsKeyEnum.ApplicationId,
+    displayName: 'Bundle ID',
+    type: 'text',
+    required: true,
+  },
+  {
+    key: CredentialsKeyEnum.Secure,
+    displayName: 'Production',
+    type: 'switch',
+    required: true,
+  },
+
   ...pushConfigBase,
 ];
 

--- a/providers/apns/src/lib/apns.provider.ts
+++ b/providers/apns/src/lib/apns.provider.ts
@@ -16,6 +16,8 @@ export class APNSPushProvider implements IPushProvider {
       key: string;
       keyId: string;
       teamId: string;
+      bundleId: string;
+      production: boolean;
     }
   ) {
     this.config = config;
@@ -25,7 +27,7 @@ export class APNSPushProvider implements IPushProvider {
         keyId: config.keyId,
         teamId: config.teamId,
       },
-      production: process.env.NODE_ENV === 'prod',
+      production: config.production,
     });
   }
 
@@ -37,6 +39,7 @@ export class APNSPushProvider implements IPushProvider {
       body: options.content,
       title: options.title,
       payload: options.payload,
+      topic: this.config.bundleId,
       ...options.overrides,
     });
     const res = await this.provider.send(notification, options.target);


### PR DESCRIPTION
Two new fields for apns config in integration store, production existed before to the apns provider but was always set to true if cloud version was used. Topic was an required field from start and was missed during first implementation

<img width="1404" alt="Screenshot 2023-02-16 at 10 00 33" src="https://user-images.githubusercontent.com/2233092/219338360-165d2b4b-d6f5-4886-a6d2-c5cc6af1d6ef.png">
 
