### PR TITLE
fix: reset page number on tab switch

### DIFF
--- a/apps/web/src/pages/changes/PromoteChangesPage.tsx
+++ b/apps/web/src/pages/changes/PromoteChangesPage.tsx
@@ -43,6 +43,7 @@ export function PromoteChangesPage() {
       value: PENDING,
       content: (
         <ChangesTable
+          key={page}
           loading={isLoadingChanges}
           changes={changes}
           handleTableChange={handleTableChange}
@@ -57,6 +58,7 @@ export function PromoteChangesPage() {
       value: HISTORY,
       content: (
         <ChangesTable
+          key={page}
           loading={isLoadingHistory}
           changes={history}
           handleTableChange={handleTableChange}
@@ -88,7 +90,7 @@ export function PromoteChangesPage() {
         }
       />
       <StyledTabs>
-        <Tabs menuTabs={menuTabs} defaultValue={PENDING} />
+        <Tabs menuTabs={menuTabs} defaultValue={PENDING} onTabChange={() => setPage(0)} />
       </StyledTabs>
     </PageContainer>
   );


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- Resets the page number on tab switch on the changes page
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
