### PR TITLE
feat: remove onboarding history management

### DIFF
--- a/apps/web/src/components/layout/components/SideNav.tsx
+++ b/apps/web/src/components/layout/components/SideNav.tsx
@@ -20,8 +20,8 @@ import OrganizationSelect from './OrganizationSelect';
 import { useSpotlightContext } from '../../providers/SpotlightProvider';
 import { HEADER_HEIGHT } from '../constants';
 import { LimitBar } from '../../../pages/integrations/components/LimitBar';
-import { localNavigate } from '../../../pages/quick-start/components/route/store';
 import { ROUTES } from '../../../constants/routes.enum';
+import { currentOnboardingStep } from '../../../pages/quick-start/components/route/store';
 
 const usePopoverStyles = createStyles(({ colorScheme }) => ({
   dropdown: {
@@ -72,13 +72,14 @@ export function SideNav({}: Props) {
     ]);
   }, [environment]);
 
-  const lastRoute = localNavigate().peek();
+  const lastStep = currentOnboardingStep().get();
+  const getStartedRoute = lastStep === ROUTES.GET_STARTED_PREVIEW ? ROUTES.GET_STARTED : lastStep;
 
   const menuItems = [
     {
       condition: !readonly,
       icon: <CheckCircleOutlined />,
-      link: lastRoute ?? ROUTES.GET_STARTED,
+      link: getStartedRoute ?? ROUTES.GET_STARTED,
       label: 'Get Started',
       testId: 'side-nav-quickstart-link',
     },

--- a/apps/web/src/constants/routes.enum.ts
+++ b/apps/web/src/constants/routes.enum.ts
@@ -19,7 +19,7 @@ export enum ROUTES {
   QUICK_START_NOTIFICATION_CENTER = '/quickstart/notification-center',
   QUICK_START_SETUP = '/quickstart/notification-center/set-up',
   QUICK_START_SETUP_FRAMEWORK = '/quickstart/notification-center/set-up/:framework',
-  QUICK_START_SETUP_TRIGGER = '/quickstart/notification-center/trigger',
+  QUICK_START_SETUP_TRIGGER = '/quickstart/notification-center/set-up/:framework/trigger',
   ACTIVITIES = '/activities',
   SETTINGS = '/settings',
   INTEGRATIONS = '/integrations',

--- a/apps/web/src/pages/quick-start/components/NavButton.tsx
+++ b/apps/web/src/pages/quick-start/components/NavButton.tsx
@@ -4,7 +4,7 @@ import { Center } from '@mantine/core';
 import styled from '@emotion/styled';
 
 import { Button } from '../../../design-system';
-import { localNavigate } from './route/store';
+import { currentOnboardingStep } from './route/store';
 
 export function NavButton({
   pulse = false,
@@ -27,7 +27,7 @@ export function NavButton({
       handleOnClick();
     }
 
-    localNavigate().push(navigateTo);
+    currentOnboardingStep().set(navigateTo);
 
     if (navigateTo) {
       navigate(navigateTo);

--- a/apps/web/src/pages/quick-start/components/QuickStartWrapper.tsx
+++ b/apps/web/src/pages/quick-start/components/QuickStartWrapper.tsx
@@ -3,24 +3,27 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Center, Stack } from '@mantine/core';
 import styled from '@emotion/styled';
 
-import { localNavigate } from './route/store';
 import PageContainer from '../../../components/layout/components/PageContainer';
 import { ArrowButton } from '../../../design-system';
 import { When } from '../../../components/utils/When';
 import { colors } from '../../../design-system';
 import { faqUrl, OnBoardingAnalyticsEnum } from '../consts';
 import { useSegment } from '../../../components/providers/SegmentProvider';
+import { currentOnboardingStep } from './route/store';
+import { ROUTES } from '../../../constants/routes.enum';
 
 export function QuickStartWrapper({
   title,
   secondaryTitle,
   description,
+  goBackPath,
   faq = false,
   children,
 }: {
   title?: React.ReactNode | string;
   secondaryTitle?: React.ReactNode | string;
   description?: React.ReactNode | string;
+  goBackPath: string;
   faq?: boolean;
   children: React.ReactNode;
 }) {
@@ -35,24 +38,29 @@ export function QuickStartWrapper({
   const onlySecondary = !!secondaryTitle && !title && !description;
 
   useEffect(() => {
-    localNavigate().push(location.pathname);
+    onRouteChangeUpdateNavigationStore();
   }, [location.pathname]);
 
-  useEffect(() => {
-    localNavigate().normalizeOldOnboarding();
+  function onRouteChangeUpdateNavigationStore() {
+    currentOnboardingStep().set(location.pathname);
+  }
 
-    const lastRoute = localNavigate().peek();
-    if (lastRoute) {
-      navigate(lastRoute);
-    }
+  useEffect(() => {
+    onStepMountNavigateToCurrentStep();
   }, []);
 
-  function goBackHandler() {
-    const route = localNavigate().pop()?.at(-1);
+  function onStepMountNavigateToCurrentStep() {
+    const route = currentOnboardingStep().get();
 
     if (route) {
       navigate(route);
+    } else {
+      navigate(ROUTES.GET_STARTED);
     }
+  }
+
+  function goBackHandler() {
+    navigate(goBackPath);
   }
 
   return (

--- a/apps/web/src/pages/quick-start/components/layout/BodyLayout.tsx
+++ b/apps/web/src/pages/quick-start/components/layout/BodyLayout.tsx
@@ -4,9 +4,9 @@ import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
 import { colors } from '../../../../design-system';
-import { localNavigate } from '../route/store';
 import { getStartedSteps, OnBoardingAnalyticsEnum } from '../../consts';
 import { useSegment } from '../../../../components/providers/SegmentProvider';
+import { ROUTES } from '../../../../constants/routes.enum';
 
 export function BodyLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -30,7 +30,7 @@ function BodyNavigation() {
   const navigate = useNavigate();
   const segment = useSegment();
 
-  const stepNum = localNavigate().length();
+  const stepNum = location.pathname === ROUTES.GET_STARTED ? 1 : 2;
 
   function handleClick(step: 'first' | 'second') {
     const eventAction =

--- a/apps/web/src/pages/quick-start/components/layout/GetStartedLayout.tsx
+++ b/apps/web/src/pages/quick-start/components/layout/GetStartedLayout.tsx
@@ -6,7 +6,8 @@ import PageContainer from '../../../../components/layout/components/PageContaine
 import { HeaderLayout } from './HeaderLayout';
 import { BodyLayout } from './BodyLayout';
 import { FooterLayout } from './FooterLayout';
-import { localNavigate } from '../route/store';
+import { currentOnboardingStep } from '../route/store';
+import { ROUTES } from '../../../../constants/routes.enum';
 
 interface IGetStartedLayoutProps {
   children?: React.ReactNode;
@@ -30,14 +31,17 @@ export function GetStartedLayout({ children, footer, header }: IGetStartedLayout
   }, []);
 
   function onStepMountNavigateToCurrentStep() {
-    const lastRoute = localNavigate().peek();
-    if (lastRoute) {
-      navigate(lastRoute);
+    const route = currentOnboardingStep().get();
+
+    if (route) {
+      navigate(route);
+    } else {
+      navigate(ROUTES.GET_STARTED);
     }
   }
 
   function onRouteChangeUpdateNavigationStore() {
-    localNavigate().push(location.pathname);
+    currentOnboardingStep().set(location.pathname);
   }
 
   return (

--- a/apps/web/src/pages/quick-start/components/route/store.ts
+++ b/apps/web/src/pages/quick-start/components/route/store.ts
@@ -1,85 +1,17 @@
 import { ROUTES } from '../../../../constants/routes.enum';
 
-export function localNavigate() {
-  const localStorageRouteStack = 'localStorageRouteStack';
+export function currentOnboardingStep() {
+  const LOCAL_STORAGE_STEP = 'onboarding-step';
 
-  function localSet(stack: string[]) {
-    localStorage.setItem(localStorageRouteStack, JSON.stringify(stack));
-  }
-
-  function localGet(): string[] | null {
-    const res = localStorage.getItem(localStorageRouteStack);
-
-    return res ? JSON.parse(res) : null;
-  }
-
-  function push(location: string) {
-    const isGetStartedFlow = location?.includes(ROUTES.GET_STARTED) || location?.includes(ROUTES.QUICKSTART);
-
-    if (!location || !isGetStartedFlow) return;
-
-    const routeStack = localGet();
-
-    if (!routeStack) {
-      localSet([location]);
-
-      return;
-    }
-
-    const index = routeStack.indexOf(location);
-    const locationExistInStack = index !== -1;
-
-    if (!locationExistInStack) {
-      routeStack.push(location);
-      localSet(routeStack);
-
-      return;
-    }
-    normalizeRouteStack(routeStack, index);
-  }
-
-  function pop(): string[] | undefined {
-    const stack = localGet();
-
-    if (!stack || stack.length <= 1) return undefined;
-
-    stack.pop();
-    localSet(stack);
-
-    return stack;
-  }
-
-  function peek(): string | undefined {
-    const stack = localGet();
-
-    if (!stack) return undefined;
-
-    return stack.at(-1);
-  }
-
-  function length() {
-    return localGet()?.length ?? 0;
-  }
-
-  function normalizeRouteStack(routeStack: string[], index: number) {
-    if (routeStack.length === index + 1) return;
-
-    const res = routeStack.slice(0, index + 1);
-
-    localSet(res);
-  }
-
-  function normalizeOldOnboarding() {
-    const stack = localGet();
-
-    if (!stack) return;
-
-    const oldOnboarding = stack[0]?.startsWith(ROUTES.QUICKSTART);
-
-    if (oldOnboarding) {
-      localSet([ROUTES.GET_STARTED]);
+  function localSet(path: string) {
+    if (path.startsWith(ROUTES.GET_STARTED) || path.startsWith(ROUTES.QUICKSTART)) {
+      localStorage.setItem(LOCAL_STORAGE_STEP, path);
     }
   }
 
-  return { push, pop, peek, length, normalizeOldOnboarding };
+  function localGet(): string | null {
+    return localStorage.getItem(LOCAL_STORAGE_STEP);
+  }
+
+  return { get: localGet, set: localSet };
 }

--- a/apps/web/src/pages/quick-start/steps/FrameworkSetup.tsx
+++ b/apps/web/src/pages/quick-start/steps/FrameworkSetup.tsx
@@ -5,6 +5,7 @@ import { QuickStartWrapper } from '../components/QuickStartWrapper';
 import { OnBoardingAnalyticsEnum, welcomeDescription } from '../consts';
 import { Cards } from '../../../design-system';
 import { useSegment } from '../../../components/providers/SegmentProvider';
+import { ROUTES } from '../../../constants/routes.enum';
 
 export function FrameworkSetup() {
   const segment = useSegment();
@@ -14,7 +15,12 @@ export function FrameworkSetup() {
   }, []);
 
   return (
-    <QuickStartWrapper title={welcomeDescription} secondaryTitle={<ImplementationDescription />} faq={true}>
+    <QuickStartWrapper
+      title={welcomeDescription}
+      secondaryTitle={<ImplementationDescription />}
+      faq={true}
+      goBackPath={ROUTES.QUICK_START_NOTIFICATION_CENTER}
+    >
       <Cards
         cells={[
           {

--- a/apps/web/src/pages/quick-start/steps/NotificationCenter.tsx
+++ b/apps/web/src/pages/quick-start/steps/NotificationCenter.tsx
@@ -5,6 +5,7 @@ import { QuickStartWrapper } from '../components/QuickStartWrapper';
 import { Cards } from '../../../design-system';
 import { useSegment } from '../../../components/providers/SegmentProvider';
 import { FlowTypeEnum, OnBoardingAnalyticsEnum } from '../consts';
+import { ROUTES } from '../../../constants/routes.enum';
 
 export function NotificationCenter() {
   const segment = useSegment();
@@ -14,7 +15,7 @@ export function NotificationCenter() {
   }, []);
 
   return (
-    <QuickStartWrapper secondaryTitle={'How would you like to start?'}>
+    <QuickStartWrapper secondaryTitle={'How would you like to start?'} goBackPath={ROUTES.GET_STARTED}>
       <Cards
         cells={[
           {

--- a/apps/web/src/pages/quick-start/steps/Setup.tsx
+++ b/apps/web/src/pages/quick-start/steps/Setup.tsx
@@ -26,16 +26,16 @@ import { getInAppActivated } from '../../../api/integration';
 import { useSegment } from '../../../components/providers/SegmentProvider';
 import { getApiKeys } from '../../../api/environment';
 import { API_ROOT, WS_URL } from '../../../config';
+import { ROUTES } from '../../../constants/routes.enum';
 
 export function Setup() {
+  const segment = useSegment();
   const { framework } = useParams();
   const { groups, loading: notificationGroupLoading } = useNotificationGroup();
   const { templates = [], loading: templatesLoading } = useTemplates();
   const { environment } = useEnvController();
   const { data: apiKeys } = useQuery<{ key: string }[]>(['getApiKeys'], getApiKeys);
   const apiKey = apiKeys?.length ? apiKeys[0].key : '';
-
-  const segment = useSegment();
 
   const { data: inAppData } = useQuery<IGetInAppActivatedResponse>(['inAppActive'], async () => getInAppActivated(), {
     refetchInterval: (data) => stopIfInAppActive(data),
@@ -44,6 +44,7 @@ export function Setup() {
 
   const instructions = frameworkInstructions.find((instruction) => instruction.key === framework)?.value ?? [];
   const environmentIdentifier = environment?.identifier ? environment.identifier : '';
+  const goBackRoute = framework === 'demo' ? ROUTES.QUICK_START_NOTIFICATION_CENTER : ROUTES.QUICK_START_SETUP;
 
   const { mutateAsync: createNotificationTemplate, isLoading: createTemplateLoading } = useMutation<
     INotificationTemplate,
@@ -92,7 +93,7 @@ export function Setup() {
   }
 
   return (
-    <QuickStartWrapper secondaryTitle={<TroubleshootingDescription />} faq={true}>
+    <QuickStartWrapper secondaryTitle={<TroubleshootingDescription />} faq={true} goBackPath={goBackRoute}>
       <Stack align="center" sx={{ width: '100%' }}>
         <TimelineWrapper>
           <Timeline
@@ -127,7 +128,7 @@ export function Setup() {
               <LoaderWrapper>
                 <LoaderProceedTernary
                   appInitialized={inAppData.active}
-                  navigatePath={'/quickstart/notification-center/trigger'}
+                  navigatePath={`/quickstart/notification-center/set-up/${framework}/trigger`}
                 />
               </LoaderWrapper>
             </Timeline.Item>
@@ -135,7 +136,7 @@ export function Setup() {
         </TimelineWrapper>
 
         <When truthy={framework === 'demo'}>{<OpenBrowser />}</When>
-      </Stack>{' '}
+      </Stack>
     </QuickStartWrapper>
   );
 }

--- a/apps/web/src/pages/quick-start/steps/Trigger.tsx
+++ b/apps/web/src/pages/quick-start/steps/Trigger.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { QuickStartWrapper } from '../components/QuickStartWrapper';
 import { CheckCircleBroken } from '../../../design-system/icons/gradient/CheckCircleBroken';
@@ -6,9 +7,11 @@ import { TestNotificationTrigger } from '../components/TestNotificationTrigger';
 import { BellGradient } from '../../../design-system/icons';
 import { useSegment } from '../../../components/providers/SegmentProvider';
 import { OnBoardingAnalyticsEnum } from '../consts';
+import { ROUTES } from '../../../constants/routes.enum';
 
 export function Trigger() {
   const segment = useSegment();
+  const { framework } = useParams();
 
   useEffect(() => {
     segment.track(OnBoardingAnalyticsEnum.TRIGGER_VISIT);
@@ -20,6 +23,7 @@ export function Trigger() {
       secondaryTitle={'Amazing, nearly done!'}
       description={<TriggerDescription />}
       faq={true}
+      goBackPath={ROUTES.QUICK_START_SETUP_FRAMEWORK.replace(':framework', framework || '')}
     >
       <TestNotificationTrigger />
     </QuickStartWrapper>


### PR DESCRIPTION
### What change does this PR introduce?

Remove all the management of the steps history logic, switched it to the parent component to be responsible for the knowledge of what is the previous page, in addition, changed the route of '/quickstart/notification-center/trigger' to '/quickstart/notification-center/set-up/:framework/trigger' in order to have the indication from what page we got to the '.../trigger' route so we could manage the route back.

### Why was this change needed?

Due to the possibility of bugs (and maintaining overhead)


### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
