### PR TITLE
Index Cleanup -  Execution Details

### DIFF
--- a/apps/api/src/app/events/usecases/message-matcher/message-matcher.usecase.ts
+++ b/apps/api/src/app/events/usecases/message-matcher/message-matcher.usecase.ts
@@ -25,13 +25,12 @@ import {
   ExecutionDetailsRepository,
   MessageRepository,
   JobRepository,
-  MessageEntity,
 } from '@novu/dal';
 
 import { IFilterVariables } from './types';
 import { FilterProcessingDetails } from './filter-processing-details';
 import { CreateExecutionDetails } from '../../../execution-details/usecases/create-execution-details';
-import { SendMessageCommand } from '../send-message/send-message.command';
+import { SendMessageCommand } from '../send-message';
 import { EXCEPTION_MESSAGE_ON_WEBHOOK_FILTER } from '../../../shared/constants';
 import { createHash } from '../../../shared/helpers/hmac.service';
 import { CreateExecutionDetailsCommand } from '../../../execution-details/usecases/create-execution-details';
@@ -278,7 +277,6 @@ export class MessageMatcher {
         _jobId: command.job._parentId,
         _messageId: message._id,
         _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
         webhookStatus: EmailEventStatusEnum.OPENED,
       });
 

--- a/apps/api/src/app/execution-details/usecases/get-execution-details/get-execution-details.usecase.ts
+++ b/apps/api/src/app/execution-details/usecases/get-execution-details/get-execution-details.usecase.ts
@@ -10,7 +10,6 @@ export class GetExecutionDetails {
     return this.executionDetailsRepository.find({
       _notificationId: command.notificationId,
       _environmentId: command.environmentId,
-      _organizationId: command.organizationId,
       _subscriberId: command.subscriberId,
     });
   }

--- a/libs/dal/src/repositories/execution-details/execution-details.repository.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.repository.ts
@@ -3,7 +3,7 @@ import { ExecutionDetailsStatusEnum } from '@novu/shared';
 import { ExecutionDetailsEntity, ExecutionDetailsDBModel } from './execution-details.entity';
 import { ExecutionDetails } from './execution-details.schema';
 import { BaseRepository } from '../base-repository';
-import type { EnforceEnvOrOrgIds } from '../../types/enforce';
+import { EnforceEnvId } from '../../types/enforce';
 
 /**
  * Execution details is meant to be read only almost exclusively as a log history of the Jobs executions.
@@ -11,7 +11,7 @@ import type { EnforceEnvOrOrgIds } from '../../types/enforce';
 export class ExecutionDetailsRepository extends BaseRepository<
   ExecutionDetailsDBModel,
   ExecutionDetailsEntity,
-  EnforceEnvOrOrgIds
+  EnforceEnvId
 > {
   constructor() {
     super(ExecutionDetails, ExecutionDetailsEntity);
@@ -40,7 +40,6 @@ export class ExecutionDetailsRepository extends BaseRepository<
    */
   public async findAllNotificationExecutions(organizationId: string, environmentId: string, notificationId: string) {
     return await this.find({
-      _organizationId: organizationId,
       _environmentId: environmentId,
       _notificationId: notificationId,
     });

--- a/libs/dal/src/repositories/execution-details/execution-details.schema.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.schema.ts
@@ -72,23 +72,39 @@ const executionDetailsSchema = new Schema<ExecutionDetailsDBModel>(
 
 /*
  * This index was initially created to optimize:
- * message matcher use case
+ *
+ * Path : libs/dal/src/repositories/job/job.schema.ts
+ *    Context : The _jobId is here because of JobSchema
+ *                                            ref: 'ExecutionDetails',
+ *                                            foreignField: '_jobId',
+ *
+ *
+ *  Path : apps/api/src/app/events/usecases/message-matcher/message-matcher.usecase.ts
+ *    Context : processPreviousStep
+ *    Query : count({
+ *      _jobId: command.job._parentId,
+ *      _messageId: message._id,
+ *      _environmentId: command.environmentId,
+ *      webhookStatus: EmailEventStatusEnum.OPENED,
+ *    });
  */
 executionDetailsSchema.index({
-  _messageId: 1,
   _jobId: 1,
-  _environmentId: 1,
-  webhookStatus: 1,
 });
 
 /*
  * This index was initially created to optimize:
- * get execution details use case
+ *
+ * Path : apps/api/src/app/execution-details/usecases/get-execution-details/get-execution-details.usecase.ts
+ *    Context : execute()
+ *        Query : find({
+ *         _notificationId: command.notificationId,
+ *         _environmentId: command.environmentId,
+ *         _subscriberId: command.subscriberId,
+ *      });
  */
 executionDetailsSchema.index({
   _notificationId: 1,
-  _environmentId: 1,
-  _subscriberId: 1,
 });
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/libs/dal/src/repositories/execution-details/execution-details.schema.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.schema.ts
@@ -70,10 +70,25 @@ const executionDetailsSchema = new Schema<ExecutionDetailsDBModel>(
   schemaOptions
 );
 
+/*
+ * This index was initially created to optimize:
+ * message matcher use case
+ */
 executionDetailsSchema.index({
   _messageId: 1,
   _jobId: 1,
   _environmentId: 1,
+  webhookStatus: 1,
+});
+
+/*
+ * This index was initially created to optimize:
+ * get execution details use case
+ */
+executionDetailsSchema.index({
+  _notificationId: 1,
+  _environmentId: 1,
+  _subscriberId: 1,
 });
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/libs/dal/src/repositories/execution-details/execution-details.schema.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.schema.ts
@@ -10,44 +10,35 @@ const executionDetailsSchema = new Schema<ExecutionDetailsDBModel>(
   {
     _jobId: {
       type: Schema.Types.String,
-      index: true,
     },
     _environmentId: {
       type: Schema.Types.ObjectId,
       ref: 'Environment',
-      index: true,
     },
     _organizationId: {
       type: Schema.Types.ObjectId,
       ref: 'Organization',
-      index: true,
     },
     _notificationId: {
       type: Schema.Types.ObjectId,
       ref: 'Notification',
-      index: true,
     },
     _notificationTemplateId: {
       type: Schema.Types.ObjectId,
       ref: 'NotificationTemplate',
-      index: false,
     },
     _subscriberId: {
       type: Schema.Types.ObjectId,
       ref: 'Subscriber',
-      index: false,
     },
     _messageId: {
       type: Schema.Types.String,
-      index: false,
     },
     providerId: {
       type: Schema.Types.String,
-      index: false,
     },
     transactionId: {
       type: Schema.Types.String,
-      index: false,
     },
     channel: {
       type: Schema.Types.String,
@@ -78,6 +69,12 @@ const executionDetailsSchema = new Schema<ExecutionDetailsDBModel>(
   },
   schemaOptions
 );
+
+executionDetailsSchema.index({
+  _messageId: 1,
+  _jobId: 1,
+  _environmentId: 1,
+});
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const ExecutionDetails =

--- a/libs/dal/src/types/enforce.ts
+++ b/libs/dal/src/types/enforce.ts
@@ -2,4 +2,5 @@ import type { EnvironmentId } from '../repositories/environment';
 import type { OrganizationId } from '../repositories/organization';
 
 export type EnforceOrgId = { _organizationId: OrganizationId };
-export type EnforceEnvOrOrgIds = { _environmentId: EnvironmentId } | EnforceOrgId;
+export type EnforceEnvId = { _environmentId: EnvironmentId };
+export type EnforceEnvOrOrgIds = EnforceEnvId | EnforceOrgId;


### PR DESCRIPTION
### What change does this PR introduce?

Why? (Context)

We want to remove as many inefficient indexs and queries as possible.

### Why was this change needed?

Stop using single indexes on the mongoose key implementation
Add compound indexes for common queries and patterns using MongoDB index best practices
Remove unused indexes from MongoDB atlas after implementing the new compound indexes

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
