### PR TITLE
feat: Add fcmOptions to Firebase provider

### DIFF
--- a/packages/stateless/src/lib/provider/provider.interface.ts
+++ b/packages/stateless/src/lib/provider/provider.interface.ts
@@ -58,6 +58,7 @@ export interface IPushOptions {
     mutableContent?: boolean;
     android?: { [key: string]: { [key: string]: string } };
     apns?: { payload: { aps: { [key: string]: { [key: string]: string } } } };
+    fcmOptions?: { analyticsLabel?: string };
   };
 }
 

--- a/providers/fcm/src/lib/fcm.provider.spec.ts
+++ b/providers/fcm/src/lib/fcm.provider.spec.ts
@@ -45,6 +45,37 @@ test('should trigger fcm correctly', async () => {
   });
 });
 
+test('should trigger fcm with fcm options override', async () => {
+  await provider.sendMessage({
+    title: 'Test',
+    content: 'Test push',
+    target: ['tester'],
+    payload: {
+      sound: 'test_sound',
+    },
+    overrides: {
+      data: { foo: 'bar' },
+      fcmOptions: {
+        analyticsLabel: 'my-label',
+      },
+    },
+  });
+  expect(app.initializeApp).toHaveBeenCalledTimes(1);
+  expect(app.cert).toHaveBeenCalledTimes(1);
+  expect(spy).toHaveBeenCalled();
+  expect(spy).toHaveBeenCalledWith({
+    notification: {
+      title: 'Test',
+      body: 'Test push',
+    },
+    tokens: ['tester'],
+    data: { foo: 'bar' },
+    fcmOptions: {
+      analyticsLabel: 'my-label',
+    },
+  });
+});
+
 test('should trigger fcm with android override', async () => {
   await provider.sendMessage({
     title: 'Test',

--- a/providers/fcm/src/lib/fcm.provider.ts
+++ b/providers/fcm/src/lib/fcm.provider.ts
@@ -8,6 +8,7 @@ import { initializeApp, cert, deleteApp, getApp } from 'firebase-admin/app';
 import {
   AndroidConfig,
   ApnsConfig,
+  FcmOptions,
   getMessaging,
   Messaging,
 } from 'firebase-admin/messaging';
@@ -49,8 +50,10 @@ export class FcmPushProvider implements IPushProvider {
     const overridesData = options.overrides || ({} as any);
     const androidData: AndroidConfig = overridesData.android;
     const apnsData: ApnsConfig = overridesData.apns;
+    const fcmOptionsData: FcmOptions = overridesData.fcmOptions;
     delete overridesData.android;
     delete overridesData.apns;
+    delete overridesData.fcmOptions;
 
     let res;
 
@@ -61,6 +64,7 @@ export class FcmPushProvider implements IPushProvider {
         data: options.payload as { [key: string]: string },
         ...(androidData ? { android: androidData } : {}),
         ...(apnsData ? { apns: apnsData } : {}),
+        ...(fcmOptionsData ? { fcmOptions: fcmOptionsData } : {}),
       });
     } else {
       const { data, ...overrides } = overridesData;
@@ -75,6 +79,7 @@ export class FcmPushProvider implements IPushProvider {
         data,
         ...(androidData ? { android: androidData } : {}),
         ...(apnsData ? { apns: apnsData } : {}),
+        ...(fcmOptionsData ? { fcmOptions: fcmOptionsData } : {}),
       });
     }
 


### PR DESCRIPTION
### What change does this PR introduce?

This PR introduces the `fcmOptions` (link [here](https://firebase.google.com/docs/reference/admin/node/firebase-admin.messaging.fcmoptions.md#fcmoptions_interface)) optional override for Firebase, as this allows us to implement analytics labels for Firebase tracking. 

### Why was this change needed?

Closes #2965 

### Other information (Screenshots)
