### PR TITLE
feat: remove yearly stats due to performance issues

### DIFF
--- a/apps/api/src/app/notifications/dtos/activity-stats-response.dto.ts
+++ b/apps/api/src/app/notifications/dtos/activity-stats-response.dto.ts
@@ -3,8 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class ActivityStatsResponseDto {
   @ApiProperty()
   weeklySent: number;
+
   @ApiProperty()
   monthlySent: number;
-  @ApiProperty()
-  yearlySent: number;
 }

--- a/apps/api/src/app/notifications/e2e/get-activity-stats.e2e.ts
+++ b/apps/api/src/app/notifications/e2e/get-activity-stats.e2e.ts
@@ -38,14 +38,13 @@ describe('Get activity stats - /notifications/stats (GET)', async () => {
       .expect(201);
   });
 
-  it('should retrieve zero for yearly, monthly and weekly stats if no notifications', async () => {
+  it('should retrieve zero for monthly and weekly stats if no notifications', async () => {
     const {
       body: { data },
     } = await session.testAgent.get('/v1/notifications/stats');
 
     expect(data.weeklySent).to.equal(0);
     expect(data.monthlySent).to.equal(0);
-    expect(data.yearlySent).to.equal(0);
   });
 
   it('should retrieve last month and last week activity', async function () {
@@ -90,7 +89,7 @@ describe('Get activity stats - /notifications/stats (GET)', async () => {
     expect(data.monthlySent).to.equal(2);
   });
 
-  it('should retrieve the expected yearly, monthly and weekly stats', async () => {
+  it('should retrieve the expected monthly and weekly stats', async () => {
     const _environmentId = session.environment._id;
     const _organizationId = session.organization._id;
     const _subscriberId = subscriberId;
@@ -190,6 +189,5 @@ describe('Get activity stats - /notifications/stats (GET)', async () => {
 
     expect(data.weeklySent).to.equal(7);
     expect(data.monthlySent).to.equal(18);
-    expect(data.yearlySent).to.equal(27);
   });
 });

--- a/apps/api/src/app/notifications/usecases/get-activity-stats/get-activity-stats.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-stats/get-activity-stats.usecase.ts
@@ -15,7 +15,6 @@ export class GetActivityStats {
     return {
       weeklySent: result.weekly,
       monthlySent: result.monthly,
-      yearlySent: result.yearly,
     };
   }
 }

--- a/apps/web/src/pages/activities/components/ActivityStatistics.tsx
+++ b/apps/web/src/pages/activities/components/ActivityStatistics.tsx
@@ -8,14 +8,12 @@ import { colors } from '../../../design-system';
 
 export function ActivityStatistics() {
   const { data: activityStats } = useQuery<{
-    yearlySent: number;
     monthlySent: number;
     weeklySent: number;
   }>(['activityStats'], getActivityStats);
   const isDark = useMantineTheme().colorScheme === 'dark';
   const weekCount = typeof activityStats?.weeklySent == 'number' ? formatNumber(activityStats.weeklySent, 0) : null;
   const monthCount = typeof activityStats?.monthlySent == 'number' ? formatNumber(activityStats.monthlySent, 0) : null;
-  const yearCount = typeof activityStats?.yearlySent == 'number' ? formatNumber(activityStats.yearlySent, 0) : null;
 
   return (
     <>
@@ -36,12 +34,6 @@ export function ActivityStatistics() {
           </StyledNumber>
           <StatsLabel isColored isDark={isDark}>
             This month
-          </StatsLabel>
-        </StatisticsBox>
-        <StatisticsBox>
-          <StyledNumber isColored={false}>{yearCount ? yearCount : <Skeleton height={30} width="60%" />}</StyledNumber>
-          <StatsLabel isColored={false} isDark={isDark}>
-            This year
           </StatsLabel>
         </StatisticsBox>
       </ContentWrapper>

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -27,8 +27,8 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement = object> {
     });
   }
 
-  async aggregate(query: any[]): Promise<any> {
-    return await this.MongooseModel.aggregate(query);
+  async aggregate(query: any[], options: { readPreference?: 'secondaryPreferred' | 'primary' } = {}): Promise<any> {
+    return await this.MongooseModel.aggregate(query).read(options.readPreference || 'primary');
   }
 
   async findById(id: string, select?: string): Promise<T_MappedEntity | null> {

--- a/libs/dal/src/repositories/notification/notification.repository.ts
+++ b/libs/dal/src/repositories/notification/notification.repository.ts
@@ -126,28 +126,33 @@ export class NotificationRepository extends BaseRepository<
   }
 
   async getActivityGraphStats(date: Date, environmentId: string) {
-    return await this.aggregate([
-      {
-        $match: {
-          createdAt: { $gte: date },
-          _environmentId: new Types.ObjectId(environmentId),
-        },
-      },
-      { $unwind: '$channels' },
-      {
-        $group: {
-          _id: {
-            $dateToString: { format: '%Y-%m-%d', date: '$createdAt' },
+    return await this.aggregate(
+      [
+        {
+          $match: {
+            createdAt: { $gte: date },
+            _environmentId: new Types.ObjectId(environmentId),
           },
-          count: {
-            $sum: 1,
-          },
-          templates: { $addToSet: '$_templateId' },
-          channels: { $addToSet: '$channels' },
         },
-      },
-      { $sort: { _id: -1 } },
-    ]);
+        { $unwind: '$channels' },
+        {
+          $group: {
+            _id: {
+              $dateToString: { format: '%Y-%m-%d', date: '$createdAt' },
+            },
+            count: {
+              $sum: 1,
+            },
+            templates: { $addToSet: '$_templateId' },
+            channels: { $addToSet: '$channels' },
+          },
+        },
+        { $sort: { _id: -1 } },
+      ],
+      {
+        readPreference: 'secondaryPreferred',
+      }
+    );
   }
 
   async getStats(environmentId: EnvironmentId): Promise<{ weekly: number; monthly: number }> {
@@ -155,23 +160,28 @@ export class NotificationRepository extends BaseRepository<
     const monthBefore = subMonths(now, 1);
     const weekBefore = subWeeks(now, 1);
 
-    const result = await this.aggregate([
-      {
-        $match: {
-          _environmentId: this.convertStringToObjectId(environmentId),
-          createdAt: {
-            $gte: monthBefore,
+    const result = await this.aggregate(
+      [
+        {
+          $match: {
+            _environmentId: this.convertStringToObjectId(environmentId),
+            createdAt: {
+              $gte: monthBefore,
+            },
           },
         },
-      },
-      {
-        $group: {
-          _id: null,
-          weekly: { $sum: { $cond: [{ $gte: ['$createdAt', weekBefore] }, 1, 0] } },
-          monthly: { $sum: { $cond: [{ $gte: ['$createdAt', monthBefore] }, 1, 0] } },
+        {
+          $group: {
+            _id: null,
+            weekly: { $sum: { $cond: [{ $gte: ['$createdAt', weekBefore] }, 1, 0] } },
+            monthly: { $sum: 1 },
+          },
         },
-      },
-    ]);
+      ],
+      {
+        readPreference: 'secondaryPreferred',
+      }
+    );
 
     const stats = result[0] || {};
 

--- a/libs/dal/src/repositories/notification/notification.repository.ts
+++ b/libs/dal/src/repositories/notification/notification.repository.ts
@@ -150,9 +150,8 @@ export class NotificationRepository extends BaseRepository<
     ]);
   }
 
-  async getStats(environmentId: EnvironmentId): Promise<{ weekly: number; monthly: number; yearly: number }> {
+  async getStats(environmentId: EnvironmentId): Promise<{ weekly: number; monthly: number }> {
     const now: number = Date.now();
-    const yearBefore = subYears(now, 1);
     const monthBefore = subMonths(now, 1);
     const weekBefore = subWeeks(now, 1);
 
@@ -161,7 +160,7 @@ export class NotificationRepository extends BaseRepository<
         $match: {
           _environmentId: this.convertStringToObjectId(environmentId),
           createdAt: {
-            $gte: yearBefore,
+            $gte: monthBefore,
           },
         },
       },
@@ -170,7 +169,6 @@ export class NotificationRepository extends BaseRepository<
           _id: null,
           weekly: { $sum: { $cond: [{ $gte: ['$createdAt', weekBefore] }, 1, 0] } },
           monthly: { $sum: { $cond: [{ $gte: ['$createdAt', monthBefore] }, 1, 0] } },
-          yearly: { $sum: 1 },
         },
       },
     ]);
@@ -180,7 +178,6 @@ export class NotificationRepository extends BaseRepository<
     return {
       weekly: stats.weekly || 0,
       monthly: stats.monthly || 0,
-      yearly: stats.yearly || 0,
     };
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

This removes the yearly aggregation from the stats endpoint that causes performance issues when doing the queries against notification collection. 


### Why was this change needed?

For larger organizations this results in a very long operations, we will review our analytical approach there in the future, but for now disabling this to avoid bottlenecks. 

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
