### PR TITLE
fix: add sender name option in mailjet

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "start:docker:embed": "cd libs/embed && npm run start:docker",
     "start:docker:widget": "cross-env nx run-many --target=start:docker --projects=@novu/widget",
     "docker:build": "pnpm -r --if-present --parallel docker:build",
-    "build": "nx run-many --target=build --exclude=angular-notification-center-example,vue-notification-center-example --all",
+    "build": "nx run-many --target=build --all",
     "prebuild": "nx run-many --target=prebuild --all",
     "build:api": "nx build @novu/api",
     "build:worker": "nx build @novu/worker",

--- a/packages/application-generic/src/factories/mail/handlers/mailjet.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/mailjet.handler.ts
@@ -8,10 +8,16 @@ export class MailjetHandler extends BaseHandler {
     super('mailjet', ChannelTypeEnum.EMAIL);
   }
   buildProvider(credentials: ICredentials, from?: string) {
-    const config: { apiKey: string; apiSecret: string; from: string } = {
+    const config: {
+      apiKey: string;
+      apiSecret: string;
+      from: string;
+      senderName: string;
+    } = {
       from: from as string,
       apiKey: credentials.apiKey as string,
       apiSecret: credentials.secretKey as string,
+      senderName: credentials.senderName as string,
     };
 
     this.provider = new MailjetEmailProvider(config);

--- a/providers/mailjet/src/lib/mailjet.provider.spec.ts
+++ b/providers/mailjet/src/lib/mailjet.provider.spec.ts
@@ -51,6 +51,7 @@ const mockConfig = {
   apiKey: 'testApiKey',
   apiSecret: 'testSecret',
   from: 'testFrom@test.com',
+  senderName: 'testSender',
 };
 const mockMessageConfig = {
   to: ['testTo@test2.com'],
@@ -67,7 +68,7 @@ test('should trigger mailjet library correctly and return proper response', asyn
   expect(requestFn).toBeCalledWith({
     Messages: [
       {
-        From: { Email: mockConfig.from },
+        From: { Email: mockConfig.from, Name: mockConfig.senderName },
         HTMLPart: mockMessageConfig.html,
         Subject: mockMessageConfig.subject,
         TextPart: undefined,

--- a/providers/mailjet/src/lib/mailjet.provider.ts
+++ b/providers/mailjet/src/lib/mailjet.provider.ts
@@ -23,6 +23,7 @@ export class MailjetEmailProvider implements IEmailProvider {
       apiKey: string;
       apiSecret: string;
       from: string;
+      senderName: string;
     }
   ) {
     this.mailjetClient = Client.connect(config.apiKey, config.apiSecret);
@@ -74,6 +75,7 @@ export class MailjetEmailProvider implements IEmailProvider {
     const message: Email.SendParamsMessage = {
       From: {
         Email: options.from || this.config.from,
+        Name: this.config.senderName,
       },
       To: options.to.map((email) => ({
         Email: email,


### PR DESCRIPTION
### What change does this PR introduce?
Add senderName option in mailjet provider

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
With mailjet as active integration, sender name was not visible in email

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
