### PR TITLE
fix: update and rename no.ts to nb.ts

### DIFF
--- a/docs/docs/notification-center/react/react-components.md
+++ b/docs/docs/notification-center/react/react-components.md
@@ -235,9 +235,9 @@ The `i18n` prop can accept 2 different types of values
           <li><code>ml</code> (Malayalam)</li>
           <li><code>mr</code> (Marathi)</li>
           <li><code>ms</code> (Malay)</li>
+          <li><code>nb</code> (Norwegian)</li>
           <li><code>ne</code> (Nepali)</li>
           <li><code>nl</code> (Dutch)</li>
-          <li><code>no</code> (Norwegian)</li>
           <li><code>or</code> (Odia)</li>
           <li><code>pa</code> (Punjabi)</li>
           <li><code>pl</code> (Polish)</li>

--- a/packages/notification-center/src/i18n/lang.ts
+++ b/packages/notification-center/src/i18n/lang.ts
@@ -42,9 +42,9 @@ import { LV } from './languages/lv';
 import { ML } from './languages/ml';
 import { MR } from './languages/mr';
 import { MS } from './languages/ms';
+import { NB } from './languages/nb';
 import { NE } from './languages/ne';
 import { NL } from './languages/nl';
-import { NO } from './languages/no';
 import { OR } from './languages/or';
 import { PA } from './languages/pa';
 import { PL } from './languages/pl';
@@ -132,7 +132,7 @@ export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
   ms: MS,
   ne: NE,
   nl: NL,
-  no: NO,
+  nb: NB,
   or: OR,
   pa: PA,
   pl: PL,
@@ -216,9 +216,9 @@ export type I18NLanguage =
   | 'ml'
   | 'mr'
   | 'ms'
+  | 'nb'
   | 'ne'
   | 'nl'
-  | 'no'
   | 'or'
   | 'pa'
   | 'pl'

--- a/packages/notification-center/src/i18n/languages/nb.ts
+++ b/packages/notification-center/src/i18n/languages/nb.ts
@@ -1,11 +1,11 @@
 import { ITranslationEntry } from '../lang';
 
-export const NO: ITranslationEntry = {
+export const NB: ITranslationEntry = {
   translations: {
     notifications: 'Varsler',
     markAllAsRead: 'Marker alle som lest',
     poweredBy: 'Drevet av',
     settings: 'Innstillinger',
   },
-  lang: 'no',
+  lang: 'nb',
 };


### PR DESCRIPTION
### What change does this PR introduce?

renaming `no` locale to `nb` 

### Why was this change needed?

date-fns [doesn't support](https://github.com/date-fns/date-fns/tree/main/src/locale) `no` locale. This pr will fix the Norwegian translation of the date/time distance in the widget.

<img width="412" alt="Screenshot 2023-02-21 at 00 06 35" src="https://user-images.githubusercontent.com/58933206/220190512-68e20ae8-de0a-44e5-8cfb-8e65cb9bfac5.png">

