### PR TITLE
Feat/Fix: Reduce Size of Web Docker Container

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,5 @@
-FROM nikolaik/python-nodejs:python3.10-nodejs16-alpine
+# start build stage
+FROM nikolaik/python-nodejs:python3.10-nodejs16-alpine as builder
 
 WORKDIR /usr/src/app
 
@@ -32,5 +33,22 @@ RUN pnpm add @babel/core -w
 COPY [".eslintrc.js",".prettierrc",".prettierignore", "./"]
 
 RUN NX_DAEMON=false pnpm build:web
+# end build stage
 
-CMD [ "pnpm", "start:static:web" ]
+# start production stage
+FROM node:16-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache bash
+RUN npm install -g pnpm@7.27.0 http-server --loglevel notice
+
+COPY --from=builder /usr/src/app/apps/web/env.sh /app/env.sh
+COPY --from=builder /usr/src/app/apps/web/.env /app/.env
+
+COPY --from=builder /usr/src/app/apps/web/build /app/build
+COPY --from=builder /usr/src/app/apps/web/public /app/public
+COPY --from=builder /usr/src/app/apps/web/package.json /app/package.json
+
+CMD [ "pnpm", "start:static:build" ]
+# end production stage


### PR DESCRIPTION
### What change does this PR introduce?

Static web apps, such as the React app being used by Novu do not need their `node_modules` at runtime. This allows for the ability to build in a `builder` container, then copy over only the static resources to a container that will serve the files.

### Why was this change needed?

Currently, `novu/web:0.12.0` is 2.42GB according to `docker image ls -a`. This change reduces the size of the container to 175MB, and keeps intact the features required for dynamic environment variable injection (upon its fix in #2943).

### Other information

I am currently running this image (`ghcr.io/joeyeamigh/novu/web:slim`) in my environments, and it is working just as well as the live one. If someone knows something I don't about a system in the project that keeps this from being possible, let me know.
