### PR TITLE
fix(integration): tlsOptions for nodemailer integration

### DIFF
--- a/apps/api/src/app/integrations/dtos/credentials.dto.ts
+++ b/apps/api/src/app/integrations/dtos/credentials.dto.ts
@@ -35,4 +35,10 @@ export class CredentialsDto {
   applicationId?: string;
   @ApiPropertyOptional()
   clientId?: string;
+  @ApiPropertyOptional()
+  requireTls?: boolean;
+  @ApiPropertyOptional()
+  ignoreTls?: boolean;
+  @ApiPropertyOptional()
+  tlsOptions?: Record<string, unknown>;
 }

--- a/apps/web/src/pages/integrations/IntegrationsStoreModal.tsx
+++ b/apps/web/src/pages/integrations/IntegrationsStoreModal.tsx
@@ -304,6 +304,9 @@ export interface ICredentials {
   clientId?: string;
   projectName?: string;
   serviceAccount?: string;
+  requireTls?: boolean;
+  ignoreTls?: boolean;
+  tlsOptions?: Record<string, unknown>;
 }
 
 export interface IntegrationEntity {

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -37,6 +37,9 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       clientId: Schema.Types.String,
       projectName: Schema.Types.String,
       serviceAccount: Schema.Types.String,
+      requireTls: Schema.Types.String,
+      ignoreTls: Schema.Types.String,
+      tlsOptions: Schema.Types.String,
     },
 
     active: {


### PR DESCRIPTION
### What change does this PR introduce?
-  added `requireTls` , `ignoreTls` and `tlsOptions`  in the Intergration Db model and credentialsDto for create integration api.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
- Fixes #3010 : While saving the configuration for custom SMTP integration  the following fields `requireTls` , `ignoreTls` and `tlsOptions` aren't saved in the Db. Hence unable test out the custom smtp with tls configurations.
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
