### PR TITLE
fix(infra): when upgrading to pnpm 7.28.0 we didn't update the images

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,7 +1,7 @@
 FROM nikolaik/python-nodejs:python3.10-nodejs16-alpine as dev_base
 
 RUN npm i pm2 -g
-RUN npm --no-update-notifier --no-fund --global install pnpm@7.27.0
+RUN npm --no-update-notifier --no-fund --global install pnpm@7.28.0
 RUN pnpm --version
 
 WORKDIR /usr/src/app

--- a/apps/inbound-mail/Dockerfile
+++ b/apps/inbound-mail/Dockerfile
@@ -1,7 +1,7 @@
 FROM nikolaik/python-nodejs:python3.10-nodejs16-alpine as dev_base
 
 RUN npm i pm2 -g
-RUN npm --no-update-notifier --no-fund --global install pnpm@7.27.0
+RUN npm --no-update-notifier --no-fund --global install pnpm@7.28.0
 RUN pnpm --version
 
 WORKDIR /usr/src/app

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -4,7 +4,7 @@ FROM nikolaik/python-nodejs:python3.10-nodejs16-alpine as builder
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache bash
-RUN npm install -g pnpm@7.27.0 --loglevel notice
+RUN npm install -g pnpm@7.28.0 --loglevel notice
 
 COPY .npmrc .
 COPY package.json .
@@ -41,7 +41,7 @@ FROM node:16-alpine
 WORKDIR /app
 
 RUN apk add --no-cache bash
-RUN npm install -g pnpm@7.27.0 http-server --loglevel notice
+RUN npm install -g pnpm@7.28.0 http-server --loglevel notice
 
 COPY --from=builder /usr/src/app/apps/web/env.sh /app/env.sh
 COPY --from=builder /usr/src/app/apps/web/.env /app/.env

--- a/apps/webhook/Dockerfile
+++ b/apps/webhook/Dockerfile
@@ -1,7 +1,7 @@
 FROM nikolaik/python-nodejs:python3.10-nodejs16-alpine as dev_base
 
 RUN npm i pm2 -g
-RUN npm --no-update-notifier --no-fund --global install pnpm@7.27.0
+RUN npm --no-update-notifier --no-fund --global install pnpm@7.28.0
 RUN pnpm --version
 
 WORKDIR /usr/src/app

--- a/apps/widget/Dockerfile
+++ b/apps/widget/Dockerfile
@@ -3,7 +3,7 @@ FROM nikolaik/python-nodejs:python3.10-nodejs16-alpine
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache bash
-RUN npm install -g pnpm@7.27.0 --loglevel notice
+RUN npm install -g pnpm@7.28.0 --loglevel notice
 
 COPY .npmrc .
 COPY package.json .

--- a/apps/ws/Dockerfile
+++ b/apps/ws/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16-alpine3.16
 
 WORKDIR /usr/src/app
 
-RUN npm install -g pnpm@7.27.0 --loglevel notice
+RUN npm install -g pnpm@7.28.0 --loglevel notice
 RUN npm i pm2 -g
 
 COPY .npmrc .

--- a/libs/embed/Dockerfile
+++ b/libs/embed/Dockerfile
@@ -2,7 +2,7 @@ FROM nikolaik/python-nodejs:python3.10-nodejs16-alpine
 
 WORKDIR /usr/src/app
 
-RUN npm install -g pnpm@7.27.0 --loglevel notice --force
+RUN npm install -g pnpm@7.28.0 --loglevel notice --force
 
 COPY .npmrc .
 COPY package.json .

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky install",
     "publish": "lerna publish from-package",
-    "setup:project": "npx --yes pnpm@7.27.0 i && node scripts/setup-env-files.js && pnpm build",
+    "setup:project": "npx --yes pnpm@7.28.0 i && node scripts/setup-env-files.js && pnpm build",
     "install:docs": "pnpm install --filter @novu/docs",
     "clean": "lerna clean --yes && npm run prebuild",
     "commit": "cz",

--- a/scripts/dev-environment-setup.sh
+++ b/scripts/dev-environment-setup.sh
@@ -318,7 +318,7 @@ install_nvm () {
 
 # PNPM is the package manager used in Novu's monorepo
 install_pnpm () {
-    PNPM_VERSION="7.27.0"
+    PNPM_VERSION="7.28.0"
     TEST_PNPM_CMD=$(execute_command_without_error_print "pnpm --version")
     if [[ -z "$TEST_PNPM_CMD" ]] || [[ "$TEST_PNPM_CMD" == "zsh: command not found: pnpm" ]]; then
          installing_dependency "PNPM $PNPM_VERSION"


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Homogenise the PNPM version all throughout the monorepo.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
PNPM it was upgraded to 7.28.0 (https://github.com/novuhq/novu/blob/56ddf76a915aba4bb26c70bfef47ef6984b08f98/package.json#L4) but not in the Docker images and some scripts. This fixes that.
Also it is an investigation step to see why this CI check fails for a dependency update:
https://github.com/novuhq/novu/actions/runs/4373578609/jobs/7651925951

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
