### PR TITLE
fix: optional cc and bcc in email creation

### DIFF
--- a/providers/sendinblue/src/lib/sendinblue.provider.ts
+++ b/providers/sendinblue/src/lib/sendinblue.provider.ts
@@ -51,9 +51,13 @@ export class SendinblueEmailProvider implements IEmailProvider {
       content: attachment?.file.toString('base64'),
       contentType: attachment.mime,
     }));
-    email.cc = options.cc?.map((ccItem) => ({ email: ccItem }));
-    email.bcc = options.bcc?.map((ccItem) => ({ email: ccItem }));
 
+    if (options.bcc)
+      email.bcc = options.bcc?.map((ccItem) => ({ email: ccItem }));
+
+    if (options.replyTo) {
+      email.replyTo.email = options.replyTo;
+    }
     if (options.replyTo) {
       email.replyTo.email = options.replyTo;
     }

--- a/providers/sendinblue/src/lib/sendinblue.provider.ts
+++ b/providers/sendinblue/src/lib/sendinblue.provider.ts
@@ -57,7 +57,7 @@ export class SendinblueEmailProvider implements IEmailProvider {
       email.cc = options.cc?.map((ccItem) => ({ email: ccItem }));
 
     if (options.bcc)
-      email.bcc = options.bcc?.map((ccItem) => ({ email: ccItem }));
+      email.bcc = options.bcc?.map((bccItem) => ({ email: bccItem }));
     if (options.replyTo) {
       email.replyTo.email = options.replyTo;
     }

--- a/providers/sendinblue/src/lib/sendinblue.provider.ts
+++ b/providers/sendinblue/src/lib/sendinblue.provider.ts
@@ -52,12 +52,12 @@ export class SendinblueEmailProvider implements IEmailProvider {
       contentType: attachment.mime,
     }));
 
+
+    if (options.cc)
+      email.cc = options.cc?.map((ccItem) => ({ email: ccItem }));
+
     if (options.bcc)
       email.bcc = options.bcc?.map((ccItem) => ({ email: ccItem }));
-
-    if (options.replyTo) {
-      email.replyTo.email = options.replyTo;
-    }
     if (options.replyTo) {
       email.replyTo.email = options.replyTo;
     }

--- a/providers/sendinblue/src/lib/sendinblue.provider.ts
+++ b/providers/sendinblue/src/lib/sendinblue.provider.ts
@@ -52,11 +52,14 @@ export class SendinblueEmailProvider implements IEmailProvider {
       contentType: attachment.mime,
     }));
 
-    if (options.cc) email.cc = options.cc?.map((ccItem) => ({ email: ccItem }));
-
-    if (options.bcc)
+    if (options.cc) {
+      email.cc = options.cc?.map((ccItem) => ({ email: ccItem }));
+    }
+    
+    if (options.bcc) {
       email.bcc = options.bcc?.map((bccItem) => ({ email: bccItem }));
-
+    }
+    
     if (options.replyTo) {
       email.replyTo.email = options.replyTo;
     }

--- a/providers/sendinblue/src/lib/sendinblue.provider.ts
+++ b/providers/sendinblue/src/lib/sendinblue.provider.ts
@@ -52,12 +52,11 @@ export class SendinblueEmailProvider implements IEmailProvider {
       contentType: attachment.mime,
     }));
 
-
-    if (options.cc)
-      email.cc = options.cc?.map((ccItem) => ({ email: ccItem }));
+    if (options.cc) email.cc = options.cc?.map((ccItem) => ({ email: ccItem }));
 
     if (options.bcc)
       email.bcc = options.bcc?.map((bccItem) => ({ email: bccItem }));
+
     if (options.replyTo) {
       email.replyTo.email = options.replyTo;
     }

--- a/providers/sendinblue/src/lib/sendinblue.provider.ts
+++ b/providers/sendinblue/src/lib/sendinblue.provider.ts
@@ -55,11 +55,11 @@ export class SendinblueEmailProvider implements IEmailProvider {
     if (options.cc) {
       email.cc = options.cc?.map((ccItem) => ({ email: ccItem }));
     }
-    
+
     if (options.bcc) {
       email.bcc = options.bcc?.map((bccItem) => ({ email: bccItem }));
     }
-    
+
     if (options.replyTo) {
       email.replyTo.email = options.replyTo;
     }


### PR DESCRIPTION
### What change does this PR introduce?

Fix for SendinBlue cc and bcc properties

### Why was this change needed?

Because we cannot send mails!
![image](https://user-images.githubusercontent.com/43750947/221239542-239369bf-a215-48c8-84a9-6651e400d0d1.png)

