### PR TITLE
fix: keep unapplied changes

### DIFF
--- a/apps/api/src/app/change/usecases/apply-change/apply-change.usecase.ts
+++ b/apps/api/src/app/change/usecases/apply-change/apply-change.usecase.ts
@@ -42,6 +42,16 @@ export class ApplyChange {
       throw new NotFoundException();
     }
 
+    await this.promoteChangeToEnvironment.execute(
+      PromoteChangeToEnvironmentCommand.create({
+        itemId: change._entityId,
+        type: change.type,
+        environmentId: change._environmentId,
+        organizationId: change._organizationId,
+        userId: command.userId,
+      })
+    );
+
     await this.changeRepository.update(
       {
         _id: change._id,
@@ -51,16 +61,6 @@ export class ApplyChange {
       {
         enabled: true,
       }
-    );
-
-    await this.promoteChangeToEnvironment.execute(
-      PromoteChangeToEnvironmentCommand.create({
-        itemId: change._entityId,
-        type: change.type,
-        environmentId: change._environmentId,
-        organizationId: change._organizationId,
-        userId: command.userId,
-      })
     );
 
     return change;


### PR DESCRIPTION
### What change does this PR introduce?

Keep the changes if the change was not applied because of an exception.

### Why was this change needed?

In order to not confuse the user, and keep the change so it could be merged once the issue is resolved. 

### Other information (Screenshots)


The downside is that the changes will accumulate to a large number
