### PR TITLE
fix: add reply to support for aws ses provider

### DIFF
--- a/providers/ses/src/lib/ses.provider.spec.ts
+++ b/providers/ses/src/lib/ses.provider.spec.ts
@@ -12,6 +12,7 @@ const mockConfig = {
 
 const mockNovuMessage = {
   to: ['test@test2.com'],
+  replyTo: 'test@test1.com',
   subject: 'test subject',
   html: '<div> Mail Content </div>',
   attachments: [

--- a/providers/ses/src/lib/ses.provider.spec.ts
+++ b/providers/ses/src/lib/ses.provider.spec.ts
@@ -93,7 +93,8 @@ test('should trigger ses library correctly', async () => {
   const provider = new SESEmailProvider(mockConfig);
   const response = await provider.sendMessage(mockNovuMessage);
 
-  const bufferArray = spy.mock.calls[0][0].input.RawMessage.Data;
+  // eslint-disable-next-line
+  const bufferArray = spy.mock.calls[0][0].input['RawMessage']['Data'];
   const buffer = Buffer.from(bufferArray);
   const emailContent = buffer.toString();
 

--- a/providers/ses/src/lib/ses.provider.spec.ts
+++ b/providers/ses/src/lib/ses.provider.spec.ts
@@ -93,7 +93,12 @@ test('should trigger ses library correctly', async () => {
   const provider = new SESEmailProvider(mockConfig);
   const response = await provider.sendMessage(mockNovuMessage);
 
+  const bufferArray = spy.mock.calls[0][0].input.RawMessage.Data;
+  const buffer = Buffer.from(bufferArray);
+  const emailContent = buffer.toString();
+
   expect(spy).toHaveBeenCalled();
+  expect(emailContent.includes('Reply-To: test@test1.com')).toBe(true);
   expect(response.id).toEqual('<mock-message-id@test-1.amazonses.com>');
 });
 

--- a/providers/ses/src/lib/ses.provider.ts
+++ b/providers/ses/src/lib/ses.provider.ts
@@ -36,6 +36,7 @@ export class SESEmailProvider implements IEmailProvider {
     attachments,
     cc,
     bcc,
+    replyTo,
   }) {
     const transporter = nodemailer.createTransport({
       SES: { ses: this.ses, aws: { SendRawEmailCommand } },
@@ -53,6 +54,7 @@ export class SESEmailProvider implements IEmailProvider {
       },
       cc,
       bcc,
+      replyTo,
     });
   }
 
@@ -65,6 +67,7 @@ export class SESEmailProvider implements IEmailProvider {
     attachments,
     cc,
     bcc,
+    replyTo,
   }: IEmailOptions): Promise<ISendMessageSuccessResponse> {
     const info = await this.sendMail({
       from: from || this.config.from,
@@ -79,6 +82,7 @@ export class SESEmailProvider implements IEmailProvider {
       })),
       cc,
       bcc,
+      replyTo,
     });
 
     return {
@@ -157,6 +161,7 @@ export class SESEmailProvider implements IEmailProvider {
         attachments: {},
         bcc: [],
         cc: [],
+        replyTo: 'support@novu.co',
       });
 
       return {


### PR DESCRIPTION
### What change does this PR introduce?

- This PR sets the replyTo parameter in nodemailer SES transport.

### Why was this change needed?

- `replyTo` wasn't working for AWS SES provider. This PR fixes that bug.

Closes #3122 