### PR TITLE
[Docs Update]: Add Resend documentation & Update Existing Email Provider docs

### DIFF
--- a/docs/docs/channels/email/custom-smtp.md
+++ b/docs/docs/channels/email/custom-smtp.md
@@ -30,5 +30,6 @@ Those options are:
   - `secure` (on demand)
   - And `DKIM` options if you want to sign messages with _DKIM_
 - Fill the `From email address` field using the authenticated email from the previous step.
-- Click on the **Save** button.
+- Click on the `Disabled` button and mark as `Active`.
+- Click on the **Connect** button.
 - You should now be able to send notifications using Custom SMTP in Novu.

--- a/docs/docs/channels/email/mailersend.md
+++ b/docs/docs/channels/email/mailersend.md
@@ -12,5 +12,6 @@ To generate the API token go visit the [MailerSend API Tokens](https://www.maile
 - Visit the [Integrations](https://web.novu.co/integrations) page on Novu.
 - Locate MailerSend and click on the **Connect** button.
 - Enter API key.
-- Click on the **Save** button.
+- Click on the `Disabled` button and mark as `Active`.
+- Click on the **Connect** button.
 - You should now be able to send notifications using MailerSend in Novu.

--- a/docs/docs/channels/email/mailjet.md
+++ b/docs/docs/channels/email/mailjet.md
@@ -11,13 +11,9 @@ To use the Mailjet channel, you will need to create a Mailjet account and add yo
 To generate a new API key in Mailjet, you can follow these steps:
 
 - Log in to your Mailjet account.
-
 - Click on the **Settings** in the top-right corner of the screen, and then click **API KEYS & TRACKING** from the drop-down menu.
-
 - On the API Keys page, click the **Create an API Key** button.
-
 - Give the API key a name and choose the access level **Write and Read**
-
 - Click the **Generate Key** button to create the new key. Once generated you can see the key but it will be hidden after refresh
 
 ## Authenticate your sender identity
@@ -35,5 +31,6 @@ Mailjet allows you to authenticate your sender identity using one of the followi
 - Locate Mailjet and click on the **Connect** button.
 - Enter your Mailjet API key.
 - Fill the `From email address` field using the authenticated email from the previous step.
-- Click on the **Save** button.
+- Click on the `Disabled` button and mark as `Active`.
+- Click on the **Connect** button.
 - You should now be able to send notifications using Mailjet in Novu.

--- a/docs/docs/channels/email/outlook365.md
+++ b/docs/docs/channels/email/outlook365.md
@@ -14,4 +14,6 @@ To use the Outlook 365 channel, you will need to have the sender's email (user) 
   - `from`: Complete email address of the sending user. (e.g. jdoe@mycompany.com)
   - `senderName`: Sender Name should be the same email address of the sending user. (e.g. jdoe@mycompany.com)
   - `password`: Password used to sign in with the email account.
+- Click on the `Disabled` button and mark as `Active`.
+- Click on the **Connect** button.
 - You should now be able to send notifications using Outlook 365 in Novu.

--- a/docs/docs/channels/email/postmark.md
+++ b/docs/docs/channels/email/postmark.md
@@ -27,5 +27,6 @@ Postmark allows the authentication of the sender identity using one of the follo
 - Locate Postmark and click on the **Connect** button.
 - Enter the Postmark API key.
 - Fill the `From email address` field using the authenticated email from the previous step.
-- Click on the **Save** button.
+- Click on the `Disabled` button and mark as `Active`.
+- Click on the **Connect** button.
 - Now is possible to send notifications using Postmark in Novu.

--- a/docs/docs/channels/email/resend.md
+++ b/docs/docs/channels/email/resend.md
@@ -1,0 +1,34 @@
+# Resend
+
+You can use the [Resend](https://resend.com/) provider to send transactional emails to your customers using the Novu Platform with a single API to create multi-channel experiences.
+
+## Getting Started
+
+To use the Resend channel, you will need to create a Resend account and add your API key to the Resend integration on the Novu platform.
+
+## Generate API Key
+
+To generate a new API key in Resend, you can follow these steps:
+
+- [Sign up](https://resend.com/secret) or [Log in](https://resend.com/login) to your Resend account.
+- Click on the **API Keys** link in the left sidebar, and then click "Create API Key" button on the top right part of the page.
+- On the [API Keys](https://resend.com/api-keys) page, click the **Create API Key** button.
+- Give the API key a name and click on the **Add** button.
+- Copy the generated API Key.
+
+## Authenticate your Sender Identity
+
+Before you can send emails on a large scale, you will need to authenticate your Sender Identity.
+
+Resend allows you to authenticate your sender identity using [Domain Authentication](https://resend.com/docs/dashboard/domains/introduction).
+
+## Create a Resend integration with Novu
+
+- Visit the [Integrations](https://web.novu.co/integrations) page on Novu.
+- Locate Resend and click on the **Connect** button.
+- Enter your Resend API Key.
+- Fill the `From email address` field using the authenticated email from the previous step.
+- Fill the `Sender name`.
+- Click on the `Disabled` button and mark as `Active`.
+- Click on the **Connect** button.
+- You should now be able to send notifications using Resend in Novu.

--- a/docs/docs/channels/email/resend.md
+++ b/docs/docs/channels/email/resend.md
@@ -28,6 +28,7 @@ Resend allows you to authenticate your sender identity using [Domain Authenticat
 - Locate Resend and click on the **Connect** button.
 - Enter your Resend API Key.
 - Fill the `From email address` field using the authenticated email from the previous step.
+  - For testing, you can use `onboarding@resend.dev` if you have not authenticated your sender identity.
 - Fill the `Sender name`.
 - Click on the `Disabled` button and mark as `Active`.
 - Click on the **Connect** button.

--- a/docs/docs/channels/email/sendgrid.md
+++ b/docs/docs/channels/email/sendgrid.md
@@ -11,11 +11,8 @@ To use the Sendgrid channel, you will need to create a Sendgrid account and add 
 To generate a new API key in SendGrid, you can follow these steps:
 
 - Log in to your SendGrid account.
-
 - Click on the **Settings** gear icon in the top right corner of the screen, and then click "API Keys" from the drop-down menu.
-
 - On the API Keys page, click the **Create API Key** button.
-
 - Give the API key a name and select the following permissions
 
 -**Mail Send** - Full Access
@@ -46,5 +43,6 @@ SendGrid allows you to authenticate your sender identity using one of the follow
 - Locate SendGrid and click on the **Connect** button.
 - Enter your SendGrid API Key.
 - Fill the `From email address` field using the authenticated email from the previous step.
-- Click on the **Save** button.
+- Click on the `Disabled` button and mark as `Active`.
+- Click on the **Connect** button.
 - You should now be able to send notifications using SendGrid in Novu.

--- a/docs/docs/channels/email/sendinblue.md
+++ b/docs/docs/channels/email/sendinblue.md
@@ -25,5 +25,6 @@ Sendinblue allows you to authenticate your sender identity using one of the foll
 - Locate Sendinblue and click on the **Connect** button.
 - Enter your Sendinblue API key.
 - Fill the `From email address` field using the authenticated email from the previous step.
-- Click on the **Save** button.
+- Click on the `Disabled` button and mark as `Active`.
+- Click on the **Connect** button.
 - You should now be able to send notifications using Sendinblue in Novu.

--- a/docs/docs/channels/email/ses.md
+++ b/docs/docs/channels/email/ses.md
@@ -24,7 +24,8 @@ To use the Amazon SES provider, you will need to create a SES account and add yo
 - Enter previously saved `ACCESS_KEY_ID` and `ACCESS_SECRET_KEY`.
 - Fill the `From email address` field using the authenticated sender email id in previous step.
 - Enter `region` and `Sender name` also.
-- Click on the **Save** button.
+- Click on the `Disabled` button and mark as `Active`.
+- Click on the **Connect** button.
 - You should now be able to send notifications using Amazon SES in Novu.
 
 ## FAQ


### PR DESCRIPTION
### What change does this PR introduce?

This adds Resend documentation to the list of [Email Channels](https://docs.novu.co/channels/email), and updates other email channel docs.

### Why was this change needed?

To make Resend visible docs, and guide users to integrate Resend.

### Other information (Screenshots)

![Screenshot 2023-02-17 at 09 42 20](https://user-images.githubusercontent.com/2946769/219609392-2737c084-f9fe-46e0-9136-0f6f1949e2e5.png)
