### PR TITLE
fix: disable node, edge, parent trigger deletion using delete key

### DIFF
--- a/apps/web/src/pages/templates/workflow/workflow/FlowEditor.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/FlowEditor.tsx
@@ -318,6 +318,7 @@ export function FlowEditor({
                 handleDisplayAddNodeOnEdge(`edge-button-${edge.source}`);
               }
             }}
+            deleteKeyCode={null}
             {...reactFlowDefaultProps}
           >
             <MinimalTemplatesSideBar


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- Disable deletion of nodes, edges, Trigger node  using delete/backspace key.
- It will be hard to sync this deletion with our form data given how we manage the state, So I decided to disable it
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
