### PR TITLE
feat(integrations): Add baseUrl to mailgun-handler

### DIFF
--- a/packages/application-generic/src/factories/mail/handlers/mailgun.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/mailgun.handler.ts
@@ -14,10 +14,12 @@ export class MailgunHandler extends BaseHandler {
       username: string;
       domain: string;
       from: string;
+      baseUrl?: string;
     } = {
-      apiKey: credentials.apiKey as string,
-      username: credentials.user as string,
-      domain: credentials.domain as string,
+      apiKey: credentials.apiKey,
+      username: credentials.user,
+      domain: credentials.domain,
+      baseUrl: credentials.baseUrl,
       from: from as string,
     };
 


### PR DESCRIPTION
modify the integration credentials DTO to include the baseUrl property.

NV-2222 #3342

### What change does this PR introduce?

Fixes https://github.com/novuhq/novu/issues/3342

### Why was this change needed?
To let users with `EU` region domain use the mail gun integration smoothly
