### PR TITLE
fix: apns production option

### DIFF
--- a/packages/application-generic/src/factories/push/handlers/apns.handler.ts
+++ b/packages/application-generic/src/factories/push/handlers/apns.handler.ts
@@ -21,7 +21,7 @@ export class APNSHandler extends BasePushHandler {
       keyId: credentials.apiKey,
       teamId: credentials.projectName,
       bundleId: credentials.applicationId as string,
-      production: credentials.secure as boolean,
+      production: credentials.secure ?? false,
     });
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

Add default value for apns `production` option. Undefined value leads to unexpected behaviour.

### Why was this change needed?
Closes #3416 - everything is well described in this issue

https://github.com/node-apn/node-apn#connecting

> By default, the provider will connect to the sandbox unless the environment variable NODE_ENV=production is set

Basically when user creates APNs integration, by default it creates credentials where `secure` is optional field so it's undefined when value not specified (`secure` field is used for `production` option for `node-apn`). So when `secure` is undefined, then `node-apn` package uses `NODE_ENV` to determine if production is true or false. It may lead to scenario where user has production set to undefined (in GUI it's switch which indicates that production should be disabled) but Novu servers are probably running with `NODE_ENV=production` and then we have bug or at least possible unexpected behaviour.

Important note - this PR is very closely related to [PR#3430](https://github.com/novuhq/novu/pull/3430). 3430 solves other problem where `secure` used for `production` field is persisted as string, so if someone provides "false" then it's interpreted by `node-apn` as true value what makes whole provider just broken actually.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
