### PR TITLE
NV-2336 - Template Store -Add grouped by category blueprints

### DIFF
--- a/apps/api/src/app/blueprint/blueprint.controller.ts
+++ b/apps/api/src/app/blueprint/blueprint.controller.ts
@@ -8,6 +8,7 @@ import { GroupedBlueprintResponse } from './dto/grouped-blueprint.response.dto';
 import { GetBlueprint, GetBlueprintCommand } from './usecases/get-blueprint';
 import { CreateBlueprintCommand, CreateBlueprint } from './usecases/create-blueprint';
 import { GetGroupedBlueprints } from './usecases/get-blueprints';
+import { GetBlueprintResponse } from './dto/get-blueprint.response.dto';
 
 @Controller('/blueprints')
 @UseInterceptors(ClassSerializerInterceptor)
@@ -19,7 +20,7 @@ export class BlueprintController {
   ) {}
 
   @Get('/:templateId')
-  getBlueprintById(@Param('templateId') templateId: string): Promise<NotificationTemplateEntity> {
+  getBlueprintById(@Param('templateId') templateId: string): Promise<GetBlueprintResponse> {
     return this.getBlueprintUsecase.execute(
       GetBlueprintCommand.create({
         templateId,

--- a/apps/api/src/app/blueprint/blueprint.controller.ts
+++ b/apps/api/src/app/blueprint/blueprint.controller.ts
@@ -1,45 +1,44 @@
-import { ClassSerializerInterceptor, Controller, Get, Param, Post, UseGuards, UseInterceptors } from '@nestjs/common';
+import { ClassSerializerInterceptor, Controller, Get, Param, Post, UseInterceptors } from '@nestjs/common';
 
 import { IJwtPayload } from '@novu/shared';
+import { NotificationTemplateEntity } from '@novu/dal';
 
 import { UserSession } from '../shared/framework/user.decorator';
-import { NotificationTemplateResponse } from '../notification-template/dto/notification-template-response.dto';
-import {
-  GetBlueprintNotificationTemplate,
-  GetBlueprintNotificationTemplateCommand,
-} from './usecases/get-blueprint-notification-template';
-import { CreateBlueprintNotificationTemplate } from './usecases/create-blueprint-notification-template';
+import { GroupedBlueprintResponse } from './dto/grouped-blueprint.response.dto';
+import { GetBlueprint, GetBlueprintCommand } from './usecases/get-blueprint';
+import { CreateBlueprintCommand, CreateBlueprint } from './usecases/create-blueprint';
+import { GetGroupedBlueprints } from './usecases/get-blueprints';
 
 @Controller('/blueprints')
 @UseInterceptors(ClassSerializerInterceptor)
 export class BlueprintController {
   constructor(
-    private getBlueprintNotificationTemplate: GetBlueprintNotificationTemplate,
-    private createBlueprintNotificationTemplate: CreateBlueprintNotificationTemplate
+    private getBlueprintUsecase: GetBlueprint,
+    private getGroupedBlueprintsUsecase: GetGroupedBlueprints,
+    private createBlueprintUsecase: CreateBlueprint
   ) {}
 
   @Get('/:templateId')
-  getNotificationTemplateBlueprintById(
-    @UserSession() user: IJwtPayload,
-    @Param('templateId') templateId: string
-  ): Promise<NotificationTemplateResponse> {
-    return this.getBlueprintNotificationTemplate.execute(
-      GetBlueprintNotificationTemplateCommand.create({
-        environmentId: user.environmentId,
-        organizationId: user.organizationId,
-        userId: user._id,
+  getBlueprintById(@Param('templateId') templateId: string): Promise<NotificationTemplateEntity> {
+    return this.getBlueprintUsecase.execute(
+      GetBlueprintCommand.create({
         templateId,
       })
     );
+  }
+
+  @Get('/group-by-category')
+  getGroupedBlueprints(@UserSession() user: IJwtPayload): Promise<GroupedBlueprintResponse[]> {
+    return this.getGroupedBlueprintsUsecase.execute();
   }
 
   @Post('/:templateId/blueprint')
   createNotificationTemplateFromBlueprintById(
     @UserSession() user: IJwtPayload,
     @Param('templateId') templateId: string
-  ): Promise<NotificationTemplateResponse> {
-    return this.createBlueprintNotificationTemplate.execute(
-      GetBlueprintNotificationTemplateCommand.create({
+  ): Promise<NotificationTemplateEntity> {
+    return this.createBlueprintUsecase.execute(
+      CreateBlueprintCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         userId: user._id,

--- a/apps/api/src/app/blueprint/blueprint.controller.ts
+++ b/apps/api/src/app/blueprint/blueprint.controller.ts
@@ -19,6 +19,11 @@ export class BlueprintController {
     private createBlueprintUsecase: CreateBlueprint
   ) {}
 
+  @Get('/group-by-category')
+  getGroupedBlueprints(): Promise<GroupedBlueprintResponse[]> {
+    return this.getGroupedBlueprintsUsecase.execute();
+  }
+
   @Get('/:templateId')
   getBlueprintById(@Param('templateId') templateId: string): Promise<GetBlueprintResponse> {
     return this.getBlueprintUsecase.execute(
@@ -26,11 +31,6 @@ export class BlueprintController {
         templateId,
       })
     );
-  }
-
-  @Get('/group-by-category')
-  getGroupedBlueprints(@UserSession() user: IJwtPayload): Promise<GroupedBlueprintResponse[]> {
-    return this.getGroupedBlueprintsUsecase.execute();
   }
 
   @Post('/:templateId')

--- a/apps/api/src/app/blueprint/dto/get-blueprint.response.dto.ts
+++ b/apps/api/src/app/blueprint/dto/get-blueprint.response.dto.ts
@@ -1,0 +1,49 @@
+import { INotificationGroup, INotificationTrigger, IPreferenceChannels, NotificationStepDto } from '@novu/shared';
+
+export class GetBlueprintResponse {
+  _id: string;
+
+  name: string;
+
+  description: string;
+
+  active: boolean;
+
+  draft: boolean;
+
+  preferenceSettings: IPreferenceChannels;
+
+  critical: boolean;
+
+  tags: string[];
+
+  steps: NotificationStepDto[];
+
+  _organizationId: string;
+
+  _creatorId: string;
+
+  _environmentId: string;
+
+  triggers: INotificationTrigger[];
+
+  _notificationGroupId: string;
+
+  _parentId?: string;
+
+  deleted: boolean;
+
+  deletedAt: string;
+
+  deletedBy: string;
+
+  createdAt?: string;
+
+  updatedAt?: string;
+
+  notificationGroup?: INotificationGroup;
+
+  isBlueprint: boolean;
+
+  blueprintId?: string;
+}

--- a/apps/api/src/app/blueprint/dto/grouped-blueprint.response.dto.ts
+++ b/apps/api/src/app/blueprint/dto/grouped-blueprint.response.dto.ts
@@ -1,0 +1,6 @@
+import { NotificationTemplateEntity } from '@novu/dal';
+
+export class GroupedBlueprintResponse {
+  name: string;
+  blueprints: NotificationTemplateEntity[];
+}

--- a/apps/api/src/app/blueprint/usecases/create-blueprint-notification-template/create-blueprint-notification-template.command.ts
+++ b/apps/api/src/app/blueprint/usecases/create-blueprint-notification-template/create-blueprint-notification-template.command.ts
@@ -1,8 +1,0 @@
-import { IsDefined, IsMongoId } from 'class-validator';
-import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
-
-export class CreateBlueprintNotificationTemplateCommand extends EnvironmentWithUserCommand {
-  @IsDefined()
-  @IsMongoId()
-  templateId: string;
-}

--- a/apps/api/src/app/blueprint/usecases/create-blueprint-notification-template/index.ts
+++ b/apps/api/src/app/blueprint/usecases/create-blueprint-notification-template/index.ts
@@ -1,2 +1,0 @@
-export * from './create-blueprint-notification-template.usecase';
-export * from './create-blueprint-notification-template.command';

--- a/apps/api/src/app/blueprint/usecases/create-blueprint/create-blueprint.command.ts
+++ b/apps/api/src/app/blueprint/usecases/create-blueprint/create-blueprint.command.ts
@@ -1,7 +1,7 @@
 import { IsDefined, IsMongoId } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class GetBlueprintNotificationTemplateCommand extends EnvironmentWithUserCommand {
+export class CreateBlueprintCommand extends EnvironmentWithUserCommand {
   @IsDefined()
   @IsMongoId()
   templateId: string;

--- a/apps/api/src/app/blueprint/usecases/create-blueprint/create-blueprint.usecase.ts
+++ b/apps/api/src/app/blueprint/usecases/create-blueprint/create-blueprint.usecase.ts
@@ -72,7 +72,7 @@ export class CreateBlueprint {
       }
 
       const originalFeed = await this.feedRepository.findOne({
-        _environmentId: this.getBlueprintEnvironmentId(),
+        _organizationId: this.getBlueprintOrganizationId,
         id: step.template._feedId,
       });
 
@@ -119,7 +119,7 @@ export class CreateBlueprint {
 
     const originalGroup = await this.notificationGroupRepository.findOne({
       _id: notificationGroupId,
-      _environmentId: this.getBlueprintEnvironmentId(),
+      _organizationId: this.getBlueprintOrganizationId,
     });
     if (!originalGroup) throw new NotFoundException(`Notification group with id ${notificationGroupId} is not found`);
 
@@ -141,7 +141,7 @@ export class CreateBlueprint {
     return group;
   }
 
-  private getBlueprintEnvironmentId(): string {
-    return NotificationTemplateRepository.getBlueprintEnvironmentId() as string;
+  private get getBlueprintOrganizationId(): string {
+    return NotificationTemplateRepository.getBlueprintOrganizationId() as string;
   }
 }

--- a/apps/api/src/app/blueprint/usecases/create-blueprint/create-blueprint.usecase.ts
+++ b/apps/api/src/app/blueprint/usecases/create-blueprint/create-blueprint.usecase.ts
@@ -12,10 +12,10 @@ import {
   CreateNotificationTemplate,
   CreateNotificationTemplateCommand,
 } from '../../../notification-template/usecases/create-notification-template';
-import { CreateBlueprintNotificationTemplateCommand } from './create-blueprint-notification-template.command';
+import { CreateBlueprintCommand } from './create-blueprint.command';
 
 @Injectable()
-export class CreateBlueprintNotificationTemplate {
+export class CreateBlueprint {
   constructor(
     private notificationTemplateRepository: NotificationTemplateRepository,
     private createNotificationTemplateUsecase: CreateNotificationTemplate,
@@ -24,7 +24,7 @@ export class CreateBlueprintNotificationTemplate {
     private analyticsService: AnalyticsService
   ) {}
 
-  async execute(command: CreateBlueprintNotificationTemplateCommand): Promise<NotificationTemplateEntity> {
+  async execute(command: CreateBlueprintCommand): Promise<NotificationTemplateEntity> {
     const template = await this.notificationTemplateRepository.findBlueprint(command.templateId);
     if (!template) {
       throw new NotFoundException(`Template with id ${command.templateId} not found`);
@@ -62,7 +62,7 @@ export class CreateBlueprintNotificationTemplate {
 
   private async handleFeeds(
     steps: NotificationStepEntity[],
-    command: CreateBlueprintNotificationTemplateCommand
+    command: CreateBlueprintCommand
   ): Promise<NotificationStepEntity[]> {
     for (let i = 0; i < steps.length; i++) {
       const step = steps[i];
@@ -72,7 +72,7 @@ export class CreateBlueprintNotificationTemplate {
       }
 
       const originalFeed = await this.feedRepository.findOne({
-        _organizationId: this.getBlueprintOrganizationId(),
+        _environmentId: this.getBlueprintEnvironmentId(),
         id: step.template._feedId,
       });
 
@@ -105,7 +105,7 @@ export class CreateBlueprintNotificationTemplate {
 
   private async handleGroup(
     notificationGroupId: string,
-    command: CreateBlueprintNotificationTemplateCommand
+    command: CreateBlueprintCommand
   ): Promise<NotificationGroupEntity> {
     let group = await this.notificationGroupRepository.findOne({
       name: 'General',
@@ -119,7 +119,7 @@ export class CreateBlueprintNotificationTemplate {
 
     const originalGroup = await this.notificationGroupRepository.findOne({
       _id: notificationGroupId,
-      _organizationId: this.getBlueprintOrganizationId(),
+      _environmentId: this.getBlueprintEnvironmentId(),
     });
     if (!originalGroup) throw new NotFoundException(`Notification group with id ${notificationGroupId} is not found`);
 
@@ -141,7 +141,7 @@ export class CreateBlueprintNotificationTemplate {
     return group;
   }
 
-  private getBlueprintOrganizationId(): string {
-    return NotificationTemplateRepository.getBlueprintOrganizationId() as string;
+  private getBlueprintEnvironmentId(): string {
+    return NotificationTemplateRepository.getBlueprintEnvironmentId() as string;
   }
 }

--- a/apps/api/src/app/blueprint/usecases/create-blueprint/index.ts
+++ b/apps/api/src/app/blueprint/usecases/create-blueprint/index.ts
@@ -1,0 +1,2 @@
+export * from './create-blueprint.usecase';
+export * from './create-blueprint.command';

--- a/apps/api/src/app/blueprint/usecases/get-blueprint-notification-template/index.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprint-notification-template/index.ts
@@ -1,2 +1,0 @@
-export * from './get-blueprint-notification-template.command';
-export * from './get-blueprint-notification-template.usecase';

--- a/apps/api/src/app/blueprint/usecases/get-blueprint/get-blueprint.command.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprint/get-blueprint.command.ts
@@ -1,0 +1,8 @@
+import { IsDefined, IsMongoId } from 'class-validator';
+import { BaseCommand } from '@novu/application-generic';
+
+export class GetBlueprintCommand extends BaseCommand {
+  @IsDefined()
+  @IsMongoId()
+  templateId: string;
+}

--- a/apps/api/src/app/blueprint/usecases/get-blueprint/get-blueprint.usecase.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprint/get-blueprint.usecase.ts
@@ -1,12 +1,12 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { NotificationTemplateEntity, NotificationTemplateRepository } from '@novu/dal';
-import { GetBlueprintNotificationTemplateCommand } from './get-blueprint-notification-template.command';
+import { GetBlueprintCommand } from './get-blueprint.command';
 
 @Injectable()
-export class GetBlueprintNotificationTemplate {
+export class GetBlueprint {
   constructor(private notificationTemplateRepository: NotificationTemplateRepository) {}
 
-  async execute(command: GetBlueprintNotificationTemplateCommand): Promise<NotificationTemplateEntity> {
+  async execute(command: GetBlueprintCommand): Promise<NotificationTemplateEntity> {
     const template = await this.notificationTemplateRepository.findBlueprint(command.templateId);
     if (!template) {
       throw new NotFoundException(`Template with id ${command.templateId} not found`);

--- a/apps/api/src/app/blueprint/usecases/get-blueprint/get-blueprint.usecase.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprint/get-blueprint.usecase.ts
@@ -1,17 +1,20 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { NotificationTemplateEntity, NotificationTemplateRepository } from '@novu/dal';
+
+import { NotificationTemplateRepository } from '@novu/dal';
+
 import { GetBlueprintCommand } from './get-blueprint.command';
+import { GetBlueprintResponse } from '../../dto/get-blueprint.response.dto';
 
 @Injectable()
 export class GetBlueprint {
   constructor(private notificationTemplateRepository: NotificationTemplateRepository) {}
 
-  async execute(command: GetBlueprintCommand): Promise<NotificationTemplateEntity> {
+  async execute(command: GetBlueprintCommand): Promise<GetBlueprintResponse> {
     const template = await this.notificationTemplateRepository.findBlueprint(command.templateId);
     if (!template) {
       throw new NotFoundException(`Template with id ${command.templateId} not found`);
     }
 
-    return template;
+    return template as GetBlueprintResponse;
   }
 }

--- a/apps/api/src/app/blueprint/usecases/get-blueprint/index.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprint/index.ts
@@ -1,0 +1,2 @@
+export * from './get-blueprint.command';
+export * from './get-blueprint.usecase';

--- a/apps/api/src/app/blueprint/usecases/get-blueprints/get-grouped-blueprints.command.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprints/get-grouped-blueprints.command.ts
@@ -1,0 +1,3 @@
+import { BaseCommand } from '@novu/application-generic';
+
+export class GetGroupedBlueprintsCommand extends BaseCommand {}

--- a/apps/api/src/app/blueprint/usecases/get-blueprints/get-grouped-blueprints.usecase.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprints/get-grouped-blueprints.usecase.ts
@@ -11,7 +11,7 @@ export class GetGroupedBlueprints {
     const blueprints = await this.notificationTemplateRepository.findAllGroupedByCategory();
     if (!blueprints) {
       throw new NotFoundException(
-        `Blueprints for environment id ${NotificationTemplateRepository.getBlueprintEnvironmentId()} were not found`
+        `Blueprints for organization id ${NotificationTemplateRepository.getBlueprintOrganizationId()} were not found`
       );
     }
 

--- a/apps/api/src/app/blueprint/usecases/get-blueprints/get-grouped-blueprints.usecase.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprints/get-grouped-blueprints.usecase.ts
@@ -11,7 +11,7 @@ export class GetGroupedBlueprints {
     const blueprints = await this.notificationTemplateRepository.findAllGroupedByCategory();
     if (!blueprints) {
       throw new NotFoundException(
-        `Blueprints with id ${NotificationTemplateRepository.getBlueprintEnvironmentId()} was not found`
+        `Blueprints for environment id ${NotificationTemplateRepository.getBlueprintEnvironmentId()} were not found`
       );
     }
 

--- a/apps/api/src/app/blueprint/usecases/get-blueprints/get-grouped-blueprints.usecase.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprints/get-grouped-blueprints.usecase.ts
@@ -1,0 +1,20 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { NotificationTemplateRepository } from '@novu/dal';
+
+import { GroupedBlueprintResponse } from '../../dto/grouped-blueprint.response.dto';
+
+@Injectable()
+export class GetGroupedBlueprints {
+  constructor(private notificationTemplateRepository: NotificationTemplateRepository) {}
+
+  async execute(): Promise<GroupedBlueprintResponse[]> {
+    const blueprints = await this.notificationTemplateRepository.findAllGroupedByCategory();
+    if (!blueprints) {
+      throw new NotFoundException(
+        `Blueprints with id ${NotificationTemplateRepository.getBlueprintEnvironmentId()} was not found`
+      );
+    }
+
+    return blueprints;
+  }
+}

--- a/apps/api/src/app/blueprint/usecases/get-blueprints/index.ts
+++ b/apps/api/src/app/blueprint/usecases/get-blueprints/index.ts
@@ -1,0 +1,2 @@
+export * from './get-grouped-blueprints.command';
+export * from './get-grouped-blueprints.usecase';

--- a/apps/api/src/app/blueprint/usecases/index.ts
+++ b/apps/api/src/app/blueprint/usecases/index.ts
@@ -1,8 +1,10 @@
-import { CreateBlueprintNotificationTemplate } from './create-blueprint-notification-template';
-import { GetBlueprintNotificationTemplate } from './get-blueprint-notification-template';
+import { CreateBlueprint } from './create-blueprint';
+import { GetBlueprint } from './get-blueprint';
+import { GetGroupedBlueprints } from './get-blueprints';
 
 export const USE_CASES = [
   //
-  CreateBlueprintNotificationTemplate,
-  GetBlueprintNotificationTemplate,
+  CreateBlueprint,
+  GetBlueprint,
+  GetGroupedBlueprints,
 ];

--- a/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
+++ b/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
@@ -129,7 +129,7 @@ export class PromoteNotificationTemplateChange {
         _environmentId: command.environmentId,
         _organizationId: command.organizationId,
         _notificationGroupId: notificationGroup._id,
-        isBlueprint: !!newItem.blueprintId,
+        isBlueprint: command.organizationId === this.blueprintOrganizationId,
         blueprintId: newItem.blueprintId,
       };
 
@@ -177,8 +177,11 @@ export class PromoteNotificationTemplateChange {
         preferenceSettings: newItem.preferenceSettings,
         steps,
         _notificationGroupId: notificationGroup._id,
-        isBlueprint: !!newItem.blueprintId,
+        isBlueprint: command.organizationId === this.blueprintOrganizationId,
       }
     );
+  }
+  private get blueprintOrganizationId() {
+    return NotificationTemplateRepository.getBlueprintOrganizationId();
   }
 }

--- a/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
+++ b/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
@@ -129,7 +129,7 @@ export class PromoteNotificationTemplateChange {
         _environmentId: command.environmentId,
         _organizationId: command.organizationId,
         _notificationGroupId: notificationGroup._id,
-        isBlueprint: command.organizationId === this.blueprintOrganizationId,
+        isBlueprint: !!newItem.blueprintId,
         blueprintId: newItem.blueprintId,
       };
 
@@ -177,12 +177,8 @@ export class PromoteNotificationTemplateChange {
         preferenceSettings: newItem.preferenceSettings,
         steps,
         _notificationGroupId: notificationGroup._id,
-        isBlueprint: command.organizationId === this.blueprintOrganizationId,
+        isBlueprint: !!newItem.blueprintId,
       }
     );
-  }
-
-  private get blueprintOrganizationId() {
-    return NotificationTemplateRepository.getBlueprintOrganizationId();
   }
 }

--- a/libs/shared/src/entities/notification-group/index.ts
+++ b/libs/shared/src/entities/notification-group/index.ts
@@ -1,0 +1,1 @@
+export * from './notification-group.interface';

--- a/libs/shared/src/entities/notification-group/notification-group.interface.ts
+++ b/libs/shared/src/entities/notification-group/notification-group.interface.ts
@@ -1,0 +1,11 @@
+export interface INotificationGroup {
+  _id?: string;
+
+  name: string;
+
+  _environmentId: string;
+
+  _organizationId: string;
+
+  _parentId?: string;
+}

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -14,6 +14,7 @@ export * from './entities/job';
 export * from './entities/subscriber-preference';
 export * from './entities/subscriber';
 export * from './entities/layout';
+export * from './entities/notification-group';
 export * from './types';
 export * from './dto';
 export * from './consts';


### PR DESCRIPTION
### What change does this PR introduce?

Adds get grouped by category blueprint list.
refactored some old code.
switched to fetch by prod env and not the organization.

### Why was this change needed?

So the client could get all the available blueprints.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
