### PR TITLE
NV-540 - After clearing notification name field - error is not shown again

### DIFF
--- a/apps/web/src/design-system/config/inputs.styles.ts
+++ b/apps/web/src/design-system/config/inputs.styles.ts
@@ -24,6 +24,9 @@ export const inputStyles = (theme: MantineTheme) => {
       '&::placeholder': {
         color: secondaryColor,
       },
+      '&:focus&:invalid': {
+        borderColor: colors.error,
+      },
     },
     label: {
       color: primaryColor,


### PR DESCRIPTION
### What change does this PR introduce
This PR introduces a new CSS rule that applies a border color of `colors.error` to an input field when it is in the invalid state and has focus. This change was made to provide a more visible indication to the user that there is an error with the input field, specifically when the notification name field in Notification settings is deleted and the workflow button is clicked. The new rule helps to focus the user's attention on the error state of the field and encourages them to correct the error.

### Why was this change needed

closes [#2714](https://github.com/novuhq/novu/issues/2714)

### Other information (Screenshots)

[Video demonstration of this fix](https://user-images.githubusercontent.com/57623705/217866864-4ffc352a-72c7-432e-b774-662566cc6694.mov)