### PR TITLE
fix(api): improve the flow of mark message as use case for performance

### DIFF
--- a/apps/api/src/app/widgets/usecases/mark-message-as/mark-message-as.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/mark-message-as/mark-message-as.usecase.ts
@@ -67,15 +67,17 @@ export class MarkMessageAs {
   }
 
   private async updateServices(command: MarkMessageAsCommand, subscriber, messages, marked: string) {
-    const admin = await this.memberRepository.getOrganizationAdminAccount(command.organizationId);
-    const count = await this.messageRepository.getCount(command.environmentId, subscriber._id, ChannelTypeEnum.IN_APP, {
-      [marked]: false,
-    });
+    const [admin, count] = await Promise.all([
+      this.memberRepository.getOrganizationAdminAccount(command.organizationId),
+      this.messageRepository.getCount(command.environmentId, subscriber._id, ChannelTypeEnum.IN_APP, {
+        [marked]: false,
+      }),
+    ]);
 
     this.updateSocketCount(subscriber, count, marked);
 
-    for (const message of messages) {
-      if (admin) {
+    if (admin) {
+      for (const message of messages) {
         this.analyticsService.track(`Mark as ${marked} - [Notification Center]`, admin._userId, {
           _subscriber: message._subscriberId,
           _organization: command.organizationId,


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Parallelises 2 calls mutually independent for quicker execution and avoids an unnecessary loop if user is not admin.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Noticed this flow improvement when analysing calls pre yesterday's deployment where calls to `markAs` endpoint were quite slow. The biggest improvement has come from our infrastructure changes but decided to add this small thing as an extra.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
