### PR TITLE
fix(infra): upgrade and clean dependencies for provider creation script

### DIFF
--- a/_templates/provider/new/package.ejs.t
+++ b/_templates/provider/new/package.ejs.t
@@ -5,7 +5,7 @@
 
 {
   "name": "@novu/<%= name %>",
-  "version": "",
+  "version": "^0.11.0",
   "description": "A <%= name %> wrapper for novu",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -34,28 +34,24 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=13.0.0 <17.0.0",
+    "pnpm": "^7.26.0"
   },
   "dependencies": {
-    "@novu/stateless": "^0.9.0"
+    "@novu/stateless": "^0.11.0"
   },
   "devDependencies": {
-    "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@types/jest": "^27.0.1",
-    "codecov": "^3.5.0",
-    "cspell": "^4.1.0",
-    "cz-conventional-changelog": "^3.3.0",
-    "gh-pages": "^3.1.0",
-    "jest": "^27.1.0",
-    "npm-run-all": "^4.1.5",
-    "nyc": "^15.1.0",
-    "open-cli": "^6.0.1",
-    "prettier": "^2.1.1",
-    "ts-jest": "^27.0.5",
+    "@istanbuljs/nyc-config-typescript": "~1.0.1",
+    "@types/jest": "~27.5.2",
+    "cspell": "~6.19.2",
+    "cz-conventional-changelog": "~3.3.0",
+    "jest": "~27.5.1",
+    "nyc": "~15.1.0",
+    "prettier": "~2.6.2",
+    "rimraf": "~3.0.2",
+    "ts-jest": "~27.1.5",
     "ts-node": "~10.9.1",
-    "typedoc": "^0.19.0",
-    "typescript": "4.9.5",
-    "rimraf": "^3.0.2"
+    "typescript": "4.9.5"
   },
   "files": [
     "build/main",

--- a/_templates/provider/new/prompt.js
+++ b/_templates/provider/new/prompt.js
@@ -8,6 +8,6 @@ module.exports = [
   {
     type: 'input',
     name: 'name',
-    message: 'Write the provider name camelCased:',
+    message: 'Write the provider name `kebab-cased` (e.g. proton-mail, outlook365, yahoo-mail):',
   },
 ];


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
It fixes dependencies upgrades, removal of unused ones and aligns the versions to the current monorepo ones.
Also gives better hint for the naming pattern (kebab-case) that we adopted recently.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Yesterday while @unicodeveloper was investigating the process of creating a new provider he ran into problems by mismatching versions, mainly of our `stateless` package. From there I decided it was better to upgrade the script until we find a way to automatically inject the latest versions of the needed dependencies.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
