### PR TITLE
fix(providers): add back to template npm-run-all

### DIFF
--- a/_templates/provider/new/package.ejs.t
+++ b/_templates/provider/new/package.ejs.t
@@ -46,6 +46,7 @@
     "cspell": "~6.19.2",
     "cz-conventional-changelog": "~3.3.0",
     "jest": "~27.5.1",
+    "npm-run-all": "^4.1.5",
     "nyc": "~15.1.0",
     "prettier": "~2.8.0",
     "rimraf": "~3.0.2",


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Adds back to provider template the dependency `npm-run-all`.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
When I cleaned the template dependencies I deleted it thinking it wasn't used but it is necessary for the building stage of the providers.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
