### PR TITLE
fix: add info for saas only in inbound parse webhook

### DIFF
--- a/apps/web/src/components/layout/components/PolishingBanner.tsx
+++ b/apps/web/src/components/layout/components/PolishingBanner.tsx
@@ -50,6 +50,7 @@ export function PolishingBanner() {
           segment.track('Polishing Banner Clicked');
         }}
         target={'_blank'}
+        rel="noreferrer"
         style={{ textDecoration: 'underline', display: 'inline-block', marginLeft: 5 }}
       >
         Learn More.

--- a/docs/docs/community/run-locally.md
+++ b/docs/docs/community/run-locally.md
@@ -145,9 +145,10 @@ cd apps/web && npm run cypress:open
 ### Different ports used by the services the project spins up
 
 - **3000** - API
-- **3002** - WebSocket service
+- **3002** - WebSocket Service
 - **4200** - Web Management UI
-- **4500** - Iframe embed for notification center
+- **4701** - Iframe embed for notification center
+- **4500** - Widget Service
 
 ### Testing providers
 

--- a/docs/docs/platform/inbound-parse-webhook.md
+++ b/docs/docs/platform/inbound-parse-webhook.md
@@ -8,6 +8,10 @@ Inbound Webhook is a feature that allows processing of incoming emails for a dom
 The feature parses the contents of the email and POSTs the information to a specified URL in a
 multipart/form-data format.
 
+:::info
+This feature is available only in our SaaS. This feature will not work in self hosted environment.
+:::
+
 ## To set up Inbound Webhook, follow these steps
 
 1. Set up an MX Record:
@@ -25,4 +29,6 @@ multipart/form-data format.
    - Enable the Inbound Parse feature.
    - Set the Webhook URL to the location where you want the parsed data to be POSTed.
 
-Note: The Webhook URL must be publicly accessible.
+:::note
+The Webhook URL must be publicly accessible.
+:::

--- a/docs/docs/platform/templates.md
+++ b/docs/docs/platform/templates.md
@@ -142,6 +142,6 @@ await novu.trigger('<REPLACE_WITH_EVENT_NAME_FROM_ADMIN_PANEL>', {
 ## FAQ
 
 <details>
- <summary>How to send dynamic HTML content as value of varibale?</summary>
+ <summary>How to send dynamic HTML content as value of variable?</summary>
  Use triple curly braces variable like <code>&#123;&#123;&#123;htmlVariable&#125;&#125;&#125;</code> .
 </details>

--- a/docs/docs/platform/templates.md
+++ b/docs/docs/platform/templates.md
@@ -138,3 +138,10 @@ await novu.trigger('<REPLACE_WITH_EVENT_NAME_FROM_ADMIN_PANEL>', {
   },
 });
 ```
+
+## FAQ
+
+<details>
+ <summary>How to send dynamic HTML content as value of varibale?</summary>
+ Use triple curly braces variable like <code>&#123;&#123;&#123;htmlVariable&#125;&#125;&#125;</code> .
+</details>


### PR DESCRIPTION
### What change does this PR introduce?
Add info for SaaS only feature in inbound parse webhook
Add triple curly braces faq in template page
Update port info for cummunity doc
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

Closes [NV-1623](https://linear.app/novu/issue/NV-1623)
Closes [NV-1676](https://linear.app/novu/issue/NV-1676)

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
