### PR TITLE
add nextjs env variable to vercel integration

### DIFF
--- a/apps/api/src/app/partner-integrations/usecases/complete-vercel-integration/complete-vercel-integration.usecase.ts
+++ b/apps/api/src/app/partner-integrations/usecases/complete-vercel-integration/complete-vercel-integration.usecase.ts
@@ -1,7 +1,7 @@
 import { HttpService } from '@nestjs/axios';
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { lastValueFrom } from 'rxjs';
-import { EnvironmentRepository, EnvironmentEntity, OrganizationRepository } from '@novu/dal';
+import { EnvironmentEntity, EnvironmentRepository, OrganizationRepository } from '@novu/dal';
 import { AnalyticsService } from '@novu/application-generic';
 
 import { CompleteVercelIntegrationCommand } from './complete-vercel-integration.command';
@@ -79,18 +79,15 @@ export class CompleteVercelIntegration {
   }
 
   private mapProjectKeys(envData: EnvironmentEntity[], projectData: Record<string, string[]>) {
-    const mappedData = envData.reduce<Record<string, MapProjectkeys>>((acc, curr) => {
-      const newData = {
+    return envData.reduce<Record<string, MapProjectkeys>>((acc, curr) => {
+      acc[curr._organizationId] = {
         privateKey: curr.apiKeys[0].key,
         clientKey: curr.identifier,
         projectIds: projectData[curr._organizationId],
       };
-      acc[curr._organizationId] = newData;
 
       return acc;
     }, {});
-
-    return mappedData;
   }
 
   private async setEnvironments({ clientKey, projectIds, privateKey, teamId, token }: ISetEnvironment): Promise<void> {
@@ -99,6 +96,12 @@ export class CompleteVercelIntegration {
     const type = 'encrypted';
 
     const apiKeys = [
+      {
+        target,
+        type,
+        value: clientKey,
+        key: 'NEXT_PUBLIC_NOVU_CLIENT_APP_ID',
+      },
       {
         target,
         type,

--- a/apps/api/src/app/partner-integrations/usecases/update-vercel-configuration/update-vercel-configuration.usecase.ts
+++ b/apps/api/src/app/partner-integrations/usecases/update-vercel-configuration/update-vercel-configuration.usecase.ts
@@ -139,20 +139,18 @@ export class UpdateVercelConfiguration {
     projectDetails: NewAndUpdatedProjectData
   ) {
     const { addProjectIds, updateProjectDetails } = projectDetails;
-    const mappedData = envData.reduce<Record<string, MapProjectkeys>>((acc, curr) => {
+
+    return envData.reduce<Record<string, MapProjectkeys>>((acc, curr) => {
       const projectIds = projectData[curr._organizationId];
-      const newData = {
+      acc[curr._organizationId] = {
         privateKey: curr.apiKeys[0].key,
         clientKey: curr.identifier,
         updateProjectDetails: updateProjectDetails.filter((detail) => projectIds.includes(detail.projectId)),
         addProjectIds: projectIds.filter((id) => addProjectIds.includes(id)),
       };
-      acc[curr._organizationId] = newData;
 
       return acc;
     }, {});
-
-    return mappedData;
   }
 
   private async setEnvironmentVariables({
@@ -178,6 +176,12 @@ export class UpdateVercelConfiguration {
         type,
         value: privateKey,
         key: 'NOVU_API_SECRET',
+      },
+      {
+        target,
+        type,
+        value: clientKey,
+        key: 'NEXT_PUBLIC_NOVU_CLIENT_APP_ID',
       },
     ];
 


### PR DESCRIPTION
### What change does this PR introduce?

This change adds the nextjs variable of NEXT_PUBLIC_NOVU_CLIENT_APP_ID that is required for nextjs apps to see the app id in the frontend.

### Why was this change needed?

This change allows projects that use nexjts to integrate with Novu to inline the NOVU_CLIENT_APP_ID in the frontend.

### Other information (Screenshots)

https://nextjs.org/docs/basic-features/environment-variables
