### PR TITLE
chore(web): refactor workflow editor state, move it to the shared context

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,8 +37,8 @@ import { FrameworkSetup } from './pages/quick-start/steps/FrameworkSetup';
 import { Setup } from './pages/quick-start/steps/Setup';
 import { Trigger } from './pages/quick-start/steps/Trigger';
 import { RequiredAuth } from './components/layout/RequiredAuth';
-import { TemplateFormProvider } from './pages/templates/components/TemplateFormProvider';
-import { TemplateEditorProvider } from './pages/templates/components/TemplateEditorProvider';
+import { TemplateEditorFormProvider } from './pages/templates/components/TemplateEditorFormProvider';
+import { TemplateEditorProvider } from './pages/templates/editor/TemplateEditorProvider';
 
 if (LOGROCKET_ID && window !== undefined) {
   LogRocket.init(LOGROCKET_ID, {
@@ -176,21 +176,21 @@ function App() {
                   <Route
                     path={ROUTES.TEMPLATES_CREATE}
                     element={
-                      <TemplateFormProvider>
+                      <TemplateEditorFormProvider>
                         <TemplateEditorProvider>
                           <TemplateEditorPage />
                         </TemplateEditorProvider>
-                      </TemplateFormProvider>
+                      </TemplateEditorFormProvider>
                     }
                   />
                   <Route
                     path={ROUTES.TEMPLATES_EDIT_TEMPLATEID}
                     element={
-                      <TemplateFormProvider>
+                      <TemplateEditorFormProvider>
                         <TemplateEditorProvider>
                           <TemplateEditorPage />
                         </TemplateEditorProvider>
-                      </TemplateFormProvider>
+                      </TemplateEditorFormProvider>
                     }
                   />
                   <Route path={ROUTES.TEMPLATES} element={<NotificationList />} />

--- a/apps/web/src/constants/editorEnums.ts
+++ b/apps/web/src/constants/editorEnums.ts
@@ -1,0 +1,11 @@
+export enum ActivePageEnum {
+  SETTINGS = 'Settings',
+  WORKFLOW = 'Workflow',
+  USER_PREFERENCE = 'UserPreference',
+  SMS = 'Sms',
+  EMAIL = 'Email',
+  IN_APP = 'in_app',
+  PUSH = 'Push',
+  CHAT = 'Chat',
+  TRIGGER_SNIPPET = 'TriggerSnippet',
+}

--- a/apps/web/src/design-system/template-button/TemplateButton.tsx
+++ b/apps/web/src/design-system/template-button/TemplateButton.tsx
@@ -7,9 +7,9 @@ import { Text } from '../typography/text/Text';
 import { Switch } from '../switch/Switch';
 import { useStyles } from './TemplateButton.styles';
 import { colors } from '../config';
-import { ActivePageEnum } from '../../pages/templates/editor/TemplateEditorPage';
 import { Button } from './Button';
 import { IconWrapper } from './IconWrapper';
+import { ActivePageEnum } from '../../constants/editorEnums';
 
 const usePopoverStyles = createStyles(() => ({
   dropdown: {

--- a/apps/web/src/hooks/useBlueprint.ts
+++ b/apps/web/src/hooks/useBlueprint.ts
@@ -1,9 +1,9 @@
-import { ActivePageEnum } from '../pages/templates/editor/TemplateEditorPage';
 import { useSearchParams } from './useSearchParams';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useEffect } from 'react';
 import { getToken } from './useAuthController';
 import { useSegment } from '../components/providers/SegmentProvider';
+import { ActivePageEnum } from '../constants/editorEnums';
 
 export const useBlueprint = () => {
   const searchParams = useSearchParams();

--- a/apps/web/src/pages/templates/components/BlueprintModal.tsx
+++ b/apps/web/src/pages/templates/components/BlueprintModal.tsx
@@ -7,10 +7,10 @@ import { useEffect, useState } from 'react';
 import { updateUserOnBoarding } from '../../../api/user';
 import { IUserEntity } from '@novu/shared';
 import { createTemplateFromBluePrintId, getBlueprintTemplateById } from '../../../api/notification-templates';
-import { ActivePageEnum } from '../editor/TemplateEditorPage';
 import { errorMessage } from '../../../utils/notifications';
 import { When } from '../../../components/utils/When';
 import { useSegment } from '../../../components/providers/SegmentProvider';
+import { ActivePageEnum } from '../../../constants/editorEnums';
 
 export function BlueprintModal() {
   const theme = useMantineTheme();

--- a/apps/web/src/pages/templates/components/TemplateEditor.tsx
+++ b/apps/web/src/pages/templates/components/TemplateEditor.tsx
@@ -5,12 +5,12 @@ import { EmailMessagesCards } from './email-editor/EmailMessagesCards';
 import { TemplateInAppEditor } from './in-app-editor/TemplateInAppEditor';
 import { TemplateSMSEditor } from './TemplateSMSEditor';
 import type { IForm } from './formTypes';
-import { ActivePageEnum } from '../editor/TemplateEditorPage';
 import { TemplatePushEditor } from './TemplatePushEditor';
 import { TemplateChatEditor } from './chat-editor/TemplateChatEditor';
 import { useActiveIntegrations } from '../../../hooks';
+import { ActivePageEnum } from '../../../constants/editorEnums';
 
-export const TemplateEditor = ({ activePage, templateId, activeStep }) => {
+export const TemplateEditor = ({ activePage, activeStep }) => {
   const { integrations } = useActiveIntegrations();
   const {
     control,

--- a/apps/web/src/pages/templates/components/TemplatePageHeader.tsx
+++ b/apps/web/src/pages/templates/components/TemplatePageHeader.tsx
@@ -2,11 +2,12 @@ import { Center, Container, Grid, Group } from '@mantine/core';
 
 import { Button, colors, Switch, Title, Text } from '../../../design-system';
 import { ArrowLeft } from '../../../design-system/icons';
-import { ActivePageEnum, EditorPages } from '../editor/TemplateEditorPage';
+import { EditorPages } from '../editor/TemplateEditorPage';
 import { useEnvController } from '../../../hooks';
 import { When } from '../../../components/utils/When';
-import { useTemplateEditor } from './TemplateEditorProvider';
+import { useTemplateEditorForm } from './TemplateEditorFormProvider';
 import { useStatusChangeControllerHook } from './useStatusChangeController';
+import { ActivePageEnum } from '../../../constants/editorEnums';
 
 const Header = ({
   activePage,
@@ -68,7 +69,7 @@ export const TemplatePageHeader = ({
   setActivePage,
   onTestWorkflowClicked,
 }: Props) => {
-  const { template, editMode } = useTemplateEditor();
+  const { template, editMode } = useTemplateEditorForm();
   const { readonly } = useEnvController();
 
   const { isTemplateActive, changeActiveStatus, isStatusChangeLoading } = useStatusChangeControllerHook(

--- a/apps/web/src/pages/templates/components/TemplateSettings.tsx
+++ b/apps/web/src/pages/templates/components/TemplateSettings.tsx
@@ -7,18 +7,18 @@ import { Button, colors } from '../../../design-system';
 import { NotificationSettingsForm } from './notification-setting-form/NotificationSettingsForm';
 import { TemplatesSideBar } from './TemplatesSideBar';
 import { TriggerSnippetTabs } from './TriggerSnippetTabs';
-import { ActivePageEnum } from '../editor/TemplateEditorPage';
 import { Trash } from '../../../design-system/icons';
 import { DeleteConfirmModal } from './DeleteConfirmModal';
 import { useEnvController } from '../../../hooks';
-import { useTemplateEditor } from './TemplateEditorProvider';
+import { useTemplateEditorForm } from './TemplateEditorFormProvider';
 import { deleteTemplateById } from '../../../api/notification-templates';
 import { ROUTES } from '../../../constants/routes.enum';
+import { ActivePageEnum } from '../../../constants/editorEnums';
 
 export const TemplateSettings = ({ activePage, setActivePage, templateId }) => {
   const { colorScheme } = useMantineColorScheme();
   const { readonly } = useEnvController();
-  const { template, editMode, trigger } = useTemplateEditor();
+  const { template, editMode, trigger } = useTemplateEditorForm();
   const [toDelete, setToDelete] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isError, setIsError] = useState<string | undefined>(undefined);

--- a/apps/web/src/pages/templates/components/TemplatesSideBar.tsx
+++ b/apps/web/src/pages/templates/components/TemplatesSideBar.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
 import { useMantineTheme } from '@mantine/core';
 import { useFormState } from 'react-hook-form';
 import styled from '@emotion/styled';
+
 import { colors, TemplateButton, Text, Tooltip } from '../../../design-system';
 import { BellGradient, ConnectGradient, LevelsGradient, TapeGradient } from '../../../design-system/icons';
-import { ActivePageEnum } from '../editor/TemplateEditorPage';
 import { When } from '../../../components/utils/When';
 import { getExplicitErrors } from '../shared/errors';
+import { ActivePageEnum } from '../../../constants/editorEnums';
 
 export function TemplatesSideBar({
   activeTab,

--- a/apps/web/src/pages/templates/components/VariableManager.cy.tsx
+++ b/apps/web/src/pages/templates/components/VariableManager.cy.tsx
@@ -3,16 +3,16 @@ import { mount } from 'cypress/react';
 import { useFormContext, useFieldArray } from 'react-hook-form';
 import { TestWrapper } from '../../../testing';
 import { VariableManager } from './VariableManager';
-import { TemplateFormProvider } from './TemplateFormProvider';
+import { TemplateEditorFormProvider } from './TemplateEditorFormProvider';
 import { useVariablesManager } from '../../../hooks';
 
 it('should show available variables - string', function () {
   mount(
     <TestWrapper>
-      <TemplateFormProvider>
+      <TemplateEditorFormProvider>
         <FormTester content={'Hello, {{ name }}'} />
         <VariableManagerTester />
-      </TemplateFormProvider>
+      </TemplateEditorFormProvider>
     </TestWrapper>
   );
 
@@ -24,10 +24,10 @@ it('should show available variables - string', function () {
 it('should show available variables - array', function () {
   mount(
     <TestWrapper>
-      <TemplateFormProvider>
+      <TemplateEditorFormProvider>
         <VariableManagerTester />
         <FormTester content={'Hello, {{#each name}} {{/each}}'} />
-      </TemplateFormProvider>
+      </TemplateEditorFormProvider>
     </TestWrapper>
   );
 
@@ -39,10 +39,10 @@ it('should show available variables - array', function () {
 it('should show available variables including nested - array', function () {
   mount(
     <TestWrapper>
-      <TemplateFormProvider>
+      <TemplateEditorFormProvider>
         <VariableManagerTester />
         <FormTester content={'Hello, {{#each name}} {{nested_variable}} {{/each}}'} />
-      </TemplateFormProvider>
+      </TemplateEditorFormProvider>
     </TestWrapper>
   );
 
@@ -56,10 +56,10 @@ it('should show available variables including nested - array', function () {
 it('should show available variables - boolean', function () {
   mount(
     <TestWrapper>
-      <TemplateFormProvider>
+      <TemplateEditorFormProvider>
         <VariableManagerTester />
         <FormTester content={'Hello, {{#if name}} {{/if}}'} />
-      </TemplateFormProvider>
+      </TemplateEditorFormProvider>
     </TestWrapper>
   );
 
@@ -71,10 +71,10 @@ it('should show available variables - boolean', function () {
 it('should show available variables including nested - boolean', function () {
   mount(
     <TestWrapper>
-      <TemplateFormProvider>
+      <TemplateEditorFormProvider>
         <VariableManagerTester />
         <FormTester content={'Hello, {{#if name}} {{nested_variable}} {{/if}}'} />
-      </TemplateFormProvider>
+      </TemplateEditorFormProvider>
     </TestWrapper>
   );
 
@@ -88,14 +88,14 @@ it('should show available variables including nested - boolean', function () {
 it('should show available variables including deeply nested', function () {
   mount(
     <TestWrapper>
-      <TemplateFormProvider>
+      <TemplateEditorFormProvider>
         <VariableManagerTester />
         <FormTester
           content={
             'Hello, {{#if name}} {{nested_variable}} {{#each nested_name}} {{deeply_nested_variable}} {{/each}} {{/if}}'
           }
         />
-      </TemplateFormProvider>
+      </TemplateEditorFormProvider>
     </TestWrapper>
   );
 
@@ -113,10 +113,10 @@ it('should show available variables including deeply nested', function () {
 it('should show reserved variables', function () {
   mount(
     <TestWrapper>
-      <TemplateFormProvider>
+      <TemplateEditorFormProvider>
         <VariableManagerTester />
         <FormTester content={'Hello, {{ subscriber }}'} />
-      </TemplateFormProvider>
+      </TemplateEditorFormProvider>
     </TestWrapper>
   );
 

--- a/apps/web/src/pages/templates/components/notification-setting-form/TemplatePreference.tsx
+++ b/apps/web/src/pages/templates/components/notification-setting-form/TemplatePreference.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import { Grid, Input, useMantineColorScheme, InputWrapperProps } from '@mantine/core';
+import { Grid, Input, InputWrapperProps } from '@mantine/core';
 import styled from '@emotion/styled';
 import { useFormContext, Controller } from 'react-hook-form';
 
@@ -26,8 +26,6 @@ export function TemplatePreference() {
 
 export function ChannelPreference() {
   const { control } = useFormContext();
-  const { colorScheme } = useMantineColorScheme();
-  const dark = colorScheme === 'dark';
 
   return (
     <Controller
@@ -46,7 +44,6 @@ export function ChannelPreference() {
 
         return (
           <InputBackground
-            dark={dark}
             label="Template Defaults"
             description="Check the channels you would like to be ON by default"
             styles={inputStyles}
@@ -59,7 +56,6 @@ export function ChannelPreference() {
                 return (
                   <Grid.Col key={key} md={6} lg={4}>
                     <StyledCheckbox
-                      isChecked={checked}
                       checked={checked}
                       disabled={readonly}
                       data-test-id={`preference-${key}`}
@@ -79,8 +75,6 @@ export function ChannelPreference() {
 
 export function CriticalPreference() {
   const { control } = useFormContext();
-  const { colorScheme } = useMantineColorScheme();
-  const dark = colorScheme === 'dark';
 
   return (
     <Controller
@@ -90,7 +84,6 @@ export function CriticalPreference() {
       render={({ field }) => {
         return (
           <InputBackground
-            dark={dark}
             label="System Critical (Always Sent)"
             description={<CriticalDescription field={field} />}
             styles={inputStyles}
@@ -117,8 +110,8 @@ export const InputWrapperProxy: FunctionComponent<InputWrapperProps> = ({ childr
   return <Input.Wrapper {...props}>{children}</Input.Wrapper>;
 };
 
-const InputBackground = styled(InputWrapperProxy)<{ dark: boolean }>`
-  background: ${({ dark }) => (dark ? colors.B17 : colors.B98)};
+const InputBackground = styled(InputWrapperProxy)`
+  background: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.B17 : colors.B98)};
   border-radius: 7px;
   padding: 20px;
 `;
@@ -128,10 +121,10 @@ const DescriptionWrapper = styled.div`
   justify-content: space-between;
 `;
 
-const StyledCheckbox = styled(CheckboxProxy)<{ isChecked: boolean }>`
+const StyledCheckbox = styled(CheckboxProxy)<{ checked: boolean }>`
   label {
-    ${({ isChecked }) =>
-      !isChecked &&
+    ${({ checked }) =>
+      !checked &&
       `
     color: ${colors.B60}
   `}

--- a/apps/web/src/pages/templates/components/notificationTemplateSchema.ts
+++ b/apps/web/src/pages/templates/components/notificationTemplateSchema.ts
@@ -1,12 +1,9 @@
-import { FormProvider, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { ChannelTypeEnum, DigestTypeEnum, StepTypeEnum, DelayTypeEnum } from '@novu/shared';
 
-import type { IForm } from './formTypes';
 import { getChannel } from '../shared/channels';
 
-const schema = z
+export const schema = z
   .object({
     name: z
       .string({
@@ -186,29 +183,3 @@ const schema = z
       .optional(),
   })
   .passthrough();
-
-const defaultValues: IForm = {
-  name: '',
-  notificationGroupId: '',
-  description: '',
-  identifier: '',
-  tags: [],
-  critical: false,
-  steps: [],
-  preferenceSettings: {
-    email: true,
-    sms: true,
-    in_app: true,
-    chat: true,
-    push: true,
-  },
-};
-export const TemplateFormProvider = ({ children }) => {
-  const methods = useForm<IForm>({
-    resolver: zodResolver(schema),
-    defaultValues,
-    mode: 'onChange',
-  });
-
-  return <FormProvider {...methods}>{children}</FormProvider>;
-};

--- a/apps/web/src/pages/templates/editor/TemplateEditorPage.tsx
+++ b/apps/web/src/pages/templates/editor/TemplateEditorPage.tsx
@@ -7,7 +7,7 @@ import { FieldErrors, useFormContext } from 'react-hook-form';
 import PageContainer from '../../../components/layout/components/PageContainer';
 import PageMeta from '../../../components/layout/components/PageMeta';
 import type { IForm } from '../components/formTypes';
-import WorkflowEditorPage from '../workflow/WorkflowEditorPage';
+import WorkflowEditor from '../workflow/WorkflowEditor';
 import { TemplateEditor } from '../components/TemplateEditor';
 import { TemplateSettings } from '../components/TemplateSettings';
 import { TemplatePageHeader } from '../components/TemplatePageHeader';
@@ -20,22 +20,12 @@ import { TestWorkflowModal } from '../components/TestWorkflowModal';
 import { SaveChangesModal } from '../components/SaveChangesModal';
 import { ExecutionDetailsModalWrapper } from '../components/ExecutionDetailsModalWrapper';
 import { BlueprintModal } from '../components/BlueprintModal';
-import { useTemplateEditor } from '../components/TemplateEditorProvider';
+import { useTemplateEditorForm } from '../components/TemplateEditorFormProvider';
 import { errorMessage } from '../../../utils/notifications';
 import { getExplicitErrors } from '../shared/errors';
 import { ROUTES } from '../../../constants/routes.enum';
-
-export enum ActivePageEnum {
-  SETTINGS = 'Settings',
-  WORKFLOW = 'Workflow',
-  USER_PREFERENCE = 'UserPreference',
-  SMS = 'Sms',
-  EMAIL = 'Email',
-  IN_APP = 'in_app',
-  PUSH = 'Push',
-  CHAT = 'Chat',
-  TRIGGER_SNIPPET = 'TriggerSnippet',
-}
+import { ActivePageEnum } from '../../../constants/editorEnums';
+import { useTemplateEditorContext } from './TemplateEditorProvider';
 
 export const EditorPages = [
   ActivePageEnum.CHAT,
@@ -51,8 +41,6 @@ export default function TemplateEditorPage() {
   const location = useLocation();
   const { readonly, environment } = useEnvController();
   const [transactionId, setTransactionId] = useState<string>('');
-  const [activeStep, setActiveStep] = useState<number>(-1);
-  const [activePage, setActivePage] = useState<ActivePageEnum>(ActivePageEnum.SETTINGS);
   const [isTriggerModalVisible, setTriggerModalVisible] = useState(false);
   const onTriggerModalDismiss = () => {
     navigate('/templates');
@@ -69,7 +57,8 @@ export default function TemplateEditorPage() {
     onSubmit,
     addStep,
     deleteStep,
-  } = useTemplateEditor();
+  } = useTemplateEditorForm();
+  const { activePage, setActivePage, activeStep } = useTemplateEditorContext();
   const methods = useFormContext<IForm>();
   const {
     formState: { isDirty },
@@ -174,10 +163,8 @@ export default function TemplateEditorPage() {
 
           {activePage === ActivePageEnum.WORKFLOW && (
             <ReactFlowProvider>
-              <WorkflowEditorPage
+              <WorkflowEditor
                 activePage={activePage}
-                activeStep={activeStep}
-                setActiveStep={setActiveStep}
                 templateId={templateId}
                 setActivePage={setActivePage}
                 onTestWorkflowClicked={onTestWorkflowClicked}
@@ -193,7 +180,7 @@ export default function TemplateEditorPage() {
             <UserPreference activePage={activePage} setActivePage={setActivePage} />
           </When>
           {!isLoading && !isIntegrationsLoading ? (
-            <TemplateEditor activeStep={activeStep} activePage={activePage} templateId={templateId} />
+            <TemplateEditor activeStep={activeStep} activePage={activePage} />
           ) : null}
           {trigger && (
             <TemplateTriggerModal

--- a/apps/web/src/pages/templates/editor/TemplateEditorProvider.tsx
+++ b/apps/web/src/pages/templates/editor/TemplateEditorProvider.tsx
@@ -1,0 +1,62 @@
+import React, { useMemo, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { StepTypeEnum } from '@novu/shared';
+
+import { ActivePageEnum } from '../../../constants/editorEnums';
+import { IForm, IStepEntity } from '../components/formTypes';
+
+interface ITemplateEditorContext {
+  activePage: ActivePageEnum;
+  setActivePage: (page: ActivePageEnum) => void;
+  selectedNodeId: string;
+  setSelectedNodeId: (nodeId: string) => void;
+  activeStepIndex: number;
+  activeStep?: IStepEntity;
+  selectedChannel?: StepTypeEnum;
+}
+
+const TemplateEditorContext = React.createContext<ITemplateEditorContext>({
+  activePage: ActivePageEnum.SETTINGS,
+  setActivePage: () => {},
+  selectedNodeId: '',
+  setSelectedNodeId: () => {},
+  activeStepIndex: -1,
+});
+
+export const useTemplateEditorContext = () => React.useContext(TemplateEditorContext);
+
+export const TemplateEditorProvider = ({ children }) => {
+  const [activePage, setActivePage] = useState<ActivePageEnum>(ActivePageEnum.SETTINGS);
+  const [selectedNodeId, setSelectedNodeId] = useState<string>('');
+  const { watch } = useFormContext<IForm>();
+  const steps = watch('steps');
+
+  const activeStepIndex = useMemo<number>(() => {
+    if (selectedNodeId.length === 0) {
+      return -1;
+    }
+
+    return steps.findIndex((item) => item._id === selectedNodeId || item.id === selectedNodeId);
+  }, [selectedNodeId, steps]);
+
+  const activeStep: IStepEntity | undefined = steps[activeStepIndex];
+
+  const value = useMemo(
+    () => ({
+      activePage,
+      setActivePage: (page: ActivePageEnum) => {
+        setActivePage(page);
+      },
+      selectedNodeId,
+      setSelectedNodeId: (id: string) => {
+        setSelectedNodeId(id);
+      },
+      activeStepIndex,
+      activeStep,
+      selectedChannel: activeStep?.template.type,
+    }),
+    [activePage, selectedNodeId, activeStepIndex, activeStep]
+  );
+
+  return <TemplateEditorContext.Provider value={value}>{children}</TemplateEditorContext.Provider>;
+};

--- a/apps/web/src/pages/templates/filter/Filters.cy.tsx
+++ b/apps/web/src/pages/templates/filter/Filters.cy.tsx
@@ -7,10 +7,12 @@ import {
   FilterPartTypeEnum,
   TimeOperatorEnum,
 } from '@novu/shared';
+
 import { TestWrapper } from '../../../testing';
+import { IStepEntity } from '../components/formTypes';
 import { Filters, translateOperator, getFilterLabel } from './Filters';
 
-const defaultStep = {
+const defaultStep: IStepEntity = {
   id: '',
   _templateId: '',
   template: {
@@ -25,7 +27,7 @@ describe('Filters Component', function () {
   it('should not render if step is null', function () {
     cy.mount(
       <TestWrapper>
-        <Filters step={null} />
+        <Filters />
       </TestWrapper>
     );
 

--- a/apps/web/src/pages/templates/filter/Filters.tsx
+++ b/apps/web/src/pages/templates/filter/Filters.tsx
@@ -5,7 +5,7 @@ import { BuilderFieldOperator, FilterParts } from '@novu/shared';
 import type { IStepEntity } from '../components/formTypes';
 import { colors } from '../../../design-system';
 
-export const Filters = ({ step }: { step: IStepEntity | null }) => {
+export const Filters = ({ step }: { step?: IStepEntity }) => {
   if (!step || !step.filters || !Array.isArray(step.filters)) {
     return null;
   }

--- a/apps/web/src/pages/templates/workflow/DigestMetadata.tsx
+++ b/apps/web/src/pages/templates/workflow/DigestMetadata.tsx
@@ -13,7 +13,7 @@ const StyledSwitch = styled(Switch)`
   margin-top: 15px;
 `;
 
-export const DigestMetadata = ({ control, index, loading, disableSubmit, setSelectedChannel }) => {
+export const DigestMetadata = ({ control, index, loading, disableSubmit, onSideMenuClose }) => {
   const { readonly } = useEnvController();
   const {
     formState: { errors, isSubmitted },
@@ -234,7 +234,7 @@ export const DigestMetadata = ({ control, index, loading, disableSubmit, setSele
         data-test-id="delete-step-button"
         loading={loading}
         disabled={disableSubmit}
-        onClick={() => setSelectedChannel(null)}
+        onClick={onSideMenuClose}
       >
         Save
       </Button>

--- a/apps/web/src/pages/templates/workflow/SideBar/AddStepMenu.tsx
+++ b/apps/web/src/pages/templates/workflow/SideBar/AddStepMenu.tsx
@@ -5,7 +5,7 @@ import { channels, NodeTypeEnum } from '../../shared/channels';
 import { useEnvController } from '../../../../hooks';
 import { When } from '../../../../components/utils/When';
 import { NavSection } from '../../components/TemplatesSideBar';
-import { StyledNav } from '../WorkflowEditorPage';
+import { StyledNav } from '../WorkflowEditor';
 
 export function AddStepMenu({
   setDragging,
@@ -20,7 +20,7 @@ export function AddStepMenu({
     <StyledNav data-test-id="drag-side-menu">
       <NavSection>
         <Title size={2}>Steps to add</Title>
-        <Text color={colors.B60} mt={5}>
+        <Text color={colors.B60} mt={5} mb={5}>
           <When truthy={!readonly}>Drag and drop new steps to the canvas</When>
           <When truthy={readonly}>You can not drag and drop new steps in Production</When>
         </Text>
@@ -40,7 +40,7 @@ export function AddStepMenu({
         }}
       >
         <Title size={2}>Actions</Title>
-        <Text color={colors.B60} mt={5}>
+        <Text color={colors.B60} mt={5} mb={5}>
           <When truthy={!readonly}>Add actions to the flow</When>
           <When truthy={readonly}>You can not drag and drop new actions in Production</When>
         </Text>

--- a/apps/web/src/pages/templates/workflow/SideBar/SelectedStep.tsx
+++ b/apps/web/src/pages/templates/workflow/SideBar/SelectedStep.tsx
@@ -1,7 +1,6 @@
-import { SetStateAction } from 'react';
 import styled from '@emotion/styled';
 import { ActionIcon, Divider, Stack } from '@mantine/core';
-import { FieldErrors } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { StepTypeEnum } from '@novu/shared';
 
 import { Button, colors, Text, Title } from '../../../../design-system';
@@ -18,44 +17,36 @@ import { Filters } from '../../filter/Filters';
 import { ShouldStopOnFailSwitch } from '../ShouldStopOnFailSwitch';
 import { ReplyCallback } from '../ReplyCallback';
 import { NavSection } from '../../components/TemplatesSideBar';
-import { StyledNav } from '../WorkflowEditorPage';
+import { StyledNav } from '../WorkflowEditor';
+import { useTemplateEditorContext } from '../../editor/TemplateEditorProvider';
 
 const capitalize = (text: string) => {
   return typeof text !== 'string' ? '' : text.charAt(0).toUpperCase() + text.slice(1);
 };
 
 export function SelectedStep({
-  selectedChannel,
-  setSelectedChannel,
   setActivePage,
-  steps,
-  activeStep,
-  control,
-  errors,
   setFilterOpen,
   isLoading,
   isUpdateLoading,
   loadingEditTemplate,
-  isDirty,
   onDelete,
-  selectedNodeId,
 }: {
-  selectedChannel: StepTypeEnum;
-  setSelectedChannel: (value: SetStateAction<StepTypeEnum | null>) => void;
   setActivePage: (string) => void;
-  steps;
-  activeStep: number;
-  control: any;
-  errors: FieldErrors<IForm>;
   setFilterOpen: (value: ((prevState: boolean) => boolean) | boolean) => void;
   isLoading: boolean;
   isUpdateLoading: boolean;
   loadingEditTemplate: boolean;
-  isDirty: boolean;
   onDelete: (id) => void;
-  selectedNodeId: string;
 }) {
+  const {
+    control,
+    formState: { errors, isDirty },
+  } = useFormContext<IForm>();
+  const { selectedNodeId, setSelectedNodeId, activeStep, activeStepIndex, selectedChannel } =
+    useTemplateEditorContext();
   const { readonly } = useEnvController();
+  const onSideMenuClose = () => setSelectedNodeId('');
 
   return (
     <StyledNav data-test-id="step-properties-side-menu">
@@ -64,12 +55,8 @@ export function SelectedStep({
           <When truthy={selectedChannel !== StepTypeEnum.DIGEST && selectedChannel !== StepTypeEnum.DELAY}>
             <NavSection>
               <ButtonWrapper>
-                <Title size={2}>{getChannel(selectedChannel)?.label} Properties</Title>
-                <ActionIcon
-                  data-test-id="close-side-menu-btn"
-                  variant="transparent"
-                  onClick={() => setSelectedChannel(null)}
-                >
+                <Title size={2}>{getChannel(selectedChannel ?? '')?.label} Properties</Title>
+                <ActionIcon data-test-id="close-side-menu-btn" variant="transparent" onClick={onSideMenuClose}>
                   <Close />
                 </ActionIcon>
               </ButtonWrapper>
@@ -82,26 +69,22 @@ export function SelectedStep({
                 fullWidth
                 onClick={() => {
                   setActivePage(
-                    selectedChannel === StepTypeEnum.IN_APP ? selectedChannel : capitalize(selectedChannel)
+                    selectedChannel === StepTypeEnum.IN_APP ? selectedChannel : capitalize(selectedChannel ?? '')
                   );
                 }}
               >
                 {readonly ? 'View' : 'Edit'} Template
               </EditTemplateButton>
               <Divider my={30} />
-              {steps.map((i, index) => {
-                return (
-                  <When key={i._id || i.id} truthy={index === activeStep}>
-                    <Stack key={index}>
-                      <StepActiveSwitch index={activeStep} control={control} />
-                      <ShouldStopOnFailSwitch index={activeStep} control={control} />
-                      <When truthy={selectedChannel === StepTypeEnum.EMAIL}>
-                        <ReplyCallback index={activeStep} control={control} errors={errors} />
-                      </When>
-                    </Stack>
+              <When truthy={activeStepIndex >= 0}>
+                <Stack>
+                  <StepActiveSwitch index={activeStepIndex} control={control} />
+                  <ShouldStopOnFailSwitch index={activeStepIndex} control={control} />
+                  <When truthy={selectedChannel === StepTypeEnum.EMAIL}>
+                    <ReplyCallback index={activeStepIndex} control={control} errors={errors} />
                   </When>
-                );
-              })}
+                </Stack>
+              </When>
             </NavSection>
             <NavSection>
               <Divider
@@ -111,9 +94,7 @@ export function SelectedStep({
                 label="Filters"
                 labelPosition="center"
               />
-              {steps.map((i, index) => {
-                return index !== activeStep ? null : <Filters key={index} step={i} />;
-              })}
+              {activeStep && <Filters step={activeStep} />}
               <FilterButton
                 fullWidth
                 variant="outline"
@@ -136,11 +117,7 @@ export function SelectedStep({
             <NavSection>
               <ButtonWrapper>
                 <Title size={2}>Digest Properties</Title>
-                <ActionIcon
-                  data-test-id="close-side-menu-btn"
-                  variant="transparent"
-                  onClick={() => setSelectedChannel(null)}
-                >
+                <ActionIcon data-test-id="close-side-menu-btn" variant="transparent" onClick={onSideMenuClose}>
                   <Close />
                 </ActionIcon>
               </ButtonWrapper>
@@ -153,41 +130,31 @@ export function SelectedStep({
               </Text>
             </NavSection>
             <NavSection>
-              {steps.map((i, index) => {
-                return index === activeStep ? (
-                  <DigestMetadata
-                    key={i._id || i.id}
-                    control={control}
-                    index={index}
-                    loading={isLoading || isUpdateLoading}
-                    disableSubmit={readonly || loadingEditTemplate || isLoading || !isDirty}
-                    setSelectedChannel={setSelectedChannel}
-                  />
-                ) : null;
-              })}
+              <When truthy={activeStepIndex >= 0}>
+                <DigestMetadata
+                  control={control}
+                  index={activeStepIndex}
+                  loading={isLoading || isUpdateLoading}
+                  disableSubmit={readonly || loadingEditTemplate || isLoading || !isDirty}
+                  onSideMenuClose={onSideMenuClose}
+                />
+              </When>
             </NavSection>
           </When>
           <When truthy={selectedChannel === StepTypeEnum.DELAY}>
             <NavSection>
               <ButtonWrapper>
                 <Title size={2}>Delay Properties</Title>
-                <ActionIcon
-                  data-test-id="close-side-menu-btn"
-                  variant="transparent"
-                  onClick={() => setSelectedChannel(null)}
-                >
+                <ActionIcon data-test-id="close-side-menu-btn" variant="transparent" onClick={onSideMenuClose}>
                   <Close />
                 </ActionIcon>
               </ButtonWrapper>
-
               <Text mr={10} mt={10} size="md" color={colors.B60}>
                 Configure the delay parameters.
               </Text>
             </NavSection>
             <NavSection>
-              {steps.map((i, index) => {
-                return index === activeStep ? <DelayMetadata key={index} control={control} index={index} /> : null;
-              })}
+              {activeStepIndex > 0 && <DelayMetadata control={control} index={activeStepIndex} />}
             </NavSection>
           </When>
         </Stack>
@@ -205,7 +172,7 @@ export function SelectedStep({
               marginRight: '5px',
             }}
           />
-          Delete {getChannel(selectedChannel.toString())?.type === NodeTypeEnum.CHANNEL ? 'Step' : 'Action'}
+          Delete {getChannel(selectedChannel?.toString() ?? '')?.type === NodeTypeEnum.CHANNEL ? 'Step' : 'Action'}
         </DeleteStepButton>
       </MenuBar>
     </StyledNav>

--- a/apps/web/src/pages/templates/workflow/WorkflowEditor.tsx
+++ b/apps/web/src/pages/templates/workflow/WorkflowEditor.tsx
@@ -11,19 +11,19 @@ import type { IForm } from '../components/formTypes';
 import { useEnvController } from '../../../hooks';
 import { When } from '../../../components/utils/When';
 import { TemplatePageHeader } from '../components/TemplatePageHeader';
-import { ActivePageEnum, EditorPages } from '../editor/TemplateEditorPage';
+import { EditorPages } from '../editor/TemplateEditorPage';
 import { DeleteConfirmModal } from '../components/DeleteConfirmModal';
 import { FilterModal } from '../filter/FilterModal';
 import { SelectedStep } from './SideBar/SelectedStep';
 import { AddStepMenu } from './SideBar/AddStepMenu';
 import { useTemplateFetcher } from '../components/useTemplateFetcher';
+import { ActivePageEnum } from '../../../constants/editorEnums';
+import { useTemplateEditorContext } from '../editor/TemplateEditorProvider';
 
-const WorkflowEditorPage = ({
+const WorkflowEditor = ({
   setActivePage,
   templateId,
-  setActiveStep,
   activePage,
-  activeStep,
   onTestWorkflowClicked,
   isCreatingTemplate,
   isUpdatingTemplate,
@@ -31,19 +31,16 @@ const WorkflowEditorPage = ({
   deleteStep,
 }: {
   setActivePage: (string) => void;
-  setActiveStep: any;
   templateId: string;
   activePage: ActivePageEnum;
-  activeStep: number;
   onTestWorkflowClicked: () => void;
   isCreatingTemplate: boolean;
   isUpdatingTemplate: boolean;
   addStep: (channelType: StepTypeEnum, id: string, index?: number) => void;
   deleteStep: (index: number) => void;
 }) => {
+  const { setSelectedNodeId, activeStepIndex, selectedChannel } = useTemplateEditorContext();
   const { colorScheme } = useMantineColorScheme();
-  const [selectedChannel, setSelectedChannel] = useState<StepTypeEnum | null>(null);
-  const [selectedNodeId, setSelectedNodeId] = useState<string>('');
   const [dragging, setDragging] = useState(false);
 
   const onDragStart = (event, nodeType) => {
@@ -63,21 +60,6 @@ const WorkflowEditorPage = ({
 
   const { readonly } = useEnvController();
   const [toDelete, setToDelete] = useState<string>('');
-
-  useEffect(() => {
-    if (selectedNodeId.length === 0) {
-      setSelectedChannel(null);
-
-      return;
-    }
-    const step = steps.find((item) => item._id === selectedNodeId || item.id === selectedNodeId);
-    const index = steps.findIndex((item) => item._id === selectedNodeId || item.id === selectedNodeId);
-    if (!step) {
-      return;
-    }
-    setSelectedChannel(step.template.type);
-    setActiveStep(index);
-  }, [selectedNodeId]);
 
   const setActivePageWrapper = (page: ActivePageEnum) => {
     if (!isSubmitted && EditorPages.includes(page)) {
@@ -100,6 +82,8 @@ const WorkflowEditorPage = ({
   const onDelete = (id) => {
     setToDelete(id);
   };
+
+  useEffect(() => () => setSelectedNodeId(''), []);
 
   return (
     <>
@@ -132,45 +116,30 @@ const WorkflowEditorPage = ({
             addStep={addStep}
             setSelectedNodeId={setSelectedNodeId}
           />
-          <When truthy={selectedChannel !== null && getChannel(selectedChannel)?.type !== NodeTypeEnum.ACTION}>
-            {steps.map((step, index) => {
-              return (
-                <When key={step._id || step.id} truthy={index === activeStep}>
-                  <FilterModal
-                    key={index}
-                    isOpen={filterOpen}
-                    cancel={() => {
-                      setFilterOpen(false);
-                    }}
-                    confirm={() => {
-                      setFilterOpen(false);
-                    }}
-                    control={control}
-                    stepIndex={activeStep}
-                  />
-                </When>
-              );
-            })}
+          <When truthy={activeStepIndex > 0}>
+            <FilterModal
+              isOpen={filterOpen}
+              cancel={() => {
+                setFilterOpen(false);
+              }}
+              confirm={() => {
+                setFilterOpen(false);
+              }}
+              control={control}
+              stepIndex={activeStepIndex}
+            />
           </When>
         </Grid.Col>
         <Grid.Col md={3} sm={6}>
           <SideBarWrapper dark={colorScheme === 'dark'}>
             {selectedChannel ? (
               <SelectedStep
-                selectedChannel={selectedChannel}
-                setSelectedChannel={setSelectedChannel}
                 setActivePage={setActivePageWrapper}
-                steps={steps}
-                activeStep={activeStep}
-                control={control}
-                errors={errors}
                 setFilterOpen={setFilterOpen}
                 isLoading={isCreatingTemplate}
                 isUpdateLoading={isUpdatingTemplate}
                 loadingEditTemplate={loadingEditTemplate}
-                isDirty={isDirtyForm}
                 onDelete={onDelete}
-                selectedNodeId={selectedNodeId}
               />
             ) : (
               <AddStepMenu setDragging={setDragging} onDragStart={onDragStart} />
@@ -180,7 +149,9 @@ const WorkflowEditorPage = ({
       </Grid>
       <DeleteConfirmModal
         target={
-          selectedChannel !== null && getChannel(selectedChannel)?.type === NodeTypeEnum.CHANNEL ? 'step' : 'action'
+          selectedChannel !== null && getChannel(selectedChannel ?? '')?.type === NodeTypeEnum.CHANNEL
+            ? 'step'
+            : 'action'
         }
         isOpen={toDelete.length > 0}
         confirm={confirmDelete}
@@ -190,7 +161,7 @@ const WorkflowEditorPage = ({
   );
 };
 
-export default WorkflowEditorPage;
+export default WorkflowEditor;
 
 const SideBarWrapper = styled.div<{ dark: boolean }>`
   background-color: ${({ dark }) => (dark ? colors.B17 : colors.white)};

--- a/apps/web/src/pages/templates/workflow/workflow/FlowEditor.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/FlowEditor.tsx
@@ -27,10 +27,10 @@ import type { IForm, IStepEntity } from '../../components/formTypes';
 import AddNode from './node-types/AddNode';
 import { useEnvController } from '../../../../hooks';
 import { MinimalTemplatesSideBar } from './layout/MinimalTemplatesSideBar';
-import { ActivePageEnum } from '../../editor/TemplateEditorPage';
 import { getFormattedStepErrors } from '../../shared/errors';
 import { AddNodeEdge, IAddNodeEdge } from './edge-types/AddNodeEdge';
-import { useTemplateEditor } from '../../components/TemplateEditorProvider';
+import { useTemplateEditorForm } from '../../components/TemplateEditorFormProvider';
+import { ActivePageEnum } from '../../../../constants/editorEnums';
 
 const nodeTypes = {
   channelNode: ChannelNode,
@@ -79,7 +79,7 @@ export function FlowEditor({
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance>();
   const { setViewport } = useReactFlow();
   const { readonly } = useEnvController();
-  const { template, trigger } = useTemplateEditor();
+  const { template, trigger } = useTemplateEditorForm();
   const { trigger: triggerErrors } = useFormContext<IForm>();
   const [displayEdgeTimeout, setDisplayEdgeTimeout] = useState<Map<string, NodeJS.Timeout | null>>(new Map());
 
@@ -318,6 +318,7 @@ export function FlowEditor({
                 handleDisplayAddNodeOnEdge(`edge-button-${edge.source}`);
               }
             }}
+            onPaneClick={() => setSelectedNodeId('')}
             {...reactFlowDefaultProps}
           >
             <MinimalTemplatesSideBar

--- a/apps/web/src/pages/templates/workflow/workflow/layout/MinimalTemplatesSideBar.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/layout/MinimalTemplatesSideBar.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { ActivePageEnum } from '../../../editor/TemplateEditorPage';
 import { WrapperButton } from '../../../../../design-system/template-button/Button';
 import { IconWrapper } from '../../../../../design-system/template-button/IconWrapper';
 import { NavSection, TemplatesSideBar } from '../../../components/TemplatesSideBar';
+import { ActivePageEnum } from '../../../../../constants/editorEnums';
 
 export function MinimalTemplatesSideBar({
   activePage,

--- a/apps/web/src/pages/user-preference/UserPreference.tsx
+++ b/apps/web/src/pages/user-preference/UserPreference.tsx
@@ -2,13 +2,13 @@ import { Grid, useMantineColorScheme } from '@mantine/core';
 import styled from '@emotion/styled';
 
 import { colors } from '../../design-system';
-import { useTemplateEditor } from '../templates/components/TemplateEditorProvider';
+import { useTemplateEditorForm } from '../templates/components/TemplateEditorFormProvider';
 import { TemplatesSideBar } from '../templates/components/TemplatesSideBar';
 import { TemplatePreference } from '../templates/components/notification-setting-form/TemplatePreference';
 
 export function UserPreference({ activePage, setActivePage }) {
   const { colorScheme } = useMantineColorScheme();
-  const { template, trigger } = useTemplateEditor();
+  const { template, trigger } = useTemplateEditorForm();
 
   return (
     <div style={{ marginLeft: 12, marginRight: 12, padding: 17.5, minHeight: 500 }}>


### PR DESCRIPTION
### What change does this PR introduce?

In this PR I've created the `TemplateEditorContext` that shares the state of: 
- selected node id (selected in the workflow tree)
- active page (like settings, editor, preferences, etc)
- active step
- selected channel

Fixed a couple of React warnings.

Added functionality to close the Step Settings when clicking on the canvas panel.

### Why was this change needed?

This context will be controlled from the hints tour that we gonna implement for the Digest Onboarding Workflow.

### Other information (Screenshots)

https://user-images.githubusercontent.com/2607232/222483653-b8569ad3-9074-43bc-9693-bced4aa5c03a.mov



