### PR TITLE
fix: force position top to avoid page crash

### DIFF
--- a/apps/web/src/pages/templates/components/email-editor/ContentRow.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/ContentRow.tsx
@@ -102,6 +102,7 @@ export function ContentRow({
                   </ActionIcon>
                 </SettingsButton>
               }
+              position="top"
             >
               {rowStyleMenu}
             </Dropdown>


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- Fixes the page crash when clicking on the content row option at the bottom of the screen.
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
Issue Reproduction: 

https://user-images.githubusercontent.com/29251776/222141164-4fd68273-c551-4d17-a1cf-59527ce0b264.mov


Fixed: 

https://user-images.githubusercontent.com/29251776/222138955-b48dac25-2e19-4679-8625-861ab6edde67.mov

