### PR TITLE
NV-2043 - add a way to unset a subcriber's credentials

### DIFF
--- a/packages/node/src/lib/subscribers/subscriber.interface.ts
+++ b/packages/node/src/lib/subscribers/subscriber.interface.ts
@@ -18,6 +18,7 @@ export interface ISubscribers {
     providerId: string,
     credentials: IChannelCredentials
   );
+  unsetCredentials(subscriberId: string, providerId: string);
   getPreference(subscriberId: string);
   updatePreference(
     subscriberId: string,

--- a/packages/node/src/lib/subscribers/subscribers.spec.ts
+++ b/packages/node/src/lib/subscribers/subscribers.spec.ts
@@ -56,6 +56,23 @@ describe('test use of novus node package - Subscribers class', () => {
     );
   });
 
+  test('should unset subscriber channel credentials correctly', async () => {
+    mockedAxios.put.mockResolvedValue({});
+
+    await novu.subscribers.unsetCredentials('test-update-subscriber', 'slack');
+
+    expect(mockedAxios.put).toHaveBeenCalled();
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `/subscribers/test-update-subscriber/credentials`,
+      {
+        providerId: 'slack',
+        credentials: {
+          webhookUrl: undefined,
+        },
+      }
+    );
+  });
+
   test('should identify subscriber correctly', async () => {
     mockedAxios.post.mockResolvedValue({});
 

--- a/packages/node/src/lib/subscribers/subscribers.ts
+++ b/packages/node/src/lib/subscribers/subscribers.ts
@@ -66,6 +66,13 @@ export class Subscribers extends WithHttp implements ISubscribers {
     });
   }
 
+  async unsetCredentials(subscriberId: string, providerId: string) {
+    return await this.http.put(`/subscribers/${subscriberId}/credentials`, {
+      providerId,
+      credentials: { webhookUrl: undefined },
+    });
+  }
+
   async delete(subscriberId: string) {
     return await this.http.delete(`/subscribers/${subscriberId}`);
   }


### PR DESCRIPTION
### What change does this PR introduce?
- adds the `unsetCredentials` method to subscribers
- Updates the tests to test the functionality of the new method

### Why was this change needed?
Closes https://github.com/novuhq/novu/issues/2043

Currently you need to do:

```javascript
await novu.subscribers.setCredentials('subscriberId', ChatProviderIdEnum.Slack, {
  webhookUrl: undefined,
});
```
to unset credentials...

### Other information (Screenshots)
