### PR TITLE
style: copy text static

### DIFF
--- a/apps/web/src/components/templates/notification-setting-form/TemplatePreference.tsx
+++ b/apps/web/src/components/templates/notification-setting-form/TemplatePreference.tsx
@@ -107,7 +107,7 @@ function CriticalDescription({ field }) {
 
   return (
     <DescriptionWrapper>
-      {"When on, the template will not show in the user preferences , meaning they wouldn't be able to opt out."}
+      {"When on, the template will not show in the user preferences, meaning they wouldn't be able to opt out."}
       <Switch {...field} checked={field.value || false} disabled={readonly} data-test-id="critical" />
     </DescriptionWrapper>
   );

--- a/apps/web/src/components/templates/notification-setting-form/TemplatePreference.tsx
+++ b/apps/web/src/components/templates/notification-setting-form/TemplatePreference.tsx
@@ -107,9 +107,7 @@ function CriticalDescription({ field }) {
 
   return (
     <DescriptionWrapper>
-      {field.value
-        ? 'Users will get your messages no matter what.'
-        : 'Users will be able to unsubscribe from channels.'}
+      {"When on, the template will not show in the user preferences , meaning they wouldn't be able to opt out."}
       <Switch {...field} checked={field.value || false} disabled={readonly} data-test-id="critical" />
     </DescriptionWrapper>
   );


### PR DESCRIPTION
copy text inside user preferences static no matter if on or off

### What change does this PR introduce?

Copy inside User Preference Editor
needs to be fixed and clear
### Why was this change needed?

Closes #2843

### Other information (Screenshots)

<img width="485" alt="image" src="https://user-images.githubusercontent.com/98285260/219966989-ad339624-477a-4a74-af9d-b8c638545e0a.png">