### PR TITLE
Update digest.md

### DIFF
--- a/docs/docs/platform/digest.md
+++ b/docs/docs/platform/digest.md
@@ -91,3 +91,5 @@ Total events in digest:
   Not a digested template
 {{/if}}
 ```
+
+Note that if only one matching trigger activates a regular digest during its period, that single item will still come through as a digest with `step.total_count` as 1.


### PR DESCRIPTION
Explicitly state behavior of digest step with only one item

### What change does this PR introduce?
Update digest.md to better explain what happens to a digest with one item.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
I spent a lot of time trying to figure out how Novu reacts to digests of one item from the documentation, since the sample template includes the digest status as a condition.  I'm guessing that's for back-off digests?

Anyway, this would explicitly note what happens to a digest with one item.
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
