### PR TITLE
fix: added check for tls options before json stringify to avoid empty string

### DIFF
--- a/apps/web/src/pages/integrations/IntegrationsStorePage.tsx
+++ b/apps/web/src/pages/integrations/IntegrationsStorePage.tsx
@@ -185,6 +185,9 @@ export interface ICredentials {
   projectName?: string;
   serviceAccount?: string;
   baseUrl?: string;
+  requireTls?: boolean;
+  ignoreTls?: boolean;
+  tlsOptions?: Record<string, unknown>;
 }
 
 export interface IntegrationEntity {
@@ -218,7 +221,7 @@ function initializeProviders(integrations: IntegrationEntity[]): IIntegratedProv
     if (integration?.credentials && Object.keys(clonedCredentials).length !== 0) {
       clonedCredentials.forEach((credential) => {
         // eslint-disable-next-line no-param-reassign
-        if (credential.type === 'object') {
+        if (credential.type === 'object' && integration.credentials[credential.key]) {
           credential.value = JSON.stringify(integration.credentials[credential.key]);
         } else {
           credential.value = integration.credentials[credential.key]?.toString();


### PR DESCRIPTION


### What change does this PR introduce?

- Added a check before json stringifying the value to avoid showing the empty string in the input textbox. ( as per screenshot)
- Added the missing keys in the credentials interface under the store page.

### Why was this change needed?

- Bug was introduced in the following PR https://github.com/novuhq/novu/pull/3048#issuecomment-1491673914 
- API docs doesn't contains following credentials keys ( `requireTls`, `ignoreTls` and `tlsOptions` ) for Integrations APIs

### Other information (Screenshots)

![image](https://user-images.githubusercontent.com/22212945/229418399-04fcbc84-5189-4cfb-ba6b-5f42386662f1.png)
