### PR TITLE
feat(api): clarify the notification steps creation

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -403,7 +403,8 @@
     "emailjs",
     "typeof",
     "nbsp",
-    "stddev"
+    "stddev",
+    "shortid"
   ],
   "flagWords": [],
   "patterns": [

--- a/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
+++ b/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
@@ -51,7 +51,10 @@ export class PromoteNotificationTemplateChange {
 
         return undefined;
       }
-      step._templateId = oldMessage._id;
+
+      if (step?._templateId && oldMessage._id) {
+        step._templateId = oldMessage._id;
+      }
 
       return step;
     };

--- a/apps/api/src/app/events/usecases/digest-filter-steps/digest-filter-steps-backoff.usecase.ts
+++ b/apps/api/src/app/events/usecases/digest-filter-steps/digest-filter-steps-backoff.usecase.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { JobStatusEnum, JobRepository, NotificationStepEntity, NotificationRepository } from '@novu/dal';
 import { StepTypeEnum } from '@novu/shared';
-import { DigestFilterStepsCommand } from './digest-filter-steps.command';
 import { sub } from 'date-fns';
+
+import { DigestFilterStepsCommand } from './digest-filter-steps.command';
 import { DigestFilterSteps } from './digest-filter-steps.usecase';
 
 @Injectable()
@@ -10,7 +11,7 @@ export class DigestFilterStepsBackoff {
   constructor(private jobRepository: JobRepository, private notificationRepository: NotificationRepository) {}
 
   public async execute(command: DigestFilterStepsCommand): Promise<NotificationStepEntity[]> {
-    const steps = [DigestFilterSteps.createTriggerStep(command)];
+    const steps: NotificationStepEntity[] = [];
 
     for (const step of command.steps) {
       if (step.template?.type !== StepTypeEnum.DIGEST) {

--- a/apps/api/src/app/events/usecases/digest-filter-steps/digest-filter-steps-regular.usecase.ts
+++ b/apps/api/src/app/events/usecases/digest-filter-steps/digest-filter-steps-regular.usecase.ts
@@ -9,7 +9,7 @@ export class DigestFilterStepsRegular {
   constructor(private jobRepository: JobRepository, private notificationRepository: NotificationRepository) {}
 
   public async execute(command: DigestFilterStepsCommand): Promise<NotificationStepEntity[]> {
-    const steps = [DigestFilterSteps.createTriggerStep(command)];
+    const steps: NotificationStepEntity[] = [];
     let delayedDigests;
 
     for (const step of command.steps) {

--- a/apps/api/src/app/events/usecases/digest-filter-steps/digest-filter-steps.command.ts
+++ b/apps/api/src/app/events/usecases/digest-filter-steps/digest-filter-steps.command.ts
@@ -1,5 +1,7 @@
 import { IsDefined, IsMongoId, IsString } from 'class-validator';
 import { NotificationStepEntity } from '@novu/dal';
+import { DigestTypeEnum } from '@novu/shared';
+
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class DigestFilterStepsCommand extends EnvironmentWithUserCommand {
@@ -20,4 +22,7 @@ export class DigestFilterStepsCommand extends EnvironmentWithUserCommand {
 
   @IsString()
   transactionId: string;
+
+  @IsString()
+  type: DigestTypeEnum;
 }

--- a/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.usecase.ts
+++ b/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.usecase.ts
@@ -18,7 +18,7 @@ export class CreateMessageTemplate {
   ) {}
 
   async execute(command: CreateMessageTemplateCommand): Promise<MessageTemplateEntity> {
-    let item = await this.messageTemplateRepository.create({
+    let item: MessageTemplateEntity = await this.messageTemplateRepository.create({
       cta: command.cta,
       name: command.name,
       variables: command.variables ? UpdateMessageTemplate.mapVariables(command.variables) : undefined,
@@ -37,7 +37,10 @@ export class CreateMessageTemplate {
       actor: command.actor,
     });
 
-    item = (await this.messageTemplateRepository.findById(item._id)) as MessageTemplateEntity;
+    if (item?._id) {
+      item = (await this.messageTemplateRepository.findById(item._id)) as MessageTemplateEntity;
+    }
+
     await this.createChange.execute(
       CreateChangeCommand.create({
         organizationId: command.organizationId,

--- a/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.usecase.ts
+++ b/apps/api/src/app/message-template/usecases/update-message-template/update-message-template.usecase.ts
@@ -110,23 +110,25 @@ export class UpdateMessageTemplate {
       );
     }
 
-    const changeId = await this.changeRepository.getChangeId(
-      command.environmentId,
-      ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
-      item._id
-    );
+    if (item._id) {
+      const changeId = await this.changeRepository.getChangeId(
+        command.environmentId,
+        ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
+        item._id
+      );
 
-    await this.createChange.execute(
-      CreateChangeCommand.create({
-        organizationId: command.organizationId,
-        environmentId: command.environmentId,
-        userId: command.userId,
-        item,
-        type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
-        parentChangeId: command.parentChangeId,
-        changeId,
-      })
-    );
+      await this.createChange.execute(
+        CreateChangeCommand.create({
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+          userId: command.userId,
+          item,
+          type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
+          parentChangeId: command.parentChangeId,
+          changeId,
+        })
+      );
+    }
 
     if (command.feedId) {
       await this.updateChange.execute(

--- a/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.usecase.ts
@@ -91,7 +91,10 @@ export class CreateNotificationTemplate {
         shouldStopOnFail: message.shouldStopOnFail,
         replyCallback: message.replyCallback,
       });
-      parentStepId = stepId;
+
+      if (stepId) {
+        parentStepId = stepId;
+      }
     }
 
     const savedTemplate = await this.notificationTemplateRepository.create({

--- a/libs/dal/src/repositories/message-template/message-template.entity.ts
+++ b/libs/dal/src/repositories/message-template/message-template.entity.ts
@@ -6,7 +6,7 @@ import type { EnvironmentId } from '../environment';
 import type { ChangePropsValueType } from '../../types/helpers';
 
 export class MessageTemplateEntity {
-  _id: string;
+  _id?: string;
 
   _environmentId: EnvironmentId;
 


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Small refactor to aggregate the logic accordingly.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Inside of the use case that was in charge on deciding if a digest step should be created or not we were doing more things, like filtering the active steps for the notification, adding extra complexity to that use case.
These changes should facilitate the vision if we are committing to decisions on creating or not digest steps before we should.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
