### PR TITLE
Nv 2109 add example for socket listener

### DIFF
--- a/docs/docs/notification-center/headless/api-reference.md
+++ b/docs/docs/notification-center/headless/api-reference.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: API Reference
+---
+
 # Headless Notification Center API Reference
 
 This page contains the complete documentation about the Headless Notification Center package. You can find here the list of all the methods that you can use.

--- a/docs/docs/notification-center/headless/api-reference.md
+++ b/docs/docs/notification-center/headless/api-reference.md
@@ -141,6 +141,27 @@ interface IListenUnseenCountChanget {
 }
 ```
 
+## listenUnreadCountChange
+
+Listens to the changes of the unread count.
+Can be used to get real time count of the unread messages.
+
+```ts
+headlessService.listenUnreadCountChange({
+  listener: (unreadCount: number) => {
+    console.log(unreadCount);
+  },
+});
+```
+
+### method args interface
+
+```ts
+interface IListenUnreadCountChanget {
+  listener: (unreadCount: number) => void;
+}
+```
+
 ## fetchNotifications
 
 Retrieves the list of notifications for the subscriber.

--- a/docs/docs/notification-center/headless/headless-service.md
+++ b/docs/docs/notification-center/headless/headless-service.md
@@ -106,11 +106,24 @@ To read more about HMAC Encryption, visit [here](../react/react-components#hmac-
 
 Novu headless library provides `listenUnseenCountChange` API to listen to real-time socket changes and get updates about new notifications added to the user's feed.
 
+### unseen count changes
+
 ```js
 headlessService.listenUnseenCountChange({
   // this will run every time there's a change in the `unseen_count` in real-time
   listener: (unseenCount: number) => {
     console.log(unseenCount);
+  },
+});
+```
+
+### unread count changes
+
+```js
+headlessService.listenUnreadCountChange({
+  // this will run every time there's a change in the `unread_count` in real-time
+  listener: (unreadCount: number) => {
+    console.log(unreadCount);
   },
 });
 ```

--- a/docs/docs/notification-center/headless/headless-service.md
+++ b/docs/docs/notification-center/headless/headless-service.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 8
+sidebar_position: 1
+sidebar_label: Headless Notification Center
 ---
 
 # Headless Notification Center
@@ -100,3 +101,16 @@ const headlessService = new HeadlessService({
 :::info
 To read more about HMAC Encryption, visit [here](../react/react-components#hmac-encryption)
 :::
+
+## Realtime Sockets
+
+Novu headless library provides `listenUnseenCountChange` API to listen to real-time socket changes and get updates about new notifications added to the user's feed.
+
+```js
+headlessService.listenUnseenCountChange({
+  // this will run every time there's a change in the `unseen_count` in real-time
+  listener: (unseenCount: number) => {
+    console.log(unseenCount);
+  },
+});
+```


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- adds an example usage for the socket listeners on the quick start page.
- adds the listener for unread_count.
- updates the API reference doc with the unread_count
- test for listenUnreadCountChange
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
