### PR TITLE
fix(novu/node): Get all Notification templates without any parameter

### DIFF
--- a/packages/node/src/lib/notification-template/notification-template.spec.ts
+++ b/packages/node/src/lib/notification-template/notification-template.spec.ts
@@ -19,12 +19,48 @@ describe('test use of novus node package - NotificationTemplates class', () => {
   test('should fetch all the notification-templates correctly', async () => {
     mockedAxios.post.mockResolvedValue({});
 
-    await novu.notificationTemplates.getAll(undefined, 0);
+    await novu.notificationTemplates.getAll();
+
+    expect(mockedAxios.get).toHaveBeenCalled();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/notification-templates', {});
+  });
+
+  test('should fetch all the notification-templates correctly of 2nd page', async () => {
+    mockedAxios.post.mockResolvedValue({});
+
+    await novu.notificationTemplates.getAll(2);
 
     expect(mockedAxios.get).toHaveBeenCalled();
     expect(mockedAxios.get).toHaveBeenCalledWith('/notification-templates', {
       params: {
-        limit: 0,
+        page: 2,
+      },
+    });
+  });
+
+  test('should fetch all the notification-templates correctly with limit of 10', async () => {
+    mockedAxios.post.mockResolvedValue({});
+
+    await novu.notificationTemplates.getAll(undefined, 10);
+
+    expect(mockedAxios.get).toHaveBeenCalled();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/notification-templates', {
+      params: {
+        limit: 10,
+      },
+    });
+  });
+
+  test('should fetch all the notification-templates correctly of page 3 with limit of 20', async () => {
+    mockedAxios.post.mockResolvedValue({});
+
+    await novu.notificationTemplates.getAll(3, 20);
+
+    expect(mockedAxios.get).toHaveBeenCalled();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/notification-templates', {
+      params: {
+        page: 3,
+        limit: 20,
       },
     });
   });
@@ -32,16 +68,16 @@ describe('test use of novus node package - NotificationTemplates class', () => {
   test('should create a template with the given parameters', async () => {
     mockedAxios.post.mockResolvedValue({});
 
-    await novu.notificationTemplates.create({
+    const result = await novu.notificationTemplates.create({
       name: 'test1',
-      notificationGroupId: 'NOTIFGROUPID',
+      notificationGroupId: '63b99e83598f5625a96c4b97',
       steps: [],
     });
 
     expect(mockedAxios.post).toHaveBeenCalled();
     expect(mockedAxios.post).toHaveBeenCalledWith('/notification-templates', {
       name: 'test1',
-      notificationGroupId: 'NOTIFGROUPID',
+      notificationGroupId: '63b99e83598f5625a96c4b97',
       steps: [],
     });
   });
@@ -73,11 +109,11 @@ describe('test use of novus node package - NotificationTemplates class', () => {
   test('should delete the specified template', async () => {
     mockedAxios.post.mockResolvedValue({});
 
-    await novu.notificationTemplates.delete('TEMPLATE_ID');
+    await novu.notificationTemplates.delete('TEMPLATE_I12D');
 
     expect(mockedAxios.delete).toHaveBeenCalled();
     expect(mockedAxios.delete).toHaveBeenCalledWith(
-      '/notification-templates/TEMPLATE_ID'
+      '/notification-templates/TEMPLATE_I12D'
     );
   });
 

--- a/packages/node/src/lib/notification-template/notification-template.ts
+++ b/packages/node/src/lib/notification-template/notification-template.ts
@@ -17,7 +17,7 @@ export class NotificationTemplates
    */
   async getAll(page?: number, limit?: number) {
     if (page === undefined && limit === undefined) {
-      return await this.http.get(`/notification-templates`);
+      return await this.http.get(`/notification-templates`, {});
     } else if (page === undefined) {
       return await this.http.get(`/notification-templates`, {
         params: {


### PR DESCRIPTION
- Also adding additional unit tests for page and limit on Getting All Notification templates

### What change does this PR introduce?

Just when I was trying to use the `novu/node` package and getting all templates.. I found that I made an error in making the SDK last year that Getting all the notification templates was throwing..

```node
import { Novu } from '@novu/node';

const novu = new Novu('<API_KEY>');

async function main() {
  const result = await novu.notificationTemplates.getAll();
  console.log(result.data);
}

main();
```

- [X] Also added a few unit tests for this function


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

No issue is open currently for this...


<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)
Output of the above code

![image](https://github.com/novuhq/novu/assets/42518907/ebd25948-e7d1-42f9-9231-ef8bc7856f71)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
