### PR TITLE
feat(cluster): implement wait until readiness functionality

### DIFF
--- a/apps/api/src/app/shared/services/distributed-lock/distributed-lock.service.spec.ts
+++ b/apps/api/src/app/shared/services/distributed-lock/distributed-lock.service.spec.ts
@@ -37,8 +37,15 @@ describe('Distributed Lock Service', () => {
     let inMemoryProviderService: InMemoryProviderService;
     let distributedLockService: DistributedLockService;
 
-    beforeEach(() => {
+    before(async () => {
       inMemoryProviderService = new InMemoryProviderService();
+
+      await inMemoryProviderService.delayUntilReadiness();
+
+      expect(inMemoryProviderService.getStatus()).to.eql('ready');
+    });
+
+    beforeEach(() => {
       distributedLockService = new DistributedLockService(inMemoryProviderService);
     });
 
@@ -93,24 +100,26 @@ describe('Distributed Lock Service', () => {
     describe('Functionalities', () => {
       it('should create lock and it should expire after the TTL set', async () => {
         const resource = 'lock-created';
-        const TTL = 100;
-        const handler = async () => setTimeout(500);
+        const TTL = 1000;
+        const handler = async () => setTimeout(1.5 * TTL);
+        const client = distributedLockService.instances[0];
 
         distributedLockService.applyLock({ resource, ttl: TTL }, handler);
+        const firstTimeout = TTL / 2;
+        await setTimeout(firstTimeout);
 
-        const client = distributedLockService.instances[0];
         let resourceExists = await client!.exists(resource);
         expect(resourceExists).to.eql(1);
         // TTL + this time should be less than the handler set one to see that the self expiration works
-        await setTimeout(TTL + 10);
+        await setTimeout(firstTimeout * 2 + 10);
         resourceExists = await client!.exists(resource);
         expect(resourceExists).to.eql(0);
 
         expect(spyLock.calledOnceWith([resource], TTL)).to.eq(true);
         expect(spyIncreaseLockCounter.calledOnce).to.eql(true);
-        expect(spyDecreaseLockCounter.callCount).to.eql(0);
-        // Unlock shouldn't be called as the lock expires by going over TTL
-        expect(spyUnlock.called).to.eq(false);
+        expect(spyDecreaseLockCounter.callCount).to.eql(1);
+        // Unlock is still called even when the lock expires by going over TTL but errors
+        expect(spyUnlock.called).to.eq(true);
       });
 
       it('should create lock and it should expire if the handler throws', async () => {

--- a/apps/api/src/app/shared/services/in-memory-provider/elasticache-cluster-provider.ts
+++ b/apps/api/src/app/shared/services/in-memory-provider/elasticache-cluster-provider.ts
@@ -81,20 +81,19 @@ export const getElasticacheCluster = (): Cluster | undefined => {
 
   const options: ClusterOptions = {
     dnsLookup: (address, callback) => callback(null, address),
+    enableAutoPipelining: true,
     enableOfflineQueue: false,
     enableReadyCheck: true,
-    scaleReads: 'slave',
     redisOptions: {
       tls: {},
       connectTimeout: 10000,
     },
-    // scaleReads: 'slave' as NodeRole, // Enable it for improved performance to read only in replicas
+    scaleReads: 'slave',
     /*
      *  Disabled in Prod as affects performance
      */
     showFriendlyErrorStack: process.env.NODE_ENV !== 'prod',
     slotsRefreshTimeout: 10000,
-    enableAutoPipelining: true,
   };
 
   Logger.log(`Initializing Elasticache Cluster service`);

--- a/apps/api/src/app/shared/services/in-memory-provider/in-memory-provider.service.spec.ts
+++ b/apps/api/src/app/shared/services/in-memory-provider/in-memory-provider.service.spec.ts
@@ -6,10 +6,14 @@ let inMemoryProviderService: InMemoryProviderService;
 
 describe('In-memory Provider Service', () => {
   describe('Non cluster mode', () => {
-    beforeEach(() => {
+    before(async () => {
       process.env.IN_MEMORY_CLUSTER_MODE_ENABLED = 'false';
 
       inMemoryProviderService = new InMemoryProviderService();
+
+      await inMemoryProviderService.delayUntilReadiness();
+
+      expect(inMemoryProviderService.getStatus()).to.eql('ready');
     });
 
     describe('Set up', () => {
@@ -35,7 +39,7 @@ describe('In-memory Provider Service', () => {
 
         const { inMemoryProviderClient } = inMemoryProviderService;
 
-        expect(inMemoryProviderClient!.status).to.eql('connecting');
+        expect(inMemoryProviderClient!.status).to.eql('ready');
         expect(inMemoryProviderClient!.isCluster).to.eql(false);
 
         const options = inMemoryProviderService.getOptions();
@@ -61,10 +65,14 @@ describe('In-memory Provider Service', () => {
   });
 
   describe('Cluster mode', () => {
-    beforeEach(() => {
+    before(async () => {
       process.env.IN_MEMORY_CLUSTER_MODE_ENABLED = 'true';
 
       inMemoryProviderService = new InMemoryProviderService();
+
+      await inMemoryProviderService.delayUntilReadiness();
+
+      expect(inMemoryProviderService.getStatus()).to.eql('ready');
     });
 
     describe('Set up', () => {
@@ -100,14 +108,14 @@ describe('In-memory Provider Service', () => {
 
         const { inMemoryProviderClient } = inMemoryProviderService;
 
-        expect(inMemoryProviderClient!.status).to.eql('connecting');
+        expect(inMemoryProviderClient!.status).to.eql('ready');
         expect(inMemoryProviderClient!.isCluster).to.eql(true);
 
         const options = inMemoryProviderService.getOptions();
         expect(options).to.eql(undefined);
 
         const clusterOptions = inMemoryProviderService.getClusterOptions();
-        expect(clusterOptions!.enableOfflineQueue).to.eql(true);
+        expect(clusterOptions!.enableOfflineQueue).to.eql(false);
         expect(clusterOptions!.enableReadyCheck).to.eql(true);
         expect(clusterOptions!.maxRedirections).to.eql(16);
         expect(clusterOptions!.retryDelayOnClusterDown).to.eql(100);

--- a/apps/api/src/app/shared/services/in-memory-provider/redis-cluster-provider.ts
+++ b/apps/api/src/app/shared/services/in-memory-provider/redis-cluster-provider.ts
@@ -80,13 +80,15 @@ export const getRedisCluster = (): Cluster | undefined => {
   const { instances } = getRedisClusterProviderConfig();
 
   const options: ClusterOptions = {
+    enableAutoPipelining: true,
+    enableOfflineQueue: false,
+    enableReadyCheck: true,
+    scaleReads: 'slave',
     /*
      *  Disabled in Prod as affects performance
      */
     showFriendlyErrorStack: process.env.NODE_ENV !== 'prod',
     slotsRefreshTimeout: 2000,
-    scaleReads: 'slave',
-    enableAutoPipelining: true,
   };
 
   Logger.log(`Initializing Redis Cluster Provider with ${instances?.length} instances`);


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
A functionality for the in-memory provider service to await to operate until it is ready.
Also fix some tests that weren't properly designed.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
We have been observing some flakiness in tests related to the implement of Redis cluster mode and therefore in services dependent of the InMemoryProvider service such the DistributedLock service.

We need to add a functionality for testing that can be used to wait to execute the tests when the in-memory providers are ready to operate to avoid race conditions and flakey tests.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
