### PR TITLE
fix: only throw error if response contains any failed data

### DIFF
--- a/providers/apns/src/lib/apns.provider.ts
+++ b/providers/apns/src/lib/apns.provider.ts
@@ -44,7 +44,7 @@ export class APNSPushProvider implements IPushProvider {
     });
     const res = await this.provider.send(notification, options.target);
 
-    if (res.failed) {
+    if (res.failed.length > 0) {
       throw new Error(
         res.failed
           .map(


### PR DESCRIPTION
### What change does this PR introduce?
Closes #2966 
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Throws error only when the notification fails, and should be able to send success response on notification being delivered successfully
### Why was this change needed?
Notifications sent successfully were being marked as failed.
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
