### PR TITLE
fix: merge template status to parent change

### DIFF
--- a/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.usecase.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { NotificationTemplateEntity, NotificationTemplateRepository } from '@novu/dal';
+import { NotificationTemplateEntity, NotificationTemplateRepository, ChangeRepository } from '@novu/dal';
 import { ChangeEntityTypeEnum } from '@novu/shared';
 import {
   buildNotificationTemplateIdentifierKey,
@@ -15,7 +15,8 @@ export class ChangeTemplateActiveStatus {
   constructor(
     private invalidateCache: InvalidateCacheService,
     private notificationTemplateRepository: NotificationTemplateRepository,
-    private createChange: CreateChange
+    private createChange: CreateChange,
+    private changeRepository: ChangeRepository
   ) {}
 
   async execute(command: ChangeTemplateActiveStatusCommand): Promise<NotificationTemplateEntity> {
@@ -62,6 +63,12 @@ export class ChangeTemplateActiveStatus {
     const item = await this.notificationTemplateRepository.findById(command.templateId, command.environmentId);
     if (!item) throw new NotFoundException(`Notification template ${command.templateId} is not found`);
 
+    const parentChangeId: string = await this.changeRepository.getChangeId(
+      command.environmentId,
+      ChangeEntityTypeEnum.NOTIFICATION_TEMPLATE,
+      command.templateId
+    );
+
     await this.createChange.execute(
       CreateChangeCommand.create({
         organizationId: command.organizationId,
@@ -69,7 +76,7 @@ export class ChangeTemplateActiveStatus {
         userId: command.userId,
         type: ChangeEntityTypeEnum.NOTIFICATION_TEMPLATE,
         item,
-        changeId: NotificationTemplateRepository.createObjectId(),
+        changeId: parentChangeId,
       })
     );
 


### PR DESCRIPTION
### What change does this PR introduce?

This PR adds a merge of status change to parent change, which will help the user to promote the changes in historical order. 
 
### Why was this change needed?

At the moment status changes create separate changes which can cause issues if the order of the promotions is different from the historical order.
Closes #3287 

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
