### PR TITLE
[NV-1759] fix(api): fixed remove subscriber from topic functionality

### DIFF
--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -42,7 +42,7 @@ export class TopicSubscribersRepository extends BaseRepository<EnforceEnvironmen
     await this.delete({
       _environmentId,
       _organizationId,
-      key: topicKey,
+      topicKey,
       externalSubscriberId: {
         $in: externalSubscriberIds,
       },


### PR DESCRIPTION
### What change does this PR introduce?

Fixes the issue: #2902 

When the subscriber is added to multiple topics the `POST /topics/:topic_key/subscribers/removal` endpoint removes him from all the topics, but should only remove from the exact topic by the `:topic_key`.

### Why was this change needed?

Fixes the above issue.

### Other information (Screenshots)
<img width="808" alt="Screenshot 2023-02-24 at 22 34 46" src="https://user-images.githubusercontent.com/2607232/221297688-d4fb56f0-89d1-49c7-a7df-dbe99a62d956.png">
<img width="1038" alt="Screenshot 2023-02-24 at 22 35 05" src="https://user-images.githubusercontent.com/2607232/221297703-ed61c59b-5fab-44aa-b4e5-f422550885be.png">
<img width="792" alt="Screenshot 2023-02-24 at 22 34 58" src="https://user-images.githubusercontent.com/2607232/221297716-835dbb82-ad7a-4f04-9c44-a225dea8fda7.png">

