### PR TITLE
change method from remove to delete

### DIFF
--- a/docs/docs/platform/subscribers.md
+++ b/docs/docs/platform/subscribers.md
@@ -79,7 +79,7 @@ import { Novu } from '@novu/node';
 
 const novu = new Novu(process.env.NOVU_API_KEY);
 
-await novu.subscribers.remove(user.id);
+await novu.subscribers.delete(user.id);
 ```
 
 ## Subscriber Preferences


### PR DESCRIPTION
according to doc i was trying to delete user using "novu.subscribers.remove" but getting error that remove is not a function. so i have checked @novu/node repo and the function name was "delete" instead of "remove"

