### PR TITLE
remove worker from docker-compose.yml

### DIFF
--- a/docker/local/deployment/docker-compose.yml
+++ b/docker/local/deployment/docker-compose.yml
@@ -49,29 +49,6 @@ services:
       API_CONTEXT_PATH: ${API_CONTEXT_PATH}
     ports:
       - '3000:3000'
-  worker:
-    image: 'ghcr.io/novuhq/novu/worker:0.13.0'
-    depends_on:
-      - mongodb
-      - redis
-    container_name: worker
-    environment:
-      NODE_ENV: ${NODE_ENV}
-      MONGO_URL: ${MONGO_URL}
-      REDIS_HOST: ${REDIS_HOST}
-      REDIS_PORT: ${REDIS_PORT}
-      REDIS_DB_INDEX: 2
-      REDIS_CACHE_SERVICE_HOST: ${REDIS_CACHE_SERVICE_HOST}
-      REDIS_CACHE_SERVICE_PORT: ${REDIS_CACHE_SERVICE_PORT}
-      S3_LOCAL_STACK: ${S3_LOCAL_STACK}
-      S3_BUCKET_NAME: ${S3_BUCKET_NAME}
-      S3_REGION: ${S3_REGION}
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      STORE_ENCRYPTION_KEY: ${STORE_ENCRYPTION_KEY}
-      SENTRY_DSN: ${SENTRY_DSN}
-      NEW_RELIC_APP_NAME: ${NEW_RELIC_APP_NAME}
-      NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY}
   ws:
     image: 'ghcr.io/novuhq/novu/ws:0.13.0'
     depends_on:
@@ -92,7 +69,6 @@ services:
     image: 'ghcr.io/novuhq/novu/web:0.13.0'
     depends_on:
       - api
-      - worker
     container_name: web
     environment:
       REACT_APP_API_URL: ${API_ROOT_URL}
@@ -106,7 +82,6 @@ services:
     image: 'ghcr.io/novuhq/novu/widget:0.13.0'
     depends_on:
       - api
-      - worker
       - web
     container_name: widget
     environment:


### PR DESCRIPTION
Removes service `worker` from docker-compose.yml because image for `ghcr.io/novuhq/novu/worker:0.13.0` does not exist

### What change does this PR introduce?

I'm following the instructions from <https://docs.novu.co/overview/docker-deploy#quick-start>, and it seems that these docs are outdated (there's no docker-compose.redis-cluster.yml at that location). 

If I check the repository, the README says that I should use deployment/docker-compose.yml  instead, which is pulling an image for worker that does not exist (there's a `worker-ee` at <https://github.com/orgs/novuhq/packages> but no luck with that one).

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

`worker` image does not exist and breaks deployment

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
