### PR TITLE
NV-1898 - Missing scrollTo channel in quickstart -> configure provider

### DIFF
--- a/apps/web/src/pages/quick-start/steps/GetStarted.tsx
+++ b/apps/web/src/pages/quick-start/steps/GetStarted.tsx
@@ -58,6 +58,7 @@ export function GetStarted() {
           closeIntegration={() => {
             setClickedChannel({ open: false });
           }}
+          scrollTo={clickedChannel.channelType}
         />
         <ChannelsConfiguration setClickedChannel={setClickedChannel} />
       </ChannelsConfigurationHolder>


### PR DESCRIPTION
### What Changes Does This PR introduce?
Scrolls to the respective `integration store's section` to which the user want to integrate when opening the `integration store modal`.

### Why Was Changes Needed?
Fixes [#3129](https://github.com/novuhq/novu/issues/3129)

### Other Information
#### After Fix
https://www.awesomescreenshot.com/video/16219996?key=ab0e9accd2560833668fbb48cde6e36e

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
