### PR TITLE
NV-1793 - enable custom transactionId in trigger

### DIFF
--- a/packages/node/src/lib/events/events.interface.ts
+++ b/packages/node/src/lib/events/events.interface.ts
@@ -23,6 +23,7 @@ export interface IBroadcastPayloadOptions {
 export interface ITriggerPayloadOptions extends IBroadcastPayloadOptions {
   to: TriggerRecipientsPayload;
   actor?: TriggerRecipientSubscriber;
+  transactionId?: string;
 }
 
 export interface ITriggerPayload {

--- a/packages/node/src/lib/events/events.ts
+++ b/packages/node/src/lib/events/events.ts
@@ -15,6 +15,7 @@ export class Events extends WithHttp {
       payload: {
         ...data?.payload,
       },
+      transactionId: data.transactionId,
       overrides: data.overrides || {},
       ...(data.actor && { actor: data.actor }),
     });


### PR DESCRIPTION
### What change does this PR introduce?</ins></b>
It adds optional `transactionId` to event request data.

### Why was this change needed?</ins></b>
To allow transactionId to be passed to event request rather than generating random id on every request.

### Other information (Screenshots)
---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.