### PR TITLE
fix: get latest version of actor details while retreiving messages/feed list

### DIFF
--- a/apps/api/src/app/events/usecases/send-message/send-message-in-app.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/send-message-in-app.usecase.ts
@@ -82,10 +82,6 @@ export class SendMessageInApp extends SendMessageBase {
 
     const { actor } = command.step.template;
 
-    if (actor && actor.type !== ActorTypeEnum.NONE) {
-      actor.data = await this.processAvatar(actor, command);
-    }
-
     const organization = await this.organizationRepository.findById(command.organizationId);
 
     try {
@@ -180,6 +176,7 @@ export class SendMessageInApp extends SendMessageBase {
         ...(actor &&
           actor.type !== ActorTypeEnum.NONE && {
             actor,
+            _actorId: command.job?._actorId,
           }),
       });
     }
@@ -307,22 +304,5 @@ export class SendMessageInApp extends SendMessageBase {
         },
       })
     );
-  }
-
-  private async processAvatar(actor: IActor, command: SendMessageCommand): Promise<string | null> {
-    const actorId = command.job?._actorId;
-    if (actor.type === ActorTypeEnum.USER && actorId) {
-      const actorSubscriber: SubscriberEntity | null = await this.subscriberRepository.findOne(
-        {
-          _environmentId: command.environmentId,
-          _id: actorId,
-        },
-        'avatar'
-      );
-
-      return actorSubscriber?.avatar || null;
-    }
-
-    return actor.data || null;
   }
 }

--- a/apps/api/src/app/messages/usecases/get-messages/get-messages.usecase.ts
+++ b/apps/api/src/app/messages/usecases/get-messages/get-messages.usecase.ts
@@ -54,7 +54,7 @@ export class GetMessages {
 
     for (const message of data) {
       if (message._actorId && message.actor?.type === ActorTypeEnum.USER) {
-        message.actor.data = await this.processAvatar(message._actorId, command.environmentId);
+        message.actor.data = this.processUserAvatar(message.actorSubscriber);
       }
     }
 
@@ -83,15 +83,7 @@ export class GetMessages {
     return await this.subscriberRepository.findBySubscriberId(_environmentId, subscriberId);
   }
 
-  private async processAvatar(actorId: string, environmentId: string): Promise<string | null> {
-    const actorSubscriber: SubscriberEntity | null = await this.subscriberRepository.findOne(
-      {
-        _environmentId: environmentId,
-        _id: actorId,
-      },
-      'avatar'
-    );
-
+  private processUserAvatar(actorSubscriber?: SubscriberEntity): string | null {
     return actorSubscriber?.avatar || null;
   }
 }

--- a/apps/api/src/app/messages/usecases/get-messages/get-messages.usecase.ts
+++ b/apps/api/src/app/messages/usecases/get-messages/get-messages.usecase.ts
@@ -47,7 +47,7 @@ export class GetMessages {
 
     const totalCount = await this.messageRepository.count(query);
 
-    const data = await this.messageRepository.find(query, '', {
+    const data = await this.messageRepository.getMessages(query, '', {
       limit: LIMIT,
       skip: command.page * LIMIT,
     });

--- a/apps/api/src/app/widgets/usecases/get-notifications-feed/get-notifications-feed.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/get-notifications-feed/get-notifications-feed.usecase.ts
@@ -65,7 +65,7 @@ export class GetNotificationsFeed {
 
     for (const message of feed) {
       if (message._actorId && message.actor?.type === ActorTypeEnum.USER) {
-        message.actor.data = await this.processAvatar(message._actorId, command.environmentId);
+        message.actor.data = this.processUserAvatar(message.actorSubscriber);
       }
     }
 
@@ -105,15 +105,7 @@ export class GetNotificationsFeed {
     return await this.subscriberRepository.findBySubscriberId(_environmentId, subscriberId);
   }
 
-  private async processAvatar(actorId: string, environmentId: string): Promise<string | null> {
-    const actorSubscriber: SubscriberEntity | null = await this.subscriberRepository.findOne(
-      {
-        _environmentId: environmentId,
-        _id: actorId,
-      },
-      'avatar'
-    );
-
+  private processUserAvatar(actorSubscriber?: SubscriberEntity): string | null {
     return actorSubscriber?.avatar || null;
   }
 }

--- a/libs/dal/src/repositories/message/message.entity.ts
+++ b/libs/dal/src/repositories/message/message.entity.ts
@@ -83,6 +83,8 @@ export class MessageEntity {
   identifier?: string;
 
   actor?: IActor;
+
+  _actorId?: string;
 }
 
 export type MessageDBModel = ChangePropsValueType<
@@ -95,6 +97,7 @@ export type MessageDBModel = ChangePropsValueType<
   | '_jobId'
   | '_subscriberId'
   | '_feedId'
+  | '_actorId'
 > & {
   createdAt?: Date;
 };

--- a/libs/dal/src/repositories/message/message.entity.ts
+++ b/libs/dal/src/repositories/message/message.entity.ts
@@ -27,6 +27,8 @@ export class MessageEntity {
 
   subscriber?: SubscriberEntity;
 
+  actorSubscriber?: SubscriberEntity;
+
   template?: NotificationTemplateEntity;
 
   templateIdentifier?: string;

--- a/libs/dal/src/repositories/message/message.schema.ts
+++ b/libs/dal/src/repositories/message/message.schema.ts
@@ -112,6 +112,11 @@ const messageSchema = new Schema<MessageDBModel>(
       },
       data: Schema.Types.Mixed,
     },
+    _actorId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Subscriber',
+      index: true,
+    },
   },
   { ...schemaOptions }
 );

--- a/libs/dal/src/repositories/message/message.schema.ts
+++ b/libs/dal/src/repositories/message/message.schema.ts
@@ -115,7 +115,6 @@ const messageSchema = new Schema<MessageDBModel>(
     _actorId: {
       type: Schema.Types.ObjectId,
       ref: 'Subscriber',
-      index: true,
     },
   },
   { ...schemaOptions }
@@ -131,6 +130,13 @@ messageSchema.virtual('subscriber', {
 messageSchema.virtual('template', {
   ref: 'NotificationTemplate',
   localField: '_templateId',
+  foreignField: '_id',
+  justOne: true,
+});
+
+messageSchema.virtual('actorSubscriber', {
+  ref: 'Subscriber',
+  localField: '_actorId',
   foreignField: '_id',
   justOne: true,
 });


### PR DESCRIPTION

### What change does this PR introduce?
- Serves the latest available avatar of the actor while fetching messages/feeds
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
- Previously, during the queue job processing the avatar was fetched and served to the notification list.
This caused a scenario where after updating the avatar, the notification list will still show the old avatar for older messages
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
