### PR TITLE
feat(web): getting started dots navigation and footer button logic

### DIFF
--- a/apps/web/src/api/hooks/notification-templates/useCreateDigestDemoWorkflow.ts
+++ b/apps/web/src/api/hooks/notification-templates/useCreateDigestDemoWorkflow.ts
@@ -1,0 +1,66 @@
+import { useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { ICreateNotificationTemplateDto, INotificationTemplate, StepTypeEnum } from '@novu/shared';
+
+import { createTemplate } from '../../notification-templates';
+import { parseUrl } from '../../../utils/routeUtils';
+import { ROUTES } from '../../../constants/routes.enum';
+import { errorMessage } from '../../../utils/notifications';
+import { useNotificationGroup } from '../../../hooks';
+
+export const useCreateDigestDemoWorkflow = () => {
+  const navigate = useNavigate();
+  const { groups, loading: areNotificationGroupLoading } = useNotificationGroup();
+  const { mutateAsync: createNotificationTemplate, isLoading: isCreating } = useMutation<
+    INotificationTemplate,
+    { error: string; message: string; statusCode: number },
+    ICreateNotificationTemplateDto
+  >(createTemplate, {
+    onSuccess: (template) => {
+      navigate(parseUrl(ROUTES.TEMPLATES_DIGEST_PLAYGROUND, { templateId: template._id as string }));
+    },
+    onError: () => {
+      errorMessage('Failed to create Digest Workflow');
+    },
+  });
+
+  const createDigestDemoWorkflow = useCallback(() => {
+    const payload = {
+      name: 'Digest Workflow Example',
+      notificationGroupId: groups[0]._id,
+      active: true,
+      draft: false,
+      critical: false,
+      tags: [],
+      steps: [
+        {
+          template: { type: StepTypeEnum.DIGEST, content: '' },
+          metadata: { amount: '10', unit: 'seconds', type: 'regular', digestKey: '' },
+          active: true,
+          filters: [],
+        },
+        {
+          template: {
+            subject: 'Digest Workflow Example',
+            senderName: 'Novu',
+            type: StepTypeEnum.EMAIL,
+            contentType: 'customHtml',
+            variables: [{ type: 'String', name: 'step.digest', defaultValue: '1', required: false }],
+            preheader: '',
+            content: `Hi {{subscriber.firstName}}! 👋 You've sent {{step.total_count}} events!`,
+          },
+          active: true,
+        },
+      ],
+    };
+
+    createNotificationTemplate(payload as any);
+  }, [createNotificationTemplate]);
+
+  return {
+    createDigestDemoWorkflow,
+    isLoading: isCreating,
+    isDisabled: areNotificationGroupLoading || isCreating,
+  };
+};

--- a/apps/web/src/components/layout/components/SideNav.tsx
+++ b/apps/web/src/components/layout/components/SideNav.tsx
@@ -76,7 +76,7 @@ export function SideNav({}: Props) {
 
   const menuItems = [
     {
-      condition: !readonly && currentUser?.showOnBoarding,
+      condition: !readonly,
       icon: <CheckCircleOutlined />,
       link: lastRoute ?? ROUTES.GET_STARTED,
       label: 'Get Started',

--- a/apps/web/src/design-system/button/Button.styles.ts
+++ b/apps/web/src/design-system/button/Button.styles.ts
@@ -24,16 +24,18 @@ export const getOutlineStyles = (theme) => {
 
 export const getPulseStyles = () => {
   return {
-    animation: 'pulse-animation 2s infinite',
-    '@keyframes pulse-animation': {
-      '0%': {
-        boxShadow: '0 0 0 0 rgba(255, 82, 82, 0.7)',
-      },
-      '70%': {
-        boxShadow: '0 0 0 10px rgba(255, 82, 82, 0)',
-      },
-      '100%': {
-        boxShadow: '0 0 0 0 rgba(255, 82, 82, 0)',
+    [`&:not(:disabled):not([data-loading])`]: {
+      animation: 'pulse-animation 2s infinite',
+      '@keyframes pulse-animation': {
+        '0%': {
+          boxShadow: '0 0 0 0 rgba(255, 82, 82, 0.7)',
+        },
+        '70%': {
+          boxShadow: '0 0 0 10px rgba(255, 82, 82, 0)',
+        },
+        '100%': {
+          boxShadow: '0 0 0 0 rgba(255, 82, 82, 0)',
+        },
       },
     },
   };

--- a/apps/web/src/design-system/input/Input.tsx
+++ b/apps/web/src/design-system/input/Input.tsx
@@ -18,6 +18,7 @@ interface IInputProps extends SpacingProps {
   min?: string | number;
   max?: string | number;
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
+  autoFocus?: boolean;
 }
 
 /**

--- a/apps/web/src/pages/quick-start/components/ChannelsConfiguration.tsx
+++ b/apps/web/src/pages/quick-start/components/ChannelsConfiguration.tsx
@@ -28,7 +28,7 @@ export function ChannelsConfiguration({ setClickedChannel }: { setClickedChannel
         const integrationStatus = isLoading ? false : integrationsStatus[channel.type];
 
         return (
-          <Grid.Col span={6} key={index} style={{ marginBottom: '43px' }}>
+          <CardCol span={5} key={index}>
             <Container>
               <IconContainer>
                 <Icon style={{ width: '28px', height: '32px' }} />
@@ -55,7 +55,7 @@ export function ChannelsConfiguration({ setClickedChannel }: { setClickedChannel
                 </StyledButton>
               </ChannelCard>
             </Container>
-          </Grid.Col>
+          </CardCol>
         );
       })}
     </Grid>
@@ -108,6 +108,15 @@ const Container = styled.div`
   display: flex;
   justify-content: flex-start;
   height: 100%;
+`;
+
+const CardCol = styled(Grid.Col)`
+  margin-bottom: 40px;
+  width: 300px;
+
+  @media screen and (min-width: 1369px) {
+    width: initial;
+  }
 `;
 
 /**

--- a/apps/web/src/pages/quick-start/components/layout/BodyLayout.tsx
+++ b/apps/web/src/pages/quick-start/components/layout/BodyLayout.tsx
@@ -66,42 +66,46 @@ function BodyNavigation() {
 
 const TimelineWrapper = styled.div`
   width: 100%;
-  padding: 0 0 0 75px;
+  padding: 0 0 0 40px;
 
   .mantine-Timeline-itemBullet {
+    width: 34px;
+    height: 34px;
     background: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.B20 : '#EDF0F2')};
     font-size: 16px;
     font-weight: bold;
     box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
+  }
+
+  @media screen and (min-width: 1369px) {
+    padding: 0 0 0 75px;
+
+    .mantine-Timeline-itemBullet {
+      width: 40px;
+      height: 40px;
+    }
   }
 `;
 
 const TimelineText = styled.div<{ active: boolean }>`
   display: flex;
   align-items: center;
-
   max-width: 320px;
   min-height: 80px;
-
-  font-size: 20px;
+  font-size: 16px;
   font-weight: 700;
-  line-height: 32px;
-
-  margin-left: 12px;
-  padding: 24px;
-
+  line-height: 1.4;
+  padding: 12px;
   transition: margin-left 0.3s ease, padding 0.3s ease;
-
-  @media (max-width: 1525px) {
-     {
-      margin-left: 6px;
-      padding: 20px 12px;
-    }
-  }
-
   border-radius: 8px;
-
   cursor: pointer;
+
+  @media screen and (min-width: 1369px) {
+    margin-left: 12px;
+    padding: 24px;
+    font-size: 20px;
+    line-height: 32px;
+  }
 
   ${({ active, theme }) => {
     return (
@@ -125,6 +129,18 @@ const TimelineText = styled.div<{ active: boolean }>`
 `;
 
 const StyledItem = styled(Timeline.Item)`
-  min-height: 140px;
+  min-height: 100px;
   min-width: 170px;
+
+  &:before {
+    left: -5px;
+  }
+
+  @media screen and (min-width: 1369px) {
+    min-height: 140px;
+
+    &:before {
+      left: -2px;
+    }
+  }
 `;

--- a/apps/web/src/pages/quick-start/components/layout/FooterLayout.tsx
+++ b/apps/web/src/pages/quick-start/components/layout/FooterLayout.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Grid } from '@mantine/core';
 import styled from '@emotion/styled';
+
+import { DotsNavigation } from '../../../../design-system';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../../../constants/routes.enum';
 
 interface IFooterLayoutProps {
   leftSide: React.ReactNode;
@@ -8,19 +12,30 @@ interface IFooterLayoutProps {
 }
 
 export function FooterLayout({ leftSide, rightSide }: IFooterLayoutProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [selectedIndex, setSelectedIndex] = React.useState(location.pathname === ROUTES.GET_STARTED ? 0 : 1);
+
+  const handleOnNavigationClick = (index: number) => {
+    setSelectedIndex(index);
+    navigate(index === 0 ? ROUTES.GET_STARTED : ROUTES.GET_STARTED_PREVIEW);
+  };
+
+  useEffect(() => {
+    if (location.pathname === ROUTES.GET_STARTED) {
+      setSelectedIndex(0);
+    } else if (location.pathname === ROUTES.GET_STARTED_PREVIEW) {
+      setSelectedIndex(1);
+    }
+  }, [location]);
+
   return (
     <FooterWrapper>
-      <Grid justify="space-between" style={{ width: '100%', padding: '0 80px' }} gutter={0}>
-        <Grid.Col span={4} style={{ display: 'flex', alignItems: 'center' }}>
-          <LeftSide>{leftSide}</LeftSide>
-        </Grid.Col>
-        <Grid.Col span={4} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <MiddleSide> .. </MiddleSide>
-        </Grid.Col>
-        <Grid.Col span={4}>
-          <RightSide>{rightSide}</RightSide>
-        </Grid.Col>
-      </Grid>
+      <LeftSide>{leftSide}</LeftSide>
+      <MiddleSide>
+        <DotsNavigation selectedIndex={selectedIndex} size={2} onClick={handleOnNavigationClick} />
+      </MiddleSide>
+      <RightSide>{rightSide}</RightSide>
     </FooterWrapper>
   );
 }
@@ -39,14 +54,17 @@ const RightSide = styled.div`
 `;
 
 const FooterWrapper = styled.div`
+  padding: 32px 40px;
   height: 150px;
-
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   flex-direction: row;
-
   box-shadow: inset 0 1px 0 #000000;
+
+  @media screen and (min-width: 1369px) {
+    padding: 32px 80px;
+  }
 
   ${({ theme }) => {
     return (

--- a/apps/web/src/pages/quick-start/components/layout/HeaderLayout.tsx
+++ b/apps/web/src/pages/quick-start/components/layout/HeaderLayout.tsx
@@ -28,11 +28,13 @@ export const HeaderSecondaryTitle = styled(Title)`
 `;
 
 const StyledHeader = styled.div`
-  height: 200px;
-
+  height: 160px;
   display: flex;
   justify-content: center;
   align-items: center;
-
   flex-direction: column;
+
+  @media screen and (min-width: 1369px) {
+    height: 200px;
+  }
 `;

--- a/apps/web/src/pages/quick-start/steps/DigestPreview.tsx
+++ b/apps/web/src/pages/quick-start/steps/DigestPreview.tsx
@@ -16,6 +16,7 @@ import { Label } from '../../../design-system/typography/label';
 import { getStartedSteps } from '../consts';
 import { ROUTES } from '../../../constants/routes.enum';
 import { HeaderSecondaryTitle, HeaderTitle } from '../components/layout/HeaderLayout';
+import { useCreateDigestDemoWorkflow } from '../../../api/hooks/notification-templates/useCreateDigestDemoWorkflow';
 
 export function DigestPreview() {
   const segment = useSegment();
@@ -38,7 +39,7 @@ export function DigestPreview() {
         leftSide: (
           <NavButton navigateTo={getStartedSteps.first}>
             <ThemeArrowLeft style={{ marginRight: '10px' }} />
-            <Label gradientColor={gradientColor}>Previous Page</Label>
+            <Label gradientColor={gradientColor}>Previous</Label>
           </NavButton>
         ),
         rightSide: <RightSide />,
@@ -46,7 +47,7 @@ export function DigestPreview() {
     >
       <DemoContainer>
         <ReactFlowProvider>
-          <DigestDemoFlow />
+          <DigestDemoFlowStyled />
         </ReactFlowProvider>
       </DemoContainer>
     </GetStartedLayout>
@@ -54,17 +55,28 @@ export function DigestPreview() {
 }
 
 function RightSide() {
+  const { createDigestDemoWorkflow, isLoading: isCreating } = useCreateDigestDemoWorkflow();
+
   return (
-    <>
-      <NavButton navigateTo={ROUTES.TEMPLATES} style={{ marginRight: '40px' }}>
+    <ButtonsHolder>
+      <NavButton navigateTo={ROUTES.TEMPLATES_CREATE}>
         <ButtonText>Build a Workflow</ButtonText>
       </NavButton>
-      <NavButton pulse={true} navigateTo={ROUTES.TEMPLATES} variant={'gradient'}>
+      <StyledButton fullWidth pulse onClick={createDigestDemoWorkflow} loading={isCreating}>
         <ButtonText>Try the Digest Playground</ButtonText>
-      </NavButton>
-    </>
+      </StyledButton>
+    </ButtonsHolder>
   );
 }
+
+const DigestDemoFlowStyled = styled(DigestDemoFlow)`
+  height: 400px;
+`;
+
+const ButtonsHolder = styled.div`
+  display: flex;
+  gap: 40px;
+`;
 
 const DemoContainer = styled.div`
   width: 400px;

--- a/apps/web/src/pages/quick-start/steps/GetStarted.tsx
+++ b/apps/web/src/pages/quick-start/steps/GetStarted.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import styled from '@emotion/styled';
 
 import { useSegment } from '../../../components/providers/SegmentProvider';
 import { GetStartedLayout } from '../components/layout/GetStartedLayout';
@@ -9,6 +10,19 @@ import { ChannelsConfiguration } from '../components/ChannelsConfiguration';
 import { HeaderSecondaryTitle } from '../components/layout/HeaderLayout';
 import { IntegrationsStoreModal } from '../../integrations/IntegrationsStoreModal';
 import { ChannelTypeEnum } from '@novu/shared';
+
+const ChannelsConfigurationHolder = styled.div`
+  display: flex;
+  margin-left: 20px;
+
+  @media screen and (min-width: 1369px) {
+    margin-left: 40px;
+  }
+
+  @media screen and (min-width: 1921px) {
+    margin-left: 8vw;
+  }
+`;
 
 export function GetStarted() {
   const segment = useSegment();
@@ -28,13 +42,13 @@ export function GetStarted() {
         leftSide: <LearnMoreRef />,
         rightSide: (
           <NavButton navigateTo={getStartedSteps.second} variant={'gradient'}>
-            <div style={{ fontSize: '16px' }}>Next Page</div>
+            <div style={{ fontSize: '16px' }}>Next</div>
             <ArrowRight style={{ marginLeft: '10px' }} />
           </NavButton>
         ),
       }}
     >
-      <div style={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
+      <ChannelsConfigurationHolder>
         <IntegrationsStoreModal
           openIntegration={clickedChannel.open}
           closeIntegration={() => {
@@ -42,7 +56,7 @@ export function GetStarted() {
           }}
         />
         <ChannelsConfiguration setClickedChannel={setClickedChannel} />
-      </div>
+      </ChannelsConfigurationHolder>
     </GetStartedLayout>
   );
 }

--- a/apps/web/src/pages/templates/TemplatesListNoData.tsx
+++ b/apps/web/src/pages/templates/TemplatesListNoData.tsx
@@ -59,7 +59,7 @@ export const TemplatesListNoData = ({
               navIcon: DigestGradientIcon,
               description: (
                 <Text size="lg" weight="bold">
-                  Try Digest Playground
+                  Try the Digest Playground
                 </Text>
               ),
               onClick: onTryDigestClick,

--- a/apps/web/src/pages/templates/components/notification-setting-form/NotificationSettingsForm.tsx
+++ b/apps/web/src/pages/templates/components/notification-setting-form/NotificationSettingsForm.tsx
@@ -90,6 +90,7 @@ export const NotificationSettingsForm = ({
                 label="Notification Name"
                 description="This will be used to identify the notification in the dashboard."
                 placeholder="Notification name goes here..."
+                autoFocus
               />
             )}
           />


### PR DESCRIPTION
### What change does this PR introduce?

Getting Started page:
- dots navigation
- footer buttons logic - create the workflow and try digest playground
- show the getting started in the nav bar always
- fixed responsiveness 

### Why was this change needed?


### Other information (Screenshots)
![Screenshot 2023-03-17 at 14 12 20](https://user-images.githubusercontent.com/2607232/225916402-aab9b65f-6207-4cb6-8107-54f060d018f9.png)
![Screenshot 2023-03-17 at 14 12 28](https://user-images.githubusercontent.com/2607232/225916432-8787b058-9990-4106-9fe5-a1092f7f4949.png)
![Screenshot 2023-03-17 at 14 12 48](https://user-images.githubusercontent.com/2607232/225916448-3788038f-b4bb-4173-a3c5-62e50b49dd4b.png)

![Screenshot 2023-03-17 at 14 12 59](https://user-images.githubusercontent.com/2607232/225916459-2ef50971-a1bd-4143-a605-f256b2216ad9.png)

https://user-images.githubusercontent.com/2607232/225916474-44f52190-c191-44ee-8be9-27f26c57dc35.mov

