### PR TITLE
fix(api): update subscriber template preferences with wrong template id

### DIFF
--- a/apps/api/src/app/subscribers/e2e/update-preference.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/update-preference.e2e.ts
@@ -61,6 +61,28 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     }
   });
 
+  it('should send a Not Found Request error if template id is wrong', async function () {
+    const updateDataEmailFalse = {
+      channel: {
+        type: ChannelTypeEnum.EMAIL,
+        enabled: false,
+      },
+    };
+
+    try {
+      const response = await updatePreference(updateDataEmailFalse as any, session, '63cc6e0b561e0a609f223e27');
+      expect(response).to.not.be;
+    } catch (error) {
+      const { response } = error;
+      expect(response.status).to.eql(404);
+      expect(response.data).to.have.include({
+        statusCode: 404,
+        message: 'Template with id 63cc6e0b561e0a609f223e27 is not found',
+        error: 'Not Found',
+      });
+    }
+  });
+
   it('should not do any action or error when sending an empty channels property', async function () {
     const initialPreferences = (await getPreference(session)).data.data[0];
     expect(initialPreferences.preference).to.eql({

--- a/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.command.ts
+++ b/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.command.ts
@@ -1,11 +1,10 @@
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
-import { IsBoolean, IsDefined, IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsBoolean, IsDefined, IsMongoId, IsOptional, ValidateNested } from 'class-validator';
 import { ChannelPreference } from '../../../shared/dtos/channel-preference';
 
 export class UpdateSubscriberPreferenceCommand extends EnvironmentWithSubscriber {
   @IsDefined()
-  @IsNotEmpty()
-  @IsString()
+  @IsMongoId()
   templateId: string;
 
   @IsBoolean()

--- a/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
@@ -56,6 +56,9 @@ export class UpdateSubscriberPreference {
     }
 
     const template = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
+    if (!template) {
+      throw new NotFoundException(`Template with id ${command.templateId} is not found`);
+    }
 
     const getSubscriberPreferenceCommand = GetSubscriberTemplatePreferenceCommand.create({
       organizationId: command.organizationId,


### PR DESCRIPTION
### What change does this PR introduce?

Fixes the Sentry issue: https://novu-r9.sentry.io/issues/3841226005/?project=6248811&query=is%3Aunresolved&referrer=issue-stream

When the `PATCH /v1/subscribers/:subscriberId/preferences/:templateId` is triggered with wrong `templateId` the API breaks with 500 error.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)
![Screenshot 2023-02-22 at 10 30 46](https://user-images.githubusercontent.com/2607232/220579448-415276df-da84-4d3f-90be-8302e4038b56.png)
![Screenshot 2023-02-22 at 10 30 34](https://user-images.githubusercontent.com/2607232/220579473-eb2d5ee6-b966-4963-95e4-ffc1ee80d50f.png)


