### PR TITLE
fix: Update node subscriber feed params typings

### DIFF
--- a/packages/node/src/lib/subscribers/subscriber.interface.ts
+++ b/packages/node/src/lib/subscribers/subscriber.interface.ts
@@ -44,6 +44,6 @@ export interface IUpdateSubscriberPreferencePayload {
 }
 export interface IGetSubscriberNotificationFeedParams {
   page?: number;
-  feedIdentifier: string;
+  feedIdentifier?: string;
   seen?: boolean;
 }

--- a/packages/node/src/lib/subscribers/subscribers.spec.ts
+++ b/packages/node/src/lib/subscribers/subscribers.spec.ts
@@ -154,6 +154,21 @@ describe('test use of novus node package - Subscribers class', () => {
   test('should get notification feed for subscriber correctly', async () => {
     mockedAxios.get.mockResolvedValue({});
 
+    await novu.subscribers.getNotificationsFeed(
+      'test-news-feed-subscriber',
+      {}
+    );
+
+    expect(mockedAxios.get).toHaveBeenCalled();
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      '/subscribers/test-news-feed-subscriber/notifications/feed',
+      { params: {} }
+    );
+  });
+
+  test('should get notification feed for subscriber with optional feedIdentifier', async () => {
+    mockedAxios.get.mockResolvedValue({});
+
     await novu.subscribers.getNotificationsFeed('test-news-feed-subscriber', {
       feedIdentifier: '123',
     });


### PR DESCRIPTION
### What change does this PR introduce?

According to the OpenAPI documentation and testing, the `feedIdentifier` param is [optional](https://github.com/novuhq/novu/blob/next/apps/api/src/app/subscribers/dtos/get-in-app-notification-feed-for-subscriber.dto.ts#L9) when fetching a subscriber's notification feed.

The node client typings have this parameter as required. This updates the node client typings to reflect the API definition, so that the param can be excluded.

### Why was this change needed?

The `feedIdentifier` is an optional parameter, and the API accepts an empty object as the second argument to `getNotificationsFeed`, but it requires suppressing the following typescript error:

```
Argument of type '{}' is not assignable to parameter of type 'IGetSubscriberNotificationFeedParams'.
  Property 'feedIdentifier' is missing in type '{}' but required in type 'IGetSubscriberNotificationFeedParams'.ts(2345)
subscriber.interface.d.ts(27, 5): 'feedIdentifier' is declared here.
```