### PR TITLE
feat: add analytics event to track usage of provider webhooks

### DIFF
--- a/apps/webhook/src/shared/shared.module.ts
+++ b/apps/webhook/src/shared/shared.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { AnalyticsService } from '@novu/application-generic';
 import {
   DalService,
   UserRepository,
@@ -40,6 +41,16 @@ const PROVIDERS = [
     },
   },
   ...DAL_MODELS,
+  {
+    provide: AnalyticsService,
+    useFactory: async () => {
+      const analyticsService = new AnalyticsService(process.env.SEGMENT_TOKEN);
+
+      await analyticsService.initialize();
+
+      return analyticsService;
+    },
+  },
 ];
 
 @Module({


### PR DESCRIPTION
### What change does this PR introduce?
Two tracking events so we can track how much provider webhooks is used.

### Why was this change needed?
To be able to understand usage of our provider webhook feature
