### PR TITLE
feat(api): move the providers decryption for the template out of loop

### DIFF
--- a/apps/api/src/app/events/usecases/create-notification-jobs/create-notification-jobs.command.ts
+++ b/apps/api/src/app/events/usecases/create-notification-jobs/create-notification-jobs.command.ts
@@ -1,6 +1,6 @@
 // TODO: We shouldn't be importing from DAL here. Needs big refactor throughout monorepo.
 import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
-import { ISubscribersDefine } from '@novu/shared';
+import { ChannelTypeEnum, ISubscribersDefine } from '@novu/shared';
 import { IsDefined, IsString, IsOptional } from 'class-validator';
 
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
@@ -21,6 +21,9 @@ export class CreateNotificationJobsCommand extends EnvironmentWithUserCommand {
 
   @IsDefined()
   template: NotificationTemplateEntity;
+
+  @IsDefined()
+  templateProviderIds: Map<ChannelTypeEnum, string>;
 
   @IsDefined()
   to: ISubscribersDefine;


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
I moved the template providers decryption out of the step generation loop when creating a notification for every subscriber.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
I consider we were doing an expensive operation multiple times when we could just do it once for all the template steps. Downstream, the decryption is using synchronous calls to the `crypto` module (`createDecipheriv` functionality), so we were doing (number of subscribers * number of steps) synchronous calls. We can expect they might be resource expensive as being cryptographic functionalities so it seems sensible to only do the minimum needed to achieve our goals. And because for now, the flow is set to just have one template when triggering an event we can safely reuse the providers of said template for the different subscribers that will be passed in the `to` property.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
