### PR TITLE
feat(api): distributed lock service should reuse in memory provider svc

### DIFF
--- a/apps/api/src/app/events/services/distributed-lock-service/index.ts
+++ b/apps/api/src/app/events/services/distributed-lock-service/index.ts
@@ -1,10 +1,15 @@
 import { Injectable } from '@nestjs/common';
 
 import { DistributedLockService } from '../../../shared/services/distributed-lock';
+import { InMemoryProviderService } from '../../../shared/services/in-memory-provider';
 
 @Injectable()
 export class EventsDistributedLockService {
-  private readonly distributedLockService = new DistributedLockService();
+  private readonly distributedLockService;
+
+  constructor(private inMemoryProviderService: InMemoryProviderService) {
+    this.distributedLockService = new DistributedLockService(inMemoryProviderService);
+  }
 
   public async applyLock<T>(settings, handler: () => Promise<T>): Promise<T> {
     return await this.distributedLockService.applyLock(settings, handler);

--- a/apps/api/src/app/events/usecases/add-job/add-digest-job.usecase.ts
+++ b/apps/api/src/app/events/usecases/add-job/add-digest-job.usecase.ts
@@ -11,8 +11,9 @@ import {
   CreateExecutionDetailsCommand,
 } from '../../../execution-details/usecases/create-execution-details';
 import { DetailEnum } from '../../../execution-details/types';
-import { ApiException } from '../../../shared/exceptions/api.exception';
 import { EventsDistributedLockService } from '../../services/distributed-lock-service';
+import { ApiException } from '../../../shared/exceptions/api.exception';
+import { InMemoryProviderService } from '../../../shared/services/in-memory-provider';
 
 interface IFindAndUpdateResponse {
   matched: number;
@@ -23,11 +24,15 @@ type AddDigestJobResult = number | undefined;
 
 @Injectable()
 export class AddDigestJob {
+  private eventsDistributedLockService: EventsDistributedLockService;
+
   constructor(
-    private distributedLockService: EventsDistributedLockService,
+    private inMemoryProviderService: InMemoryProviderService,
     private jobRepository: JobRepository,
     protected createExecutionDetails: CreateExecutionDetails
-  ) {}
+  ) {
+    this.eventsDistributedLockService = new EventsDistributedLockService(inMemoryProviderService);
+  }
 
   public async execute(command: AddDigestJobCommand): Promise<AddDigestJobResult> {
     const { job } = command;
@@ -92,7 +97,7 @@ export class AddDigestJob {
     const shouldDelayDigestJobOrMerge = async () =>
       this.jobRepository.shouldDelayDigestJobOrMerge(job, digestKey, digestValue);
 
-    const result = await this.distributedLockService.applyLock<IFindAndUpdateResponse>(
+    const result = await this.eventsDistributedLockService.applyLock<IFindAndUpdateResponse>(
       {
         resource,
         ttl: TTL,

--- a/apps/api/src/app/shared/services/distributed-lock/distributed-lock.service.spec.ts
+++ b/apps/api/src/app/shared/services/distributed-lock/distributed-lock.service.spec.ts
@@ -5,17 +5,18 @@ import Redis from 'ioredis';
 import * as Redlock from 'redlock';
 import { setTimeout } from 'timers/promises';
 
+import { InMemoryProviderClient, InMemoryProviderService } from '../in-memory-provider';
 import { DistributedLockService } from './distributed-lock.service';
 
-const distributedLockService = new DistributedLockService();
-let redisClient: Redis;
+const originalRedisCacheServiceHost = process.env.REDIS_CACHE_SERVICE_HOST;
+const originalRedisCacheServicePort = process.env.REDIS_CACHE_SERVICE_PORT;
+
 let spyDecreaseLockCounter: SinonSpy;
 let spyIncreaseLockCounter: SinonSpy;
 let spyLock: SinonSpy;
 let spyUnlock: SinonSpy;
 
 beforeEach(() => {
-  redisClient = distributedLockService.instances[0];
   spyDecreaseLockCounter = sinon.spy(DistributedLockService.prototype, <any>'decreaseLockCounter');
   spyIncreaseLockCounter = sinon.spy(DistributedLockService.prototype, <any>'increaseLockCounter');
   spyLock = sinon.spy(Redlock.prototype, 'acquire');
@@ -30,184 +31,244 @@ afterEach(() => {
 });
 
 describe('Distributed Lock Service', () => {
-  describe('Set up', () => {
-    it('should have made a connection to the unique instance implemented', async () => {
-      expect(distributedLockService.distributedLock).to.be.ok;
-      expect(distributedLockService.instances.length).to.eql(1);
-      expect(await distributedLockService.instances[0].ping()).to.eql('PONG');
-      expect(distributedLockService.instances[0].options.host).to.eql(process.env.REDIS_HOST);
-      expect(distributedLockService.instances[0].options.port).to.eql(Number(process.env.REDIS_PORT));
+  describe('In-memory provider service set', () => {
+    let inMemoryProviderService: InMemoryProviderService;
+    let distributedLockService: DistributedLockService;
+    let client: InMemoryProviderClient;
+
+    beforeEach(() => {
+      inMemoryProviderService = new InMemoryProviderService();
+      distributedLockService = new DistributedLockService(inMemoryProviderService);
+      client = distributedLockService.instances[0];
     });
 
-    it('should have default settings', () => {
-      expect(distributedLockService.distributedLock.driftFactor).to.eql(0.01);
-      expect(distributedLockService.distributedLock.retryCount).to.eql(50);
-      expect(distributedLockService.distributedLock.retryDelay).to.eql(100);
-      expect(distributedLockService.distributedLock.retryJitter).to.eql(200);
-    });
-  });
+    describe('Set up', () => {
+      it('should have made a connection to the unique instance implemented', async () => {
+        expect(distributedLockService.distributedLock).to.be.ok;
+        expect(distributedLockService.instances.length).to.eql(1);
+        expect(await client!.ping()).to.eql('PONG');
+        expect(client!.status).to.eql('ready');
+        expect(client!.options.host).to.eql(process.env.REDIS_CACHE_SERVICE_HOST);
+        expect(client!.options.port).to.eql(Number(process.env.REDIS_CACHE_SERVICE_PORT));
+      });
 
-  describe('Shutdown side effects', () => {
-    it('should not allow the signal to shutdown if not all locks are released', () => {
-      const lockCounter = {
-        lock1: 2,
-        lock2: 0,
-        lock3: undefined,
-      };
-
-      distributedLockService.lockCounter = lockCounter;
-
-      const result = distributedLockService.areAllLocksReleased();
-      expect(result).to.eql(false);
+      it('should have default settings', () => {
+        expect(distributedLockService.distributedLock.driftFactor).to.eql(0.01);
+        expect(distributedLockService.distributedLock.retryCount).to.eql(50);
+        expect(distributedLockService.distributedLock.retryDelay).to.eql(100);
+        expect(distributedLockService.distributedLock.retryJitter).to.eql(200);
+      });
     });
 
-    it('should allow the signal to shutdown if  all locks are released', () => {
-      const lockCounter = {
-        lock1: 0,
-        lock2: 0,
-        lock3: undefined,
-        lock4: null,
-      };
+    describe('Shutdown side effects', () => {
+      it('should not allow the signal to shutdown if not all locks are released', () => {
+        const lockCounter = {
+          lock1: 2,
+          lock2: 0,
+          lock3: undefined,
+        };
 
-      distributedLockService.lockCounter = lockCounter;
+        distributedLockService.lockCounter = lockCounter;
 
-      const result = distributedLockService.areAllLocksReleased();
-      expect(result).to.eql(true);
-    });
-  });
+        const result = distributedLockService.areAllLocksReleased();
+        expect(result).to.eql(false);
+      });
 
-  describe('Functionalities', () => {
-    it('should create lock and it should expire after the TTL set', async () => {
-      const resource = 'lock-created';
-      const TTL = 100;
-      const handler = async () => setTimeout(500);
+      it('should allow the signal to shutdown if  all locks are released', () => {
+        const lockCounter = {
+          lock1: 0,
+          lock2: 0,
+          lock3: undefined,
+          lock4: null,
+        };
 
-      distributedLockService.applyLock({ resource, ttl: TTL }, handler);
+        distributedLockService.lockCounter = lockCounter;
 
-      let resourceExists = await redisClient.exists(resource);
-      expect(resourceExists).to.eql(1);
-      // TTL + this time should be less than the handler set one to see that the self expiration works
-      await setTimeout(TTL + 10);
-      resourceExists = await redisClient.exists(resource);
-      expect(resourceExists).to.eql(0);
-
-      expect(spyLock.calledOnceWith([resource], TTL)).to.eq(true);
-      expect(spyIncreaseLockCounter.calledOnce).to.eql(true);
-      expect(spyDecreaseLockCounter.callCount).to.eql(0);
-      // Unlock shouldn't be called as the lock expires by going over TTL
-      expect(spyUnlock.called).to.eq(false);
+        const result = distributedLockService.areAllLocksReleased();
+        expect(result).to.eql(true);
+      });
     });
 
-    it('should create lock and it should expire if the handler throws', async () => {
-      const resource = 'lock-created-but-handler-throws';
-      const TTL = 100;
-      const handler = async () => {
-        const resourceExists = await redisClient.exists(resource);
+    describe('Functionalities', () => {
+      it('should create lock and it should expire after the TTL set', async () => {
+        const resource = 'lock-created';
+        const TTL = 100;
+        const handler = async () => setTimeout(500);
+
+        distributedLockService.applyLock({ resource, ttl: TTL }, handler);
+
+        let resourceExists = await client!.exists(resource);
         expect(resourceExists).to.eql(1);
-
-        throw new Error();
-      };
-
-      try {
-        const result = await distributedLockService.applyLock({ resource, ttl: TTL }, handler);
-        expect(result).to.not.be;
-      } catch {
-        const resourceExists = await redisClient.exists(resource);
+        // TTL + this time should be less than the handler set one to see that the self expiration works
+        await setTimeout(TTL + 10);
+        resourceExists = await client!.exists(resource);
         expect(resourceExists).to.eql(0);
-      }
 
-      expect(spyLock.calledOnceWith([resource], TTL)).to.eq(true);
-      expect(spyIncreaseLockCounter.calledOnce).to.eql(true);
-      expect(spyDecreaseLockCounter.calledOnce).to.eql(true);
-      expect(spyUnlock.calledOnceWith()).to.eq(true);
-    });
+        expect(spyLock.calledOnceWith([resource], TTL)).to.eq(true);
+        expect(spyIncreaseLockCounter.calledOnce).to.eql(true);
+        expect(spyDecreaseLockCounter.callCount).to.eql(0);
+        // Unlock shouldn't be called as the lock expires by going over TTL
+        expect(spyUnlock.called).to.eq(false);
+      });
 
-    it('should create a lock and process after any other sequential call while lock is enabled', async () => {
-      const resource = 'lock-created-and-sequential-calls';
-      const TTL = 500;
-      let expectedResult: Record<string, boolean> = {
-        firstCall: false,
-        secondCall: false,
-      };
+      it('should create lock and it should expire if the handler throws', async () => {
+        const resource = 'lock-created-but-handler-throws';
+        const TTL = 100;
+        const handler = async () => {
+          const resourceExists = await client!.exists(resource);
+          expect(resourceExists).to.eql(1);
 
-      const action = async (fn: () => Promise<void>): Promise<void> => {
-        await distributedLockService.applyLock({ resource, ttl: TTL }, fn);
-      };
+          throw new Error();
+        };
 
-      const firstCall = async () => {
-        await setTimeout(50);
-        expectedResult.firstCall = true;
-      };
-
-      const secondCall = async () => {
-        expectedResult.secondCall = true;
-      };
-
-      await action(firstCall);
-      await action(secondCall);
-
-      expect(expectedResult).to.deep.eq({ firstCall: true, secondCall: true });
-      expect(spyLock.callCount).to.eql(2);
-      expect(spyLock.calledWithExactly([resource], TTL)).to.eq(true);
-      expect(spyIncreaseLockCounter.callCount).to.eql(2);
-      expect(spyIncreaseLockCounter.calledWithExactly(resource)).to.eql(true);
-      expect(spyDecreaseLockCounter.callCount).to.eql(2);
-      expect(spyDecreaseLockCounter.calledWithExactly(resource)).to.eql(true);
-      expect(spyUnlock.callCount).to.eql(2);
-    });
-
-    it('should create a lock and process all 5 concurrent calls while lock is enabled but avoiding race conditions', async () => {
-      const resource = 'lock-created-and-concurrent-calls';
-      const TTL = 500;
-      let executed = 0;
-
-      const action = async (fn: () => Promise<void>): Promise<void> => {
-        await distributedLockService.applyLock({ resource, ttl: TTL }, fn);
-      };
-
-      const call = async () => {
-        if (executed < 1) {
-          await setTimeout(90);
-          executed++;
-        }
-      };
-
-      await Promise.all([action(call), action(call), action(call), action(call), action(call)]);
-
-      expect(executed).to.eql(1);
-      expect(spyLock.callCount).to.eql(5);
-      expect(spyLock.calledWithExactly([resource], TTL)).to.eq(true);
-      expect(spyIncreaseLockCounter.callCount).to.eql(5);
-      expect(spyIncreaseLockCounter.calledWithExactly(resource)).to.eql(true);
-      expect(spyUnlock.callCount).to.greaterThanOrEqual(5);
-    });
-
-    it('should create a lock and log a release lock error if any of the calls duration is longer than the TTL but still execute all calls', async () => {
-      const resource = 'lock-created-and-concurrent-calls-one-over-ttl';
-      const TTL = 500;
-      let executed = 0;
-
-      const action = async (fn: () => Promise<void>): Promise<void> => {
-        await distributedLockService.applyLock({ resource, ttl: TTL }, fn);
-      };
-
-      const call = (duration: number) => {
-        async function closure() {
-          await setTimeout(duration);
-          executed++;
+        try {
+          const result = await distributedLockService.applyLock({ resource, ttl: TTL }, handler);
+          expect(result).to.not.be;
+        } catch {
+          const resourceExists = await client!.exists(resource);
+          expect(resourceExists).to.eql(0);
         }
 
-        return closure;
-      };
+        expect(spyLock.calledOnceWith([resource], TTL)).to.eq(true);
+        expect(spyIncreaseLockCounter.calledOnce).to.eql(true);
+        expect(spyDecreaseLockCounter.calledOnce).to.eql(true);
+        expect(spyUnlock.calledOnceWith()).to.eq(true);
+      });
 
-      await Promise.all([action(call(100)), action(call(1000)), action(call(90)), action(call(56)), action(call(89))]);
+      it('should create a lock and process after any other sequential call while lock is enabled', async () => {
+        const resource = 'lock-created-and-sequential-calls';
+        const TTL = 500;
+        let expectedResult: Record<string, boolean> = {
+          firstCall: false,
+          secondCall: false,
+        };
 
-      expect(executed).to.eql(5);
-      expect(spyLock.callCount).to.eql(5);
-      expect(spyLock.calledWithExactly([resource], TTL)).to.eq(true);
-      expect(spyIncreaseLockCounter.callCount).to.eql(5);
-      expect(spyIncreaseLockCounter.calledWithExactly(resource)).to.eql(true);
-      expect(spyUnlock.callCount).to.greaterThanOrEqual(5);
+        const action = async (fn: () => Promise<void>): Promise<void> => {
+          await distributedLockService.applyLock({ resource, ttl: TTL }, fn);
+        };
+
+        const firstCall = async () => {
+          await setTimeout(50);
+          expectedResult.firstCall = true;
+        };
+
+        const secondCall = async () => {
+          expectedResult.secondCall = true;
+        };
+
+        await action(firstCall);
+        await action(secondCall);
+
+        expect(expectedResult).to.deep.eq({ firstCall: true, secondCall: true });
+        expect(spyLock.callCount).to.eql(2);
+        expect(spyLock.calledWithExactly([resource], TTL)).to.eq(true);
+        expect(spyIncreaseLockCounter.callCount).to.eql(2);
+        expect(spyIncreaseLockCounter.calledWithExactly(resource)).to.eql(true);
+        expect(spyDecreaseLockCounter.callCount).to.eql(2);
+        expect(spyDecreaseLockCounter.calledWithExactly(resource)).to.eql(true);
+        expect(spyUnlock.callCount).to.eql(2);
+      });
+
+      it('should create a lock and process all 5 concurrent calls while lock is enabled but avoiding race conditions', async () => {
+        const resource = 'lock-created-and-concurrent-calls';
+        const TTL = 500;
+        let executed = 0;
+
+        const action = async (fn: () => Promise<void>): Promise<void> => {
+          await distributedLockService.applyLock({ resource, ttl: TTL }, fn);
+        };
+
+        const call = async () => {
+          if (executed < 1) {
+            await setTimeout(90);
+            executed++;
+          }
+        };
+
+        await Promise.all([action(call), action(call), action(call), action(call), action(call)]);
+
+        expect(executed).to.eql(1);
+        expect(spyLock.callCount).to.eql(5);
+        expect(spyLock.calledWithExactly([resource], TTL)).to.eq(true);
+        expect(spyIncreaseLockCounter.callCount).to.eql(5);
+        expect(spyIncreaseLockCounter.calledWithExactly(resource)).to.eql(true);
+        expect(spyUnlock.callCount).to.greaterThanOrEqual(5);
+      });
+
+      it('should create a lock and log a release lock error if any of the calls duration is longer than the TTL but still execute all calls', async () => {
+        const resource = 'lock-created-and-concurrent-calls-one-over-ttl';
+        const TTL = 500;
+        let executed = 0;
+
+        const action = async (fn: () => Promise<void>): Promise<void> => {
+          await distributedLockService.applyLock({ resource, ttl: TTL }, fn);
+        };
+
+        const call = (duration: number) => {
+          async function closure() {
+            await setTimeout(duration);
+            executed++;
+          }
+
+          return closure;
+        };
+
+        await Promise.all([
+          action(call(100)),
+          action(call(1000)),
+          action(call(90)),
+          action(call(56)),
+          action(call(89)),
+        ]);
+
+        expect(executed).to.eql(5);
+        expect(spyLock.callCount).to.eql(5);
+        expect(spyLock.calledWithExactly([resource], TTL)).to.eq(true);
+        expect(spyIncreaseLockCounter.callCount).to.eql(5);
+        expect(spyIncreaseLockCounter.calledWithExactly(resource)).to.eql(true);
+        expect(spyUnlock.callCount).to.greaterThanOrEqual(5);
+      });
+    });
+  });
+
+  describe('Bypass - In-memory provider service not set', () => {
+    let inMemoryProviderService: InMemoryProviderService;
+    let distributedLockService: DistributedLockService;
+    let client: InMemoryProviderClient;
+
+    beforeEach(() => {
+      process.env.REDIS_CACHE_SERVICE_HOST = '';
+      process.env.REDIS_CACHE_SERVICE_URL = '0';
+
+      inMemoryProviderService = new InMemoryProviderService();
+      expect(inMemoryProviderService.inMemoryProviderConfig.host).to.eql('');
+      distributedLockService = new DistributedLockService(inMemoryProviderService);
+    });
+
+    afterEach(() => {
+      process.env.REDIS_CACHE_SERVICE_HOST = originalRedisCacheServiceHost;
+      process.env.REDIS_CACHE_SERVICE_URL = originalRedisCacheServicePort;
+    });
+
+    describe('No in-memory instance', () => {
+      it('should execute the locked code anyway even if no instance to manage the distributed locks', async () => {
+        const resource = 'no-lock';
+        const TTL = 100;
+        const handler = async () => {
+          await setTimeout(500);
+          return {
+            executed: true,
+          };
+        };
+
+        const result = await distributedLockService.applyLock({ resource, ttl: TTL }, handler);
+        expect(result).to.deep.equal({ executed: true });
+
+        expect(spyLock.calledOnceWith([resource], TTL)).to.eq(false);
+        expect(spyIncreaseLockCounter.calledOnce).to.eql(false);
+        expect(spyDecreaseLockCounter.callCount).to.eql(0);
+        expect(spyUnlock.called).to.eq(false);
+      });
     });
   });
 });

--- a/apps/api/src/app/shared/services/distributed-lock/distributed-lock.service.ts
+++ b/apps/api/src/app/shared/services/distributed-lock/distributed-lock.service.ts
@@ -1,30 +1,11 @@
-import Redis from 'ioredis';
 import * as Redlock from 'redlock';
 import { setTimeout } from 'timers/promises';
 import { Logger } from '@nestjs/common';
-import { getRedisPrefix } from '@novu/shared';
-import { ConnectionOptions } from 'tls';
 
+import { InMemoryProviderClient, InMemoryProviderService } from '../in-memory-provider';
 import { ApiException } from '../../exceptions/api.exception';
 
 const LOG_CONTEXT = 'DistributedLock';
-
-const getRedisObject = () => {
-  if (!process.env.REDIS_HOST || !process.env.REDIS_PORT) {
-    throw new ApiException(
-      'Missing needed environment variables for Redis instance configuration for the distributed lock service'
-    );
-  }
-
-  return {
-    db: Number(process.env.REDIS_DB_INDEX),
-    port: Number(process.env.REDIS_PORT),
-    host: process.env.REDIS_HOST,
-    password: process.env.REDIS_PASSWORD,
-    keyPrefix: getRedisPrefix(),
-    tls: process.env.REDIS_TLS as ConnectionOptions,
-  };
-};
 
 interface ILockOptions {
   resource: string;
@@ -33,15 +14,16 @@ interface ILockOptions {
 
 export class DistributedLockService {
   public distributedLock: Redlock;
-  public instances: Redis[];
+  public instances: InMemoryProviderClient[];
   public lockCounter = {};
   public shuttingDown = false;
 
-  constructor() {
-    this.startup();
+  constructor(private inMemoryProviderService: InMemoryProviderService) {
+    this.startup(inMemoryProviderService.inMemoryProviderClient);
   }
 
   public startup(
+    client: InMemoryProviderClient,
     settings = {
       driftFactor: 0.01,
       retryCount: 50,
@@ -53,29 +35,39 @@ export class DistributedLockService {
       return;
     }
 
-    // TODO: Implement distributed nodes (at least 3 Redis instances)
-    this.instances = [getRedisObject()]
-      .filter((instanceSettings) => !!instanceSettings)
-      .map((redisSettings) => new Redis(redisSettings));
-    this.distributedLock = new Redlock(this.instances, settings);
-    Logger.verbose('Redlock started', LOG_CONTEXT);
+    if (client) {
+      // TODO: Implement distributed nodes (at least 3 Redis instances)
+      this.instances = [client];
+      this.distributedLock = new Redlock(this.instances, settings);
+      Logger.verbose('Redlock started', LOG_CONTEXT);
 
-    /**
-     * https://github.com/mike-marcacci/node-redlock/blob/dc7bcd923f70f66abc325d23ae618f7caf01ad75/src/index.ts#L192
-     *
-     * Because Redlock is designed for high availability, it does not care if
-     * a minority of redis instances/clusters fail at an operation.
-     *
-     * However, it can be helpful to monitor and log such cases. Redlock emits
-     * an "error" event whenever it encounters an error, even if the error is
-     * ignored in its normal operation.
-     *
-     * This function serves to prevent Node's default behavior of crashing
-     * when an "error" event is emitted in the absence of listeners.
-     */
-    this.distributedLock.on('error', (error) => {
-      Logger.error(error, LOG_CONTEXT);
-    });
+      /**
+       * https://github.com/mike-marcacci/node-redlock/blob/dc7bcd923f70f66abc325d23ae618f7caf01ad75/src/index.ts#L192
+       *
+       * Because Redlock is designed for high availability, it does not care if
+       * a minority of redis instances/clusters fail at an operation.
+       *
+       * However, it can be helpful to monitor and log such cases. Redlock emits
+       * an "error" event whenever it encounters an error, even if the error is
+       * ignored in its normal operation.
+       *
+       * This function serves to prevent Node's default behavior of crashing
+       * when an "error" event is emitted in the absence of listeners.
+       */
+      this.distributedLock.on('error', (error) => {
+        Logger.error(error, LOG_CONTEXT);
+      });
+    }
+  }
+
+  public isDistributedLockEnabled(): boolean {
+    if (!this.distributedLock) {
+      Logger.log('Distributed lock service is not enabled', LOG_CONTEXT);
+
+      return false;
+    } else {
+      return true;
+    }
   }
 
   public areAllLocksReleased(): boolean {
@@ -118,6 +110,10 @@ export class DistributedLockService {
   }
 
   public async applyLock<T>({ resource, ttl }: ILockOptions, handler: () => Promise<T>): Promise<T> {
+    if (!this.isDistributedLockEnabled()) {
+      return await handler();
+    }
+
     const releaseLock = await this.lock(resource, ttl);
 
     try {
@@ -133,11 +129,6 @@ export class DistributedLockService {
   }
 
   private async lock(resource: string, ttl: number): Promise<() => Promise<void>> {
-    if (!this.distributedLock) {
-      Logger.verbose(`Redlock was not started. Starting after calling lock ${resource} for ${ttl} ms`, LOG_CONTEXT);
-      this.startup();
-    }
-
     try {
       const acquiredLock = await this.distributedLock.acquire([resource], ttl);
       Logger.verbose(`Lock ${resource} acquired for ${ttl} ms`, LOG_CONTEXT);

--- a/apps/api/src/app/shared/services/in-memory-provider/in-memory-provider.service.ts
+++ b/apps/api/src/app/shared/services/in-memory-provider/in-memory-provider.service.ts
@@ -45,10 +45,9 @@ export class InMemoryProviderService {
       Logger.log('Missing host for in-memory provider', LOG_CONTEXT);
     }
 
-    if (host) {
+    const inMemoryProviderClient = getRedisInstance();
+    if (host && inMemoryProviderClient) {
       Logger.log(`Connecting to ${host}:${port}`, LOG_CONTEXT);
-
-      const inMemoryProviderClient = getRedisInstance();
 
       inMemoryProviderClient.on('connect', () => {
         Logger.log('REDIS CONNECTED', LOG_CONTEXT);

--- a/apps/api/src/app/shared/services/in-memory-provider/redis-provider.ts
+++ b/apps/api/src/app/shared/services/in-memory-provider/redis-provider.ts
@@ -14,7 +14,7 @@ const TTL_VARIANT_PERCENTAGE = 0.1;
 interface IRedisConfig {
   connectTimeout?: string;
   family?: string;
-  host: string;
+  host?: string;
   keepAlive?: string;
   keyPrefix?: string;
   password?: string;
@@ -26,29 +26,29 @@ interface IRedisConfig {
 export interface IRedisProviderConfig {
   connectTimeout: number;
   family: number;
-  host: string;
+  host?: string;
   keepAlive: number;
   keyPrefix: string;
   password?: string;
-  port: number;
+  port?: number;
   tls?: ConnectionOptions;
   ttl: number;
 }
 
-const redisConfig: IRedisConfig = {
-  host: process.env.REDIS_CACHE_SERVICE_HOST || 'localhost',
-  port: process.env.REDIS_CACHE_SERVICE_PORT || '6379',
-  ttl: process.env.REDIS_CACHE_TTL,
-  password: process.env.REDIS_CACHE_PASSWORD,
-  connectTimeout: process.env.REDIS_CACHE_CONNECTION_TIMEOUT,
-  keepAlive: process.env.REDIS_CACHE_KEEP_ALIVE,
-  family: process.env.REDIS_CACHE_FAMILY,
-  keyPrefix: process.env.REDIS_CACHE_KEY_PREFIX,
-  tls: process.env.REDIS_CACHE_SERVICE_TLS as ConnectionOptions,
-};
-
 export const getRedisProviderConfig = (): IRedisProviderConfig => {
-  const port = Number(redisConfig.port || 6379);
+  const redisConfig: IRedisConfig = {
+    host: process.env.REDIS_CACHE_SERVICE_HOST,
+    port: process.env.REDIS_CACHE_SERVICE_PORT,
+    ttl: process.env.REDIS_CACHE_TTL,
+    password: process.env.REDIS_CACHE_PASSWORD,
+    connectTimeout: process.env.REDIS_CACHE_CONNECTION_TIMEOUT,
+    keepAlive: process.env.REDIS_CACHE_KEEP_ALIVE,
+    family: process.env.REDIS_CACHE_FAMILY,
+    keyPrefix: process.env.REDIS_CACHE_KEY_PREFIX,
+    tls: process.env.REDIS_CACHE_SERVICE_TLS as ConnectionOptions,
+  };
+
+  const port = Number(redisConfig.port);
   const host = redisConfig.host;
   const password = redisConfig.password;
   const connectTimeout = redisConfig.connectTimeout ? Number(redisConfig.connectTimeout) : DEFAULT_CONNECT_TIMEOUT;
@@ -69,8 +69,12 @@ export const getRedisProviderConfig = (): IRedisProviderConfig => {
   };
 };
 
-export const getRedisInstance = (): Redis => {
+export const getRedisInstance = (): Redis | undefined => {
   const { port, host, ...options } = getRedisProviderConfig();
 
-  return new Redis(port, host, options);
+  if (port && host) {
+    return new Redis(port, host, options);
+  }
+
+  return undefined;
 };

--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -92,14 +92,19 @@ const cacheService = {
   },
 };
 
+const distributedLockService = {
+  provide: DistributedLockService,
+  useFactory: () => {
+    const factoryInMemoryProviderService = inMemoryProviderService.useFactory();
+
+    return new DistributedLockService(factoryInMemoryProviderService);
+  },
+};
+
 const PROVIDERS = [
   inMemoryProviderService,
-  {
-    provide: DistributedLockService,
-    useFactory: () => {
-      return new DistributedLockService();
-    },
-  },
+  cacheService,
+  distributedLockService,
   {
     provide: QueueService,
     useFactory: () => {
@@ -120,7 +125,6 @@ const PROVIDERS = [
       return new PerformanceService();
     },
   },
-  cacheService,
   InvalidateCacheService,
   ...DAL_MODELS,
   {


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Makes the distributed lock service to reuse the in-memory provider service.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
We plan to implement Redis cluster as in-memory provider service for the Cache service and the Distributed Lock service. So far we had both connections to the in-memory provider (ioredis) separatedly even if using the same instance.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
