### PR TITLE
feat(cluster): add prefix to distributed lock for autopipelining

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -434,7 +434,8 @@
     "maqsam",
     "Millis",
     "sscan",
-    "vishnudxb"
+    "vishnudxb",
+    "autopipelining"
   ],
   "flagWords": [],
   "patterns": [


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Allows the `autopipelining` feature of Ioredis in Cluster mode to be used by the DistributedLock service.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Seems we are still seeing spikes and probably head-of-line blocking is happening. We have `autopipelining` enabled in our Redis Cluster configuration. Adding the prefix should help to the problems we are noticing it.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
