### PR TITLE
Activity Feed: show subscriberId instead of novu's internal id 

### DIFF
--- a/apps/web/src/pages/activities/components/ActivityItem.tsx
+++ b/apps/web/src/pages/activities/components/ActivityItem.tsx
@@ -120,7 +120,8 @@ export const ActivityItem = ({ item, onClick }) => {
               </small>
               <div data-test-id="subscriber-id">
                 <small>
-                  <b>Subscriber id:</b> {item?.subscriber?.id ? item.subscriber.id : 'Deleted Subscriber'}
+                  <b>Subscriber id:</b>
+                  {item?.subscriber?.subscriberId ? item.subscriber.subscriberId : 'Deleted Subscriber'}
                 </small>
               </div>
               <div data-test-id="transaction-id">

--- a/libs/dal/src/repositories/notification/notification.repository.ts
+++ b/libs/dal/src/repositories/notification/notification.repository.ts
@@ -91,7 +91,7 @@ export class NotificationRepository extends BaseRepository<
           readPreference: 'secondaryPreferred',
         },
         path: 'subscriber',
-        select: 'firstName _id lastName email phone',
+        select: 'firstName _id lastName email phone subscriberId',
       })
       .populate({
         options: {


### PR DESCRIPTION
### What change does this PR introduce?
Fix - show the user's defined id for the subscriber (subscriberId). Currently in Activity Feed we are showing novu's id for that subscriber(subscriber._id). 
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
<img width="1501" alt="Screen Shot 2023-04-19 at 13 31 20" src="https://user-images.githubusercontent.com/7778680/233048270-cb421173-9ee7-4100-b474-ea9d73a5c1db.png">

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
