### PR TITLE
fix: corrected apple dev link in apns docs

### DIFF
--- a/docs/docs/channels/push/apns.md
+++ b/docs/docs/channels/push/apns.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 
 Apple provides two authentication methods to make a secure connection to APNs. The first is Certificate-Based Authentication (using a .p12 certificate). The second is Token-Based Authentication (using a .p8 key). We'll make use of the **.p8** key.
 
-To enable APNS integration, you need to create an [Apple Developer](https://developer.apple.com.) account with [Admin role](https://appstoreconnect.apple.com/access/users).
+To enable APNS integration, you need to create an [Apple Developer](https://developer.apple.com) account with [Admin role](https://appstoreconnect.apple.com/access/users).
 
 To generate the p8 key for your account:
 <br />


### PR DESCRIPTION
### What change does this PR introduce?
changes link from [developer.apple.com.](https://developer.apple.com.) to [developer.apple.com](https://developer.apple.com) in [APNs docs](https://docs.novu.co/channels/push/apns/).

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
because we don't want invalid links in docs :)

### Other information (Screenshots)
![screenshot](https://github.com/novuhq/novu/assets/43048524/81eb5fe8-de42-45ea-977d-dd0d32c675a8)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
