### PR TITLE
feat(web): templates store - templates page when there is no data show create template tiles

### DIFF
--- a/apps/web/cypress/tests/digest-playground.spec.ts
+++ b/apps/web/cypress/tests/digest-playground.spec.ts
@@ -9,6 +9,7 @@ describe('Digest Playground Workflow Page', function () {
 
     cy.getByTestId('get-started-footer-left-side').click();
     cy.wait('@notificationTemplates');
+    cy.waitForNetworkIdle(500);
 
     cy.getByTestId('try-digest-playground-btn').click();
 
@@ -25,6 +26,7 @@ describe('Digest Playground Workflow Page', function () {
 
     cy.getByTestId('get-started-footer-left-side').click();
     cy.wait('@notificationTemplates');
+    cy.waitForNetworkIdle(500);
 
     cy.getByTestId('try-digest-playground-btn').click();
 
@@ -45,6 +47,7 @@ describe('Digest Playground Workflow Page', function () {
     // click try digest playground
     cy.getByTestId('get-started-footer-left-side').click();
     cy.wait('@notificationTemplates');
+    cy.waitForNetworkIdle(500);
 
     cy.getByTestId('try-digest-playground-btn').click();
 
@@ -119,6 +122,7 @@ describe('Digest Playground Workflow Page', function () {
     // click try digest playground
     cy.getByTestId('get-started-footer-left-side').click();
     cy.wait('@notificationTemplates');
+    cy.waitForNetworkIdle(500);
 
     cy.getByTestId('try-digest-playground-btn').click();
 
@@ -147,6 +151,7 @@ describe('Digest Playground Workflow Page', function () {
     // click try digest playground
     cy.getByTestId('get-started-footer-left-side').click();
     cy.wait('@notificationTemplates');
+    cy.waitForNetworkIdle(500);
 
     cy.getByTestId('try-digest-playground-btn').click();
 

--- a/apps/web/cypress/tests/digest-playground.spec.ts
+++ b/apps/web/cypress/tests/digest-playground.spec.ts
@@ -4,12 +4,13 @@ describe('Digest Playground Workflow Page', function () {
   });
 
   it('should have a link to the docs', function () {
-    cy.intercept('**/notification-templates**').as('notificationTemplates');
-    cy.visit('/templates');
+    cy.intercept('GET', '**/notification-templates**').as('notificationTemplates');
+    cy.visit('/get-started');
+
+    cy.getByTestId('get-started-footer-left-side').click();
     cy.wait('@notificationTemplates');
 
-    cy.getByTestId('no-workflow-templates-placeholder').should('be.visible');
-    cy.getByTestId('try-digest-playground-tile').click();
+    cy.getByTestId('try-digest-playground-btn').click();
 
     cy.url().should('include', '/digest-playground');
     cy.contains('Digest Workflow Playground');
@@ -18,35 +19,41 @@ describe('Digest Playground Workflow Page', function () {
   });
 
   it('the set up digest workflow should redirec to template edit page', function () {
-    cy.intercept('**/notification-templates**').as('notificationTemplates');
-    cy.visit('/templates');
+    cy.intercept('GET', '**/notification-templates**').as('notificationTemplates');
+    cy.intercept('GET', '**/notification-templates/**').as('getNotificationTemplate');
+    cy.visit('/get-started');
+
+    cy.getByTestId('get-started-footer-left-side').click();
     cy.wait('@notificationTemplates');
 
-    cy.getByTestId('no-workflow-templates-placeholder').should('be.visible');
-    cy.getByTestId('try-digest-playground-tile').click();
+    cy.getByTestId('try-digest-playground-btn').click();
 
     cy.url().should('include', '/digest-playground');
     cy.contains('Digest Workflow Playground');
 
     cy.get('button').contains('Set Up Digest Workflow').click();
+    cy.wait('@getNotificationTemplate');
 
     cy.url().should('include', '/templates/edit');
   });
 
   it('should show the digest workflow hints', () => {
-    cy.intercept('**/notification-templates**').as('notificationTemplates');
-    cy.visit('/templates');
-    cy.wait('@notificationTemplates');
+    cy.intercept('GET', '**/notification-templates**').as('notificationTemplates');
+    cy.intercept('GET', '**/notification-templates/**').as('getNotificationTemplate');
+    cy.visit('/get-started');
 
     // click try digest playground
-    cy.getByTestId('no-workflow-templates-placeholder').should('be.visible');
-    cy.getByTestId('try-digest-playground-tile').click();
+    cy.getByTestId('get-started-footer-left-side').click();
+    cy.wait('@notificationTemplates');
+
+    cy.getByTestId('try-digest-playground-btn').click();
 
     cy.url().should('include', '/digest-playground');
     cy.contains('Digest Workflow Playground');
 
     // click set up digest workflow
     cy.get('button').contains('Set Up Digest Workflow').click();
+    cy.wait('@getNotificationTemplate');
 
     // in the template workflow editor
     cy.url().should('include', '/templates/edit');
@@ -105,19 +112,22 @@ describe('Digest Playground Workflow Page', function () {
   });
 
   it('should hide the digest workflow hints when clicking on skip tour button', () => {
-    cy.intercept('**/notification-templates**').as('notificationTemplates');
-    cy.visit('/templates');
-    cy.wait('@notificationTemplates');
+    cy.intercept('GET', '**/notification-templates**').as('notificationTemplates');
+    cy.intercept('GET', '**/notification-templates/**').as('getNotificationTemplate');
+    cy.visit('/get-started');
 
     // click try digest playground
-    cy.getByTestId('no-workflow-templates-placeholder').should('be.visible');
-    cy.getByTestId('try-digest-playground-tile').click();
+    cy.getByTestId('get-started-footer-left-side').click();
+    cy.wait('@notificationTemplates');
+
+    cy.getByTestId('try-digest-playground-btn').click();
 
     cy.url().should('include', '/digest-playground');
     cy.contains('Digest Workflow Playground');
 
     // click set up digest workflow
     cy.get('button').contains('Set Up Digest Workflow').click();
+    cy.wait('@getNotificationTemplate');
 
     // in the template workflow editor
     cy.url().should('include', '/templates/edit');
@@ -127,5 +137,24 @@ describe('Digest Playground Workflow Page', function () {
     cy.getByTestId('digest-workflow-tooltip-skip-button').contains('Skip tour').click();
 
     cy.getByTestId('digest-workflow-tooltip').should('not.exist');
+  });
+
+  it('when clicking on the back button from the playground it should redirect to /get-started/preview', function () {
+    cy.intercept('GET', '**/notification-templates**').as('notificationTemplates');
+    cy.intercept('GET', '**/notification-templates/**').as('getNotificationTemplate');
+    cy.visit('/get-started');
+
+    // click try digest playground
+    cy.getByTestId('get-started-footer-left-side').click();
+    cy.wait('@notificationTemplates');
+
+    cy.getByTestId('try-digest-playground-btn').click();
+
+    cy.url().should('include', '/digest-playground');
+    cy.contains('Digest Workflow Playground');
+
+    cy.contains('Go Back').click();
+
+    cy.url().should('include', '/get-started/preview');
   });
 });

--- a/apps/web/cypress/tests/digest-playground.spec.ts
+++ b/apps/web/cypress/tests/digest-playground.spec.ts
@@ -18,7 +18,7 @@ describe('Digest Playground Workflow Page', function () {
     cy.get('a[href="https://docs.novu.co/platform/digest"]').contains('Learn more in docs');
   });
 
-  it('the set up digest workflow should redirec to template edit page', function () {
+  it('the set up digest workflow should redirect to template edit page', function () {
     cy.intercept('GET', '**/notification-templates**').as('notificationTemplates');
     cy.intercept('GET', '**/notification-templates/**').as('getNotificationTemplate');
     cy.visit('/get-started');

--- a/apps/web/cypress/tests/notifications.spec.ts
+++ b/apps/web/cypress/tests/notifications.spec.ts
@@ -25,6 +25,7 @@ describe('Notification Templates Screen', function () {
     cy.getByTestId('category-label').contains('General');
   });
 
+  // TODO refactor no try-digest-playground-tile
   it('when no workflow templates created it should show the page placeholder', function () {
     cy.initializeSession({ noTemplates: true }).as('session');
     cy.intercept('**/notification-templates**').as('notificationTemplates');
@@ -47,37 +48,5 @@ describe('Notification Templates Screen', function () {
     cy.getByTestId('create-workflow-tile').click();
 
     cy.url().should('include', '/templates/create');
-  });
-
-  it('when clicking on the try digest playground it should redirect to digest playground page', function () {
-    cy.initializeSession({ noTemplates: true }).as('session');
-    cy.intercept('**/notification-templates**').as('notificationTemplates');
-    cy.visit('/templates');
-    cy.wait('@notificationTemplates');
-
-    cy.getByTestId('no-workflow-templates-placeholder').should('be.visible');
-    cy.getByTestId('try-digest-playground-tile').should('not.be.disabled').click();
-
-    cy.url().should('include', '/digest-playground');
-    cy.contains('Digest Workflow Playground');
-  });
-
-  it('when clicking on the try digest playground it should create an example digest workflow', function () {
-    cy.initializeSession({ noTemplates: true }).as('session');
-    cy.intercept('**/notification-templates**').as('notificationTemplates');
-    cy.visit('/templates');
-    cy.wait('@notificationTemplates');
-
-    cy.getByTestId('no-workflow-templates-placeholder').should('be.visible');
-    cy.getByTestId('try-digest-playground-tile').click();
-
-    cy.url().should('include', '/digest-playground');
-    cy.contains('Digest Workflow Playground');
-
-    cy.contains('Go Back').click();
-
-    cy.url().should('include', '/templates');
-
-    cy.getByTestId('notifications-template').get('tbody tr td').contains('Digest Workflow Example');
   });
 });

--- a/apps/web/cypress/tests/notifications.spec.ts
+++ b/apps/web/cypress/tests/notifications.spec.ts
@@ -25,7 +25,6 @@ describe('Notification Templates Screen', function () {
     cy.getByTestId('category-label').contains('General');
   });
 
-  // TODO refactor no try-digest-playground-tile
   it('when no workflow templates created it should show the page placeholder', function () {
     cy.initializeSession({ noTemplates: true }).as('session');
     cy.intercept('**/notification-templates**').as('notificationTemplates');

--- a/apps/web/cypress/tests/notifications.spec.ts
+++ b/apps/web/cypress/tests/notifications.spec.ts
@@ -32,8 +32,7 @@ describe('Notification Templates Screen', function () {
     cy.wait('@notificationTemplates');
 
     cy.getByTestId('no-workflow-templates-placeholder').should('be.visible');
-    cy.getByTestId('create-workflow-tile').should('not.be.disabled');
-    cy.getByTestId('try-digest-playground-tile').should('not.be.disabled');
+    cy.getByTestId('create-workflow-tile').should('exist');
   });
 
   it('when clicking on create workflow it should redirect to create template page', function () {
@@ -43,7 +42,7 @@ describe('Notification Templates Screen', function () {
     cy.wait('@notificationTemplates');
 
     cy.getByTestId('no-workflow-templates-placeholder').should('be.visible');
-    cy.getByTestId('create-workflow-tile').should('not.be.disabled');
+    cy.getByTestId('create-workflow-tile').should('exist');
     cy.getByTestId('create-workflow-tile').click();
 
     cy.url().should('include', '/templates/create');

--- a/apps/web/src/api/hooks/notification-templates/index.ts
+++ b/apps/web/src/api/hooks/notification-templates/index.ts
@@ -1,2 +1,3 @@
 export { useTemplateFetcher } from './useTemplateFetcher';
 export { useUpdateTemplate } from './useUpdateTemplate';
+export * from './useFetchBlueprints';

--- a/apps/web/src/api/hooks/notification-templates/useFetchBlueprints.ts
+++ b/apps/web/src/api/hooks/notification-templates/useFetchBlueprints.ts
@@ -1,0 +1,148 @@
+/* eslint-disable max-len */
+/* cSpell:disable */
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { IconName } from '@fortawesome/fontawesome-svg-core';
+
+import { QueryKeys } from '../../query.keys';
+
+export interface IBlueprintsGrouped {
+  name: string;
+  templates: { name: string; description: string; iconName: IconName }[];
+}
+
+interface IBlueprintsGroupedAndPopular {
+  groupedBlueprints: IBlueprintsGrouped[];
+  popularBlueprints: { id: string; name: string; description: string; iconName: IconName }[];
+}
+
+const TEMPLATES_GROUPED = [
+  {
+    name: 'Collaboration',
+    templates: [
+      {
+        id: '1',
+        name: ':fa-regular fa-message: Comments',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+      {
+        id: '2',
+        name: ':fa-solid fa-user-check: Mentions',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+      {
+        id: '3',
+        name: ':fa-solid fa-reply: Reply',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+    ],
+  },
+  {
+    name: 'Growth',
+    templates: [
+      {
+        id: '4',
+        name: ':fa-regular fa-hand: Welcome message',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+      {
+        id: '5',
+        name: ':fa-solid fa-envelope-open-text: Invite message',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+      {
+        id: '6',
+        name: ':fa-solid fa-gift: Refferal link',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+    ],
+  },
+  {
+    name: 'Authentification',
+    templates: [
+      {
+        id: '7',
+        name: ':fa-solid fa-wand-magic-sparkles: Magic link',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+      {
+        id: '8',
+        name: ':fa-solid fa-unlock: Password change',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+      {
+        id: '9',
+        name: ':fa-solid fa-unlock: Password change2',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+      {
+        id: '10',
+        name: ':fa-solid fa-unlock: Password change3',
+        description:
+          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
+      },
+    ],
+  },
+];
+
+const getTemplateDetails = (templateName: string): { name: string; iconName: IconName } => {
+  const regexResult = /^:.{1,}: /.exec(templateName);
+  let name = '';
+  let iconName = 'fa-solid fa-question';
+  if (regexResult !== null) {
+    name = templateName.replace(regexResult[0], '').trim();
+    iconName = regexResult[0].replace(/:/g, '').trim();
+  }
+
+  return { name, iconName: iconName as IconName };
+};
+
+export function useFetchBlueprints(
+  options: UseQueryOptions<IBlueprintsGroupedAndPopular, any, IBlueprintsGroupedAndPopular> = {}
+) {
+  const { data, ...rest } = useQuery<IBlueprintsGroupedAndPopular>(
+    [QueryKeys.blueprintsList],
+    () => {
+      return new Promise((resolve) => {
+        const groupedBlueprints = TEMPLATES_GROUPED.map((group) => ({
+          name: group.name,
+          templates: group.templates.map((template) => {
+            const { name, iconName } = getTemplateDetails(template.name);
+
+            return {
+              ...template,
+              name,
+              iconName,
+            };
+          }),
+        }));
+
+        setTimeout(() => {
+          resolve({
+            groupedBlueprints,
+            popularBlueprints: groupedBlueprints[0].templates.slice(0, 3),
+          });
+        }, 3000);
+      });
+    },
+    {
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchInterval: false,
+      ...options,
+    }
+  );
+
+  return {
+    blueprintsGroupedAndPopular: data,
+    ...rest,
+  };
+}

--- a/apps/web/src/api/hooks/notification-templates/useFetchBlueprints.ts
+++ b/apps/web/src/api/hooks/notification-templates/useFetchBlueprints.ts
@@ -94,7 +94,7 @@ const TEMPLATES_GROUPED = [
 ];
 
 const getTemplateDetails = (templateName: string): { name: string; iconName: IconName } => {
-  const regexResult = /^:.{1,}: /.exec(templateName);
+  const regexResult = /^:.{1,}:/.exec(templateName);
   let name = '';
   let iconName = 'fa-solid fa-question';
   if (regexResult !== null) {

--- a/apps/web/src/api/query.keys.ts
+++ b/apps/web/src/api/query.keys.ts
@@ -9,6 +9,7 @@ interface IQueryKeys {
   getLayoutById: string;
   activeNotificationsList: string;
   integrationsList: string;
+  blueprintsList: string;
   getTemplateById: (templateId?: string) => string;
 }
 
@@ -23,5 +24,6 @@ export const QueryKeys: IQueryKeys = Object.freeze({
   getLayoutById: 'getLayoutById',
   activeNotificationsList: 'activeNotificationsList',
   integrationsList: 'integrationsList',
+  blueprintsList: 'blueprintsList',
   getTemplateById: (templateId?: string) => `notificationById:${templateId}`,
 });

--- a/apps/web/src/design-system/popover/Popover.tsx
+++ b/apps/web/src/design-system/popover/Popover.tsx
@@ -17,7 +17,7 @@ type PopoverProps = {
   url?: string;
   urlText?: string;
   onUrlClick?: MouseEventHandler<HTMLAnchorElement>;
-  titleGradient: 'red' | 'blue' | 'none';
+  titleGradient?: 'red' | 'blue' | 'none';
   className?: string;
   opacity?: string | number;
   onDropdownMouseEnter?: MouseEventHandler<HTMLDivElement>;

--- a/apps/web/src/pages/quick-start/steps/DigestPreview.tsx
+++ b/apps/web/src/pages/quick-start/steps/DigestPreview.tsx
@@ -80,7 +80,13 @@ function FooterRightSide() {
       <NavButton navigateTo={ROUTES.TEMPLATES_CREATE} handleOnClick={handlerBuildWorkflowClick}>
         <ButtonText>Build a Workflow</ButtonText>
       </NavButton>
-      <StyledButton fullWidth pulse onClick={handlerTryDigestClick} loading={isCreating}>
+      <StyledButton
+        fullWidth
+        pulse
+        onClick={handlerTryDigestClick}
+        loading={isCreating}
+        data-test-id="try-digest-playground-btn"
+      >
         <ButtonText>Try the Digest Playground</ButtonText>
       </StyledButton>
     </ButtonsHolder>

--- a/apps/web/src/pages/templates/TemplatesListNoData.tsx
+++ b/apps/web/src/pages/templates/TemplatesListNoData.tsx
@@ -1,7 +1,12 @@
+import { useState } from 'react';
 import styled from '@emotion/styled';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconName } from '@fortawesome/fontawesome-svg-core';
+import { faDiagramNext } from '@fortawesome/free-solid-svg-icons';
+import { faFile } from '@fortawesome/free-regular-svg-icons';
 
-import { Cards, colors, Text } from '../../design-system';
-import { PageGradient, DigestGradient } from '../../design-system/icons';
+import { colors, Popover, shadows } from '../../design-system';
+import { Skeleton } from '@mantine/core';
 
 const NoDataHolder = styled.div`
   display: flex;
@@ -11,66 +16,158 @@ const NoDataHolder = styled.div`
   height: 500px;
 `;
 
-const NoDataHeading = styled.h2`
-  font-size: 28px;
-  font-weight: bold;
-  color: ${colors.B40};
-`;
-
 const NoDataSubHeading = styled.p`
   margin: 0;
   font-size: 20px;
-  color: ${colors.B40};
+  color: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.B40 : colors.B80)};
+`;
+
+const Card = styled.button`
+  outline: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  min-width: 140px;
+  width: 140px;
+  height: 100px;
+  border-radius: 8px;
+  color: ${colors.B60};
+  background: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.B20 : colors.B98)};
+  box-shadow: ${shadows.dark};
+  font-size: 14px;
+  transition: all 0.25s ease;
+
+  > svg {
+    font-size: 20px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+
+  &:not(:disabled)&:hover {
+    color: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.white : colors.B60)};
+    background: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.B30 : colors.BGLight)};
+  }
+
+  &[data-can-be-hidden='true'] {
+    &:nth-last-of-type(2) {
+      display: none;
+    }
+
+    @media screen and (min-width: 1369px) {
+      &:nth-last-of-type(2) {
+        display: flex;
+      }
+    }
+  }
+
+  @media screen and (min-width: 1025px) {
+    min-width: 160px;
+    width: 160px;
+    height: 120px;
+
+    > svg {
+      font-size: 24px;
+    }
+  }
 `;
 
 const CardsContainer = styled.div`
   display: flex;
-  gap: 40px;
-  margin: 50px 40px;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  margin: 50px 20px;
+
+  @media screen and (min-width: 1025px) {
+    gap: 24px;
+    margin: 50px 40px;
+  }
+`;
+
+const SkeletonIcon = styled(Skeleton)`
+  min-width: 24px;
+  width: 24px;
+  height: 24px;
+
+  @media screen and (min-width: 1025px) {
+    min-width: 28px;
+    width: 28px;
+    height: 28px;
+  }
 `;
 
 export const TemplatesListNoData = ({
-  onCreateClick,
-  onTryDigestClick,
-  tryDigestDisabled,
+  blueprints,
+  isLoading,
+  allTemplatesDisabled,
+  onBlankWorkflowClick,
+  onTemplateClick,
+  onAllTemplatesClick,
 }: {
-  onCreateClick: React.MouseEventHandler<HTMLButtonElement>;
-  onTryDigestClick: React.MouseEventHandler<HTMLButtonElement>;
-  tryDigestDisabled: boolean;
+  blueprints?: { id: string; name: string; description: string; iconName: IconName }[];
+  isLoading?: boolean;
+  allTemplatesDisabled?: boolean;
+  onBlankWorkflowClick: React.MouseEventHandler<HTMLButtonElement>;
+  onTemplateClick: (template: { id: string; name: string; description: string; iconName: IconName }) => void;
+  onAllTemplatesClick: React.MouseEventHandler<HTMLButtonElement>;
 }) => {
+  const [templateId, setTemplateId] = useState<string | null>(null);
+
   return (
     <NoDataHolder data-test-id="no-workflow-templates-placeholder">
-      <NoDataHeading>You don't have a workflow yet,</NoDataHeading>
-      <NoDataSubHeading>Start from scratch or play around with the Digest Demo Playground</NoDataSubHeading>
+      <NoDataSubHeading>Start from a blank workflow or use a template</NoDataSubHeading>
       <CardsContainer>
-        <Cards
-          cells={[
-            {
-              navIcon: PageGradient,
-              description: (
-                <Text size="lg" weight="bold">
-                  Create Workflow
-                </Text>
-              ),
-              onClick: onCreateClick,
-              testId: 'create-workflow-tile',
-            },
-            {
-              navIcon: DigestGradientIcon,
-              description: (
-                <Text size="lg" weight="bold">
-                  Try the Digest Playground
-                </Text>
-              ),
-              onClick: onTryDigestClick,
-              disabled: tryDigestDisabled,
-              testId: 'try-digest-playground-tile',
-            },
-          ]}
-        />
+        <Card data-test-id="create-workflow-tile" onClick={onBlankWorkflowClick}>
+          <FontAwesomeIcon icon={faFile} />
+          <span>Blank Workflow</span>
+        </Card>
+        {isLoading
+          ? Array.from({ length: 3 }).map((_, index) => (
+              <Card key={index} data-can-be-hidden={index === 2} data-test-id="second-workflow-tile">
+                <SkeletonIcon />
+                <Skeleton height={14} width="100%" />
+              </Card>
+            ))
+          : blueprints?.map((template, index) => (
+              <Popover
+                key={template.name}
+                opened={template.id === templateId}
+                withArrow
+                withinPortal
+                offset={5}
+                transitionDuration={300}
+                position="top"
+                width={300}
+                target={
+                  <Card
+                    data-can-be-hidden={index === 2}
+                    data-test-id="second-workflow-tile"
+                    onClick={() => onTemplateClick(template)}
+                    onMouseEnter={() => {
+                      setTemplateId(template.id);
+                    }}
+                    onMouseLeave={() => {
+                      setTemplateId(null);
+                    }}
+                  >
+                    <FontAwesomeIcon icon={template.iconName} />
+                    <span>{template.name}</span>
+                  </Card>
+                }
+                content={template.description}
+              />
+            ))}
+        <Card data-test-id="all-workflow-tile" onClick={onAllTemplatesClick} disabled={allTemplatesDisabled}>
+          <FontAwesomeIcon icon={faDiagramNext} />
+          <span>All templates</span>
+        </Card>
       </CardsContainer>
     </NoDataHolder>
   );
 };
-
-const DigestGradientIcon = () => <DigestGradient style={{ height: '40px', width: '40px' }} />;

--- a/apps/web/src/pages/templates/TemplatesListPage.tsx
+++ b/apps/web/src/pages/templates/TemplatesListPage.tsx
@@ -16,29 +16,27 @@ import { Data } from '../../design-system/table/Table';
 import { ROUTES } from '../../constants/routes.enum';
 import { parseUrl } from '../../utils/routeUtils';
 import { TemplatesListNoData } from './TemplatesListNoData';
-import { useCreateDigestDemoWorkflow } from '../../api/hooks/notification-templates/useCreateDigestDemoWorkflow';
 import { useSegment } from '../../components/providers/SegmentProvider';
 import { TemplateAnalyticsEnum } from './constants';
-/*
- * TODO uncomment when will be using templates store
- * import { useTemplatesStoreModal } from './hooks/useTemplatesStoreModal';
- */
+import { useTemplatesStoreModal } from './hooks/useTemplatesStoreModal';
+import { useFetchBlueprints } from '../../api/hooks/notification-templates/useFetchBlueprints';
 
 function NotificationList() {
   const segment = useSegment();
   const { readonly } = useEnvController();
   const [page, setPage] = useState<number>(0);
-  const { groups, loading: areNotificationGroupLoading } = useNotificationGroup();
+  const { loading: areNotificationGroupLoading } = useNotificationGroup();
   const { templates, loading: isLoading, totalCount: totalTemplatesCount, pageSize } = useTemplates(page);
   const theme = useMantineTheme();
   const navigate = useNavigate();
+  const {
+    blueprintsGroupedAndPopular: { groupedBlueprints, popularBlueprints } = {},
+    isLoading: areBlueprintsLoading,
+  } = useFetchBlueprints();
+  const hasGroups = groupedBlueprints && groupedBlueprints.length > 0;
+  const hasTemplates = templates && templates.length > 0;
 
-  /*
-   * TODO uncomment when will be using templates store
-   * const { TemplatesStoreModal, openModal, closeModal } = useTemplatesStoreModal();
-   */
-
-  const { createDigestDemoWorkflow, isDisabled: isTryDigestDisabled } = useCreateDigestDemoWorkflow();
+  const { TemplatesStoreModal, openModal } = useTemplatesStoreModal({ groupedBlueprints });
 
   function handleTableChange(pageIndex) {
     setPage(pageIndex);
@@ -47,11 +45,6 @@ function NotificationList() {
   const handleRedirectToCreateTemplate = (isFromHeader: boolean) => {
     segment.track(TemplateAnalyticsEnum.CREATE_TEMPLATE_CLICK, { isFromHeader });
     navigate(ROUTES.TEMPLATES_CREATE);
-  };
-
-  const handleCreateDigestDemoWorkflow = () => {
-    segment.track(TemplateAnalyticsEnum.TRY_DIGEST_CLICK);
-    createDigestDemoWorkflow();
   };
 
   const columns: ColumnWithStrictAccessor<Data>[] = [
@@ -143,27 +136,31 @@ function NotificationList() {
         }
       />
       <TemplateListTableWrapper>
-        <Table
-          onRowClick={onRowClick}
-          loading={isLoading || areNotificationGroupLoading}
-          data-test-id="notifications-template"
-          columns={columns}
-          data={templates || []}
-          pagination={{
-            pageSize: pageSize,
-            current: page,
-            total: totalTemplatesCount,
-            onPageChange: handleTableChange,
-          }}
-          noDataPlaceholder={
-            <TemplatesListNoData
-              onCreateClick={() => handleRedirectToCreateTemplate(false)}
-              onTryDigestClick={handleCreateDigestDemoWorkflow}
-              tryDigestDisabled={isTryDigestDisabled}
-            />
-          }
-        />
-        {/* <TemplatesStoreModal /> */}
+        {hasTemplates ? (
+          <Table
+            onRowClick={onRowClick}
+            loading={isLoading || areNotificationGroupLoading}
+            data-test-id="notifications-template"
+            columns={columns}
+            data={templates}
+            pagination={{
+              pageSize: pageSize,
+              current: page,
+              total: totalTemplatesCount,
+              onPageChange: handleTableChange,
+            }}
+          />
+        ) : (
+          <TemplatesListNoData
+            blueprints={popularBlueprints}
+            isLoading={areBlueprintsLoading}
+            allTemplatesDisabled={areBlueprintsLoading || !hasGroups}
+            onBlankWorkflowClick={() => handleRedirectToCreateTemplate(false)}
+            onTemplateClick={console.log}
+            onAllTemplatesClick={openModal}
+          />
+        )}
+        <TemplatesStoreModal />
       </TemplateListTableWrapper>
     </PageContainer>
   );

--- a/apps/web/src/pages/templates/TemplatesListPage.tsx
+++ b/apps/web/src/pages/templates/TemplatesListPage.tsx
@@ -156,7 +156,7 @@ function NotificationList() {
             isLoading={areBlueprintsLoading}
             allTemplatesDisabled={areBlueprintsLoading || !hasGroups}
             onBlankWorkflowClick={() => handleRedirectToCreateTemplate(false)}
-            onTemplateClick={console.log}
+            onTemplateClick={() => {}}
             onAllTemplatesClick={openModal}
           />
         )}

--- a/apps/web/src/pages/templates/components/TemplateEditorFormProvider.tsx
+++ b/apps/web/src/pages/templates/components/TemplateEditorFormProvider.tsx
@@ -19,7 +19,7 @@ import { mapNotificationTemplateToForm, mapFormToCreateNotificationTemplate } fr
 import { errorMessage, successMessage } from '../../../utils/notifications';
 import { schema } from './notificationTemplateSchema';
 import { v4 as uuid4 } from 'uuid';
-import { useNotificationGroup } from '../../../hooks';
+import { useEffectOnce, useNotificationGroup } from '../../../hooks';
 import { useCreate } from '../hooks/useCreate';
 import { stepNames } from '../constants';
 
@@ -164,16 +164,18 @@ const TemplateEditorFormProvider = ({ children }) => {
     }
   }, [name]);
 
-  const { template, isLoading, isCreating, isUpdating, isDeleting, updateNotificationTemplate } = useTemplateController(
-    templateId,
-    {
-      onFetchSuccess: (fetchedTemplate) => {
-        setTrigger(fetchedTemplate.triggers[0]);
-        const form = mapNotificationTemplateToForm(fetchedTemplate);
-        reset(form);
-      },
-    }
-  );
+  const { template, isLoading, isCreating, isUpdating, isDeleting, updateNotificationTemplate } =
+    useTemplateController(templateId);
+
+  useEffectOnce(() => {
+    if (!template) return;
+
+    // we don't call this on success because the templates might be fetched before
+    setTrigger(template.triggers[0]);
+    const form = mapNotificationTemplateToForm(template);
+    reset(form);
+  }, !!template);
+
   const { groups, loading: loadingGroups } = useNotificationGroup();
 
   useCreate(templateId, groups, setTrigger, methods.getValues);

--- a/apps/web/src/pages/templates/components/templates-store/TemplatesStoreModal.tsx
+++ b/apps/web/src/pages/templates/components/templates-store/TemplatesStoreModal.tsx
@@ -1,9 +1,6 @@
-/* eslint-disable max-len */
-/* cSpell:disable */
 import { useState } from 'react';
 import { ActionIcon, Modal, useMantineTheme } from '@mantine/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { IconName } from '@fortawesome/fontawesome-svg-core';
 
 import { Button, colors, shadows } from '../../../../design-system';
 import { Close } from '../../../../design-system/icons/actions/Close';
@@ -23,97 +20,18 @@ import {
   TemplateDescription,
   useStyles,
 } from './templateStoreStyles';
-
-const TEMPLATES_GROUPED = [
-  {
-    name: 'Collaboration',
-    templates: [
-      {
-        name: ':fa-regular fa-message: Comments',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-      {
-        name: ':fa-solid fa-user-check: Mentions',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-      {
-        name: ':fa-solid fa-reply: Reply',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-    ],
-  },
-  {
-    name: 'Growth',
-    templates: [
-      {
-        name: ':fa-regular fa-hand: Welcome message',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-      {
-        name: ':fa-solid fa-envelope-open-text: Invite message',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-      {
-        name: ':fa-solid fa-gift: Refferal link',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-    ],
-  },
-  {
-    name: 'Authentification',
-    templates: [
-      {
-        name: ':fa-solid fa-wand-magic-sparkles: Magic link',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-      {
-        name: ':fa-solid fa-unlock: Password change',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-      {
-        name: ':fa-solid fa-unlock: Password change2',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-      {
-        name: ':fa-solid fa-unlock: Password change3',
-        description:
-          'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas totam quod beatae. Ipsam quasi fugiat commodi adipisci eligendi necessitatibus cumque aliquam, dicta natus cupiditate suscipit voluptatum rerum debitis. Ipsum!',
-      },
-    ],
-  },
-];
-
-const getTemplateDetails = (templateName: string): { name: string; iconName: IconName } => {
-  const regexResult = /^:.{1,}: /.exec(templateName);
-  let name = '';
-  let iconName = 'fa-solid fa-question';
-  if (regexResult !== null) {
-    name = templateName.replace(regexResult[0], '').trim();
-    iconName = regexResult[0].replace(/:/g, '').trim();
-  }
-
-  return { name, iconName: iconName as IconName };
-};
+import { IBlueprintsGrouped } from '../../../../api/hooks';
 
 export interface ITemplatesStoreModalProps {
+  groupedBlueprints: IBlueprintsGrouped[];
   isOpened: boolean;
   onClose: () => void;
 }
 
-export const TemplatesStoreModal = ({ isOpened, onClose }: ITemplatesStoreModalProps) => {
+export const TemplatesStoreModal = ({ groupedBlueprints, isOpened, onClose }: ITemplatesStoreModalProps) => {
   const theme = useMantineTheme();
   const { classes: modalClasses } = useStyles();
-  const [selectedTemplate, setTemplate] = useState(TEMPLATES_GROUPED[0].templates[0]);
-  const { name: selectedTemplateName, iconName: selectedTemplateIconName } = getTemplateDetails(selectedTemplate.name);
+  const [selectedTemplate, setTemplate] = useState(groupedBlueprints[0].templates[0]);
 
   return (
     <Modal
@@ -134,16 +52,14 @@ export const TemplatesStoreModal = ({ isOpened, onClose }: ITemplatesStoreModalP
     >
       <ModalBodyHolder>
         <TemplatesSidebarHolder>
-          {TEMPLATES_GROUPED.map((group) => (
+          {groupedBlueprints.map((group) => (
             <TemplatesGroup key={group.name}>
               <GroupName>{group.name}</GroupName>
               {group.templates.map((template) => {
-                const { name, iconName } = getTemplateDetails(template.name);
-
                 return (
                   <TemplateItem key={template.name} onClick={() => setTemplate(template)}>
-                    <FontAwesomeIcon icon={iconName} />
-                    <span>{name}</span>
+                    <FontAwesomeIcon icon={template.iconName} />
+                    <span>{template.name}</span>
                   </TemplateItem>
                 );
               })}
@@ -153,9 +69,9 @@ export const TemplatesStoreModal = ({ isOpened, onClose }: ITemplatesStoreModalP
         <TemplatesDetailsHolder>
           <TemplateHeader>
             <TemplateDetails>
-              <TemplateName key={selectedTemplateName}>
-                <FontAwesomeIcon icon={selectedTemplateIconName} />
-                <span>{selectedTemplateName}</span>
+              <TemplateName key={selectedTemplate.name}>
+                <FontAwesomeIcon icon={selectedTemplate.iconName} />
+                <span>{selectedTemplate.name}</span>
               </TemplateName>
               <TemplateDescription>{selectedTemplate.description}</TemplateDescription>
             </TemplateDetails>

--- a/apps/web/src/pages/templates/constants.tsx
+++ b/apps/web/src/pages/templates/constants.tsx
@@ -3,7 +3,6 @@ import { Bell, Chat, DigestGradient, Mail, Mobile, Sms, TimerGradient } from '..
 
 export enum TemplateAnalyticsEnum {
   CREATE_TEMPLATE_CLICK = 'Create Template Click - [Templates]',
-  TRY_DIGEST_CLICK = 'Try Digest Click - [Templates]',
 }
 
 export enum TemplateEditorAnalyticsEnum {

--- a/apps/web/src/pages/templates/hooks/useTemplatesStoreModal.tsx
+++ b/apps/web/src/pages/templates/hooks/useTemplatesStoreModal.tsx
@@ -1,20 +1,23 @@
 import { useDisclosure } from '@mantine/hooks';
 
+import { IBlueprintsGrouped } from '../../../api/hooks';
 import { useInlineComponent } from '../../../hooks';
 import { ITemplatesStoreModalProps, TemplatesStoreModal } from '../components/templates-store';
 
 const NULL_COMPONENT = () => null;
 
-export const useTemplatesStoreModal = () => {
-  const [isOpened, { open, close }] = useDisclosure(true);
+export const useTemplatesStoreModal = ({ groupedBlueprints = [] }: { groupedBlueprints?: IBlueprintsGrouped[] }) => {
+  const [isOpened, { open, close }] = useDisclosure(false);
+  const hasGroups = groupedBlueprints && groupedBlueprints.length > 0;
 
   const Component = useInlineComponent<ITemplatesStoreModalProps>(TemplatesStoreModal, {
+    groupedBlueprints,
     isOpened,
     onClose: close,
   });
 
   return {
-    TemplatesStoreModal: isOpened ? Component : NULL_COMPONENT,
+    TemplatesStoreModal: isOpened && hasGroups ? Component : NULL_COMPONENT,
     openModal: open,
     closeModal: close,
   };


### PR DESCRIPTION
### What change does this PR introduce?

When there is no data on the Notification Templates page we will show the "empty state" component that allows you to create a blank template, pick the most popular one, or browse the Templates Store modal for one.

### Why was this change needed?

Templates Store PRD.

### Other information (Screenshots)

![Screenshot 2023-05-18 at 17 31 41](https://github.com/novuhq/novu/assets/2607232/2dc91602-3d18-4580-98a9-b630d764a1e4)
![Screenshot 2023-05-18 at 17 31 50](https://github.com/novuhq/novu/assets/2607232/8ef40d84-f907-4b23-85aa-e8b1ad19bd12)
![Screenshot 2023-05-18 at 17 32 06](https://github.com/novuhq/novu/assets/2607232/1fb0ba01-f207-4d83-9423-7116bf347a12)
![Screenshot 2023-05-18 at 17 32 33](https://github.com/novuhq/novu/assets/2607232/dff3395b-3e6f-4cfc-9fee-eb70b0c1bf56)

![Screenshot 2023-05-18 at 17 32 48](https://github.com/novuhq/novu/assets/2607232/cc93c0dd-b460-4740-abf0-6ba2e93c8e6a)

https://github.com/novuhq/novu/assets/2607232/ab12a2ac-aabd-45e8-80a5-267a1aa4592c



https://github.com/novuhq/novu/assets/2607232/f5dab96b-a273-4cb6-8c4d-1c4d79169171


https://github.com/novuhq/novu/assets/2607232/7572458c-74b5-4302-a7e0-97cf651387e5

