### PR TITLE
Add missing worker resources.

### DIFF
--- a/docker/kubernetes/kustomize/env-dev
+++ b/docker/kubernetes/kustomize/env-dev
@@ -23,6 +23,7 @@ REDIS_PORT=6379
 WS_PORT=3002
 
 # Root URL
+REACT_APP_API_URL=http://localhost:3000
 REACT_APP_WS_URL=http://localhost:3002
 API_ROOT_URL=http://localhost:3000
 DISABLE_USER_REGISTRATION=false

--- a/docker/kubernetes/kustomize/kustomization.yaml
+++ b/docker/kubernetes/kustomize/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - widget-service.yaml
   - ws-deployment.yaml
   - ws-service.yaml
+  - worker-deployment.yaml
+  - worker-service.yaml
 
 # namespace
 # Adds namespace to all resources.


### PR DESCRIPTION
- Add missing worker resources
- Add missing env

### What change does this PR introduce?

1. Add missing worker resources in kustomization.yaml.
2. Add missing `REACT_APP_API_URL` env.


### Why was this change needed?

- Worker resource is missing when running `kubectl apply -f ./kustomize`
- When deploying to custom api URL, `web` app was still pointing to `http://localhost:3000`
