### PR TITLE
fix(api): publishing measures had wrong method names, always the same

### DIFF
--- a/apps/api/src/app/events/services/performance-service/index.ts
+++ b/apps/api/src/app/events/services/performance-service/index.ts
@@ -51,7 +51,7 @@ export class EventsPerformanceService {
     });
 
     Object.keys(measures).forEach((key) => {
-      this.performanceService.calculateAverage(MarkFunctionNameEnum.ENDPOINT_TRIGGER_EVENT, measures[key]);
+      this.performanceService.calculateAverage(key, measures[key]);
     });
   }
 


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Prints the proper method name when calculating the averages for the marks we want to measure. So far was printing the same name. I introduced that bug.
Tested locally. Safe to merge. Tagging you to be aware.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Proper binding to the method name.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
