### PR TITLE
fix(app-generic): allow jest to use axios using cjs

### DIFF
--- a/packages/application-generic/jest.config.js
+++ b/packages/application-generic/jest.config.js
@@ -3,6 +3,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleNameMapper: {
-    axios: "axios/dist/node/axios.cjs"
-  }
+    axios: 'axios/dist/node/axios.cjs',
+  },
 };

--- a/packages/application-generic/jest.config.js
+++ b/packages/application-generic/jest.config.js
@@ -2,4 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  moduleNameMapper: {
+    axios: "axios/dist/node/axios.cjs"
+  }
 };


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Instructs Jest to use Axios CJS module.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Allows the Application Generic package tests to be run in the local environment. Some of the test suites were failing because they used Axios and Jest was not correctly instructed to use the CJS package of Axios.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
