### PR TITLE
feat(api): create webhook filter backoff strategy use case

### DIFF
--- a/apps/api/src/app/events/dtos/event-job.dto.ts
+++ b/apps/api/src/app/events/dtos/event-job.dto.ts
@@ -1,0 +1,5 @@
+import { JobEntity } from '@novu/dal';
+
+export class EventJobDto {
+  data: JobEntity;
+}

--- a/apps/api/src/app/events/dtos/index.ts
+++ b/apps/api/src/app/events/dtos/index.ts
@@ -1,3 +1,4 @@
+export * from './event-job.dto';
 export * from './test-email-request.dto';
 export * from './trigger-event-response.dto';
 export * from './trigger-event-request.dto';

--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -38,7 +38,9 @@ import { v4 as uuid } from 'uuid';
 
 const axiosInstance = axios.create();
 
-describe('Trigger event - /v1/events/trigger (POST)', function () {
+const eventTriggerPath = '/v1/events/trigger';
+
+describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
   let session: UserSession;
   let template: NotificationTemplateEntity;
   let subscriber: SubscriberEntity;
@@ -68,7 +70,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
 
   it('should trigger an event successfully', async function () {
     const response = await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -101,7 +103,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       locale: 'en',
     };
     const { data: body } = await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: {
@@ -131,7 +133,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
   it('should override subscriber email based on event data', async function () {
     const subscriberId = SubscriberRepository.createObjectId();
     const { data: body } = await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: [
@@ -184,7 +186,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
 
   it('should generate message and notification based on event', async function () {
     const { data: body } = await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: {
@@ -264,7 +266,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     });
 
     const { data: body } = await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: [subscriber.subscriberId],
@@ -288,7 +290,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       channel: ChannelTypeEnum.SMS,
     });
 
-    expect(message.phone).to.equal(subscriber.phone);
+    expect(message?.phone).to.equal(subscriber.phone);
   });
 
   it('should trigger SMS notification for all subscribers', async function () {
@@ -303,7 +305,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     });
 
     const { data: body } = await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: [{ subscriberId: subscriber.subscriberId }, { subscriberId: subscriberId, phone: '+972541111111' }],
@@ -336,7 +338,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       channel: ChannelTypeEnum.SMS,
     });
 
-    expect(message2.phone).to.equal('+972541111111');
+    expect(message2?.phone).to.equal('+972541111111');
   });
 
   it('should trigger an sms error', async function () {
@@ -349,7 +351,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       ],
     });
     const { data: body } = await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -373,8 +375,8 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       _subscriberId: subscriber._id,
     });
 
-    expect(message.status).to.equal('error');
-    expect(message.errorText).to.contains('Currently 3rd-party packages test are not support on test env');
+    expect(message?.status).to.equal('error');
+    expect(message?.errorText).to.contains('Currently 3rd-party packages test are not support on test env');
   });
 
   it('should trigger In-App notification with subscriber data', async function () {
@@ -398,7 +400,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       channel: channelType,
     });
 
-    expect(message.content).to.equal('Hello Smith, Welcome to Umbrella Corp');
+    expect(message?.content).to.equal('Hello Smith, Welcome to Umbrella Corp');
   });
 
   it('should trigger SMS notification with subscriber data', async function () {
@@ -422,7 +424,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       channel: channelType,
     });
 
-    expect(message.content).to.equal('Hello Smith, Welcome to Umbrella Corp');
+    expect(message?.content).to.equal('Hello Smith, Welcome to Umbrella Corp');
   });
 
   it('should trigger E-Mail notification with subscriber data', async function () {
@@ -466,10 +468,10 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       channel: channelType,
     });
 
-    const block = message.content[0] as IEmailBlock;
+    const block = message?.content[0] as IEmailBlock;
 
     expect(block.content).to.equal('Hello Smith, Welcome to Umbrella Corp');
-    expect(message.subject).to.equal('Test email a subject nested');
+    expect(message?.subject).to.equal('Test email a subject nested');
   });
 
   it('should not trigger notification with subscriber data if integration is inactive', async function () {
@@ -483,7 +485,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     });
 
     await integrationRepository.update(
-      { _environmentId: session.environment._id, _id: integration._id },
+      { _environmentId: session.environment._id, _id: integration?._id },
       { active: false }
     );
 
@@ -581,7 +583,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       channel: channelType,
     });
 
-    expect(message.providerId).to.equal(EmailProviderIdEnum.Novu);
+    expect(message?.providerId).to.equal(EmailProviderIdEnum.Novu);
   });
 
   it('should trigger message with active integration', async function () {
@@ -674,7 +676,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     });
 
     let response = await session.testAgent
-      .post(`/v1/events/trigger`)
+      .post(eventTriggerPath)
       .send({
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -687,7 +689,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     );
 
     response = await session.testAgent
-      .post(`/v1/events/trigger`)
+      .post(eventTriggerPath)
       .send({
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -706,7 +708,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     );
 
     response = await session.testAgent
-      .post(`/v1/events/trigger`)
+      .post(eventTriggerPath)
       .send({
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -756,7 +758,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     });
 
     await session.testAgent
-      .post(`/v1/events/trigger`)
+      .post(eventTriggerPath)
       .send({
         name: template.triggers[0].identifier,
         to: newSubscriberIdInAppNotification,
@@ -779,14 +781,14 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       channel: channelType,
     });
 
-    const block = message.content[0] as IEmailBlock;
+    const block = message?.content[0] as IEmailBlock;
 
     expect(block.content).to.equal('Hello John Doe, Welcome to Umbrella Corp');
   });
 
   it('should throw an error when workflow identifier provided is not in the database', async () => {
     const response = await session.testAgent
-      .post(`/v1/events/trigger`)
+      .post(eventTriggerPath)
       .send({
         name: 'non-existent-template-identifier',
         to: subscriber.subscriberId,
@@ -813,7 +815,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     });
 
     const response = await session.testAgent
-      .post(`/v1/events/trigger`)
+      .post(eventTriggerPath)
       .send({
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -849,7 +851,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     });
 
     await session.testAgent
-      .post(`/v1/events/trigger`)
+      .post(eventTriggerPath)
       .send({
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -888,7 +890,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     });
 
     await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger/broadcast`,
+      `${session.serverUrl}${eventTriggerPath}/broadcast`,
       {
         name: template.triggers[0].identifier,
         payload: {
@@ -986,7 +988,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     });
 
     await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -1057,7 +1059,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     );
 
     await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -1087,7 +1089,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     );
 
     await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -1151,7 +1153,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
     const axiosPostStub = sinon.stub(axios, 'post').throws(new Error('Users remote error'));
 
     await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -1223,7 +1225,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       });
 
     await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -1261,7 +1263,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       );
 
     await axiosInstance.post(
-      `${session.serverUrl}/v1/events/trigger`,
+      `${session.serverUrl}${eventTriggerPath}`,
       {
         name: template.triggers[0].identifier,
         to: subscriber.subscriberId,
@@ -1326,7 +1328,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       });
 
       await axiosInstance.post(
-        `${session.serverUrl}/v1/events/trigger`,
+        `${session.serverUrl}${eventTriggerPath}`,
         {
           name: template.triggers[0].identifier,
           to: [subscriber.subscriberId],
@@ -1426,7 +1428,7 @@ describe('Trigger event - /v1/events/trigger (POST)', function () {
       });
 
       await axiosInstance.post(
-        `${session.serverUrl}/v1/events/trigger`,
+        `${session.serverUrl}${eventTriggerPath}`,
         {
           name: template.triggers[0].identifier,
           to: [subscriber.subscriberId],
@@ -1510,7 +1512,7 @@ export async function sendTrigger(
   payload: Record<string, unknown> = {}
 ) {
   await axiosInstance.post(
-    `${session.serverUrl}/v1/events/trigger`,
+    `${session.serverUrl}${eventTriggerPath}`,
     {
       name: template.triggers[0].identifier,
       to: [{ subscriberId: newSubscriberIdInAppNotification, lastName: 'Smith', email: 'test@email.novu' }],

--- a/apps/api/src/app/events/services/workflow-queue/workflow.queue.service.spec.ts
+++ b/apps/api/src/app/events/services/workflow-queue/workflow.queue.service.spec.ts
@@ -63,6 +63,7 @@ describe('Workflow Queue service', () => {
       'runJob',
       'setJobAsCompleted',
       'setJobAsFailed',
+      'webhookFilterWebhookFilterBackoffStrategy',
       'worker'
     );
     expect(workflowQueueService.DEFAULT_ATTEMPTS).to.eql(3);

--- a/apps/api/src/app/events/usecases/index.ts
+++ b/apps/api/src/app/events/usecases/index.ts
@@ -27,6 +27,7 @@ import { ParseEventRequest } from './parse-event-request';
 import { ProcessBulkTrigger } from './process-bulk-trigger';
 import { StoreSubscriberJobs } from './store-subscriber-jobs';
 import { SetJobAsCompleted, SetJobAsFailed, UpdateJobStatus } from './update-job-status';
+import { WebhookFilterBackoffStrategy } from './webhook-filter-backoff-strategy';
 
 export const USE_CASES = [
   MessageMatcher,
@@ -62,4 +63,5 @@ export const USE_CASES = [
   SetJobAsCompleted,
   SetJobAsFailed,
   UpdateJobStatus,
+  WebhookFilterBackoffStrategy,
 ];

--- a/apps/api/src/app/events/usecases/webhook-filter-backoff-strategy/index.ts
+++ b/apps/api/src/app/events/usecases/webhook-filter-backoff-strategy/index.ts
@@ -1,0 +1,2 @@
+export * from './webhook-filter-backoff-strategy.command';
+export * from './webhook-filter-backoff-strategy.usecase';

--- a/apps/api/src/app/events/usecases/webhook-filter-backoff-strategy/webhook-filter-backoff-strategy.command.ts
+++ b/apps/api/src/app/events/usecases/webhook-filter-backoff-strategy/webhook-filter-backoff-strategy.command.ts
@@ -1,0 +1,17 @@
+import { IsDefined, IsNumber, IsOptional } from 'class-validator';
+
+import { EventJobDto } from '../../dtos';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class WebhookFilterBackoffStrategyCommand extends EnvironmentWithUserCommand {
+  @IsDefined()
+  @IsNumber()
+  attemptsMade: number;
+
+  @IsOptional()
+  eventError: Error;
+
+  @IsDefined()
+  eventJob: EventJobDto;
+}

--- a/apps/api/src/app/events/usecases/webhook-filter-backoff-strategy/webhook-filter-backoff-strategy.usecase.ts
+++ b/apps/api/src/app/events/usecases/webhook-filter-backoff-strategy/webhook-filter-backoff-strategy.usecase.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
+
+import { WebhookFilterBackoffStrategyCommand } from './webhook-filter-backoff-strategy.command';
+
+import { DetailEnum } from '../../../execution-details/types';
+import {
+  CreateExecutionDetails,
+  CreateExecutionDetailsCommand,
+} from '../../../execution-details/usecases/create-execution-details';
+
+@Injectable()
+export class WebhookFilterBackoffStrategy {
+  constructor(private createExecutionDetails: CreateExecutionDetails) {}
+
+  public async execute(command: WebhookFilterBackoffStrategyCommand): Promise<number> {
+    const { attemptsMade, eventError: error, eventJob } = command;
+    const job = eventJob.data;
+
+    await this.createExecutionDetails.execute(
+      CreateExecutionDetailsCommand.create({
+        ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
+        detail: DetailEnum.WEBHOOK_FILTER_FAILED_RETRY,
+        source: ExecutionDetailsSourceEnum.WEBHOOK,
+        status: ExecutionDetailsStatusEnum.PENDING,
+        isTest: false,
+        isRetry: true,
+        raw: JSON.stringify({ message: JSON.parse(error?.message).message, attempt: attemptsMade }),
+      })
+    );
+
+    return Math.round(Math.random() * Math.pow(2, attemptsMade) * 1000);
+  }
+}


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Extracts from the WorkflowService the logic to calculate the backoff strategy and it also helps to move a step forward to remove the ExecutionDetails dependency from it.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Keep on the work to make WorkflowService driven by dependency injection so the use cases injected drive the behaviour of it in a more formal clean architecture.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
