### PR TITLE
FCM support add extra options

### DIFF
--- a/packages/stateless/src/lib/provider/provider.interface.ts
+++ b/packages/stateless/src/lib/provider/provider.interface.ts
@@ -56,8 +56,13 @@ export interface IPushOptions {
     channelId?: string;
     categoryId?: string;
     mutableContent?: boolean;
-    android?: { [key: string]: { [key: string]: string } };
-    apns?: { payload: { aps: { [key: string]: { [key: string]: string } } } };
+    android?: { [key: string]: { [key: string]: string } | string };
+    apns?: {
+      headers?: { [key: string]: string };
+      payload: {
+        aps: { [key: string]: { [key: string]: string } | string };
+      };
+    };
     fcmOptions?: { analyticsLabel?: string };
   };
 }

--- a/providers/fcm/src/lib/fcm.provider.spec.ts
+++ b/providers/fcm/src/lib/fcm.provider.spec.ts
@@ -167,3 +167,131 @@ test('should trigger fcm with apns (ios) override', async () => {
     },
   });
 });
+
+test('should trigger fcm data for ios with headers options', async () => {
+  await provider.sendMessage({
+    title: 'Test',
+    content: 'Test push',
+    target: ['tester'],
+    payload: {
+      key_1: 'val_1',
+      key_2: 'val_2',
+    },
+    overrides: {
+      type: 'data',
+      apns: {
+        headers: {
+          'apns-priority': '5',
+        },
+        payload: {
+          aps: {
+            alert: {
+              'loc-key': 'some_body',
+              'title-loc-key': 'some_title',
+            },
+            sound: 'demo.wav',
+          },
+        },
+      },
+    },
+  });
+  expect(app.initializeApp).toHaveBeenCalledTimes(1);
+  expect(app.cert).toHaveBeenCalledTimes(1);
+  expect(spy).toHaveBeenCalled();
+  expect(spy).toHaveBeenCalledWith({
+    tokens: ['tester'],
+    apns: {
+      headers: {
+        'apns-priority': '5',
+      },
+      payload: {
+        aps: {
+          alert: {
+            'loc-key': 'some_body',
+            'title-loc-key': 'some_title',
+          },
+          sound: 'demo.wav',
+        },
+      },
+    },
+    data: {
+      key_1: 'val_1',
+      key_2: 'val_2',
+    },
+  });
+});
+
+test('should trigger fcm data for both android and ios with override options', async () => {
+  await provider.sendMessage({
+    title: 'Test',
+    content: 'Test push',
+    target: ['tester'],
+    payload: {
+      key_1: 'val_1',
+      key_2: 'val_2',
+    },
+    overrides: {
+      type: 'data',
+      android: {
+        data: {
+          body_loc_key: 'body_loc_value',
+          title_loc_key: 'title_loc_value',
+          sound: 'demo.wav',
+        },
+        priority: 'high',
+      },
+      apns: {
+        headers: {
+          'apns-priority': '5',
+        },
+        payload: {
+          aps: {
+            alert: {
+              'loc-key': 'some_body',
+              'title-loc-key': 'some_title',
+            },
+            sound: 'demo.wav',
+          },
+        },
+      },
+      fcmOptions: {
+        analyticsLabel: 'test_label',
+      },
+    },
+  });
+  expect(app.initializeApp).toHaveBeenCalledTimes(1);
+  expect(app.cert).toHaveBeenCalledTimes(1);
+  expect(spy).toHaveBeenCalled();
+  expect(spy).toHaveBeenCalledWith({
+    tokens: ['tester'],
+    android: {
+      data: {
+        body_loc_key: 'body_loc_value',
+        title_loc_key: 'title_loc_value',
+        sound: 'demo.wav',
+      },
+      priority: 'high',
+    },
+    apns: {
+      headers: {
+        'apns-priority': '5',
+      },
+      payload: {
+        aps: {
+          alert: {
+            'loc-key': 'some_body',
+            'title-loc-key': 'some_title',
+          },
+          sound: 'demo.wav',
+        },
+      },
+    },
+    fcmOptions: {
+      analyticsLabel: 'test_label',
+    },
+    data: {
+      key_1: 'val_1',
+      key_2: 'val_2',
+    },
+  });
+});

--- a/providers/fcm/src/lib/fcm.provider.spec.ts
+++ b/providers/fcm/src/lib/fcm.provider.spec.ts
@@ -221,7 +221,7 @@ test('should trigger fcm data for ios with headers options', async () => {
   });
 });
 
-test('should trigger fcm data for both android and ios with override options', async () => {
+test('should trigger fcm data for android with priority option', async () => {
   await provider.sendMessage({
     title: 'Test',
     content: 'Test push',
@@ -234,28 +234,9 @@ test('should trigger fcm data for both android and ios with override options', a
       type: 'data',
       android: {
         data: {
-          body_loc_key: 'body_loc_value',
-          title_loc_key: 'title_loc_value',
-          sound: 'demo.wav',
+          for_android: 'only',
         },
         priority: 'high',
-      },
-      apns: {
-        headers: {
-          'apns-priority': '5',
-        },
-        payload: {
-          aps: {
-            alert: {
-              'loc-key': 'some_body',
-              'title-loc-key': 'some_title',
-            },
-            sound: 'demo.wav',
-          },
-        },
-      },
-      fcmOptions: {
-        analyticsLabel: 'test_label',
       },
     },
   });
@@ -266,28 +247,9 @@ test('should trigger fcm data for both android and ios with override options', a
     tokens: ['tester'],
     android: {
       data: {
-        body_loc_key: 'body_loc_value',
-        title_loc_key: 'title_loc_value',
-        sound: 'demo.wav',
+        for_android: 'only',
       },
       priority: 'high',
-    },
-    apns: {
-      headers: {
-        'apns-priority': '5',
-      },
-      payload: {
-        aps: {
-          alert: {
-            'loc-key': 'some_body',
-            'title-loc-key': 'some_title',
-          },
-          sound: 'demo.wav',
-        },
-      },
-    },
-    fcmOptions: {
-      analyticsLabel: 'test_label',
     },
     data: {
       key_1: 'val_1',

--- a/providers/fcm/src/lib/fcm.provider.ts
+++ b/providers/fcm/src/lib/fcm.provider.ts
@@ -48,6 +48,7 @@ export class FcmPushProvider implements IPushProvider {
     delete (options.overrides as { deviceTokens?: string[] })?.deviceTokens;
 
     const overridesData = options.overrides || ({} as any);
+
     const androidData: AndroidConfig = overridesData.android;
     const apnsData: ApnsConfig = overridesData.apns;
     const fcmOptionsData: FcmOptions = overridesData.fcmOptions;


### PR DESCRIPTION
### What change does this PR introduce?

Support adding additional options for FCM message

- ~FCM option with analytics_label~ It already done on #2979
- Priority for android message
- `apns` with additional headers include priority header, Ref https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns
- Add test case for above changes

### Why was this change needed?

Closes #2233, #2965

### Other information (Screenshots)

- Update IPushOptions for new extra fields
- ~add fcmOptions~ It already done on #2979

