### PR TITLE
feat(notification-center-vue): use the novu forked floating-vue library

### DIFF
--- a/packages/notification-center-vue/package.json
+++ b/packages/notification-center-vue/package.json
@@ -20,8 +20,8 @@
   ],
   "dependencies": {
     "@emotion/css": "^11.10.5",
+    "@novu/floating-vue": "^2.0.3",
     "@novu/notification-center": "^0.12.0",
-    "floating-vue": "https://github.com/LetItRock/floating-vue/raw/main/packages/floating-vue/floating-vue-2.0.0-beta.21.tgz",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/packages/notification-center-vue/src/index.ts
+++ b/packages/notification-center-vue/src/index.ts
@@ -1,6 +1,6 @@
 import type { App } from 'vue';
-import FloatingVue from 'floating-vue';
-import 'floating-vue/dist/style.css';
+import FloatingVue from '@novu/floating-vue';
+import '@novu/floating-vue/dist/style.css';
 import { NotificationCenterContentWebComponent } from '@novu/notification-center';
 
 import { NotificationCenterComponent } from './lib';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,7 +449,7 @@ importers:
       cross-env: 7.0.3
       nodemon: 2.0.15
       prettier: 2.8.4
-      ts-jest: 27.1.4_cnngzrja2umb46xxazlucyx2qu
+      ts-jest: 27.1.4_dwaltnofjt727p7olboxmdxrie
       ts-loader: 9.4.2_hhrrucqyg4eysmfpujvov2ym5u
       ts-node: 10.9.1_shievopl57bw2yyflx5da526ye
       tsconfig-paths: 3.14.1
@@ -1891,6 +1891,7 @@ importers:
   packages/notification-center-vue:
     specifiers:
       '@emotion/css': ^11.10.5
+      '@novu/floating-vue': ^2.0.3
       '@novu/notification-center': ^0.12.0
       '@rushstack/eslint-patch': ^1.1.4
       '@types/node': ^18.11.12
@@ -1901,7 +1902,6 @@ importers:
       '@vue/tsconfig': ^0.1.3
       eslint: ^8.22.0
       eslint-plugin-vue: ^9.3.0
-      floating-vue: https://github.com/LetItRock/floating-vue/raw/main/packages/floating-vue/floating-vue-2.0.0-beta.21.tgz
       npm-run-all: ^4.1.5
       prettier: ~2.8.0
       react: ^17.0.1
@@ -1912,8 +1912,8 @@ importers:
       vue-tsc: ^1.2.0
     dependencies:
       '@emotion/css': 11.10.5_@babel+core@7.20.12
+      '@novu/floating-vue': 2.0.3_vue@3.2.45
       '@novu/notification-center': link:../notification-center
-      floating-vue: '@github.com/LetItRock/floating-vue/raw/main/packages/floating-vue/floating-vue-2.0.0-beta.21.tgz_vue@3.2.45'
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -20691,6 +20691,16 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
 
+  /@novu/floating-vue/2.0.3_vue@3.2.45:
+    resolution: {integrity: sha512-ypymfdAx55M30bd6IluQujtxTlZwJk9ZeTzptj5UFixMjE4MqgTmBe4wQ1+tHcwUSFY3R+CoVR+RpOLO3XODqg==}
+    peerDependencies:
+      vue: ^3.2.0
+    dependencies:
+      '@floating-ui/dom': 0.1.10
+      vue: 3.2.45
+      vue-resize: 2.0.0-alpha.1_vue@3.2.45
+    dev: false
+
   /@novu/stateless/0.7.2:
     resolution: {integrity: sha512-hZPVjtdckROXF4WpcpUJGigA+7Nfz1mM5dIHwuDfh6MZ6cRGOgjQVq2TKhiOjHcu2umcKORem4cuyz47KoSA5w==}
     engines: {node: '>=10'}
@@ -27043,7 +27053,7 @@ packages:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.4_pvgfg2i233iclh4uhrrgev3t5a
       '@storybook/node-logger': 6.4.19
       '@storybook/react': 6.4.21_qpmapylff2xgpc65qzzxq2uhoq
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.cd77847.0_63xtaxbd5aftweb5kajvrft2fm
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.630821.0_63xtaxbd5aftweb5kajvrft2fm
       '@types/babel__core': 7.1.19
       babel-plugin-react-docgen: 4.2.1
       pnp-webpack-plugin: 1.7.0_typescript@4.9.5
@@ -27130,8 +27140,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@storybook/react-docgen-typescript-plugin/1.0.6--canary.9.cd77847.0_63xtaxbd5aftweb5kajvrft2fm:
-    resolution: {integrity: sha512-I4oBYmnUCX5IsrZhg+ST72dubSIV4wdwY+SfqJiJ3NHvDpdb240ZjdHAmjIy/yJh5rh42Fl4jbG8Tr4SzwV53Q==}
+  /@storybook/react-docgen-typescript-plugin/1.0.6--canary.9.630821.0_63xtaxbd5aftweb5kajvrft2fm:
+    resolution: {integrity: sha512-adrUdN/hb/bzRBmSJtHBEwoPpZzmMbr9WIEp83As69j0hkSa2Rp/Fvp+f97A2FyEx0+skiSX8ENLnwuup+5yuA==}
     peerDependencies:
       typescript: '>= 4.x'
       webpack: '>= 4'
@@ -36286,7 +36296,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.12
-      '@types/node': 14.18.12
+      '@types/node': 18.11.13
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -55443,7 +55453,7 @@ packages:
       tslib: 1.14.1
     dev: true
 
-  /ts-jest/27.1.4_cnngzrja2umb46xxazlucyx2qu:
+  /ts-jest/27.1.4_dwaltnofjt727p7olboxmdxrie:
     resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -55464,6 +55474,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
+      '@babel/core': 7.20.12
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1_ts-node@10.9.1
@@ -58366,19 +58377,6 @@ packages:
 
   /zxcvbn/4.4.2:
     resolution: {integrity: sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==}
-    dev: false
-
-  '@github.com/LetItRock/floating-vue/raw/main/packages/floating-vue/floating-vue-2.0.0-beta.21.tgz_vue@3.2.45':
-    resolution: {tarball: https://github.com/LetItRock/floating-vue/raw/main/packages/floating-vue/floating-vue-2.0.0-beta.21.tgz}
-    id: '@github.com/LetItRock/floating-vue/raw/main/packages/floating-vue/floating-vue-2.0.0-beta.21.tgz'
-    name: floating-vue
-    version: 2.0.0-beta.21
-    peerDependencies:
-      vue: ^3.2.0
-    dependencies:
-      '@floating-ui/dom': 0.1.10
-      vue: 3.2.45
-      vue-resize: 2.0.0-alpha.1_vue@3.2.45
     dev: false
 
   '@github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz':


### PR DESCRIPTION
### What change does this PR introduce?

The `notification-center-vue` package has a dependency on the forked `floating-vue` library, which has an important fix applied. The original library is not maintained. 

The quick fix for use before was to as the link to a GH resource (tarball) in the dependencies list. But, this solution is not working well everywhere, for ex. some Indian ISPs are blocking downloads from the GH, resulting in the failed installation of the `notification-center-vue` package.

Now, we've forked the `floating-vue` library under the Novu org and released it on the NPM, so we can now install it normally through the NPM registry. And this PR is using that NPM package.

### Why was this change needed?

Context: https://discord.com/channels/895029566685462578/1083589887804067880

### Other information (Screenshots)

![Screenshot 2023-03-20 at 17 58 51](https://user-images.githubusercontent.com/2607232/226416608-8bdc7b56-a787-492e-9b06-25f33c70266f.png)

https://user-images.githubusercontent.com/2607232/226416626-3a982f40-f703-43ed-89c2-8da398502e74.mov


