### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/local/deployment/docker-compose.yml
+++ b/docker/local/deployment/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       REACT_APP_ENVIRONMENT: ${NODE_ENV}
       REACT_APP_WIDGET_EMBED_PATH: ${WIDGET_EMBED_PATH}
       REACT_APP_DOCKER_HOSTED_ENV: 'true'
+      REACT_APP_WS_URL: ${REACT_APP_WS_URL}
     ports:
       - 4200:4200
   widget:


### PR DESCRIPTION

### What change does this PR introduce?

add: environment config for deployment compose file to fix ws pointing to local host because of env not reflecting inside the docker

### Why was this change needed?
 
In the docker compose file of **local/deployment** there's no mapping for REACT_APP_WS_URL which will create issue of default mapping to localhost:3002. 

### Other information (Screenshots)

![WhatsApp Image 2023-04-11 at 2 06 24 AM](https://user-images.githubusercontent.com/93864853/230999255-c15ec28c-647c-40ff-87f5-09462342d3bf.jpeg)

