### PR TITLE
Index Cleanup - Subscriber

### DIFF
--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -35,7 +35,141 @@ const subscriberSchema = new Schema<SubscriberDBModel>(
   schemaOptions
 );
 
-subscriberSchema.index({ _environmentId: 1, subscriberId: 1 });
+/*
+ * This index was initially created to optimize:
+ *
+ * Path: apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.usecase.ts
+ * Context: execute()
+ * Query: findBatch({
+ *       _environmentId: command.environmentId,
+ *       _organizationId: command.organizationId,
+ *     }
+ *
+ * Path: apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.usecase.ts
+ * Context: execute()
+ * Query: count({
+ *    _environmentId: command.environmentId,
+ *    _organizationId: command.organizationId,
+ *  });
+ *
+ * Path: apps/api/src/app/subscribers/usecases/get-subscribers/get-subscriber.usecase.ts
+ * Context: execute()
+ * Query: find({
+ *     _environmentId: command.environmentId,
+ *     _organizationId: command.organizationId,
+ *   });
+ *
+ * Path: libs/dal/src/repositories/subscriber/subscriber.repository.ts
+ * Context: searchSubscribers()
+ * Query: find({
+ *    _environmentId: environmentId,
+ *      {email: {$in: emails,}
+ */
+subscriberSchema.index({
+  _environmentId: 1,
+  email: 1,
+});
+
+/*
+ * This index was initially created to optimize:
+ *
+ * Path: libs/dal/src/repositories/subscriber/subscriber.repository.ts
+ * Context: searchSubscribers()
+ * Query: find({
+ *    _environmentId: environmentId,
+ *    $or: {
+ *      {email: {$in: emails,}
+ *      {email: {
+ *          $regex: regExpEscape(search),
+ *          $options: 'i',},}
+ *        },
+ *      {subscriberId: search,}
+ *  });
+ * Path: libs/dal/src/repositories/subscriber/subscriber.repository.ts
+ * Context: findBySubscriberId()
+ * Query: findOne(
+ *     {
+ *       _environmentId: environmentId,
+ *       subscriberId,
+ *     }
+ *
+ * Path: libs/dal/src/repositories/subscriber/subscriber.repository.ts
+ * Context: searchByExternalSubscriberIds()
+ * Query: find({
+ *     _environmentId,
+ *     _organizationId,
+ *     subscriberId: {
+ *       $in: externalSubscriberIds,
+ *     },
+ *   });
+ *
+ * Path: libs/dal/src/repositories/subscriber/subscriber.repository.ts
+ * Context: delete()
+ * Query: findOne({
+ *    _environmentId: query._environmentId,
+ *    subscriberId: query.subscriberId,
+ *  });
+ *
+ *
+ * Path: libs/dal/src/repositories/subscriber/subscriber.repository.ts
+ * Context: delete()
+ * Query: delete({
+ *     _environmentId: query._environmentId,
+ *     subscriberId: query.subscriberId,
+ *   });
+ *
+ *
+ * Path: libs/dal/src/repositories/subscriber/subscriber.repository.ts
+ * Context: findDeleted()
+ * Query: findDeleted({
+ *    _environmentId: query._environmentId,
+ *    subscriberId: query.subscriberId,
+ *  });
+ *
+ * Path: apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
+ * Context: execute()
+ * Query: delete({
+ *      _environmentId: subscriber._environmentId,
+ *      _organizationId: subscriber._organizationId,
+ *      subscriberId: subscriber.subscriberId,
+ *    });
+ *
+ * Path: apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
+ * Context: execute()
+ * Query: delete({
+ *      _environmentId: subscriber._environmentId,
+ *      _organizationId: subscriber._organizationId,
+ *      subscriberId: subscriber.subscriberId,
+ *    });
+ *
+ * Path: apps/api/src/app/events/usecases/send-message/send-message.base.ts
+ * Context: getSubscriberBySubscriberId()
+ * Query: findOne({
+ *    subscriberId,
+ *    _environmentId,
+ *  });
+ *
+ * Path: apps/api/src/app/events/usecases/send-message/send-message.usecase.ts
+ * Context: getSubscriberBySubscriberId()
+ * Query: findOne({
+ *     subscriberId,
+ *     _environmentId,
+ *   });
+ *
+ * Path: apps/api/src/app/integrations/usecases/get-In-app-activated/get-In-app-activated.usecase.ts
+ * Context: execute()
+ * Query: count({
+ *    _organizationId: command.organizationId,
+ *    _environmentId: command.environmentId,
+ *    isOnline: { $exists: true },
+ *    subscriberId: /on-boarding-subscriber/i,
+ *  });
+ */
+subscriberSchema.index({
+  subscriberId: 1,
+  _environmentId: 1,
+  email: 1,
+});
 
 subscriberSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, overrideMethods: 'all' });
 

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -168,7 +168,7 @@ subscriberSchema.index({
 subscriberSchema.index({
   subscriberId: 1,
   _environmentId: 1,
-  email: 1,
+  _id: 1,
 });
 
 subscriberSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, overrideMethods: 'all' });


### PR DESCRIPTION
### What change does this PR introduce?

Why? (Context)

We want to remove as many inefficient indexs and queries as possible.

### Why was this change needed?

Stop using single indexes on the mongoose key implementation
Add compound indexes for common queries and patterns using MongoDB index best practices
Remove unused indexes from MongoDB atlas after implementing the new compound indexes

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
