### PR TITLE
fix(docker): revert docker readme change

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -26,7 +26,7 @@ cd novu/docker
 cp .env.example ./local/deployment/.env
 
 # Start Novu
-docker-compose -f ./local/deployment/docker-compose.redis-cluster.yml up
+docker-compose -f ./local/deployment/docker-compose.yml up
 ```
 
 Now visit [http://localhost:4200](http://localhost:4200) to start using Novu.

--- a/docker/local/Readme.md
+++ b/docker/local/Readme.md
@@ -2,11 +2,13 @@
 
 For a full guide on running novu locally for development needs, please read our guide here: https://docs.novu.co/community/run-locally
 
-### Redis Cluster
+### Advanced - Running with a Redis Cluster
 
-Novu has support for redis cluster, however you must set the following env variables to:
-// FIXME
+Novu has support for redis cluster, however you must set the following env variables to enable it:
+// To be determined
 
-In the local development example, the primary nodes are hard coded to 6391 through 6393 and
-the secondary (read) node to 6381 through 6383 on localhost.
+In the local development example in the docker-compose.redis-cluster.yml file, the primary nodes are hard coded to 6391 through 6393 and
+the secondary (read) node to 6394 through 6396 on localhost.
+In addition, for the queue service there is a redis sentinel cluster that has ones primary and two read nodes
+with append-only file enabled that run on ports 6381 through 6383 on localhost.
 We have also set up redis commander on 5001 for you to be able to see the keys and statistics of the cluster.


### PR DESCRIPTION
### What change does this PR introduce?

Revert reference to redis cluster in docker get started readme
