### PR TITLE
fix: delay metadata should show if active index is zero

### DIFF
--- a/apps/web/src/pages/templates/workflow/SideBar/StepSettings.tsx
+++ b/apps/web/src/pages/templates/workflow/SideBar/StepSettings.tsx
@@ -158,7 +158,9 @@ export function StepSettings({
               </Text>
             </NavSection>
             <NavSection>
-              {activeStepIndex > 0 && <DelayMetadata control={control} index={activeStepIndex} />}
+              <When truthy={hasActiveStepSelected}>
+                <DelayMetadata control={control} index={activeStepIndex} />
+              </When>
             </NavSection>
           </When>
         </Stack>


### PR DESCRIPTION
### What change does this PR introduce?

Adding Delay Step after Trigger (delay has active index of 0) would not show the delay's settings in side menu
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
