### PR TITLE
fix: office 365 email provider is failing

### DIFF
--- a/providers/outlook365/src/lib/outlook365.provider.ts
+++ b/providers/outlook365/src/lib/outlook365.provider.ts
@@ -27,7 +27,7 @@ export class Outlook365Provider implements IEmailProvider {
       connectionTImeout: 30000,
       auth: {
         user: this.config.from,
-        password: this.config.password,
+        pass: this.config.password,
       },
       tls: {
         ciphers: 'SSLv3',
@@ -86,6 +86,6 @@ export class Outlook365Provider implements IEmailProvider {
       sendMailOptions.replyTo = options.replyTo;
     }
 
-    return;
+    return sendMailOptions;
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

Fix - office 365 email provider failing. 

1. password to pass
2. weren't returning the created mail data

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
