### PR TITLE
refactor: remove duplicate cache service initialization

### DIFF
--- a/apps/api/src/app/events/services/distributed-lock-service/index.ts
+++ b/apps/api/src/app/events/services/distributed-lock-service/index.ts
@@ -5,11 +5,7 @@ import { InMemoryProviderService } from '../../../shared/services/in-memory-prov
 
 @Injectable()
 export class EventsDistributedLockService {
-  private readonly distributedLockService;
-
-  constructor(private inMemoryProviderService: InMemoryProviderService) {
-    this.distributedLockService = new DistributedLockService(inMemoryProviderService);
-  }
+  constructor(private distributedLockService: DistributedLockService) {}
 
   public async applyLock<T>(settings, handler: () => Promise<T>): Promise<T> {
     return await this.distributedLockService.applyLock(settings, handler);

--- a/apps/api/src/app/events/usecases/add-job/add-digest-job.usecase.ts
+++ b/apps/api/src/app/events/usecases/add-job/add-digest-job.usecase.ts
@@ -24,15 +24,11 @@ type AddDigestJobResult = number | undefined;
 
 @Injectable()
 export class AddDigestJob {
-  private eventsDistributedLockService: EventsDistributedLockService;
-
   constructor(
-    private inMemoryProviderService: InMemoryProviderService,
+    private eventsDistributedLockService: EventsDistributedLockService,
     private jobRepository: JobRepository,
     protected createExecutionDetails: CreateExecutionDetails
-  ) {
-    this.eventsDistributedLockService = new EventsDistributedLockService(inMemoryProviderService);
-  }
+  ) {}
 
   public async execute(command: AddDigestJobCommand): Promise<AddDigestJobResult> {
     const { job } = command;

--- a/apps/api/src/app/shared/services/in-memory-provider/in-memory-provider.service.ts
+++ b/apps/api/src/app/shared/services/in-memory-provider/in-memory-provider.service.ts
@@ -34,6 +34,8 @@ export class InMemoryProviderService {
   public inMemoryProviderConfig: InMemoryProviderConfig;
 
   constructor() {
+    Logger.log('In-memory provider service initialized', LOG_CONTEXT);
+
     this.inMemoryProviderClient = this.buildClient();
   }
 

--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -102,7 +102,6 @@ const distributedLockService = {
 };
 
 const PROVIDERS = [
-  inMemoryProviderService,
   cacheService,
   distributedLockService,
   {


### PR DESCRIPTION
### What change does this PR introduce?

Previously the caching service was initialized 3 times because it was injected another un-needed time.

### Why was this change needed?

I'm concerned that we have a split connection for some of the redis calls. 

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
