### PR TITLE
NV-1557 🚀 Feature: Allow pagination handling in refetch method

### DIFF
--- a/packages/notification-center/src/hooks/useFetchNotifications.ts
+++ b/packages/notification-center/src/hooks/useFetchNotifications.ts
@@ -1,6 +1,7 @@
 import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query';
 import type { IStoreQuery } from '@novu/client';
 import type { IMessage, IPaginatedResponse } from '@novu/shared';
+import { INotificationsContext } from '../shared/interfaces';
 
 import { useNovuContext } from './useNovuContext';
 import { INFINITE_NOTIFICATIONS_QUERY_KEY } from './queryKeys';
@@ -22,5 +23,16 @@ export const useFetchNotifications = (
     }
   );
 
-  return result;
+  const refetch: INotificationsContext['refetch'] = ({ page, ...otherOptions } = {}) => {
+    if (page !== undefined) {
+      result.fetchNextPage({ pageParam: page, ...otherOptions });
+    } else {
+      result.refetch(otherOptions);
+    }
+  };
+
+  return {
+    ...result,
+    refetch,
+  };
 };

--- a/packages/notification-center/src/hooks/useNotifications.test.tsx
+++ b/packages/notification-center/src/hooks/useNotifications.test.tsx
@@ -326,6 +326,51 @@ describe('useNotifications', () => {
     expect(result.current.notifications).toStrictEqual([mockNotification1, mockNotification2, mockNotification3]);
   });
 
+  it('refetch will fetch notifications from a specified page number', async () => {
+    const mockNotification1 = { ...mockNotification, _id: 'mockNotification1' };
+    const mockNotification2 = { ...mockNotification, _id: 'mockNotification2' };
+    const mockNotification3 = { ...mockNotification, _id: 'mockNotification3' };
+    const mockNotificationsResponse1 = {
+      data: [mockNotification1],
+      totalCount: 1,
+      pageSize: 10,
+      page: 0,
+    };
+    const mockNotificationsResponse2 = {
+      data: [mockNotification2, mockNotification3],
+      totalCount: 3,
+      pageSize: 10,
+      page: 1,
+    };
+    mockServiceInstance.getNotificationsList
+      .mockImplementationOnce(() => promiseResolveTimeout(0, mockNotificationsResponse1))
+      .mockImplementationOnce(() => promiseResolveTimeout(0, mockNotificationsResponse2));
+
+    const { rerender, result } = hook;
+
+    expect(result.current.isLoading).toBeTruthy();
+
+    await promiseResolveTimeout(100);
+    rerender();
+
+    expect(mockServiceInstance.getNotificationsList).toHaveBeenNthCalledWith(1, 0, {});
+    expect(result.current.notifications).toStrictEqual([mockNotification1]);
+
+    act(() => {
+      result.current.refetch({ page: 1 });
+    });
+    rerender();
+
+    expect(result.current.isLoading).toBeFalsy();
+    expect(result.current.isFetching).toBeTruthy();
+
+    await promiseResolveTimeout(100);
+    rerender();
+
+    expect(mockServiceInstance.getNotificationsList).toHaveBeenNthCalledWith(2, 1, {});
+    expect(result.current.notifications).toStrictEqual([mockNotification1, mockNotification2, mockNotification3]);
+  });
+
   it('mark notification as read', async () => {
     mockServiceInstance.markMessageAs.mockImplementationOnce(() =>
       promiseResolveTimeout(0, [{ ...mockNotification, read: true, seen: true }])

--- a/packages/notification-center/src/shared/interfaces/index.ts
+++ b/packages/notification-center/src/shared/interfaces/index.ts
@@ -1,5 +1,6 @@
 import { ButtonTypeEnum, IMessage, IMessageAction, IOrganizationEntity, ISubscriberJwt } from '@novu/shared';
 import type { ApiService, IStoreQuery } from '@novu/client';
+import { RefetchOptions, RefetchQueryFilters } from '@tanstack/react-query';
 
 export {
   IMessage,
@@ -104,7 +105,13 @@ export interface INotificationsContext {
   isFetchingNextPage: boolean;
   setStore: (storeId?: string) => void;
   fetchNextPage: () => void;
-  refetch: () => void;
+  refetch: <TPageData>({
+    page,
+    ...otherOptions
+  }?: {
+    page?: number;
+  } & RefetchOptions &
+    RefetchQueryFilters<TPageData>) => void;
   markNotificationAsRead: (messageId: string) => void;
   markNotificationAsUnRead: (messageId: string) => void;
   markNotificationAsSeen: (messageId: string) => void;


### PR DESCRIPTION
 ### What change does this PR introduce?
 Adds an optional parameter  `page` to the `refetch` function in the `notification-center` which  enables the user to `refetch` the notifications for a specific page, rather than resetting the page to `0`.

 ### Why was this change needed?
 This change enables the user to `refetch` the notifications for a specific page, which means they can view the notifications from that point on without having to load possibly multiple pages.
Closes: https://github.com/novuhq/novu/issues/2561

### Other information (Screenshots)

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
