### PR TITLE
Add Resend to email provider list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Novu provides a single API to manage providers across multiple channels with a s
 - [x] [Mandrill](https://github.com/novuhq/novu/tree/main/providers/mandrill)
 - [x] [SendinBlue](https://github.com/novuhq/novu/tree/main/providers/sendinblue)
 - [x] [MailerSend](https://github.com/novuhq/novu/tree/main/providers/mailersend)
+- [x] [Resend](https://github.com/novuhq/novu/tree/main/providers/resend)
 - [ ] SparkPost
 
 #### 📞 SMS


### PR DESCRIPTION
### What change does this PR introduce?

Added Resend to email provider list in README, pointed to existing provider subdir

### Why was this change needed?

To keep email provider list up to date in README

### Other information (Screenshots)

N/A
