### PR TITLE
fix: content service not iterating over push title 

### DIFF
--- a/apps/api/src/app/shared/helpers/content.service.ts
+++ b/apps/api/src/app/shared/helpers/content.service.ts
@@ -76,6 +76,9 @@ export class ContentService {
         }
       } else if (message.template?.type === StepTypeEnum.SMS) {
         yield message.template.content as string;
+      } else if (message.template?.type === StepTypeEnum.PUSH) {
+        yield message.template.content as string;
+        yield message.template.title as string;
       } else if (Array.isArray(message.template?.content)) {
         yield message.template.subject || '';
 

--- a/apps/web/src/components/execution-detail/helpers.ts
+++ b/apps/web/src/components/execution-detail/helpers.ts
@@ -10,6 +10,7 @@ import {
   ErrorIcon,
   InApp,
   Mail,
+  Mobile,
   Read,
   Received,
   Seen,
@@ -71,6 +72,10 @@ export const getLogoByType = (
 
   if (type === StepTypeEnum.CHAT) {
     return Chat;
+  }
+
+  if (type === StepTypeEnum.PUSH) {
+    return Mobile;
   }
 
   return null;

--- a/libs/shared/src/entities/message-template/message-template.interface.ts
+++ b/libs/shared/src/entities/message-template/message-template.interface.ts
@@ -13,6 +13,7 @@ export interface IMessageTemplate {
   _id?: string;
   subject?: string;
   name?: string;
+  title?: string;
   type: StepTypeEnum;
   contentType?: MessageTemplateContentType;
   content: string | IEmailBlock[];


### PR DESCRIPTION
…n execution detail

### What change does this PR introduce?
content service does not iterate over the push title - vars are not saved for trigger and handlebars errors in title are not shown to user on update(allows submit with errors)
also - fix push icon not shown in execution steps in activity feed
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
