### PR TITLE
feat(api): endpoint to check if subscriber belongs to a topic

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -404,7 +404,8 @@
     "typeof",
     "nbsp",
     "stddev",
-    "shortid"
+    "shortid",
+    "upsert"
   ],
   "flagWords": [],
   "patterns": [

--- a/apps/api/src/app/topics/dtos/index.ts
+++ b/apps/api/src/app/topics/dtos/index.ts
@@ -5,4 +5,4 @@ export * from './get-topic.dto';
 export * from './remove-subscribers.dto';
 export * from './rename-topic.dto';
 export * from './topic.dto';
-export * from './topic-subscribers.dto';
+export * from './topic-subscriber.dto';

--- a/apps/api/src/app/topics/dtos/topic-subscriber.dto.ts
+++ b/apps/api/src/app/topics/dtos/topic-subscriber.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { EnvironmentId, ExternalSubscriberId, OrganizationId, SubscriberId, TopicId, TopicKey } from '../types';
 
-export class TopicSubscribersDto {
+export class TopicSubscriberDto {
   @ApiProperty()
   _organizationId: OrganizationId;
 

--- a/apps/api/src/app/topics/e2e/get-topic-subscriber.e2e.ts
+++ b/apps/api/src/app/topics/e2e/get-topic-subscriber.e2e.ts
@@ -1,0 +1,94 @@
+import { SubscriberEntity } from '@novu/dal';
+import { SubscribersService, UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+import { ExternalSubscriberId, TopicId, TopicKey } from '../types';
+
+const BASE_PATH = '/v1/topics';
+
+const buildGetTopicSubscriberUrl = (topicKey: TopicKey, externalSubscriberId: ExternalSubscriberId): string =>
+  `${BASE_PATH}/${topicKey}/subscribers/${externalSubscriberId}`;
+
+describe('Check if a subscriber belongs to a topic - /topics/:topicKey/subscribers/:externalSubscriberId (GET)', () => {
+  const topicKey = 'topic-key-get-topic-subscriber';
+  const topicName = 'topic-name';
+
+  let session: UserSession;
+  let subscriber: SubscriberEntity;
+  let externalSubscriberId: ExternalSubscriberId;
+  let topicId: TopicId;
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    const subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+    subscriber = await subscriberService.createSubscriber();
+
+    const response = await session.testAgent.post(BASE_PATH).send({
+      key: topicKey,
+      name: topicName,
+    });
+
+    expect(response.statusCode).to.eql(201);
+
+    const { body } = response;
+    const { _id, key } = body.data;
+    expect(_id).to.exist;
+    expect(_id).to.be.string;
+    expect(key).to.eq(topicKey);
+
+    topicId = _id;
+
+    const topicUrl = `${BASE_PATH}/${topicKey}`;
+    const addSubscribersUrl = `${topicUrl}/subscribers`;
+    externalSubscriberId = subscriber.subscriberId;
+    const subscribers = [externalSubscriberId];
+    const addSubscribersResponse = await session.testAgent.post(addSubscribersUrl).send({ subscribers });
+    expect(addSubscribersResponse.statusCode).to.eql(200);
+    expect(addSubscribersResponse.body.data).to.eql({
+      succeeded: [externalSubscriberId],
+    });
+  });
+
+  it('should check the requested subscriber belongs to a topic successfully in the database for that user', async () => {
+    const url = buildGetTopicSubscriberUrl(topicKey, externalSubscriberId);
+    const getResponse = await session.testAgent.get(url);
+
+    expect(getResponse.statusCode).to.eql(200);
+
+    const topicSubscriber = getResponse.body.data;
+
+    expect(topicSubscriber._id).to.be.ok;
+    expect(topicSubscriber._environmentId).to.eql(session.environment._id);
+    expect(topicSubscriber._organizationId).to.eql(session.organization._id);
+    expect(topicSubscriber._subscriberId).to.eql(subscriber._id);
+    expect(topicSubscriber._topicId).to.eql(topicId);
+    expect(topicSubscriber.topicKey).to.eql(topicKey);
+    expect(topicSubscriber.externalSubscriberId).to.eql(externalSubscriberId);
+  });
+
+  it('should throw a not found error when the external subscriber id passed does not belong to the chosen topic', async () => {
+    const nonExistingExternalSubscriberId = 'ab12345678901234567890ab';
+    const url = buildGetTopicSubscriberUrl(topicKey, nonExistingExternalSubscriberId);
+    const { body } = await session.testAgent.get(url);
+
+    expect(body.statusCode).to.equal(404);
+    expect(body.message).to.eql(
+      `Subscriber ${nonExistingExternalSubscriberId} not found for topic ${topicKey} in the environment ${session.environment._id}`
+    );
+    expect(body.error).to.eql('Not Found');
+  });
+
+  it('should throw a not found error when the topic key does not exist in the database for the call', async () => {
+    const nonExistingTopicKey = 'ab12345678901234567890ab';
+    const url = buildGetTopicSubscriberUrl(nonExistingTopicKey, externalSubscriberId);
+    const { body } = await session.testAgent.get(url);
+
+    expect(body.statusCode).to.equal(404);
+    expect(body.message).to.eql(
+      `Subscriber ${externalSubscriberId} not found for topic ${nonExistingTopicKey} in the environment ${session.environment._id}`
+    );
+    expect(body.error).to.eql('Not Found');
+  });
+});

--- a/apps/api/src/app/topics/topics.controller.ts
+++ b/apps/api/src/app/topics/topics.controller.ts
@@ -32,6 +32,7 @@ import {
   RemoveSubscribersRequestDto,
   RenameTopicRequestDto,
   RenameTopicResponseDto,
+  TopicSubscriberDto,
 } from './dtos';
 import {
   AddSubscribersCommand,
@@ -42,6 +43,8 @@ import {
   FilterTopicsUseCase,
   GetTopicCommand,
   GetTopicUseCase,
+  GetTopicSubscriberCommand,
+  GetTopicSubscriberUseCase,
   RemoveSubscribersCommand,
   RemoveSubscribersUseCase,
   RenameTopicCommand,
@@ -60,6 +63,7 @@ export class TopicsController {
     private addSubscribersUseCase: AddSubscribersUseCase,
     private createTopicUseCase: CreateTopicUseCase,
     private filterTopicsUseCase: FilterTopicsUseCase,
+    private getTopicSubscriberUseCase: GetTopicSubscriberUseCase,
     private getTopicUseCase: GetTopicUseCase,
     private removeSubscribersUseCase: RemoveSubscribersUseCase,
     private renameTopicUseCase: RenameTopicUseCase,
@@ -123,6 +127,25 @@ export class TopicsController {
         },
       }),
     };
+  }
+
+  @Get('/:topicKey/subscribers/:externalSubscriberId')
+  @ExternalApiAccessible()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Check topic subscriber', description: 'Check if a subscriber belongs to a certain topic' })
+  async getTopicSubscriber(
+    @UserSession() user: IJwtPayload,
+    @Param('topicKey') topicKey: TopicKey,
+    @Param('externalSubscriberId') externalSubscriberId: ExternalSubscriberId
+  ): Promise<TopicSubscriberDto> {
+    return await this.getTopicSubscriberUseCase.execute(
+      GetTopicSubscriberCommand.create({
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        externalSubscriberId,
+        topicKey,
+      })
+    );
   }
 
   @Post('/:topicKey/subscribers/removal')

--- a/apps/api/src/app/topics/use-cases/get-topic-subscriber/get-topic-subscriber.command.ts
+++ b/apps/api/src/app/topics/use-cases/get-topic-subscriber/get-topic-subscriber.command.ts
@@ -1,0 +1,15 @@
+import { IsDefined, IsString } from 'class-validator';
+
+import { ExternalSubscriberId, TopicKey } from '../../types';
+
+import { EnvironmentCommand } from '../../../shared/commands/project.command';
+
+export class GetTopicSubscriberCommand extends EnvironmentCommand {
+  @IsString()
+  @IsDefined()
+  externalSubscriberId: ExternalSubscriberId;
+
+  @IsString()
+  @IsDefined()
+  topicKey: TopicKey;
+}

--- a/apps/api/src/app/topics/use-cases/get-topic-subscriber/get-topic-subscriber.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/get-topic-subscriber/get-topic-subscriber.use-case.ts
@@ -1,0 +1,40 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { TopicSubscribersEntity, TopicSubscribersRepository } from '@novu/dal';
+
+import { GetTopicSubscriberCommand } from './get-topic-subscriber.command';
+
+import { TopicSubscriberDto } from '../../dtos';
+import { ExternalSubscriberId } from '../../types';
+
+@Injectable()
+export class GetTopicSubscriberUseCase {
+  constructor(private topicSubscribersRepository: TopicSubscribersRepository) {}
+
+  async execute(command: GetTopicSubscriberCommand) {
+    const topicSubscriber = await this.topicSubscribersRepository.findOneByTopicKeyAndExternalSubscriberId(
+      command.environmentId,
+      command.organizationId,
+      command.topicKey,
+      command.externalSubscriberId
+    );
+
+    if (!topicSubscriber) {
+      throw new NotFoundException(
+        `Subscriber ${command.externalSubscriberId} not found for topic ${command.topicKey} in the environment ${command.environmentId}`
+      );
+    }
+
+    return this.mapFromEntity(topicSubscriber);
+  }
+
+  private mapFromEntity(topicSubscriber: TopicSubscribersEntity): TopicSubscriberDto {
+    return {
+      ...topicSubscriber,
+      topicKey: topicSubscriber.topicKey,
+      _topicId: topicSubscriber._topicId,
+      _organizationId: topicSubscriber._organizationId,
+      _environmentId: topicSubscriber._environmentId,
+      _subscriberId: topicSubscriber._subscriberId,
+    };
+  }
+}

--- a/apps/api/src/app/topics/use-cases/get-topic-subscriber/index.ts
+++ b/apps/api/src/app/topics/use-cases/get-topic-subscriber/index.ts
@@ -1,0 +1,2 @@
+export * from './get-topic-subscriber.command';
+export * from './get-topic-subscriber.use-case';

--- a/apps/api/src/app/topics/use-cases/get-topic-subscribers/get-topic-subscribers.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/get-topic-subscribers/get-topic-subscribers.use-case.ts
@@ -3,7 +3,7 @@ import { TopicSubscribersEntity, TopicSubscribersRepository, TopicRepository } f
 
 import { GetTopicSubscribersCommand } from './get-topic-subscribers.command';
 
-import { TopicSubscribersDto } from '../../dtos/topic-subscribers.dto';
+import { TopicSubscriberDto } from '../../dtos/topic-subscriber.dto';
 
 @Injectable()
 export class GetTopicSubscribersUseCase {
@@ -37,14 +37,14 @@ export class GetTopicSubscribersUseCase {
     return topicSubscribers.map(this.mapFromEntity);
   }
 
-  private mapFromEntity(topicSubscribers: TopicSubscribersEntity): TopicSubscribersDto {
+  private mapFromEntity(topicSubscriber: TopicSubscribersEntity): TopicSubscriberDto {
     return {
-      ...topicSubscribers,
-      topicKey: topicSubscribers.topicKey,
-      _topicId: topicSubscribers._topicId,
-      _organizationId: topicSubscribers._organizationId,
-      _environmentId: topicSubscribers._environmentId,
-      _subscriberId: topicSubscribers._subscriberId,
+      ...topicSubscriber,
+      topicKey: topicSubscriber.topicKey,
+      _topicId: topicSubscriber._topicId,
+      _organizationId: topicSubscriber._organizationId,
+      _environmentId: topicSubscriber._environmentId,
+      _subscriberId: topicSubscriber._subscriberId,
     };
   }
 }

--- a/apps/api/src/app/topics/use-cases/get-topic/get-topic.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/get-topic/get-topic.use-case.ts
@@ -3,7 +3,7 @@ import { TopicEntity, TopicRepository } from '@novu/dal';
 
 import { GetTopicCommand } from './get-topic.command';
 
-import { TopicDto } from '../../dtos/topic.dto';
+import { TopicDto } from '../../dtos';
 import { ExternalSubscriberId } from '../../types';
 
 @Injectable()

--- a/apps/api/src/app/topics/use-cases/index.ts
+++ b/apps/api/src/app/topics/use-cases/index.ts
@@ -2,6 +2,7 @@ import { AddSubscribersUseCase } from './add-subscribers/add-subscribers.use-cas
 import { CreateTopicUseCase } from './create-topic/create-topic.use-case';
 import { FilterTopicsUseCase } from './filter-topics/filter-topics.use-case';
 import { GetTopicUseCase } from './get-topic/get-topic.use-case';
+import { GetTopicSubscriberUseCase } from './get-topic-subscriber/get-topic-subscriber.use-case';
 import { GetTopicSubscribersUseCase } from './get-topic-subscribers/get-topic-subscribers.use-case';
 import { RemoveSubscribersUseCase } from './remove-subscribers/remove-subscribers.use-case';
 import { RenameTopicUseCase } from './rename-topic';
@@ -10,6 +11,7 @@ export * from './add-subscribers';
 export * from './create-topic';
 export * from './filter-topics';
 export * from './get-topic';
+export * from './get-topic-subscriber';
 export * from './get-topic-subscribers';
 export * from './remove-subscribers';
 export * from './rename-topic';
@@ -19,6 +21,7 @@ export const USE_CASES = [
   CreateTopicUseCase,
   FilterTopicsUseCase,
   GetTopicUseCase,
+  GetTopicSubscriberUseCase,
   GetTopicSubscribersUseCase,
   RemoveSubscribersUseCase,
   RenameTopicUseCase,

--- a/docs/docs/platform/topics.md
+++ b/docs/docs/platform/topics.md
@@ -109,6 +109,25 @@ const response = await novu.topics.removeSubscribers(topicKey, {
 
 Where `subscribers` will be an array of the subscriber identifiers we want to unassign from the topic. If successful an empty response will be returned.
 
+### Verify a subscriber belongs to a topic
+
+There would be times when it would be needed to verify if a certain subscriber belongs to a topic in order to decide what to do with that subscriber. The API call to achieve that is the following:
+
+```typescript
+import { Novu } from '@novu/node';
+
+const novu = new Novu(process.env.NOVU_API_KEY);
+
+const externalSubscriberId = 'external-subscriber-id-1';
+const topicKey = 'posts:comment:12345';
+
+const response = await novu.topics.getSubscriber(topicKey, externalSubscriberId);
+```
+
+:::info
+The subscriber ID to use in this API call is the one used as subscriber identifier. The choice was done to make easier for the user to use this endpoint without extra calls to Novu.
+:::
+
 ## Sending a notification to a topic
 
 In the section [Quick Start](/overview/quick-start#trigger-the-notification) it is explained how to trigger a notification for a single subscriber either by passing the subscribers identifier or by passing the full subscriber information if user wants to skip the identify step.

--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -23,6 +23,20 @@ export class TopicSubscribersRepository extends BaseRepository<
     await this.upsertMany(subscribers);
   }
 
+  async findOneByTopicKeyAndExternalSubscriberId(
+    _environmentId: EnvironmentId,
+    _organizationId: OrganizationId,
+    topicKey: TopicKey,
+    externalSubscriberId: ExternalSubscriberId
+  ): Promise<TopicSubscribersEntity | null> {
+    return this.findOne({
+      _environmentId,
+      _organizationId,
+      topicKey,
+      externalSubscriberId,
+    });
+  }
+
   async findSubscribersByTopicId(
     _environmentId: EnvironmentId,
     _organizationId: OrganizationId,

--- a/packages/node/src/lib/topics/topic.interface.ts
+++ b/packages/node/src/lib/topics/topic.interface.ts
@@ -14,6 +14,7 @@ export interface ITopics {
   addSubscribers(topicKey: TopicKey, data: ITopicSubscribersPayload);
   create(data: ITopicPayload);
   get(topicKey: TopicKey);
+  getSubscriber(topicKey: TopicKey, externalSubscriberId: ExternalSubscriberId);
   list(data: ITopicPaginationPayload);
   rename(topicKey: TopicKey, newName: TopicName);
   removeSubscribers(topicKey: TopicKey, data: ITopicSubscribersPayload);

--- a/packages/node/src/lib/topics/topics.spec.ts
+++ b/packages/node/src/lib/topics/topics.spec.ts
@@ -101,6 +101,39 @@ describe('Novu Node.js package - Topics class', () => {
     expect(result).toStrictEqual(mockedResponse);
   });
 
+  test('should get topic subscriber by the external subscriber ID', async () => {
+    const topicKey = 'topic-key';
+    const externalSubscriberId = 'external-subscriber-id';
+
+    const topicSubscriber = {
+      _id: 'topic-subscriber-id',
+      _environmentId: 'environment-id',
+      _organizationId: 'organization-id',
+      _subscriberId: 'subscriber-id',
+      _topicId: 'topic-id',
+      topicKey,
+      externalSubscriberId,
+    };
+
+    const mockedResponse = {
+      data: {
+        ...topicSubscriber,
+      },
+    };
+    mockedAxios.get.mockResolvedValue(mockedResponse);
+
+    const result = await novu.topics.getSubscriber(
+      topicKey,
+      externalSubscriberId
+    );
+
+    expect(mockedAxios.get).toHaveBeenCalled();
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `/topics/${topicKey}/subscribers/${externalSubscriberId}`
+    );
+    expect(result).toStrictEqual(mockedResponse);
+  });
+
   test('should list topics', async () => {
     const key = 'topic-key';
     const name = 'topic-name';

--- a/packages/node/src/lib/topics/topics.ts
+++ b/packages/node/src/lib/topics/topics.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance } from 'axios';
-import { TopicKey, TopicName } from '@novu/shared';
+import { ExternalSubscriberId, TopicKey, TopicName } from '@novu/shared';
 
 import {
   ITopicPayload,
@@ -34,6 +34,15 @@ export class Topics extends WithHttp implements ITopics {
 
   async get(topicKey: TopicKey) {
     return await this.http.get(`/topics/${topicKey}`);
+  }
+
+  async getSubscriber(
+    topicKey: TopicKey,
+    externalSubscriberId: ExternalSubscriberId
+  ) {
+    return await this.http.get(
+      `/topics/${topicKey}/subscribers/${externalSubscriberId}`
+    );
   }
 
   async rename(topicKey: TopicKey, newName: TopicName) {


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Implement and endpoint that provided a topicKey and the external subscriber ID retrieves the relationship if existing or a 404 Not Found if any of both are not existing.
Implement it in Novu package.
Add tests and documentation.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
We have been requested by users to provide with a way for them to check if a subscriber belongs to a certain topic. This could improve the engagement with the feature and traction of potential new users that could implement their use cases and use Novu.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
