### PR TITLE
Index Cleanup - Job

### DIFF
--- a/apps/api/src/app/events/usecases/add-job/add-delay-job.usecase.ts
+++ b/apps/api/src/app/events/usecases/add-job/add-delay-job.usecase.ts
@@ -77,16 +77,19 @@ export class AddDelayJob {
     currentDelayPath: string,
     currentDelayDate: string
   ): Promise<boolean> {
-    return !(await this.jobRepository.findOne({
-      status: JobStatusEnum.DELAYED,
-      type: StepTypeEnum.DELAY,
-      _subscriberId: data._subscriberId,
-      _templateId: data._templateId,
-      _environmentId: data._environmentId,
-      transactionId: { $ne: data.transactionId },
-      'step.metadata.type': DelayTypeEnum.SCHEDULED,
-      'step.metadata.delayPath': currentDelayPath,
-      [`payload.${currentDelayPath}`]: currentDelayDate,
-    }));
+    return !((await this.jobRepository.findOne(
+      {
+        status: JobStatusEnum.DELAYED,
+        type: StepTypeEnum.DELAY,
+        _subscriberId: data._subscriberId,
+        _templateId: data._templateId,
+        _environmentId: data._environmentId,
+        transactionId: { $ne: data.transactionId },
+        'step.metadata.type': DelayTypeEnum.SCHEDULED,
+        'step.metadata.delayPath': currentDelayPath,
+        [`payload.${currentDelayPath}`]: currentDelayDate,
+      },
+      '_subscriberId'
+    )) as Pick<JobEntity, '_subscriberId'>);
   }
 }

--- a/apps/api/src/app/events/usecases/queue-next-job/queue-next-job.usecase.ts
+++ b/apps/api/src/app/events/usecases/queue-next-job/queue-next-job.usecase.ts
@@ -14,7 +14,6 @@ export class QueueNextJob {
   public async execute(command: QueueNextJobCommand): Promise<JobEntity | undefined> {
     const job = await this.jobRepository.findOne({
       _environmentId: command.environmentId,
-      _organizationId: command.organizationId,
       _parentId: command.parentId,
     });
 
@@ -25,7 +24,7 @@ export class QueueNextJob {
     await this.addJobUsecase.execute({
       userId: job._userId,
       environmentId: job._environmentId,
-      organizationId: job._organizationId,
+      organizationId: command.organizationId,
       jobId: job._id,
       job,
     });

--- a/apps/api/src/app/events/usecases/queue-next-job/queue-next-job.usecase.ts
+++ b/apps/api/src/app/events/usecases/queue-next-job/queue-next-job.usecase.ts
@@ -1,6 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { JobEntity, JobRepository } from '@novu/dal';
-import { AddJob } from '../add-job/add-job.usecase';
+import { AddJob } from '../add-job';
 import { QueueNextJobCommand } from './queue-next-job.command';
 
 @Injectable()

--- a/apps/api/src/app/events/usecases/send-message/digest/get-digest-events.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/digest/get-digest-events.usecase.ts
@@ -8,7 +8,7 @@ import {
   CreateExecutionDetailsCommand,
 } from '../../../../execution-details/usecases/create-execution-details';
 import { DetailEnum } from '../../../../execution-details/types';
-import { DigestFilterSteps } from '../../digest-filter-steps/digest-filter-steps.usecase';
+import { DigestFilterSteps } from '../../digest-filter-steps';
 
 @Injectable()
 export abstract class GetDigestEvents {

--- a/apps/api/src/app/events/usecases/send-message/digest/get-digest-events.usecase.ts
+++ b/apps/api/src/app/events/usecases/send-message/digest/get-digest-events.usecase.ts
@@ -22,11 +22,16 @@ export abstract class GetDigestEvents {
       return DigestFilterSteps.getNestedValue(job.payload, currentJob.digest?.digestKey) === batchValue;
     });
 
-    const currentTrigger = await this.jobRepository.findOne({
-      _environmentId: currentJob._environmentId,
-      transactionId: transactionId,
-      type: StepTypeEnum.TRIGGER,
-    });
+    const currentTrigger = (await this.jobRepository.findOne(
+      {
+        _environmentId: currentJob._environmentId,
+        _subscriberId: currentJob._subscriberId,
+        transactionId: transactionId,
+        type: StepTypeEnum.TRIGGER,
+      },
+      '_id'
+    )) as Pick<JobEntity, '_id'>;
+
     if (!currentTrigger) {
       this.createExecutionDetails.execute(
         CreateExecutionDetailsCommand.create({

--- a/apps/api/src/app/events/usecases/trigger-event/trigger-event.usecase.ts
+++ b/apps/api/src/app/events/usecases/trigger-event/trigger-event.usecase.ts
@@ -41,7 +41,7 @@ export class TriggerEvent {
 
     const { actor, environmentId, identifier, organizationId, to, userId } = command;
 
-    await this.validateTransactionIdProperty(command.transactionId, organizationId, environmentId);
+    await this.validateTransactionIdProperty(command.transactionId, environmentId);
 
     Sentry.addBreadcrumb({
       message: 'Sending trigger',
@@ -155,16 +155,14 @@ export class TriggerEvent {
     );
   }
 
-  private async validateTransactionIdProperty(
-    transactionId: string,
-    organizationId: string,
-    environmentId: string
-  ): Promise<void> {
-    const found = await this.jobRepository.count({
-      transactionId,
-      _organizationId: organizationId,
-      _environmentId: environmentId,
-    });
+  private async validateTransactionIdProperty(transactionId: string, environmentId: string): Promise<void> {
+    const found = (await this.jobRepository.findOne(
+      {
+        transactionId,
+        _environmentId: environmentId,
+      },
+      '_id'
+    )) as Pick<JobEntity, '_id'>;
 
     if (found) {
       throw new ApiException(

--- a/libs/dal/src/repositories/job/job.repository.ts
+++ b/libs/dal/src/repositories/job/job.repository.ts
@@ -1,5 +1,5 @@
 import { ProjectionType } from 'mongoose';
-import { ChannelTypeEnum, StepTypeEnum } from '@novu/shared';
+import { StepTypeEnum } from '@novu/shared';
 
 import { BaseRepository } from '../base-repository';
 import { JobEntity, JobDBModel, JobStatusEnum } from './job.entity';
@@ -73,15 +73,6 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
         `There was a problem when trying to set an error for the job ${jobId} in the organization ${organizationId}`
       );
     }
-  }
-
-  public async findInAppsForDigest(organizationId: string, transactionId: string, subscriberId: string) {
-    return await this.find({
-      _organizationId: organizationId,
-      type: ChannelTypeEnum.IN_APP,
-      _subscriberId: subscriberId,
-      transactionId,
-    });
   }
 
   public async findJobsToDigest(from: Date, templateId: string, environmentId: string, subscriberId: string) {

--- a/libs/dal/src/repositories/job/job.schema.ts
+++ b/libs/dal/src/repositories/job/job.schema.ts
@@ -345,8 +345,7 @@ jobSchema.index({
 /*
  * This index was initially created to optimize:
  *
- * Path : apps/api/src/app/events/usecases/send-message/send-message<CHANNEL>.usecase.ts
- *    Context : The reason for this Index is because of
+ *    Context : The reason for this Index is that it used by the activity feed with populate,
  *              Notification scheme virtual localField: '_id', foreignField: '_notificationId', one to many
  */
 jobSchema.index({

--- a/libs/dal/src/repositories/job/job.schema.ts
+++ b/libs/dal/src/repositories/job/job.schema.ts
@@ -159,16 +159,6 @@ jobSchema.virtual('environment', {
  *           'step.uuid': filter.step,
  *        })
  *
- *
- */
-jobSchema.index({
-  transactionId: 1,
-  _subscriberId: 1,
-});
-
-/*
- * This index was initially created to optimize:
- *
  * Path : apps/api/src/app/events/usecases/trigger-event/trigger-event.usecase.ts
  *    Context : validateTransactionIdProperty()
  *       Query : findOne(
@@ -204,8 +194,7 @@ jobSchema.index({
  */
 jobSchema.index({
   transactionId: 1,
-  _environmentId: 1,
-  _id: 1,
+  _subscriberId: 1,
 });
 
 /*
@@ -225,20 +214,6 @@ jobSchema.index({
 
 /*
  * This index was initially created to optimize:
- *
- * Path : apps/api/src/app/events/usecases/send-message/digest/get-digest-events-backoff.usecase.ts
- *    Context : execute()
- *              **** createdAt is missing *
- *       Query : find({
- *          _subscriberId: command._subscriberId ? command._subscriberId : command.subscriberId,
- *          _templateId: currentJob._templateId,
- *          _environmentId: command.environmentId,
- *          type: StepTypeEnum.TRIGGER,
- *          status: JobStatusEnum.COMPLETED,
- *          createdAt: {
- *            $gte: currentJob.createdAt,
- *          },
- *        }
  *
  * Path : apps/api/src/app/events/usecases/digest-filter-steps/digest-filter-steps-backoff.usecase.ts
  *    Context : getTrigger()
@@ -341,7 +316,41 @@ jobSchema.index({
   type: 1,
   status: 1,
   updatedAt: 1,
-  transactionId: 1,
+});
+
+/*
+ * This index was initially created to optimize:
+ *
+ * Path : apps/api/src/app/events/usecases/send-message/digest/get-digest-events-backoff.usecase.ts
+ *    Context : execute()
+ *       Query : find({
+ *          _subscriberId: command._subscriberId ? command._subscriberId : command.subscriberId,
+ *          _templateId: currentJob._templateId,
+ *          _environmentId: command.environmentId,
+ *          type: StepTypeEnum.TRIGGER,
+ *          status: JobStatusEnum.COMPLETED,
+ *          createdAt: {
+ *            $gte: currentJob.createdAt,
+ *          },
+ *        }
+ */
+jobSchema.index({
+  _subscriberId: 1,
+  _templateId: 1,
+  type: 1,
+  status: 1,
+  createdAt: 1,
+});
+
+/*
+ * This index was initially created to optimize:
+ *
+ * Path : apps/api/src/app/events/usecases/send-message/send-message<CHANNEL>.usecase.ts
+ *    Context : The reason for this Index is because of
+ *              Notification scheme virtual localField: '_id', foreignField: '_notificationId', one to many
+ */
+jobSchema.index({
+  _notificationId: 1,
 });
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/libs/dal/src/repositories/job/job.schema.ts
+++ b/libs/dal/src/repositories/job/job.schema.ts
@@ -194,7 +194,6 @@ jobSchema.virtual('environment', {
  */
 jobSchema.index({
   transactionId: 1,
-  _subscriberId: 1,
 });
 
 /*
@@ -209,7 +208,6 @@ jobSchema.index({
  */
 jobSchema.index({
   _parentId: 1,
-  _environmentId: 1,
 });
 
 /*

--- a/libs/dal/src/repositories/job/job.schema.ts
+++ b/libs/dal/src/repositories/job/job.schema.ts
@@ -139,23 +139,34 @@ jobSchema.virtual('environment', {
  * apps/api/src/app/events/usecases/add-job/add-delay-job.usecase.ts
  */
 jobSchema.index({
-  transactionId: 1,
   _subscriberId: 1,
   _templateId: 1,
-  _environmentId: 1,
   status: 1,
   type: 1,
+  transactionId: 1,
 });
 
 /*
  * This index was initially created to optimize:
+ * apps/api/src/app/events/usecases/send-message/digest/get-digest-events.usecase.ts
  * apps/api/src/app/events/usecases/message-matcher/message-matcher.usecase.ts
  */
 jobSchema.index({
   transactionId: 1,
   _subscriberId: 1,
-  'step.uuid': 1,
+});
+
+/*
+ * This index was initially created to optimize:
+ * apps/api/src/app/events/usecases/trigger-event/trigger-event.usecase.ts
+ * repo
+ * apps/api/src/app/events/usecases/send-message/digest/digest.usecase.ts * _id is the last on because it is used with $ne which means it is a range operator
+ * apps/api/src/app/events/usecases/cancel-delayed/cancel-delayed.usecase.ts * but OMIT 'status'
+ */
+jobSchema.index({
+  transactionId: 1,
   _environmentId: 1,
+  _id: 1,
 });
 
 /*
@@ -165,22 +176,6 @@ jobSchema.index({
 jobSchema.index({
   _parentId: 1,
   _environmentId: 1,
-  _organizationId: 1,
-});
-
-/*
- * This index was initially created to optimize:
- * apps/api/src/app/events/usecases/send-message/digest/get-digest-events.usecase.ts
- * apps/api/src/app/events/usecases/trigger-event/trigger-event.usecase.ts
- * repo
- * apps/api/src/app/events/usecases/send-message/digest/digest.usecase.ts * _id is the last on because it is used with $ne which means it is a range operator
- * apps/api/src/app/events/usecases/cancel-delayed/cancel-delayed.usecase.ts * but OMIT 'status'
- */
-jobSchema.index({
-  transactionId: 1,
-  _environmentId: 1,
-  type: 1,
-  _id: 1,
 });
 
 /*
@@ -203,11 +198,6 @@ jobSchema.index({
   updatedAt: 1,
   transactionId: 1,
 });
-
-/*
- * This index was initially created to optimize:
- */
-jobSchema.index({});
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const Job = (mongoose.models.Job as mongoose.Model<JobDBModel>) || mongoose.model<JobDBModel>('Job', jobSchema);

--- a/libs/dal/src/repositories/job/job.schema.ts
+++ b/libs/dal/src/repositories/job/job.schema.ts
@@ -137,34 +137,6 @@ jobSchema.virtual('environment', {
 /*
  * This index was initially created to optimize:
  *
- * Path : apps/api/src/app/events/usecases/add-job/add-delay-job.usecase.ts
- *    Context : noExistingDelayedJobForDate()
- *       Query : findOne(
- *          {
- *            status: JobStatusEnum.DELAYED,
- *            type: StepTypeEnum.DELAY,
- *            _subscriberId: data._subscriberId,
- *            _templateId: data._templateId,
- *            _environmentId: data._environmentId,
- *            transactionId: { $ne: data.transactionId },
- *            'step.metadata.type': DelayTypeEnum.SCHEDULED,
- *            'step.metadata.delayPath': currentDelayPath,
- *            [`payload.${currentDelayPath}`]: currentDelayDate,
- *          },
- *          '_subscriberId'
- *       )
- */
-jobSchema.index({
-  _subscriberId: 1,
-  _templateId: 1,
-  status: 1,
-  type: 1,
-  transactionId: 1,
-});
-
-/*
- * This index was initially created to optimize:
- *
  * Path : apps/api/src/app/events/usecases/send-message/digest/get-digest-events.usecase.ts
  *    Context : filterJobs()
  *       Query : findOne.(
@@ -345,6 +317,23 @@ jobSchema.index({
  *          type: StepTypeEnum.DIGEST,
  *          ...(digestKey && { [`payload.${digestKey}`]: digestValue }),
  *        }
+ *
+ * Path : apps/api/src/app/events/usecases/add-job/add-delay-job.usecase.ts
+ *    Context : noExistingDelayedJobForDate()
+ *       Query : findOne(
+ *          {
+ *            status: JobStatusEnum.DELAYED,
+ *            type: StepTypeEnum.DELAY,
+ *            _subscriberId: data._subscriberId,
+ *            _templateId: data._templateId,
+ *            _environmentId: data._environmentId,
+ *            transactionId: { $ne: data.transactionId },
+ *            'step.metadata.type': DelayTypeEnum.SCHEDULED,
+ *            'step.metadata.delayPath': currentDelayPath,
+ *            [`payload.${currentDelayPath}`]: currentDelayDate,
+ *          },
+ *          '_subscriberId'
+ *       )
  */
 jobSchema.index({
   _subscriberId: 1,

--- a/libs/dal/src/repositories/job/job.schema.ts
+++ b/libs/dal/src/repositories/job/job.schema.ts
@@ -139,7 +139,7 @@ jobSchema.virtual('environment', {
  *
  * Path : apps/api/src/app/events/usecases/add-job/add-delay-job.usecase.ts
  *    Context : noExistingDelayedJobForDate()
- *       Query : (
+ *       Query : findOne(
  *          {
  *            status: JobStatusEnum.DELAYED,
  *            type: StepTypeEnum.DELAY,
@@ -349,7 +349,6 @@ jobSchema.index({
 jobSchema.index({
   _subscriberId: 1,
   _templateId: 1,
-  _environmentId: 1,
   type: 1,
   status: 1,
   updatedAt: 1,


### PR DESCRIPTION
### What change does this PR introduce?

Why? (Context)

We want to remove as many inefficient indexs and queries as possible.

### Why was this change needed?

Stop using single indexes on the mongoose key implementation
Add compound indexes for common queries and patterns using MongoDB index best practices
Remove unused indexes from MongoDB atlas after implementing the new compound indexes

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
