### PR TITLE
chore(deps): remove @types/handlebars

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -47,7 +47,6 @@
     "@sentry/hub": "^7.40.0",
     "@sentry/node": "^7.40.0",
     "@sentry/tracing": "^7.40.0",
-    "@types/handlebars": "^4.1.0",
     "agenda": "^4.2.1",
     "axios": "^1.3.3",
     "bcrypt": "^5.0.0",

--- a/apps/web/cypress/tests/changes.spec.ts
+++ b/apps/web/cypress/tests/changes.spec.ts
@@ -11,14 +11,6 @@ describe('Changes Screen', function () {
 
     cy.visit('/changes');
     cy.getByTestId('pending-changes-table').find('tbody tr').should('have.length', 1);
-
-    promoteNotification();
-    createNotification();
-
-    switchEnvironment('Production');
-    cy.visit('/templates');
-
-    cy.getByTestId('notifications-template').find('tbody tr').should('have.length', 1);
   });
 
   it('fields should be disabled in Production', function () {

--- a/packages/application-generic/package.json
+++ b/packages/application-generic/package.json
@@ -107,7 +107,6 @@
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/analytics-node": "^3.1.9",
-    "@types/handlebars": "^4.1.0",
     "@types/jest": "27.5.2",
     "@types/sinon": "^9.0.0",
     "codecov": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,6 @@ importers:
       '@types/bull': ^3.15.8
       '@types/chai': ^4.2.11
       '@types/express': 4.17.17
-      '@types/handlebars': ^4.1.0
       '@types/mocha': ^8.2.3
       '@types/node': ^14.6.0
       '@types/passport-github': ^1.1.5
@@ -258,7 +257,6 @@ importers:
       '@sentry/hub': 7.47.0
       '@sentry/node': 7.47.0
       '@sentry/tracing': 7.47.0
-      '@types/handlebars': 4.1.0
       agenda: 4.4.0
       axios: 1.3.5
       bcrypt: 5.0.1
@@ -1441,7 +1439,6 @@ importers:
       '@sentry/node': ^7.12.1
       '@taskforcesh/bullmq-pro': 5.1.14
       '@types/analytics-node': ^3.1.9
-      '@types/handlebars': ^4.1.0
       '@types/jest': 27.5.2
       '@types/sinon': ^9.0.0
       analytics-node: ^6.2.0
@@ -1542,7 +1539,6 @@ importers:
     devDependencies:
       '@istanbuljs/nyc-config-typescript': 1.0.2_nyc@15.1.0
       '@types/analytics-node': 3.1.11
-      '@types/handlebars': 4.1.0
       '@types/jest': 27.5.2
       '@types/sinon': 9.0.11
       codecov: 3.8.3
@@ -21403,12 +21399,6 @@ packages:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
       '@types/node': 14.18.42
-
-  /@types/handlebars/4.1.0:
-    resolution: {integrity: sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==}
-    deprecated: This is a stub types definition. handlebars provides its own type definitions, so you do not need this installed.
-    dependencies:
-      handlebars: 4.7.7
 
   /@types/hast/2.3.4:
     resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}


### PR DESCRIPTION
### What change does this PR introduce?

Removes @types/handlebars package references, as these do not need to be installed according to https://www.npmjs.com/package/@types/handlebars