### PR TITLE
feat(api): in-memory provider service

### DIFF
--- a/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
+++ b/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
@@ -9,12 +9,14 @@ import { UserSession, SubscribersService } from '@novu/testing';
 import { expect } from 'chai';
 import axios from 'axios';
 import { ChannelTypeEnum, ISubscribersDefine, StepTypeEnum } from '@novu/shared';
+
 import { UpdateSubscriberPreferenceRequestDto } from '../../widgets/dtos/update-subscriber-preference-request.dto';
 import { CacheService, InvalidateCacheService } from '../../shared/services/cache';
 import {
   buildNotificationTemplateIdentifierKey,
   buildNotificationTemplateKey,
 } from '../../shared/services/cache/key-builders/entities';
+import { InMemoryProviderService } from '../../shared/services/in-memory-provider';
 
 const axiosInstance = axios.create();
 
@@ -24,12 +26,8 @@ describe('Trigger event - process subscriber /v1/events/trigger (POST)', functio
   let subscriber: SubscriberEntity;
   let subscriberService: SubscribersService;
 
-  const invalidateCache = new InvalidateCacheService(
-    new CacheService({
-      host: process.env.REDIS_CACHE_SERVICE_HOST as string,
-      port: process.env.REDIS_CACHE_SERVICE_PORT as string,
-    })
-  );
+  const inMemoryProviderService = new InMemoryProviderService();
+  const invalidateCache = new InvalidateCacheService(new CacheService(inMemoryProviderService));
 
   const subscriberRepository = new SubscriberRepository();
   const messageRepository = new MessageRepository();

--- a/apps/api/src/app/events/services/workflow-queue/trigger-handler-queue.service.ts
+++ b/apps/api/src/app/events/services/workflow-queue/trigger-handler-queue.service.ts
@@ -2,10 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import { QueueBaseOptions } from 'bullmq';
 import { getRedisPrefix } from '@novu/shared';
 import { ConnectionOptions } from 'tls';
-import { PinoLogger, storage, Store } from '@novu/application-generic';
+import { BullmqService, PinoLogger, storage, Store } from '@novu/application-generic';
 
 import { TriggerEvent, TriggerEventCommand } from '../../usecases/trigger-event';
-import { BullmqService } from '@novu/application-generic';
 
 @Injectable()
 export class TriggerHandlerQueueService {

--- a/apps/api/src/app/shared/services/in-memory-provider/in-memory-provider.service.ts
+++ b/apps/api/src/app/shared/services/in-memory-provider/in-memory-provider.service.ts
@@ -1,0 +1,84 @@
+import { Logger } from '@nestjs/common';
+
+import { CLIENT_READY, getRedisInstance, getRedisProviderConfig, IRedisProviderConfig, Redis } from './redis-provider';
+
+import { ApiException } from '../../exceptions/api.exception';
+
+const LOG_CONTEXT = 'InMemoryCluster';
+
+export type InMemoryProviderClient = Redis | undefined;
+type InMemoryProviderConfig = IRedisProviderConfig;
+
+export class InMemoryProviderService {
+  public inMemoryProviderClient: InMemoryProviderClient;
+  public inMemoryProviderConfig: InMemoryProviderConfig;
+
+  constructor() {
+    if (!this.inMemoryProviderClient) {
+      this.inMemoryProviderClient = process.env.IN_MEMORY_CLUSTER_MODE_ENABLED
+        ? this.inMemoryClusterProviderSetup()
+        : this.inMemoryProviderSetup();
+    }
+  }
+
+  public isClientReady(): boolean {
+    if (!this.inMemoryProviderClient) {
+      return false;
+    }
+
+    return this.inMemoryProviderClient.status === CLIENT_READY;
+  }
+
+  private inMemoryClusterProviderSetup(): InMemoryProviderClient {
+    Logger.verbose('In-memory cluster service set up', LOG_CONTEXT);
+
+    return {} as InMemoryProviderClient;
+  }
+
+  private inMemoryProviderSetup(): InMemoryProviderClient {
+    Logger.verbose('In-memory service set up', LOG_CONTEXT);
+
+    this.inMemoryProviderConfig = getRedisProviderConfig();
+    const { host, port, ttl } = getRedisProviderConfig();
+
+    if (!host) {
+      Logger.log('Missing host for in-memory provider', LOG_CONTEXT);
+    }
+
+    if (host) {
+      Logger.log(`Connecting to ${host}:${port}`, LOG_CONTEXT);
+
+      const inMemoryProviderClient = getRedisInstance();
+
+      inMemoryProviderClient.on('connect', () => {
+        Logger.log('REDIS CONNECTED', LOG_CONTEXT);
+      });
+
+      inMemoryProviderClient.on('error', (error) => {
+        Logger.error(error, LOG_CONTEXT);
+      });
+
+      return inMemoryProviderClient;
+    }
+  }
+
+  public async shutdown(): Promise<void> {
+    if (this.inMemoryProviderClient) {
+      Logger.verbose('In-memory cluster service shutdown', LOG_CONTEXT);
+      await this.inMemoryProviderClient.quit();
+    }
+  }
+
+  /**
+   * This Nest.js hook allows us to execute logic on termination after signal.
+   * https://docs.nestjs.com/fundamentals/lifecycle-events#application-shutdown
+   *
+   * Enabled by:
+   *   app.enableShutdownHooks();
+   *
+   * in /apps/api/src/bootstrap.ts
+   */
+  public async onApplicationShutdown(signal): Promise<void> {
+    await this.shutdown();
+  }
+}

--- a/apps/api/src/app/shared/services/in-memory-provider/index.ts
+++ b/apps/api/src/app/shared/services/in-memory-provider/index.ts
@@ -1,0 +1,1 @@
+export * from './in-memory-provider.service';

--- a/apps/api/src/app/shared/services/in-memory-provider/redis-provider.ts
+++ b/apps/api/src/app/shared/services/in-memory-provider/redis-provider.ts
@@ -1,0 +1,76 @@
+import Redis from 'ioredis';
+import { ConnectionOptions } from 'tls';
+
+export { Redis };
+
+export const CLIENT_READY = 'ready';
+const DEFAULT_TTL_SECONDS = 60 * 60 * 2;
+const DEFAULT_CONNECT_TIMEOUT = 50000;
+const DEFAULT_KEEP_ALIVE = 30000;
+const DEFAULT_FAMILY = 4;
+const DEFAULT_KEY_PREFIX = '';
+const TTL_VARIANT_PERCENTAGE = 0.1;
+
+interface IRedisConfig {
+  connectTimeout?: string;
+  family?: string;
+  host: string;
+  keepAlive?: string;
+  keyPrefix?: string;
+  password?: string;
+  port?: string;
+  tls?: ConnectionOptions;
+  ttl?: string;
+}
+
+export interface IRedisProviderConfig {
+  connectTimeout: number;
+  family: number;
+  host: string;
+  keepAlive: number;
+  keyPrefix: string;
+  password?: string;
+  port: number;
+  tls?: ConnectionOptions;
+  ttl: number;
+}
+
+const redisConfig: IRedisConfig = {
+  host: process.env.REDIS_CACHE_SERVICE_HOST || 'localhost',
+  port: process.env.REDIS_CACHE_SERVICE_PORT || '6379',
+  ttl: process.env.REDIS_CACHE_TTL,
+  password: process.env.REDIS_CACHE_PASSWORD,
+  connectTimeout: process.env.REDIS_CACHE_CONNECTION_TIMEOUT,
+  keepAlive: process.env.REDIS_CACHE_KEEP_ALIVE,
+  family: process.env.REDIS_CACHE_FAMILY,
+  keyPrefix: process.env.REDIS_CACHE_KEY_PREFIX,
+  tls: process.env.REDIS_CACHE_SERVICE_TLS as ConnectionOptions,
+};
+
+export const getRedisProviderConfig = (): IRedisProviderConfig => {
+  const port = Number(redisConfig.port || 6379);
+  const host = redisConfig.host;
+  const password = redisConfig.password;
+  const connectTimeout = redisConfig.connectTimeout ? Number(redisConfig.connectTimeout) : DEFAULT_CONNECT_TIMEOUT;
+  const family = redisConfig.family ? Number(redisConfig.family) : DEFAULT_FAMILY;
+  const keepAlive = redisConfig.keepAlive ? Number(redisConfig.keepAlive) : DEFAULT_KEEP_ALIVE;
+  const keyPrefix = redisConfig.keyPrefix ?? DEFAULT_KEY_PREFIX;
+  const ttl = redisConfig.ttl ? Number(redisConfig.ttl) : DEFAULT_TTL_SECONDS;
+
+  return {
+    host,
+    port,
+    password,
+    connectTimeout,
+    family,
+    keepAlive,
+    keyPrefix,
+    ttl,
+  };
+};
+
+export const getRedisInstance = (): Redis => {
+  const { port, host, ...options } = getRedisProviderConfig();
+
+  return new Redis(port, host, options);
+};

--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -26,6 +26,7 @@ import { AnalyticsService, createNestLoggingModuleOptions, LoggerModule } from '
 import { ConnectionOptions } from 'tls';
 
 import { DistributedLockService } from './services/distributed-lock';
+import { InMemoryProviderService } from './services/in-memory-provider';
 import { PerformanceService } from './services/performance';
 import { QueueService } from './services/queue';
 import {
@@ -75,24 +76,24 @@ const dalService = new DalService();
 
 export const ANALYTICS_SERVICE = 'AnalyticsService';
 
+const inMemoryProviderService = {
+  provide: InMemoryProviderService,
+  useFactory: () => {
+    return new InMemoryProviderService();
+  },
+};
+
 const cacheService = {
   provide: CacheService,
-  useFactory: async () => {
-    return new CacheService({
-      host: process.env.REDIS_CACHE_SERVICE_HOST,
-      port: process.env.REDIS_CACHE_SERVICE_PORT || '6379',
-      ttl: process.env.REDIS_CACHE_TTL,
-      password: process.env.REDIS_CACHE_PASSWORD,
-      connectTimeout: process.env.REDIS_CACHE_CONNECTION_TIMEOUT,
-      keepAlive: process.env.REDIS_CACHE_KEEP_ALIVE,
-      family: process.env.REDIS_CACHE_FAMILY,
-      keyPrefix: process.env.REDIS_CACHE_KEY_PREFIX,
-      tls: process.env.REDIS_CACHE_SERVICE_TLS as ConnectionOptions,
-    });
+  useFactory: () => {
+    const factoryInMemoryProviderService = inMemoryProviderService.useFactory();
+
+    return new CacheService(factoryInMemoryProviderService);
   },
 };
 
 const PROVIDERS = [
+  inMemoryProviderService,
   {
     provide: DistributedLockService,
     useFactory: () => {

--- a/apps/api/src/app/widgets/e2e/get-unseen-count.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/get-unseen-count.e2e.ts
@@ -3,8 +3,10 @@ import { MessageRepository, NotificationTemplateEntity, SubscriberRepository } f
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import { ChannelTypeEnum } from '@novu/shared';
+
 import { CacheService, InvalidateCacheService } from '../../shared/services/cache';
 import { buildFeedKey, buildMessageCountKey } from '../../shared/services/cache/key-builders/queries';
+import { InMemoryProviderService } from '../../shared/services/in-memory-provider';
 
 describe('Unseen Count - GET /widget/notifications/unseen', function () {
   const messageRepository = new MessageRepository();
@@ -15,12 +17,9 @@ describe('Unseen Count - GET /widget/notifications/unseen', function () {
   let subscriberProfile: {
     _id: string;
   } | null = null;
-  const invalidateCache = new InvalidateCacheService(
-    new CacheService({
-      host: process.env.REDIS_CACHE_SERVICE_HOST as string,
-      port: process.env.REDIS_CACHE_SERVICE_PORT as string,
-    })
-  );
+
+  const inMemoryProviderService = new InMemoryProviderService();
+  const invalidateCache = new InvalidateCacheService(new CacheService(inMemoryProviderService));
 
   beforeEach(async () => {
     session = new UserSession();
@@ -57,7 +56,7 @@ describe('Unseen Count - GET /widget/notifications/unseen', function () {
 
     const messages = await messageRepository.findBySubscriberChannel(
       session.environment._id,
-      subscriberProfile._id,
+      subscriberProfile!._id,
       ChannelTypeEnum.IN_APP
     );
     const messageId = messages[0]._id;
@@ -120,7 +119,7 @@ describe('Unseen Count - GET /widget/notifications/unseen', function () {
 
     const messages = await messageRepository.findBySubscriberChannel(
       session.environment._id,
-      subscriberProfile._id,
+      subscriberProfile!._id,
       ChannelTypeEnum.IN_APP
     );
     const messageId = messages[0]._id;


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Created a new service that isolates the implementation of any in-memory provider (in this case `ioredis`) so we can easily swap the mode (from normal provider to cluster mode) or to even swap a provider as needed. It will also would allow us to have different providers available depending on environment.
So far we leave it connected only to the cache service.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
It is one of the first steps of the performance improvements by targeting to move cache service and distributed lock service to a Redis cluster setting.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
