### PR TITLE
fix(infra): docker compose development fix

### DIFF
--- a/docker/local/development/docker-compose.development.yml
+++ b/docker/local/development/docker-compose.development.yml
@@ -2,21 +2,21 @@ version: "3"
 services:
   api:
     build:
-      dockerfile: "../../apps/api/Dockerfile"
+      dockerfile: "./apps/api/Dockerfile"
       context: "../../.."
   web:
     build:
-      dockerfile: "../../apps/web/Dockerfile"
+      dockerfile: "./apps/web/Dockerfile"
       context: "../../.."
   ws:
     build:
-      dockerfile: "../../apps/ws/Dockerfile"
+      dockerfile: "./apps/ws/Dockerfile"
       context: "../../.."
   widget:
     build:
-      dockerfile: "../../apps/widget/Dockerfile"
+      dockerfile: "./apps/widget/Dockerfile"
       context: "../../.."
   embed:
     build:
-      dockerfile: "../../libs/embed/Dockerfile"
+      dockerfile: "./libs/embed/Dockerfile"
       context: "../../.."


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Fixes the Docker compose YAML so when executing anywhere from the monorepo tree it can find the different Dockerfiles and compose them. We keep the same context as it moves the execution of the different actions to the monorepo root.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Wasn't working being executed from anywhere.

### Other information (Screenshots)

Unfortunately it doesn't make it fully work as right now the Dockerfiles are optimised for production builds and they fail for local development. Further work needs to be addressed.
<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->

How to test this? Download the branch and from anywhere inside of the monorepo execute:
```shell
docker-compose -f ./path/to/file/docker-compose.yml up
```
And see it runs.
