### PR TITLE
fix(web): improved timed digest form behaviour

### DIFF
--- a/apps/web/src/api/hooks/notification-templates/useTemplateFetcher.ts
+++ b/apps/web/src/api/hooks/notification-templates/useTemplateFetcher.ts
@@ -13,6 +13,7 @@ export function useTemplateFetcher(
     () => getTemplateById(templateId as string),
     {
       enabled: !!templateId,
+      refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchInterval: false,
       ...options,

--- a/apps/web/src/design-system/tooltip/Tooltip.tsx
+++ b/apps/web/src/design-system/tooltip/Tooltip.tsx
@@ -13,7 +13,7 @@ export function Tooltip({
   ...props
 }: Pick<
   TooltipProps,
-  'multiline' | 'width' | 'label' | 'opened' | 'position' | 'disabled' | 'children' | 'sx' | 'withinPortal'
+  'multiline' | 'width' | 'label' | 'opened' | 'position' | 'disabled' | 'children' | 'sx' | 'withinPortal' | 'offset'
 >) {
   const { classes } = useStyles();
 

--- a/apps/web/src/pages/templates/components/StepNameInput.tsx
+++ b/apps/web/src/pages/templates/components/StepNameInput.tsx
@@ -17,6 +17,7 @@ export const StepNameInput = ({ index, defaultValue }: { index: number; defaultV
     <Controller
       control={control}
       name={`steps.${index}.name`}
+      defaultValue=""
       render={({ field, fieldState }) => {
         return (
           <TextInput

--- a/apps/web/src/pages/templates/components/TemplateEditor.tsx
+++ b/apps/web/src/pages/templates/components/TemplateEditor.tsx
@@ -111,7 +111,7 @@ export const TemplateEditor = () => {
             isIntegrationActive={!!integrations?.some((integration) => integration.channel === ChannelTypeEnum.CHAT)}
           />
         )}
-        {channel === StepTypeEnum.DIGEST && <DigestMetadata control={control} index={index} readonly={readonly} />}
+        {channel === StepTypeEnum.DIGEST && <DigestMetadata index={index} readonly={readonly} />}
         {channel === StepTypeEnum.DELAY && <DelayMetadata control={control} index={index} />}
         <DeleteStepRow />
       </SubPageWrapper>

--- a/apps/web/src/pages/templates/components/TemplateEditorFormProvider.tsx
+++ b/apps/web/src/pages/templates/components/TemplateEditorFormProvider.tsx
@@ -3,11 +3,17 @@ import slugify from 'slugify';
 import { FormProvider, useForm, useFieldArray } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useParams } from 'react-router-dom';
-import { DigestTypeEnum, INotificationTemplate, INotificationTrigger } from '@novu/shared';
+import {
+  DelayTypeEnum,
+  DigestTypeEnum,
+  DigestUnitEnum,
+  INotificationTemplate,
+  INotificationTrigger,
+} from '@novu/shared';
 import * as Sentry from '@sentry/react';
 import { StepTypeEnum, ActorTypeEnum, EmailBlockTypeEnum, IEmailBlock, TextAlignEnum } from '@novu/shared';
 
-import type { IForm, IStepEntity } from './formTypes';
+import type { IForm, IFormStep } from './formTypes';
 import { useTemplateController } from './useTemplateController';
 import { mapNotificationTemplateToForm, mapFormToCreateNotificationTemplate } from './templateToFormMappers';
 import { errorMessage, successMessage } from '../../../utils/notifications';
@@ -27,7 +33,7 @@ const defaultEmailBlocks: IEmailBlock[] = [
   },
 ];
 
-const makeStep = (channelType: StepTypeEnum, id: string): IStepEntity => {
+const makeStep = (channelType: StepTypeEnum, id: string): IFormStep => {
   return {
     _id: id,
     uuid: uuid4(),
@@ -55,13 +61,23 @@ const makeStep = (channelType: StepTypeEnum, id: string): IStepEntity => {
       },
     }),
     ...(channelType === StepTypeEnum.DIGEST && {
-      metadata: {
+      digestMetadata: {
+        digestKey: '',
         type: DigestTypeEnum.REGULAR,
+        regular: {
+          unit: DigestUnitEnum.MINUTES,
+          amount: '5',
+          backoff: false,
+        },
       },
     }),
     ...(channelType === StepTypeEnum.DELAY && {
-      metadata: {
-        type: DigestTypeEnum.REGULAR,
+      delayMetadata: {
+        type: DelayTypeEnum.REGULAR,
+        regular: {
+          unit: DigestUnitEnum.MINUTES,
+          amount: '5',
+        },
       },
     }),
   };
@@ -152,28 +168,23 @@ const TemplateEditorFormProvider = ({ children }) => {
     }
   }, [name]);
 
-  const { template, isLoading, isCreating, isUpdating, isDeleting, updateNotificationTemplate } =
-    useTemplateController(templateId);
+  const { template, isLoading, isCreating, isUpdating, isDeleting, updateNotificationTemplate } = useTemplateController(
+    templateId,
+    {
+      onFetchSuccess: (fetchedTemplate) => {
+        setTrigger(fetchedTemplate.triggers[0]);
+        const form = mapNotificationTemplateToForm(fetchedTemplate);
+        reset(form);
+      },
+    }
+  );
   const { groups, loading: loadingGroups } = useNotificationGroup();
-
-  useEffect(() => {
-    if (isDirtyForm) {
-      return;
-    }
-
-    if (template && template.steps) {
-      setTrigger(template.triggers[0]);
-      const form = mapNotificationTemplateToForm(template);
-      reset(form);
-    }
-  }, [isDirtyForm, template]);
 
   useCreate(templateId, groups, setTrigger, methods.getValues);
 
   const onSubmit = useCallback(
     async (form: IForm, showMessage = true) => {
       const payloadToCreate = mapFormToCreateNotificationTemplate(form);
-
       try {
         const response = await updateNotificationTemplate({
           id: templateId,
@@ -183,7 +194,7 @@ const TemplateEditorFormProvider = ({ children }) => {
           },
         });
         setTrigger(response.triggers[0]);
-        reset(payloadToCreate);
+        reset(form);
         if (showMessage) {
           successMessage('Trigger code is updated successfully', 'workflowSaved');
         }
@@ -198,7 +209,7 @@ const TemplateEditorFormProvider = ({ children }) => {
 
   const addStep = useCallback(
     (channelType: StepTypeEnum, id: string, stepIndex?: number) => {
-      const newStep: IStepEntity = makeStep(channelType, id);
+      const newStep: IFormStep = makeStep(channelType, id);
 
       if (stepIndex != null) {
         steps.insert(stepIndex, newStep);

--- a/apps/web/src/pages/templates/components/email-editor/EmailInboxContent.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/EmailInboxContent.tsx
@@ -49,6 +49,7 @@ export const EmailInboxContent = ({
         <Grid.Col span={3}>
           <Controller
             name={`steps.${index}.template.senderName`}
+            defaultValue=""
             control={control}
             render={({ field }) => {
               return (

--- a/apps/web/src/pages/templates/components/email-editor/EmailMessageEditor.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/EmailMessageEditor.tsx
@@ -11,9 +11,9 @@ import { ContentRow } from './ContentRow';
 import { ControlBar } from './ControlBar';
 import { ButtonRowContent } from './ButtonRowContent';
 import { TextRowContent } from './TextRowContent';
-import type { IForm, IStepEntity, ITemplates } from '../formTypes';
+import type { IForm, IFormStep, ITemplates } from '../formTypes';
 
-interface IStepEntityExtended extends IStepEntity {
+interface IStepEntityExtended extends IFormStep {
   template: ITemplates & {
     content: IEmailBlock[];
   };

--- a/apps/web/src/pages/templates/components/formTypes.ts
+++ b/apps/web/src/pages/templates/components/formTypes.ts
@@ -5,6 +5,11 @@ import type {
   BuilderFieldType,
   BuilderGroupValues,
   FilterParts,
+  DaysEnum,
+  DelayTypeEnum,
+  MonthlyTypeEnum,
+  OrdinalEnum,
+  OrdinalValueEnum,
 } from '@novu/shared';
 import { DigestTypeEnum } from '@novu/shared';
 
@@ -15,7 +20,7 @@ export interface ITemplates extends IMessageTemplate {
   layoutId?: string;
 }
 
-export interface IStepEntity {
+export interface IFormStep {
   id?: string;
   _id?: string;
   name?: string;
@@ -28,19 +33,58 @@ export interface IStepEntity {
     value?: BuilderGroupValues;
     children?: FilterParts[];
   }[];
-  active: boolean;
-  shouldStopOnFail: boolean;
+  active?: boolean;
+  shouldStopOnFail?: boolean;
   replyCallback?: {
     active: boolean;
     url?: string;
   };
-  metadata?: {
-    amount?: number;
-    unit?: DigestUnitEnum;
-    type?: DigestTypeEnum;
+  digestMetadata?: {
+    type: DigestTypeEnum;
     digestKey?: string;
-    delayPath?: string;
-    backoff?: boolean;
+    [DigestTypeEnum.REGULAR]?: {
+      amount: string;
+      unit: DigestUnitEnum;
+      backoff?: boolean;
+      backoffAmount?: number;
+      backoffUnit?: DigestUnitEnum;
+    };
+    [DigestTypeEnum.TIMED]?: {
+      unit: DigestUnitEnum;
+      [DigestUnitEnum.MINUTES]?: {
+        amount: string;
+      };
+      [DigestUnitEnum.HOURS]?: {
+        amount: string;
+      };
+      [DigestUnitEnum.DAYS]?: {
+        amount: string;
+        atTime: string;
+      };
+      [DigestUnitEnum.WEEKS]?: {
+        amount: string;
+        atTime: string;
+        weekDays: DaysEnum[];
+      };
+      [DigestUnitEnum.MONTHS]?: {
+        amount: string;
+        atTime: string;
+        monthDays: number[];
+        monthlyType: MonthlyTypeEnum;
+        ordinal?: OrdinalEnum;
+        ordinalValue?: OrdinalValueEnum;
+      };
+    };
+  };
+  delayMetadata?: {
+    type: DelayTypeEnum;
+    [DelayTypeEnum.REGULAR]?: {
+      amount: string;
+      unit: DigestUnitEnum;
+    };
+    [DelayTypeEnum.SCHEDULED]?: {
+      delayPath: string;
+    };
   };
 }
 
@@ -51,6 +95,6 @@ export interface IForm {
   identifier: string;
   tags: string[];
   critical: boolean;
-  steps: IStepEntity[];
+  steps: IFormStep[];
   preferenceSettings: IPreferenceChannels;
 }

--- a/apps/web/src/pages/templates/components/notificationTemplateSchema.ts
+++ b/apps/web/src/pages/templates/components/notificationTemplateSchema.ts
@@ -1,7 +1,83 @@
 import * as z from 'zod';
-import { ChannelTypeEnum, StepTypeEnum, DelayTypeEnum } from '@novu/shared';
+import {
+  ChannelTypeEnum,
+  StepTypeEnum,
+  DelayTypeEnum,
+  DigestTypeEnum,
+  DigestUnitEnum,
+  DaysEnum,
+  MonthlyTypeEnum,
+  OrdinalEnum,
+  OrdinalValueEnum,
+} from '@novu/shared';
 
 import { getChannel } from '../shared/channels';
+
+const validateAmount = ({
+  ctx,
+  amount,
+  unit,
+  message,
+  path,
+}: {
+  ctx: z.RefinementCtx;
+  amount?: string | number;
+  unit?: string;
+  message: string;
+  path: string[];
+}) => {
+  const amountNumber = parseInt(`${amount ?? ''}`, 10);
+
+  if (!amountNumber) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message,
+      path,
+    });
+  }
+
+  if (unit === 'hours' && amountNumber > 24) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.too_big,
+      maximum: 24,
+      type: 'number',
+      inclusive: true,
+      message: 'Hours must be 24 or below',
+      path: path,
+    });
+  }
+
+  if (unit === 'days' && amountNumber > 31) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.too_big,
+      maximum: 31,
+      type: 'number',
+      inclusive: true,
+      message: 'Days must be 31 or below',
+      path: path,
+    });
+  }
+};
+
+const validateUnit = ({
+  ctx,
+  unit,
+  message,
+  path,
+}: {
+  ctx: z.RefinementCtx;
+  unit?: string;
+  message: string;
+  path: string[];
+}) => {
+  if (!unit) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message,
+      path,
+    });
+  }
+};
 
 export const schema = z
   .object({
@@ -89,94 +165,176 @@ export const schema = z
                   });
                 }
               }),
-            metadata: z
+            digestMetadata: z
               .object({
-                amount: z.any().optional(),
-                unit: z.string().optional(),
+                type: z.enum([DigestTypeEnum.REGULAR, DigestTypeEnum.TIMED]),
+                digestKey: z.string().optional(),
+                [DigestTypeEnum.REGULAR]: z
+                  .object({
+                    amount: z.string(),
+                    unit: z.enum([
+                      DigestUnitEnum.MINUTES,
+                      DigestUnitEnum.HOURS,
+                      DigestUnitEnum.DAYS,
+                      DigestUnitEnum.WEEKS,
+                      DigestUnitEnum.MONTHS,
+                    ]),
+                    backoff: z.boolean().optional(),
+                    backoffAmount: z.number().optional(),
+                    backoffUnit: z
+                      .enum([
+                        DigestUnitEnum.MINUTES,
+                        DigestUnitEnum.HOURS,
+                        DigestUnitEnum.DAYS,
+                        DigestUnitEnum.WEEKS,
+                        DigestUnitEnum.MONTHS,
+                      ])
+                      .optional(),
+                  })
+                  .passthrough()
+                  .optional(),
+                [DigestTypeEnum.TIMED]: z
+                  .object({
+                    unit: z.enum([
+                      DigestUnitEnum.MINUTES,
+                      DigestUnitEnum.HOURS,
+                      DigestUnitEnum.DAYS,
+                      DigestUnitEnum.WEEKS,
+                      DigestUnitEnum.MONTHS,
+                    ]),
+                    [DigestUnitEnum.MINUTES]: z
+                      .object({
+                        amount: z.string(),
+                      })
+                      .passthrough()
+                      .optional(),
+                    [DigestUnitEnum.HOURS]: z
+                      .object({
+                        amount: z.string(),
+                      })
+                      .passthrough()
+                      .optional(),
+                    [DigestUnitEnum.DAYS]: z
+                      .object({
+                        amount: z.string(),
+                        atTime: z.string(),
+                      })
+                      .passthrough()
+                      .optional(),
+                    [DigestUnitEnum.WEEKS]: z
+                      .object({
+                        amount: z.string(),
+                        atTime: z.string(),
+                        weekDays: z.array(
+                          z.enum([
+                            DaysEnum.MONDAY,
+                            DaysEnum.TUESDAY,
+                            DaysEnum.WEDNESDAY,
+                            DaysEnum.THURSDAY,
+                            DaysEnum.FRIDAY,
+                            DaysEnum.SATURDAY,
+                            DaysEnum.SUNDAY,
+                          ])
+                        ),
+                      })
+                      .passthrough()
+                      .optional(),
+                    [DigestUnitEnum.MONTHS]: z
+                      .object({
+                        amount: z.string(),
+                        atTime: z.string(),
+                        monthDays: z.array(z.number()),
+                        monthlyType: z.enum([MonthlyTypeEnum.EACH, MonthlyTypeEnum.ON]),
+                        ordinal: z
+                          .enum([
+                            OrdinalEnum.FIRST,
+                            OrdinalEnum.SECOND,
+                            OrdinalEnum.THIRD,
+                            OrdinalEnum.FOURTH,
+                            OrdinalEnum.FIFTH,
+                            OrdinalEnum.LAST,
+                          ])
+                          .optional(),
+                        ordinalValue: z
+                          .enum([
+                            OrdinalValueEnum.DAY,
+                            OrdinalValueEnum.WEEKDAY,
+                            OrdinalValueEnum.WEEKEND,
+                            OrdinalValueEnum.MONDAY,
+                            OrdinalValueEnum.TUESDAY,
+                            OrdinalValueEnum.WEDNESDAY,
+                            OrdinalValueEnum.THURSDAY,
+                            OrdinalValueEnum.FRIDAY,
+                            OrdinalValueEnum.SATURDAY,
+                            OrdinalValueEnum.SUNDAY,
+                          ])
+                          .optional(),
+                      })
+                      .passthrough()
+                      .optional(),
+                  })
+                  .passthrough()
+                  .optional(),
+              })
+              .passthrough()
+              .optional(),
+            delayMetadata: z
+              .object({
+                type: z.enum([DelayTypeEnum.REGULAR, DelayTypeEnum.SCHEDULED]),
+                [DelayTypeEnum.REGULAR]: z
+                  .object({
+                    amount: z.string(),
+                    unit: z.string(),
+                  })
+                  .passthrough()
+                  .optional(),
+                [DelayTypeEnum.SCHEDULED]: z
+                  .object({
+                    delayPath: z.string(),
+                  })
+                  .passthrough()
+                  .optional(),
               })
               .passthrough()
               .optional(),
           })
           .passthrough()
-          .superRefine((step: any, ctx) => {
+          .superRefine((step, ctx) => {
             if (step.template.type !== StepTypeEnum.DIGEST && step.template.type !== StepTypeEnum.DELAY) {
               return;
             }
 
-            if (step.metadata?.type === DelayTypeEnum.SCHEDULED) {
-              if (!step.metadata?.delayPath) {
+            if (step.delayMetadata?.type === DelayTypeEnum.REGULAR) {
+              validateAmount({
+                ctx,
+                amount: step.delayMetadata?.regular?.amount,
+                unit: step.delayMetadata?.regular?.unit,
+                message: `Required - ${getChannel(step.template.type)?.label} Amount`,
+                path: ['delayMetadata', 'regular', 'amount'],
+              });
+              validateUnit({
+                ctx,
+                unit: step.delayMetadata?.regular?.unit,
+                message: `Required - ${getChannel(step.template.type)?.label} Unit`,
+                path: ['delayMetadata', 'regular', 'unit'],
+              });
+
+              return;
+            }
+
+            if (step.delayMetadata?.type === DelayTypeEnum.SCHEDULED) {
+              if (!step.delayMetadata?.scheduled?.delayPath) {
                 ctx.addIssue({
                   code: z.ZodIssueCode.too_small,
                   minimum: 1,
                   type: 'string',
                   inclusive: true,
                   message: 'Required - Delay Path',
-                  path: ['metadata', 'delayPath'],
+                  path: ['delayMetadata', 'scheduled', 'delayPath'],
                 });
               }
 
               return;
-            }
-
-            let amount = parseInt(step.metadata?.amount, 10);
-            let unit = step.metadata?.unit;
-
-            if (!amount) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Required - ${getChannel(step.template.type)?.label} Amount`,
-                path: ['metadata', 'amount'],
-              });
-            }
-            if (!unit) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Required - ${getChannel(step.template.type)?.label} Unit`,
-                path: ['metadata', 'unit'],
-              });
-            }
-
-            if (unit === 'hours' && amount > 24) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.too_big,
-                maximum: 24,
-                type: 'number',
-                inclusive: true,
-                message: 'Hours must be 24 or below',
-                path: ['metadata', 'amount'],
-              });
-            }
-
-            if (unit === 'days' && amount > 31) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.too_big,
-                maximum: 31,
-                type: 'number',
-                inclusive: true,
-                message: 'Days must be 31 or below',
-                path: ['metadata', 'amount'],
-              });
-            }
-
-            if (!step.metadata.backoff) {
-              return;
-            }
-            amount = step.metadata?.backoffAmount;
-            unit = step.metadata?.backoffUnit;
-            if (!unit) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: 'Required - Backoff Unit',
-                path: ['metadata', 'backoffUnit'],
-              });
-            }
-
-            if (!amount) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: 'Required - Backoff Amount',
-                path: ['metadata', 'backoffAmount'],
-              });
             }
           })
       )

--- a/apps/web/src/pages/templates/components/templateToFormMappers.ts
+++ b/apps/web/src/pages/templates/components/templateToFormMappers.ts
@@ -1,10 +1,20 @@
-import { INotificationTemplate, ICreateNotificationTemplateDto, DigestTypeEnum } from '@novu/shared';
+import {
+  INotificationTemplate,
+  ICreateNotificationTemplateDto,
+  DigestTypeEnum,
+  INotificationTemplateStep,
+  NotificationStepDto,
+  DelayTypeEnum,
+  DigestUnitEnum,
+  INotificationTemplateStepMetadata,
+  MonthlyTypeEnum,
+} from '@novu/shared';
 import { StepTypeEnum, ActorTypeEnum, ChannelCTATypeEnum } from '@novu/shared';
 import { v4 as uuid4 } from 'uuid';
 
-import type { IForm, IStepEntity } from './formTypes';
+import type { IForm, IFormStep } from './formTypes';
 
-const mapEmailStep = (item: IStepEntity): IStepEntity => ({
+const mapToEmailFormStep = (item: INotificationTemplateStep): IFormStep => ({
   ...item,
   ...(!item.replyCallback && {
     replyCallback: {
@@ -14,54 +24,148 @@ const mapEmailStep = (item: IStepEntity): IStepEntity => ({
   }),
   template: {
     ...item.template,
-    layoutId: item.template._layoutId ?? '',
-    preheader: item.template.preheader ?? '',
-    senderName: item.template.senderName ?? '',
-    content: item.template.content,
-    ...(item.template?.contentType === 'customHtml' && {
-      htmlContent: item.template.content as string,
+    type: item?.template?.type ?? StepTypeEnum.EMAIL,
+    layoutId: item?.template?._layoutId ?? '',
+    preheader: item?.template?.preheader ?? '',
+    senderName: item?.template?.senderName ?? '',
+    content: item?.template?.content ?? '',
+    ...(item?.template?.contentType === 'customHtml' && {
+      htmlContent: item?.template?.content as string,
       content: [],
     }),
   },
 });
 
-const mapInAppStep = (item: IStepEntity): IStepEntity => ({
+const mapToInAppFormStep = (item: INotificationTemplateStep): IFormStep => ({
   ...item,
   template: {
     ...item.template,
-    feedId: item.template._feedId ?? '',
-    actor: item.template.actor?.type
-      ? item.template.actor
+    type: item?.template?.type ?? StepTypeEnum.IN_APP,
+    content: item?.template?.content ?? '',
+    feedId: item?.template?._feedId ?? '',
+    actor: item?.template?.actor?.type
+      ? item?.template?.actor
       : {
           type: ActorTypeEnum.NONE,
           data: null,
         },
-    enableAvatar: item.template.actor?.type && item.template.actor.type !== ActorTypeEnum.NONE ? true : false,
+    enableAvatar: item?.template?.actor?.type && item?.template?.actor.type !== ActorTypeEnum.NONE ? true : false,
     cta: {
-      data: item.template.cta?.data ?? { url: '' },
+      data: item?.template?.cta?.data ?? { url: '' },
       type: ChannelCTATypeEnum.REDIRECT,
-      action: item.template.cta?.action ?? '',
+      action: item?.template?.cta?.action ?? '',
     },
   },
 });
 
-const mapDigestStep = (item: IStepEntity): IStepEntity => {
-  if (item.metadata?.type === DigestTypeEnum.BACKOFF) {
+const mapToDigestFormStep = (item: INotificationTemplateStep): IFormStep => {
+  const { metadata, template, ...rest } = item;
+  if (!metadata) {
     return {
-      ...item,
-      metadata: {
-        ...item.metadata,
-        type: DigestTypeEnum.REGULAR,
-        backoff: true,
+      ...rest,
+      template: template as any,
+    };
+  }
+
+  if (metadata.type === DigestTypeEnum.BACKOFF || metadata.type === DigestTypeEnum.REGULAR) {
+    return {
+      ...rest,
+      template: template as any,
+      digestMetadata: {
+        type: metadata.type,
+        digestKey: metadata.digestKey,
+        regular: {
+          amount: `${metadata.amount}`,
+          unit: metadata.unit,
+          backoff: metadata.backoff,
+          backoffAmount: metadata.backoffAmount,
+          backoffUnit: metadata.backoffUnit,
+        },
+      },
+    };
+  }
+
+  if (metadata.type === DigestTypeEnum.TIMED) {
+    return {
+      ...rest,
+      template: template as any,
+      digestMetadata: {
+        type: metadata.type,
+        digestKey: metadata.digestKey,
+        timed: {
+          unit: metadata.unit,
+          ...(metadata.unit === DigestUnitEnum.MINUTES && { minutes: { amount: `${metadata.amount}` } }),
+          ...(metadata.unit === DigestUnitEnum.HOURS && { hours: { amount: `${metadata.amount}` } }),
+          ...(metadata.unit === DigestUnitEnum.DAYS && {
+            days: { amount: `${metadata.amount}`, atTime: metadata.timed?.atTime ?? '' },
+          }),
+          ...(metadata.unit === DigestUnitEnum.WEEKS && {
+            weeks: {
+              amount: `${metadata.amount}`,
+              atTime: metadata.timed?.atTime ?? '',
+              weekDays: metadata.timed?.weekDays ?? [],
+            },
+          }),
+          ...(metadata.unit === DigestUnitEnum.MONTHS && {
+            months: {
+              amount: `${metadata.amount}`,
+              atTime: metadata.timed?.atTime ?? '',
+              monthDays: metadata.timed?.monthDays ?? [],
+              monthlyType: metadata.timed?.monthlyType ?? MonthlyTypeEnum.EACH,
+              ordinal: metadata.timed?.ordinal,
+              ordinalValue: metadata.timed?.ordinalValue,
+            },
+          }),
+        },
       },
     };
   }
 
   return {
-    ...item,
-    metadata: {
-      ...item.metadata,
-    },
+    ...rest,
+    template: template as any,
+  };
+};
+
+const mapToDelayFormStep = (item: INotificationTemplateStep): IFormStep => {
+  const { metadata, template, ...rest } = item;
+  if (!metadata) {
+    return {
+      ...rest,
+      template: template as any,
+    };
+  }
+
+  if (metadata.type === DelayTypeEnum.REGULAR) {
+    return {
+      ...rest,
+      template: template as any,
+      delayMetadata: {
+        type: metadata.type,
+        regular: {
+          amount: `${metadata.amount}`,
+          unit: metadata.unit,
+        },
+      },
+    };
+  }
+
+  if (metadata.type === DelayTypeEnum.SCHEDULED) {
+    return {
+      ...rest,
+      template: template as any,
+      delayMetadata: {
+        type: metadata.type,
+        scheduled: {
+          delayPath: metadata.delayPath,
+        },
+      },
+    };
+  }
+
+  return {
+    ...rest,
+    template: template as any,
   };
 };
 
@@ -77,51 +181,70 @@ export const mapNotificationTemplateToForm = (template: INotificationTemplate): 
     steps: [],
   };
 
-  form.steps = (template.steps as IStepEntity[]).map((item) => {
+  form.steps = template.steps.map((item) => {
     if (!item.uuid) {
       item.uuid = uuid4();
     }
 
-    if (item.template.type === StepTypeEnum.EMAIL) {
-      return mapEmailStep(item);
+    if (item?.template?.type === StepTypeEnum.EMAIL) {
+      return mapToEmailFormStep(item);
     }
-    if (item.template.type === StepTypeEnum.IN_APP) {
-      return mapInAppStep(item);
+    if (item?.template?.type === StepTypeEnum.IN_APP) {
+      return mapToInAppFormStep(item);
     }
-    if (item.template.type === StepTypeEnum.DIGEST) {
-      return mapDigestStep(item);
+    if (item?.template?.type === StepTypeEnum.DIGEST) {
+      return mapToDigestFormStep(item);
+    }
+    if (item?.template?.type === StepTypeEnum.DELAY) {
+      return mapToDelayFormStep(item);
     }
 
-    return item;
+    return item as IFormStep;
   });
 
   return form;
 };
 
 export const mapFormToCreateNotificationTemplate = (form: IForm): ICreateNotificationTemplateDto => {
-  let stepsToSave = form.steps;
+  const steps = form.steps.map((formStep: IFormStep) => {
+    const { digestMetadata, delayMetadata, template, ...rest } = formStep;
+    const step: NotificationStepDto = { ...rest };
 
-  stepsToSave = stepsToSave.map((step: IStepEntity) => {
-    if (step.template.type === StepTypeEnum.EMAIL && step.template.contentType === 'customHtml') {
-      step.template.content = step.template.htmlContent as string;
+    if (template.type === StepTypeEnum.EMAIL && template.contentType === 'customHtml') {
+      template.content = template.htmlContent as string;
     }
 
-    if (step.template.type === StepTypeEnum.IN_APP) {
-      if (!step.template.enableAvatar) {
-        step.template.actor = {
+    if (template.type === StepTypeEnum.IN_APP) {
+      if (!template.enableAvatar) {
+        template.actor = {
           type: ActorTypeEnum.NONE,
           data: null,
         };
       }
 
-      delete step.template.enableAvatar;
+      delete template.enableAvatar;
     }
 
-    if (step.template.type === StepTypeEnum.DIGEST && step.metadata?.digestKey === '') {
-      delete step.metadata.digestKey;
+    if (template.type === StepTypeEnum.DIGEST) {
+      return {
+        ...step,
+        template,
+        metadata: mapFormStepDigestMetadata(formStep),
+      };
     }
 
-    return step;
+    if (template.type === StepTypeEnum.DELAY) {
+      return {
+        ...step,
+        template,
+        metadata: mapFormStepDelayMetadata(formStep),
+      };
+    }
+
+    return {
+      ...step,
+      template,
+    };
   });
 
   return {
@@ -131,6 +254,105 @@ export const mapFormToCreateNotificationTemplate = (form: IForm): ICreateNotific
     tags: form.tags,
     critical: form.critical,
     preferenceSettings: form.preferenceSettings,
-    steps: stepsToSave,
+    steps,
   };
+};
+
+const mapFormStepDelayMetadata = (formStep: IFormStep): INotificationTemplateStepMetadata | undefined => {
+  if (!formStep.delayMetadata) {
+    return undefined;
+  }
+
+  if (formStep.delayMetadata.type === DelayTypeEnum.REGULAR && formStep.delayMetadata.regular) {
+    return {
+      type: formStep.delayMetadata.type,
+      ...formStep.delayMetadata.regular,
+      amount: parseInt(formStep.delayMetadata.regular.amount, 10),
+    };
+  }
+  if (formStep.delayMetadata.type === DelayTypeEnum.SCHEDULED && formStep.delayMetadata.scheduled) {
+    return {
+      type: formStep.delayMetadata.type,
+      ...formStep.delayMetadata.scheduled,
+    };
+  }
+
+  return undefined;
+};
+
+const mapFormStepDigestMetadata = (formStep: IFormStep): INotificationTemplateStepMetadata | undefined => {
+  if (!formStep.digestMetadata) {
+    return undefined;
+  }
+
+  if (formStep.digestMetadata?.digestKey === '') {
+    delete formStep.digestMetadata.digestKey;
+  }
+
+  if (formStep.digestMetadata.type === DigestTypeEnum.REGULAR && formStep.digestMetadata.regular) {
+    return {
+      type: formStep.digestMetadata.type,
+      digestKey: formStep.digestMetadata.digestKey,
+      ...formStep.digestMetadata.regular,
+      amount: parseInt(formStep.digestMetadata.regular.amount, 10),
+    };
+  }
+
+  if (formStep.digestMetadata.type === DigestTypeEnum.TIMED && formStep.digestMetadata.timed) {
+    if (formStep.digestMetadata.timed.unit === DigestUnitEnum.MINUTES && formStep.digestMetadata.timed.minutes) {
+      return {
+        type: formStep.digestMetadata.type,
+        digestKey: formStep.digestMetadata.digestKey,
+        unit: formStep.digestMetadata.timed.unit,
+        amount: parseInt(formStep.digestMetadata.timed.minutes.amount, 10),
+      };
+    }
+    if (formStep.digestMetadata.timed.unit === DigestUnitEnum.HOURS && formStep.digestMetadata.timed.hours) {
+      return {
+        type: formStep.digestMetadata.type,
+        digestKey: formStep.digestMetadata.digestKey,
+        unit: formStep.digestMetadata.timed.unit,
+        amount: parseInt(formStep.digestMetadata.timed.hours.amount, 10),
+      };
+    }
+    if (formStep.digestMetadata.timed.unit === DigestUnitEnum.DAYS && formStep.digestMetadata.timed.days) {
+      return {
+        type: formStep.digestMetadata.type,
+        digestKey: formStep.digestMetadata.digestKey,
+        unit: formStep.digestMetadata.timed.unit,
+        amount: parseInt(formStep.digestMetadata.timed.days.amount, 10),
+        timed: {
+          atTime: formStep.digestMetadata.timed.days.atTime,
+        },
+      };
+    }
+    if (formStep.digestMetadata.timed.unit === DigestUnitEnum.WEEKS && formStep.digestMetadata.timed.weeks) {
+      return {
+        type: formStep.digestMetadata.type,
+        digestKey: formStep.digestMetadata.digestKey,
+        unit: formStep.digestMetadata.timed.unit,
+        amount: parseInt(formStep.digestMetadata.timed.weeks.amount, 10),
+        timed: {
+          atTime: formStep.digestMetadata.timed.weeks.atTime,
+          weekDays: formStep.digestMetadata.timed.weeks.weekDays,
+        },
+      };
+    }
+    if (formStep.digestMetadata.timed.unit === DigestUnitEnum.MONTHS && formStep.digestMetadata.timed.months) {
+      return {
+        type: formStep.digestMetadata.type,
+        unit: formStep.digestMetadata.timed.unit,
+        amount: parseInt(formStep.digestMetadata.timed.months.amount, 10),
+        timed: {
+          atTime: formStep.digestMetadata.timed.months.atTime,
+          monthDays: formStep.digestMetadata.timed.months.monthDays,
+          monthlyType: formStep.digestMetadata.timed.months.monthlyType,
+          ordinal: formStep.digestMetadata.timed.months.ordinal,
+          ordinalValue: formStep.digestMetadata.timed.months.ordinalValue,
+        },
+      };
+    }
+  }
+
+  return undefined;
 };

--- a/apps/web/src/pages/templates/components/useTemplateController.ts
+++ b/apps/web/src/pages/templates/components/useTemplateController.ts
@@ -3,11 +3,13 @@ import { ICreateNotificationTemplateDto, INotificationTemplate, IUpdateNotificat
 
 import { useTemplateFetcher } from '../../../api/hooks';
 import { QueryKeys } from '../../../api/query.keys';
-import { successMessage } from '../../../utils/notifications';
 import { createTemplate, deleteTemplateById, updateTemplate } from '../../../api/notification-templates';
 
-export function useTemplateController(templateId?: string) {
-  const { template, refetch, isInitialLoading: isLoading } = useTemplateFetcher({ templateId });
+export function useTemplateController(
+  templateId?: string,
+  { onFetchSuccess }: { onFetchSuccess?: (template: INotificationTemplate) => void } = {}
+) {
+  const { template, isInitialLoading: isLoading } = useTemplateFetcher({ templateId }, { onSuccess: onFetchSuccess });
   const client = useQueryClient();
 
   const { isLoading: isCreating, mutateAsync: createNotificationTemplate } = useMutation<
@@ -26,7 +28,6 @@ export function useTemplateController(templateId?: string) {
     { id: string; data: Partial<IUpdateNotificationTemplateDto> }
   >(({ id, data }) => updateTemplate(id, data), {
     onSuccess: async () => {
-      refetch();
       await client.refetchQueries([QueryKeys.changesCount]);
     },
   });

--- a/apps/web/src/pages/templates/filter/Filters.cy.tsx
+++ b/apps/web/src/pages/templates/filter/Filters.cy.tsx
@@ -10,10 +10,10 @@ import {
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { TestWrapper } from '../../../testing';
-import { IStepEntity } from '../components/formTypes';
+import { IFormStep } from '../components/formTypes';
 import { Filters, translateOperator, getFilterLabel } from './Filters';
 
-const defaultStep: IStepEntity = {
+const defaultStep: IFormStep = {
   id: '',
   _templateId: '',
   template: {

--- a/apps/web/src/pages/templates/filter/Filters.tsx
+++ b/apps/web/src/pages/templates/filter/Filters.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled';
 import { useMantineColorScheme } from '@mantine/core';
 import { BuilderFieldOperator, FilterParts, FilterPartTypeEnum } from '@novu/shared';
 
-import type { IStepEntity } from '../components/formTypes';
+import type { IFormStep } from '../components/formTypes';
 import { colors } from '../../../design-system';
 import { useWatch } from 'react-hook-form';
 import { useMemo } from 'react';
 import { channels } from '../shared/channels';
 
-export const Filters = ({ step }: { step?: IStepEntity }) => {
+export const Filters = ({ step }: { step?: IFormStep }) => {
   if (!step || !step.filters || !Array.isArray(step.filters)) {
     return null;
   }
@@ -32,7 +32,7 @@ export const Filters = ({ step }: { step?: IStepEntity }) => {
 
 export const Filter = ({ filter }: { filter: FilterParts }) => {
   const { colorScheme } = useMantineColorScheme();
-  const steps: IStepEntity[] = useWatch({
+  const steps: IFormStep[] = useWatch({
     name: 'steps',
   });
 
@@ -72,7 +72,7 @@ export const translateOperator = (operator?: BuilderFieldOperator) => {
   return 'equal';
 };
 
-export const getFilterLabel = (filter: FilterParts, steps: IStepEntity[]): string => {
+export const getFilterLabel = (filter: FilterParts, steps: IFormStep[]): string => {
   if (filter.on === FilterPartTypeEnum.IS_ONLINE) {
     return `is online right now ${translateOperator('EQUAL')}`;
   }

--- a/apps/web/src/pages/templates/shared/errors.ts
+++ b/apps/web/src/pages/templates/shared/errors.ts
@@ -28,6 +28,22 @@ export function getSettingsErrors(errors) {
   return errorsArray;
 }
 
+function findMessages(obj: object): string[] {
+  let messages: string[] = [];
+
+  for (const key in obj) {
+    const value = obj[key];
+
+    if (typeof value === 'object' && value !== null) {
+      messages = messages.concat(findMessages(value));
+    } else if (key === 'message' && typeof value === 'string') {
+      messages.push(value);
+    }
+  }
+
+  return messages;
+}
+
 export function getStepErrors(index: number | string, errors: FieldErrors<IForm>): string[] {
   if (errors?.steps) {
     const stepErrors = errors.steps[index]?.template;
@@ -37,12 +53,15 @@ export function getStepErrors(index: number | string, errors: FieldErrors<IForm>
 
       return keys.map((key) => stepErrors[key]?.message);
     }
-    const actionErrors = errors.steps[index]?.metadata;
 
-    if (actionErrors) {
-      const keys = Object.keys(actionErrors);
+    const digestMetadataErrors = errors.steps[index]?.digestMetadata;
+    if (digestMetadataErrors) {
+      return findMessages(digestMetadataErrors);
+    }
 
-      return keys.map((key) => actionErrors[key]?.message);
+    const delayMetadataErrors = errors.steps[index]?.digestMetadata;
+    if (delayMetadataErrors) {
+      return findMessages(delayMetadataErrors);
     }
 
     const nameError = errors.steps[index]?.name;

--- a/apps/web/src/pages/templates/workflow/DelayMetadata.tsx
+++ b/apps/web/src/pages/templates/workflow/DelayMetadata.tsx
@@ -16,7 +16,7 @@ export const DelayMetadata = ({ control, index }) => {
     watch,
     trigger,
   } = useFormContext();
-  const type = watch(`steps.${index}.metadata.type`);
+  const type = watch(`steps.${index}.delayMetadata.type`);
   const showErrors = isSubmitted && errors?.steps;
 
   return (
@@ -29,7 +29,7 @@ export const DelayMetadata = ({ control, index }) => {
         <Controller
           control={control}
           defaultValue={DelayTypeEnum.REGULAR}
-          name={`steps.${index}.metadata.type`}
+          name={`steps.${index}.delayMetadata.type`}
           render={({ field }) => {
             return (
               <SegmentedControl
@@ -45,7 +45,7 @@ export const DelayMetadata = ({ control, index }) => {
                 ]}
                 onChange={async (segmentValue) => {
                   field.onChange(segmentValue);
-                  await trigger(`steps.${index}.metadata`);
+                  await trigger(`steps.${index}.delayMetadata`);
                 }}
                 data-test-id="delay-type"
               />
@@ -66,7 +66,7 @@ export const DelayMetadata = ({ control, index }) => {
           <Grid.Col span={4}>
             <Controller
               control={control}
-              name={`steps.${index}.metadata.amount`}
+              name={`steps.${index}.delayMetadata.${DelayTypeEnum.REGULAR}.amount`}
               defaultValue=""
               render={({ field, fieldState }) => {
                 return (
@@ -93,7 +93,11 @@ export const DelayMetadata = ({ control, index }) => {
             />
           </Grid.Col>
           <Grid.Col span={8}>
-            <IntervalRadios control={control} name={`steps.${index}.metadata.unit`} showErrors={showErrors} />
+            <IntervalRadios
+              control={control}
+              name={`steps.${index}.delayMetadata.${DelayTypeEnum.REGULAR}.unit`}
+              showErrors={showErrors}
+            />
           </Grid.Col>
         </Grid>
       </When>
@@ -101,7 +105,7 @@ export const DelayMetadata = ({ control, index }) => {
       <When truthy={type === DelayTypeEnum.SCHEDULED}>
         <Controller
           control={control}
-          name={`steps.${index}.metadata.delayPath`}
+          name={`steps.${index}.delayMetadata.${DelayTypeEnum.SCHEDULED}.delayPath`}
           defaultValue=""
           render={({ field, fieldState }) => {
             return (

--- a/apps/web/src/pages/templates/workflow/DigestMetadata.cy.tsx
+++ b/apps/web/src/pages/templates/workflow/DigestMetadata.cy.tsx
@@ -12,7 +12,7 @@ const DigestWrapper = ({ data }) => {
     defaultValues: {
       steps: [
         {
-          metadata: data,
+          digestMetadata: data,
         },
       ],
     },
@@ -21,7 +21,7 @@ const DigestWrapper = ({ data }) => {
 
   return (
     <FormProvider {...methods}>
-      <DigestMetadata control={methods.control} readonly={false} index={0} />
+      <DigestMetadata readonly={false} index={0} />
     </FormProvider>
   );
 };

--- a/apps/web/src/pages/templates/workflow/RegularDigestMetadata.tsx
+++ b/apps/web/src/pages/templates/workflow/RegularDigestMetadata.tsx
@@ -1,0 +1,81 @@
+import { Controller, useFormContext } from 'react-hook-form';
+import { Group } from '@mantine/core';
+import { DigestTypeEnum } from '@novu/shared';
+
+import { colors, Input } from '../../../design-system';
+import { inputStyles } from '../../../design-system/config/inputs.styles';
+import { IntervalSelect } from './digest/IntervalSelect';
+import { BackOffFields } from './digest/BackOffFields';
+
+const amountDefaultValue = '5';
+
+export const RegularDigestMetadata = ({ index, readonly }: { index: number; readonly: boolean }) => {
+  const {
+    control,
+    formState: { errors, isSubmitted },
+    watch,
+    setValue,
+  } = useFormContext();
+  const showErrors = isSubmitted && errors?.steps;
+  const amountFieldName = `steps.${index}.digestMetadata.${DigestTypeEnum.REGULAR}.amount`;
+
+  return (
+    <>
+      <Group spacing={8} sx={{ color: colors.B60 }}>
+        <span>digest events for</span>
+        <Controller
+          control={control}
+          name={amountFieldName}
+          defaultValue={amountDefaultValue}
+          render={({ field, fieldState }) => {
+            return (
+              <Input
+                {...field}
+                value={field.value || ''}
+                error={showErrors && fieldState.error?.message}
+                min={0}
+                max={100}
+                type="number"
+                data-test-id="time-amount"
+                placeholder="0"
+                disabled={readonly}
+                styles={(theme) => ({
+                  ...inputStyles(theme),
+                  input: {
+                    textAlign: 'center',
+                    ...inputStyles(theme).input,
+                    minHeight: '30px',
+                    margin: 0,
+                    height: 30,
+                    lineHeight: '32px',
+                  },
+                })}
+                onBlur={(e) => {
+                  if (e.target.value === '') {
+                    setValue(amountFieldName, amountDefaultValue);
+                  }
+                  field.onBlur();
+                }}
+              />
+            );
+          }}
+        />
+        <div
+          style={{
+            width: '90px',
+            height: 30,
+          }}
+        >
+          <IntervalSelect
+            readonly={readonly}
+            control={control}
+            name={`steps.${index}.digestMetadata.${DigestTypeEnum.REGULAR}.unit`}
+            showErrors={showErrors}
+          />
+        </div>
+        <span>before send</span>
+      </Group>
+      <BackOffFields index={index} control={control} readonly={readonly} />
+    </>
+  );
+};

--- a/apps/web/src/pages/templates/workflow/TimedDigestMetadata.tsx
+++ b/apps/web/src/pages/templates/workflow/TimedDigestMetadata.tsx
@@ -1,0 +1,155 @@
+import { Controller, useFormContext } from 'react-hook-form';
+import { Group } from '@mantine/core';
+import { format } from 'date-fns';
+import { DigestTypeEnum, DigestUnitEnum } from '@novu/shared';
+
+import { colors, Input, SegmentedControl } from '../../../design-system';
+import { inputStyles } from '../../../design-system/config/inputs.styles';
+import { WeekDaySelect } from './digest/WeekDaySelect';
+import { ScheduleMonthlyFields } from './digest/ScheduleMonthlyFields';
+import { When } from '../../../components/utils/When';
+
+const convertUnitToLabel = (unit: DigestUnitEnum) => {
+  switch (unit) {
+    case DigestUnitEnum.SECONDS:
+      return 'second';
+    case DigestUnitEnum.MINUTES:
+      return 'minute';
+    case DigestUnitEnum.HOURS:
+      return 'hour';
+    case DigestUnitEnum.DAYS:
+      return 'day';
+    case DigestUnitEnum.WEEKS:
+      return 'week';
+    case DigestUnitEnum.MONTHS:
+      return 'month';
+  }
+};
+
+export const TimedDigestMetadata = ({ index, readonly }: { index: number; readonly: boolean }) => {
+  const { control, watch, setValue } = useFormContext();
+  const unit: DigestUnitEnum =
+    watch(`steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.unit`) ?? DigestUnitEnum.DAYS;
+  const amountFieldName = `steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.${unit}.amount`;
+  const atTimeFieldName = `steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.${unit}.atTime`;
+  const amountDefaultValue = unit === DigestUnitEnum.MINUTES ? '5' : '1';
+  const atTimeDefaultValue = format(new Date(), 'HH:mm');
+
+  return (
+    <>
+      <Controller
+        control={control}
+        defaultValue={DigestUnitEnum.DAYS}
+        name={`steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.unit`}
+        render={({ field }) => {
+          return (
+            <SegmentedControl
+              {...field}
+              size="sm"
+              sx={{
+                maxWidth: '100% !important',
+              }}
+              fullWidth
+              disabled={readonly}
+              data={[
+                { value: DigestUnitEnum.MINUTES, label: 'Min' },
+                { value: DigestUnitEnum.HOURS, label: 'Hour' },
+                { value: DigestUnitEnum.DAYS, label: 'Daily' },
+                { value: DigestUnitEnum.WEEKS, label: 'Weekly' },
+                { value: DigestUnitEnum.MONTHS, label: 'Monthly' },
+              ]}
+              onChange={field.onChange}
+              data-test-id="digest-unit"
+            />
+          );
+        }}
+      />
+      <Group data-test-id="timed-group" spacing={8} sx={{ color: colors.B60 }}>
+        <span>Every</span>
+        <Controller
+          control={control}
+          key={amountFieldName}
+          name={amountFieldName}
+          defaultValue={amountDefaultValue}
+          render={({ field }) => {
+            return (
+              <Input
+                {...field}
+                value={field.value}
+                min={1}
+                max={100}
+                type="number"
+                data-test-id="time-amount"
+                placeholder="0"
+                disabled={readonly}
+                styles={(theme) => ({
+                  ...inputStyles(theme),
+                  input: {
+                    textAlign: 'center',
+                    ...inputStyles(theme).input,
+                  },
+                })}
+                onBlur={(e) => {
+                  if (e.target.value === '') {
+                    setValue(amountFieldName, amountDefaultValue);
+                  }
+                  field.onBlur();
+                }}
+              />
+            );
+          }}
+        />
+        <span>{convertUnitToLabel(unit)}(s)</span>
+        <When truthy={[DigestUnitEnum.DAYS, DigestUnitEnum.WEEKS, DigestUnitEnum.MONTHS].includes(unit)}>
+          <span>at</span>
+          <Controller
+            control={control}
+            key={atTimeFieldName}
+            name={atTimeFieldName}
+            defaultValue={atTimeDefaultValue}
+            render={({ field }) => {
+              return (
+                <Input
+                  {...field}
+                  value={field.value || ''}
+                  type="time"
+                  data-test-id="time-at"
+                  disabled={readonly}
+                  styles={(theme) => ({
+                    ...inputStyles(theme),
+                    input: {
+                      textAlign: 'center',
+                      ...inputStyles(theme).input,
+                    },
+                  })}
+                  onBlur={(e) => {
+                    if (e.target.value === '') {
+                      setValue(atTimeFieldName, atTimeDefaultValue);
+                    }
+                    field.onBlur();
+                  }}
+                />
+              );
+            }}
+          />
+        </When>
+        <When truthy={[DigestUnitEnum.WEEKS, DigestUnitEnum.MONTHS].includes(unit)}>
+          <span>on:</span>
+        </When>
+      </Group>
+      <When truthy={unit === DigestUnitEnum.WEEKS}>
+        <Controller
+          control={control}
+          name={`steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.${unit}.weekDays`}
+          defaultValue={[format(new Date(), 'EEEE').toLowerCase()]}
+          render={({ field }) => {
+            return <WeekDaySelect value={field.value} disabled={readonly} onChange={field.onChange} />;
+          }}
+        />
+      </When>
+      <When truthy={unit === DigestUnitEnum.MONTHS}>
+        <ScheduleMonthlyFields readonly={readonly} index={index} control={control} />
+      </When>
+    </>
+  );
+};

--- a/apps/web/src/pages/templates/workflow/digest/BackOffFields.tsx
+++ b/apps/web/src/pages/templates/workflow/digest/BackOffFields.tsx
@@ -1,10 +1,13 @@
 import { Group } from '@mantine/core';
 import { Controller, useFormContext } from 'react-hook-form';
+import { Collapse } from '@mantine/core';
+import { DigestTypeEnum } from '@novu/shared';
+
 import { colors, Input, Switch, Tooltip } from '../../../../design-system';
 import { inputStyles } from '../../../../design-system/config/inputs.styles';
 import { IntervalSelect } from './IntervalSelect';
-import { Collapse } from '@mantine/core';
 import { BackOffTooltipIcon } from './icons/BackOffTooltipIcon';
+import { When } from '../../../../components/utils/When';
 
 export const BackOffFields = ({ index, control, readonly }) => {
   const {
@@ -12,7 +15,7 @@ export const BackOffFields = ({ index, control, readonly }) => {
     watch,
   } = useFormContext();
 
-  const backoff = watch(`steps.${index}.metadata.backoff`);
+  const backoff = watch(`steps.${index}.digestMetadata.${DigestTypeEnum.REGULAR}.backoff`);
   const showErrors = isSubmitted && errors?.steps;
 
   return (
@@ -33,7 +36,7 @@ export const BackOffFields = ({ index, control, readonly }) => {
       >
         <Group spacing={0} mt={20} sx={{ color: colors.B60 }}>
           <Controller
-            name={`steps.${index}.metadata.backoff`}
+            name={`steps.${index}.digestMetadata.${DigestTypeEnum.REGULAR}.backoff`}
             defaultValue={false}
             control={control}
             render={({ field }) => {
@@ -44,56 +47,58 @@ export const BackOffFields = ({ index, control, readonly }) => {
         </Group>
       </Tooltip>
       <Collapse in={backoff}>
-        <div style={{ color: colors.B60, marginBottom: 16, marginTop: 16 }}>Start digest only after occurred:</div>
-        <Group spacing={8} sx={{ color: colors.B60 }}>
-          <span>more than 1 event for the last</span>
-          <Controller
-            control={control}
-            name={`steps.${index}.metadata.backoffAmount`}
-            defaultValue=""
-            render={({ field, fieldState }) => {
-              return (
-                <Input
-                  {...field}
-                  value={field.value || ''}
-                  error={showErrors && fieldState.error?.message}
-                  min={0}
-                  max={100}
-                  type="number"
-                  data-test-id="backoff-amount"
-                  placeholder="0"
-                  required
-                  disabled={readonly}
-                  styles={(theme) => ({
-                    ...inputStyles(theme),
-                    input: {
-                      textAlign: 'center',
-                      ...inputStyles(theme).input,
-                      minHeight: '30px',
-                      margin: 0,
-                      height: 30,
-                      lineHeight: '32px',
-                    },
-                  })}
-                />
-              );
-            }}
-          />
-          <div
-            style={{
-              width: '90px',
-              height: 30,
-            }}
-          >
-            <IntervalSelect
-              readonly={readonly}
+        <When truthy={backoff}>
+          <div style={{ color: colors.B60, marginBottom: 16, marginTop: 16 }}>Start digest only after occurred:</div>
+          <Group spacing={8} sx={{ color: colors.B60 }}>
+            <span>more than 1 event for the last</span>
+            <Controller
               control={control}
-              name={`steps.${index}.metadata.backoffUnit`}
-              showErrors={showErrors}
-              testId="time-unit-backoff"
+              name={`steps.${index}.digestMetadata.${DigestTypeEnum.REGULAR}.backoffAmount`}
+              defaultValue=""
+              render={({ field, fieldState }) => {
+                return (
+                  <Input
+                    {...field}
+                    value={field.value || ''}
+                    error={showErrors && fieldState.error?.message}
+                    min={0}
+                    max={100}
+                    type="number"
+                    data-test-id="backoff-amount"
+                    placeholder="0"
+                    required
+                    disabled={readonly}
+                    styles={(theme) => ({
+                      ...inputStyles(theme),
+                      input: {
+                        textAlign: 'center',
+                        ...inputStyles(theme).input,
+                        minHeight: '30px',
+                        margin: 0,
+                        height: 30,
+                        lineHeight: '32px',
+                      },
+                    })}
+                  />
+                );
+              }}
             />
-          </div>
-        </Group>
+            <div
+              style={{
+                width: '90px',
+                height: 30,
+              }}
+            >
+              <IntervalSelect
+                readonly={readonly}
+                control={control}
+                name={`steps.${index}.digestMetadata.${DigestTypeEnum.REGULAR}.backoffUnit`}
+                showErrors={showErrors}
+                testId="time-unit-backoff"
+              />
+            </div>
+          </Group>
+        </When>
       </Collapse>
     </>
   );

--- a/apps/web/src/pages/templates/workflow/digest/BackOffFields.tsx
+++ b/apps/web/src/pages/templates/workflow/digest/BackOffFields.tsx
@@ -9,13 +9,17 @@ import { IntervalSelect } from './IntervalSelect';
 import { BackOffTooltipIcon } from './icons/BackOffTooltipIcon';
 import { When } from '../../../../components/utils/When';
 
+const defaultBackoffAmount = '5';
+
 export const BackOffFields = ({ index, control, readonly }) => {
   const {
     formState: { errors, isSubmitted },
     watch,
+    setValue,
   } = useFormContext();
 
   const backoff = watch(`steps.${index}.digestMetadata.${DigestTypeEnum.REGULAR}.backoff`);
+  const backoffAmountFieldName = `steps.${index}.digestMetadata.${DigestTypeEnum.REGULAR}.backoffAmount`;
   const showErrors = isSubmitted && errors?.steps;
 
   return (
@@ -53,14 +57,13 @@ export const BackOffFields = ({ index, control, readonly }) => {
             <span>more than 1 event for the last</span>
             <Controller
               control={control}
-              name={`steps.${index}.digestMetadata.${DigestTypeEnum.REGULAR}.backoffAmount`}
-              defaultValue=""
+              name={backoffAmountFieldName}
+              defaultValue={defaultBackoffAmount}
               render={({ field, fieldState }) => {
                 return (
                   <Input
                     {...field}
                     value={field.value || ''}
-                    error={showErrors && fieldState.error?.message}
                     min={0}
                     max={100}
                     type="number"
@@ -79,6 +82,12 @@ export const BackOffFields = ({ index, control, readonly }) => {
                         lineHeight: '32px',
                       },
                     })}
+                    onBlur={(e) => {
+                      if (e.target.value === '') {
+                        setValue(backoffAmountFieldName, defaultBackoffAmount);
+                      }
+                      field.onBlur();
+                    }}
                   />
                 );
               }}

--- a/apps/web/src/pages/templates/workflow/digest/ScheduleMonthlyFields.tsx
+++ b/apps/web/src/pages/templates/workflow/digest/ScheduleMonthlyFields.tsx
@@ -35,7 +35,7 @@ export const ScheduleMonthlyFields = ({ index, control, readonly }) => {
             <Controller
               control={control}
               name={`steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.${DigestUnitEnum.MONTHS}.monthDays`}
-              defaultValue={[new Date().getDay()]}
+              defaultValue={[new Date().getDate()]}
               render={({ field }) => {
                 return <DaySelect value={field.value} disabled={readonly} onChange={field.onChange} />;
               }}

--- a/apps/web/src/pages/templates/workflow/digest/ScheduleMonthlyFields.tsx
+++ b/apps/web/src/pages/templates/workflow/digest/ScheduleMonthlyFields.tsx
@@ -1,129 +1,122 @@
 import { Group, Radio, SimpleGrid, Text } from '@mantine/core';
 import { Controller, useFormContext } from 'react-hook-form';
-import { DigestUnitEnum, OrdinalEnum, OrdinalValueEnum, MonthlyTypeEnum } from '@novu/shared';
+import { DigestUnitEnum, OrdinalEnum, OrdinalValueEnum, MonthlyTypeEnum, DigestTypeEnum } from '@novu/shared';
 
 import { When } from '../../../../components/utils/When';
 import { colors, Select } from '../../../../design-system';
 import { DaySelect } from './DaySelect';
-import { format } from 'date-fns';
 
 export const ScheduleMonthlyFields = ({ index, control, readonly }) => {
-  const { watch, trigger } = useFormContext();
+  const { watch } = useFormContext();
 
-  const unit = watch(`steps.${index}.metadata.unit`);
-  const ordinal = watch(`steps.${index}.metadata.timed.ordinal`);
-  const ordinalValue = watch(`steps.${index}.metadata.timed.ordinalValue`);
+  const unit = watch(`steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.unit`);
+  const ordinalFieldName = `steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.${DigestUnitEnum.MONTHS}.ordinal`;
+  const ordinalValueFieldName = `steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.${DigestUnitEnum.MONTHS}.ordinalValue`;
+  const ordinal = watch(ordinalFieldName);
+  const ordinalValue = watch(ordinalValueFieldName);
 
   return (
-    <When truthy={unit === DigestUnitEnum.MONTHS}>
-      <Controller
-        name={`steps.${index}.metadata.timed.monthlyType`}
-        control={control}
-        render={({ field: radioGroup }) => {
-          return (
-            <Radio.Group
-              spacing={0}
-              defaultValue={MonthlyTypeEnum.EACH}
-              value={radioGroup.value}
-              onChange={radioGroup.onChange}
-            >
-              <Group spacing={8} mb={10} mt={34} sx={{ color: colors.B60 }}>
-                <Radio value={MonthlyTypeEnum.EACH} />
-                <div>Each</div>
-              </Group>
+    <Controller
+      name={`steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.${DigestUnitEnum.MONTHS}.monthlyType`}
+      defaultValue={MonthlyTypeEnum.EACH}
+      control={control}
+      render={({ field: radioGroup }) => {
+        return (
+          <Radio.Group
+            spacing={0}
+            defaultValue={MonthlyTypeEnum.EACH}
+            value={radioGroup.value}
+            onChange={radioGroup.onChange}
+          >
+            <Group spacing={8} mb={10} mt={34} sx={{ color: colors.B60 }}>
+              <Radio value={MonthlyTypeEnum.EACH} />
+              <div>Each</div>
+            </Group>
+            <Controller
+              control={control}
+              name={`steps.${index}.digestMetadata.${DigestTypeEnum.TIMED}.${DigestUnitEnum.MONTHS}.monthDays`}
+              defaultValue={[new Date().getDay()]}
+              render={({ field }) => {
+                return <DaySelect value={field.value} disabled={readonly} onChange={field.onChange} />;
+              }}
+            />
+            <Group spacing={8} mb={10} mt={34} sx={{ color: colors.B60 }}>
+              <Radio value={MonthlyTypeEnum.ON} />
+              <div>On the</div>
+            </Group>
+            <SimpleGrid cols={2} spacing={16}>
               <Controller
+                name={ordinalFieldName}
+                defaultValue={OrdinalEnum.FIRST}
                 control={control}
-                name={`steps.${index}.metadata.timed.monthDays`}
-                defaultValue={[new Date().getDay()]}
                 render={({ field }) => {
                   return (
-                    <DaySelect
+                    <Select
                       value={field.value}
-                      disabled={readonly}
-                      onChange={async (value) => {
-                        field.onChange(value);
-                        await trigger(`steps.${index}.metadata`);
-                      }}
+                      onChange={field.onChange}
+                      mt={-5}
+                      mb={-5}
+                      data={[
+                        { value: OrdinalEnum.FIRST, label: 'First' },
+                        { value: OrdinalEnum.SECOND, label: 'Second' },
+                        { value: OrdinalEnum.THIRD, label: 'Third' },
+                        { value: OrdinalEnum.FOURTH, label: 'Fourth' },
+                        { value: OrdinalEnum.FIFTH, label: 'Fifth' },
+                        { value: OrdinalEnum.LAST, label: 'Last' },
+                      ]}
+                      placeholder="First"
                     />
                   );
                 }}
               />
-              <Group spacing={8} mb={10} mt={34} sx={{ color: colors.B60 }}>
-                <Radio value={MonthlyTypeEnum.ON} />
-                <div>On the</div>
-              </Group>
-              <SimpleGrid cols={2} spacing={16}>
-                <Controller
-                  name={`steps.${index}.metadata.timed.ordinal`}
-                  control={control}
-                  render={({ field }) => {
-                    return (
-                      <Select
-                        value={field.value}
-                        onChange={field.onChange}
-                        mt={-5}
-                        mb={-5}
-                        data={[
-                          { value: OrdinalEnum.FIRST, label: 'First' },
-                          { value: OrdinalEnum.SECOND, label: 'Second' },
-                          { value: OrdinalEnum.THIRD, label: 'Third' },
-                          { value: OrdinalEnum.FOURTH, label: 'Fourth' },
-                          { value: OrdinalEnum.FIFTH, label: 'Fifth' },
-                          { value: OrdinalEnum.LAST, label: 'Last' },
-                        ]}
-                        placeholder="First"
-                      />
-                    );
-                  }}
-                />
-                <Controller
-                  name={`steps.${index}.metadata.timed.ordinalValue`}
-                  control={control}
-                  render={({ field }) => {
-                    return (
-                      <Select
-                        value={field.value}
-                        onChange={field.onChange}
-                        mt={-5}
-                        mb={-5}
-                        data={[
-                          { value: OrdinalValueEnum.DAY, label: 'Day' },
-                          { value: OrdinalValueEnum.WEEKDAY, label: 'Weekday' },
-                          { value: OrdinalValueEnum.WEEKEND, label: 'Weekend day' },
-                          { value: OrdinalValueEnum.SUNDAY, label: 'Sunday' },
-                          { value: OrdinalValueEnum.MONDAY, label: 'Monday' },
-                          { value: OrdinalValueEnum.TUESDAY, label: 'Tuesday' },
-                          { value: OrdinalValueEnum.WEDNESDAY, label: 'Wednesday' },
-                          { value: OrdinalValueEnum.THURSDAY, label: 'Thursday' },
-                          { value: OrdinalValueEnum.FRIDAY, label: 'Friday' },
-                          { value: OrdinalValueEnum.SATURDAY, label: 'Saturday' },
-                        ]}
-                        placeholder="Day"
-                      />
-                    );
-                  }}
-                />
-              </SimpleGrid>
-              <When
-                truthy={
-                  ordinal === OrdinalEnum.FIFTH &&
-                  ![OrdinalValueEnum.DAY, OrdinalValueEnum.WEEKDAY, undefined].includes(ordinalValue)
-                }
+              <Controller
+                name={ordinalValueFieldName}
+                defaultValue={OrdinalValueEnum.DAY}
+                control={control}
+                render={({ field }) => {
+                  return (
+                    <Select
+                      value={field.value}
+                      onChange={field.onChange}
+                      mt={-5}
+                      mb={-5}
+                      data={[
+                        { value: OrdinalValueEnum.DAY, label: 'Day' },
+                        { value: OrdinalValueEnum.WEEKDAY, label: 'Weekday' },
+                        { value: OrdinalValueEnum.WEEKEND, label: 'Weekend day' },
+                        { value: OrdinalValueEnum.SUNDAY, label: 'Sunday' },
+                        { value: OrdinalValueEnum.MONDAY, label: 'Monday' },
+                        { value: OrdinalValueEnum.TUESDAY, label: 'Tuesday' },
+                        { value: OrdinalValueEnum.WEDNESDAY, label: 'Wednesday' },
+                        { value: OrdinalValueEnum.THURSDAY, label: 'Thursday' },
+                        { value: OrdinalValueEnum.FRIDAY, label: 'Friday' },
+                        { value: OrdinalValueEnum.SATURDAY, label: 'Saturday' },
+                      ]}
+                      placeholder="Day"
+                    />
+                  );
+                }}
+              />
+            </SimpleGrid>
+            <When
+              truthy={
+                ordinal === OrdinalEnum.FIFTH &&
+                ![OrdinalValueEnum.DAY, OrdinalValueEnum.WEEKDAY, undefined].includes(ordinalValue)
+              }
+            >
+              <Text
+                size={12}
+                color={colors.error}
+                sx={{
+                  lineHeight: '20px',
+                }}
               >
-                <Text
-                  size={12}
-                  color={colors.error}
-                  sx={{
-                    lineHeight: '20px',
-                  }}
-                >
-                  Will not be sent in those months in which there is no such day
-                </Text>
-              </When>
-            </Radio.Group>
-          );
-        }}
-      />
-    </When>
+                Will not be sent in those months in which there is no such day
+              </Text>
+            </When>
+          </Radio.Group>
+        );
+      }}
+    />
   );
 };

--- a/apps/web/src/pages/templates/workflow/digest/TimedDigestWillBeSentHeader.tsx
+++ b/apps/web/src/pages/templates/workflow/digest/TimedDigestWillBeSentHeader.tsx
@@ -1,0 +1,214 @@
+import { useFormContext } from 'react-hook-form';
+import * as capitalize from 'lodash.capitalize';
+import { useMantineColorScheme } from '@mantine/core';
+import { DigestUnitEnum, MonthlyTypeEnum } from '@novu/shared';
+
+import { colors } from '../../../../design-system';
+import { pluralizeTime } from '../../../../utils';
+
+const Highlight = ({ children }) => {
+  const { colorScheme } = useMantineColorScheme();
+
+  return (
+    <b
+      style={{
+        color: colorScheme === 'dark' ? colors.B80 : colors.B40,
+      }}
+    >
+      {children}
+    </b>
+  );
+};
+
+const getOrdinalValueLabel = (value: string) => {
+  if (value === 'day' || value === 'weekday') {
+    return value;
+  }
+  if (value === 'weekend') {
+    return 'weekend day';
+  }
+
+  return capitalize(value);
+};
+
+const getOrdinal = (num: string | number) => {
+  if (typeof num === 'string') {
+    const res = parseInt(num, 10);
+
+    if (isNaN(res)) {
+      return num;
+    }
+    num = res;
+  }
+  const ord = ['st', 'nd', 'rd'];
+  const exceptions = [11, 12, 13];
+  let nth = ord[(num % 10) - 1];
+
+  if (ord[(num % 10) - 1] == undefined || exceptions.includes(num % 100)) {
+    nth = 'th';
+  }
+
+  return num + nth;
+};
+
+export const TimedDigestWillBeSentHeader = ({ index }: { index: number }) => {
+  const { watch } = useFormContext();
+
+  const unit = watch(`steps.${index}.digestMetadata.timed.unit`);
+  if (unit == DigestUnitEnum.MINUTES) {
+    const amount = watch(`steps.${index}.digestMetadata.timed.minutes.amount`);
+
+    return (
+      <>
+        Every <Highlight>{pluralizeTime(amount, 'minute')}</Highlight>
+      </>
+    );
+  }
+
+  if (unit == DigestUnitEnum.HOURS) {
+    const amount = watch(`steps.${index}.digestMetadata.timed.hours.amount`);
+
+    return (
+      <>
+        Every <Highlight>{pluralizeTime(amount, 'hour')}</Highlight>
+      </>
+    );
+  }
+
+  if (unit === DigestUnitEnum.DAYS) {
+    const amount = watch(`steps.${index}.digestMetadata.timed.days.amount`);
+    const atTime = watch(`steps.${index}.digestMetadata.timed.days.atTime`);
+
+    if (amount !== '' && amount !== '1') {
+      return (
+        <>
+          Every <Highlight>{getOrdinal(amount)} </Highlight> day
+          {atTime && (
+            <>
+              {' '}
+              at <Highlight>{atTime}</Highlight>
+            </>
+          )}
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Highlight>Daily</Highlight>
+        {atTime && (
+          <>
+            {' '}
+            at <Highlight>{atTime}</Highlight>
+          </>
+        )}
+      </>
+    );
+  }
+
+  if (unit === DigestUnitEnum.WEEKS) {
+    const amount = watch(`steps.${index}.digestMetadata.timed.weeks.amount`);
+    const atTime = watch(`steps.${index}.digestMetadata.timed.weeks.atTime`);
+    const weekDays = watch(`steps.${index}.digestMetadata.timed.weeks.weekDays`) || [];
+
+    if (amount !== '' && amount !== '1') {
+      return (
+        <>
+          Every <Highlight>{getOrdinal(amount)} </Highlight> week on{' '}
+          <Highlight>{weekDays?.map((item) => capitalize(item)).join(', ')}</Highlight>
+          {atTime && (
+            <>
+              {' '}
+              at <Highlight>{atTime}</Highlight>
+            </>
+          )}
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Highlight>Weekly</Highlight> on <Highlight>{weekDays?.map((item) => capitalize(item)).join(', ')}</Highlight>
+        {atTime && (
+          <>
+            {' '}
+            at <Highlight>{atTime}</Highlight>
+          </>
+        )}
+      </>
+    );
+  }
+
+  const amount = watch(`steps.${index}.digestMetadata.timed.months.amount`);
+  const monthlyType = watch(`steps.${index}.digestMetadata.timed.months.monthlyType`);
+  const atTime = watch(`steps.${index}.digestMetadata.timed.months.atTime`);
+  const monthDays = watch(`steps.${index}.digestMetadata.timed.months.monthDays`) || [];
+
+  if (monthlyType === MonthlyTypeEnum.ON) {
+    const ordinal = watch(`steps.${index}.digestMetadata.timed.months.ordinal`);
+    const ordinalValue = watch(`steps.${index}.digestMetadata.timed.months.ordinalValue`);
+
+    if (!ordinal || !ordinalValue) {
+      return null;
+    }
+
+    if (amount !== '' && amount !== '1') {
+      return (
+        <>
+          Every <Highlight>{getOrdinal(amount)} </Highlight> month on{' '}
+          <Highlight>
+            {getOrdinal(ordinal)} {getOrdinalValueLabel(ordinalValue)}
+          </Highlight>
+          {atTime && (
+            <>
+              {' '}
+              at <Highlight>{atTime}</Highlight>
+            </>
+          )}
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Highlight>Monthly</Highlight> on the{' '}
+        <Highlight>
+          {getOrdinal(ordinal)} {getOrdinalValueLabel(ordinalValue)}
+        </Highlight>
+        {atTime && (
+          <>
+            {' '}
+            at <Highlight>{atTime}</Highlight>
+          </>
+        )}
+      </>
+    );
+  }
+
+  if (amount !== '' && amount !== '1') {
+    return (
+      <>
+        Every <Highlight>{getOrdinal(amount)} </Highlight> month on{' '}
+        <Highlight>{monthDays?.map((item) => getOrdinal(item)).join(', ')}</Highlight>
+        {atTime && (
+          <>
+            {' '}
+            at <Highlight>{atTime}</Highlight>
+          </>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Highlight>Monthly</Highlight> on <Highlight>{monthDays?.map((item) => getOrdinal(item)).join(', ')}</Highlight>
+      {atTime && (
+        <>
+          {' '}
+          at <Highlight>{atTime}</Highlight>
+        </>
+      )}
+    </>
+  );
+};

--- a/apps/web/src/pages/templates/workflow/digest/WillBeSentHeader.tsx
+++ b/apps/web/src/pages/templates/workflow/digest/WillBeSentHeader.tsx
@@ -1,42 +1,10 @@
-import { useCallback, useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
-import * as capitalize from 'lodash.capitalize';
 import { useMantineColorScheme } from '@mantine/core';
-import { DigestTypeEnum, DigestUnitEnum, MonthlyTypeEnum } from '@novu/shared';
+import { DigestTypeEnum } from '@novu/shared';
 
 import { colors } from '../../../../design-system';
 import { pluralizeTime } from '../../../../utils';
-
-const getOrdinalValueLabel = (value: string) => {
-  if (value === 'day' || value === 'weekday') {
-    return value;
-  }
-  if (value === 'weekend') {
-    return 'weekend day';
-  }
-
-  return capitalize(value);
-};
-
-const getOrdinal = (num: string | number) => {
-  if (typeof num === 'string') {
-    const res = parseInt(num, 10);
-
-    if (isNaN(res)) {
-      return num;
-    }
-    num = res;
-  }
-  const ord = ['st', 'nd', 'rd'];
-  const exceptions = [11, 12, 13];
-  let nth = ord[(num % 10) - 1];
-
-  if (ord[(num % 10) - 1] == undefined || exceptions.includes(num % 100)) {
-    nth = 'th';
-  }
-
-  return num + nth;
-};
+import { TimedDigestWillBeSentHeader } from './TimedDigestWillBeSentHeader';
 
 const Highlight = ({ children }) => {
   const { colorScheme } = useMantineColorScheme();
@@ -51,125 +19,30 @@ const Highlight = ({ children }) => {
     </b>
   );
 };
-export const WillBeSentHeader = ({ index }) => {
-  const { watch, setValue } = useFormContext();
 
-  const type = watch(`steps.${index}.metadata.type`);
-  const unit = watch(`steps.${index}.metadata.unit`);
-  const backoff = watch(`steps.${index}.metadata.backoff`);
-  const atTime = watch(`steps.${index}.metadata.timed.atTime`);
-  const weekDays = watch(`steps.${index}.metadata.timed.weekDays`) || [];
-  const monthDays = watch(`steps.${index}.metadata.timed.monthDays`) || [];
-  const amount = watch(`steps.${index}.metadata.amount`);
+export const WillBeSentHeader = ({ index }: { index: number }) => {
+  const { watch } = useFormContext();
 
-  useEffect(() => {
-    if (!backoff) {
-      return;
-    }
-    if (type !== DigestTypeEnum.TIMED) {
-      return;
-    }
-    setValue(`steps.${index}.metadata.backoff`, false);
-  }, [backoff, type, index]);
+  const type = watch(`steps.${index}.digestMetadata.type`);
 
-  const BackoffText = useCallback(() => {
-    return backoff ? (
-      <>
-        only if <Highlight>frequent events</Highlight> occur
-      </>
-    ) : null;
-  }, [backoff]);
-
-  if (type === DigestTypeEnum.TIMED && unit == DigestUnitEnum.HOURS) {
-    return (
-      <>
-        Every <Highlight>{pluralizeTime(amount, 'hour')}</Highlight> <BackoffText />
-      </>
-    );
+  if (type === DigestTypeEnum.TIMED) {
+    return <TimedDigestWillBeSentHeader index={index} />;
   }
 
-  if (type === DigestTypeEnum.TIMED && unit == DigestUnitEnum.MINUTES) {
-    return (
-      <>
-        Every <Highlight>{pluralizeTime(amount, 'minute')}</Highlight> <BackoffText />
-      </>
-    );
-  }
-
-  if (type === DigestTypeEnum.TIMED && unit === DigestUnitEnum.DAYS) {
-    if (!atTime) {
-      return (
-        <>
-          Every <Highlight>{getOrdinal(amount)} </Highlight> day
-        </>
-      );
-    }
-
-    if (amount !== '1') {
-      return (
-        <>
-          Every <Highlight>{getOrdinal(amount)} </Highlight> day at <Highlight>{atTime}</Highlight> <BackoffText />
-        </>
-      );
-    }
-
-    return (
-      <>
-        <Highlight>Daily</Highlight> at <Highlight>{atTime}</Highlight> <BackoffText />
-      </>
-    );
-  }
-  if (type === DigestTypeEnum.TIMED && unit === DigestUnitEnum.WEEKS) {
-    return (
-      <>
-        <Highlight>Weekly</Highlight> on <Highlight>{weekDays?.map((item) => capitalize(item)).join(', ')}</Highlight>{' '}
-        at <Highlight>{atTime}</Highlight>{' '}
-        <div>
-          <BackoffText />
-        </div>
-      </>
-    );
-  }
-
-  if (type === DigestTypeEnum.TIMED && unit === DigestUnitEnum.MONTHS) {
-    const monthlyType = watch(`steps.${index}.metadata.timed.monthlyType`);
-
-    if (monthlyType === MonthlyTypeEnum.ON) {
-      const ordinal = watch(`steps.${index}.metadata.timed.ordinal`);
-      const ordinalValue = watch(`steps.${index}.metadata.timed.ordinalValue`);
-
-      if (!ordinal || !ordinalValue) {
-        return null;
-      }
-
-      return (
-        <>
-          Every month on the{' '}
-          <Highlight>
-            {getOrdinal(ordinal)} {getOrdinalValueLabel(ordinalValue)}
-          </Highlight>
-        </>
-      );
-    }
-
-    return (
-      <>
-        <Highlight>Monthly</Highlight> on <Highlight>{monthDays?.map((item) => getOrdinal(item)).join(', ')}</Highlight>{' '}
-        at <Highlight>{atTime}</Highlight>
-        <div>
-          <BackoffText />
-        </div>
-      </>
-    );
-  }
+  const unit = watch(`steps.${index}.digestMetadata.regular.unit`);
+  const amount = watch(`steps.${index}.digestMetadata.regular.amount`);
+  const backoff = watch(`steps.${index}.digestMetadata.regular.backoff`);
 
   return (
     <>
-      after{' '}
-      <Highlight>
-        {amount} {unit}
-      </Highlight>{' '}
-      after collecting first event
+      after <Highlight>{pluralizeTime(amount, unit)}</Highlight>
+      {backoff ? (
+        <>
+          only if <Highlight>frequent events</Highlight> occur
+        </>
+      ) : (
+        ' occur on'
+      )}
     </>
   );
 };

--- a/apps/web/src/pages/templates/workflow/workflow/FlowEditor.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/FlowEditor.tsx
@@ -23,7 +23,7 @@ import ChannelNode from './node-types/ChannelNode';
 import { colors } from '../../../../design-system';
 import TriggerNode from './node-types/TriggerNode';
 import { getChannel } from '../../shared/channels';
-import type { IForm, IStepEntity } from '../../components/formTypes';
+import type { IForm, IFormStep } from '../../components/formTypes';
 import AddNode from './node-types/AddNode';
 import { useEnvController } from '../../../../hooks';
 import { getFormattedStepErrors } from '../../shared/errors';
@@ -58,7 +58,7 @@ export function FlowEditor({
   onDelete,
 }: {
   onDelete: (id: string) => void;
-  steps: IStepEntity[];
+  steps: IFormStep[];
   addStep: (channelType: StepTypeEnum, id: string, index?: number) => void;
   dragging: boolean;
   errors: any;
@@ -204,7 +204,7 @@ export function FlowEditor({
     newId: string,
     oldNode: { position: { x: number; y: number } },
     parentId: string,
-    step: IStepEntity,
+    step: IFormStep,
     i: number
   ): Node {
     const channel = getChannel(step.template.type);

--- a/apps/web/src/utils/pluralize.ts
+++ b/apps/web/src/utils/pluralize.ts
@@ -1,2 +1,2 @@
 export const pluralizeTime = (amount: string | number, unit: 'minute' | 'hour' | 'day' | 'week' | 'month'): string =>
-  amount === '1' || amount === 1 ? unit : `${amount} ${unit}s`;
+  amount === '1' || amount === '' || amount === 1 ? unit : `${amount} ${unit}s`;

--- a/libs/shared/src/dto/message-template/message-template.dto.ts
+++ b/libs/shared/src/dto/message-template/message-template.dto.ts
@@ -1,7 +1,7 @@
 import { MessageTemplateContentType } from '../../entities/message-template';
 import { IMessageCTA } from '../../entities/messages';
 
-import { ChannelCTATypeEnum, IEmailBlock, StepTypeEnum } from '../../types';
+import { ActorTypeEnum, ChannelCTATypeEnum, IEmailBlock, StepTypeEnum } from '../../types';
 
 export class ChannelCTADto {
   type: ChannelCTATypeEnum;
@@ -19,4 +19,9 @@ export class MessageTemplateDto {
   contentType?: MessageTemplateContentType;
 
   cta?: IMessageCTA;
+
+  actor?: {
+    type: ActorTypeEnum;
+    data: string | null;
+  };
 }

--- a/libs/shared/src/dto/notification-templates/notification-template.dto.ts
+++ b/libs/shared/src/dto/notification-templates/notification-template.dto.ts
@@ -1,6 +1,25 @@
+import { INotificationTemplateStepMetadata } from '../../entities/step';
+import { BuilderFieldType, BuilderGroupValues, FilterParts } from '../../types';
 import { MessageTemplateDto } from '../message-template';
 
 export class NotificationStepDto {
-  active?: boolean;
+  id?: string;
+  _id?: string;
+  name?: string;
+  uuid?: string;
+  _templateId?: string;
   template?: MessageTemplateDto;
+  filters?: {
+    isNegated?: boolean;
+    type?: BuilderFieldType;
+    value?: BuilderGroupValues;
+    children?: FilterParts[];
+  }[];
+  active?: boolean;
+  shouldStopOnFail?: boolean;
+  replyCallback?: {
+    active: boolean;
+    url?: string;
+  };
+  metadata?: INotificationTemplateStepMetadata;
 }


### PR DESCRIPTION
### What change does this PR introduce?

Improved the timed digest form:
- updated form schema
- the digest/delay step metadata in the form state is split between `digestMetadata` and `delayMetadata`;
- independent form state for the different digest tabs:
  - regular and timed
  - min, hour, daily, weekly, monthly; 
  - thanks to this the values typed in the form are persisted when switching tabs
- default value set on blur when the value is empty: regular digest - amount, backoff amount; timed digest - amount, at time
- improved "Will be sent" field accordion header
- code split into separate components
- added missed default values

### Why was this change needed?

This is a part of the Timed Digest PRD.

### Other information (Screenshots)

![Screenshot 2023-05-14 at 01 02 31](https://github.com/novuhq/novu/assets/2607232/9faf0cbd-c254-4690-ba20-7752e57ea41f)



https://github.com/novuhq/novu/assets/2607232/88e93618-baf4-451e-9c9d-e945e3c4b921



https://github.com/novuhq/novu/assets/2607232/5047d046-db79-4c2c-8752-95e651aaddd2



https://github.com/novuhq/novu/assets/2607232/032a3016-0971-4954-94c5-fb522f9e8229

