### PR TITLE
Fix type definition

### DIFF
--- a/packages/notification-center/src/hooks/useNotifications.ts
+++ b/packages/notification-center/src/hooks/useNotifications.ts
@@ -4,5 +4,5 @@ import { NotificationsContext } from '../store/notifications.context';
 import { INotificationsContext } from '../shared/interfaces';
 
 export function useNotifications() {
-  return useContext<INotificationsContext>(NotificationsContext);
+  return useContext<INotificationsContext | null>(NotificationsContext);
 }


### PR DESCRIPTION
### What change does this PR introduce?

Added proper types definition based on type used in `novu/packages/notification-center/src/store/notifications.context.ts`

### Why was this change needed?

The actual value returned by the hook is sometimes `null` ( probably on init ). Based on types it should not be `null`.

