### PR TITLE
(docs/readme) removed broken jarvis link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ With Novu, you can create custom workflows and define conditions for each channe
   - [Chat](https://github.com/novuhq/novu#-chat)
   - [In-App](https://github.com/novuhq/novu#-in-app)
   - [Others](https://github.com/novuhq/novu#other-coming-soon)
-- [Jarvis](https://github.com/novuhq/novu#-meet-jarvis)
 - [Need Help?](https://github.com/novuhq/novu#-need-help)
 - [Links](https://github.com/novuhq/novu#-links)
 - [License](https://github.com/novuhq/novu#%EF%B8%8F-license)


### PR DESCRIPTION
Removed the broken Jarvis link from the README ToC.

(apologies the PR body doesn't use the PR template, GH Codespaces created the PR automatically)