### PR TITLE
[NV-2360] fix(web): fixed the issue when visiting the same workflow template editor twice

### DIFF
--- a/apps/web/cypress/global.d.ts
+++ b/apps/web/cypress/global.d.ts
@@ -35,6 +35,7 @@ declare namespace Cypress {
     initializeSession(settings?: {
       noEnvironment?: boolean;
       disableLocalStorage?: boolean;
+      showOnBoardingTour?: boolean;
       noTemplates?: boolean;
       partialTemplate?: Partial<ICreateNotificationTemplateDto>;
     }): Chainable<Response>;

--- a/apps/web/cypress/plugins/index.ts
+++ b/apps/web/cypress/plugins/index.ts
@@ -95,6 +95,7 @@ module.exports = (on, config) => {
         noEnvironment?: boolean;
         partialTemplate?: Partial<NotificationTemplateEntity>;
         noTemplates?: boolean;
+        showOnBoardingTour?: boolean;
       } = {}
     ) {
       const dal = new DalService();
@@ -103,6 +104,7 @@ module.exports = (on, config) => {
       const session = new UserSession('http://localhost:1336');
       await session.initialize({
         noEnvironment: settings?.noEnvironment,
+        showOnBoardingTour: settings?.showOnBoardingTour,
       });
 
       const notificationTemplateService = new NotificationTemplateService(

--- a/apps/web/cypress/support/commands.ts
+++ b/apps/web/cypress/support/commands.ts
@@ -71,7 +71,11 @@ Cypress.Commands.add('clickNodeButton', (selector: string) => {
 
 Cypress.Commands.add(
   'initializeSession',
-  (settings: { disableLocalStorage?: boolean; noTemplates?: boolean } = { disableLocalStorage: false }) => {
+  (
+    settings: { disableLocalStorage?: boolean; noTemplates?: boolean; showOnBoardingTour?: boolean } = {
+      disableLocalStorage: false,
+    }
+  ) => {
     return cy.task('getSession', settings).then((response: any) => {
       if (!settings.disableLocalStorage) {
         window.localStorage.setItem('auth_token', response.token);

--- a/apps/web/cypress/tests/notification-editor/create-notification.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/create-notification.spec.ts
@@ -2,7 +2,7 @@ import { addAndEditChannel, clickWorkflow, dragAndDrop, editChannel, fillBasicNo
 
 describe('Creation functionality', function () {
   beforeEach(function () {
-    cy.initializeSession().as('session');
+    cy.initializeSession({ showOnBoardingTour: false }).as('session');
   });
 
   it('should create in-app notification', function () {
@@ -350,7 +350,7 @@ describe('Creation functionality', function () {
     cy.waitLoadTemplatePage(() => {
       cy.visit('/templates/create');
     });
-    cy.getByTestId('scratch-workflow-tooltip-skip-button').should('have.text', 'Watch later').click();
+
     fillBasicNotificationDetails('Test 15 Nodes');
     goBack();
     cy.waitForNetworkIdle(500);

--- a/apps/web/cypress/tests/notification-editor/main-functionality.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/main-functionality.spec.ts
@@ -386,4 +386,76 @@ describe('Workflow Editor - Main Functionality', function () {
 
     cy.getByTestId('control-add').first();
   });
+
+  it('should load successfully the recently created notification template, when going back from editor -> templates list -> editor', function () {
+    cy.intercept('GET', '*/notification-templates**').as('getNotificationTemplates');
+    cy.intercept('GET', '*/notification-templates/*').as('getNotificationTemplate');
+    cy.visit('/templates');
+    cy.wait('@getNotificationTemplates');
+
+    cy.getByTestId('create-template-btn').click();
+    cy.wait('@getNotificationTemplate');
+
+    fillBasicNotificationDetails('Test notification');
+
+    addAndEditChannel('inApp');
+    cy.get('.ace_text-input').first().type('Test in-app', {
+      force: true,
+    });
+
+    addAndEditChannel('email');
+    cy.getByTestId('editable-text-content').clear().type('Test email');
+    cy.getByTestId('emailSubject').type('this is email subject');
+    cy.getByTestId('emailPreheader').type('this is email preheader');
+    goBack();
+
+    cy.getByTestId('notification-template-submit-btn').click();
+
+    cy.getByTestId('side-nav-templates-link').click();
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId('template-edit-link');
+    cy.getByTestId('notifications-template')
+      .get('tbody tr td')
+      .contains('Test notification', {
+        matchCase: false,
+      })
+      .click();
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId(`node-inAppSelector`).should('exist');
+    cy.getByTestId(`node-emailSelector`).should('exist');
+  });
+
+  it('should load successfully the same notification template, when going back from templates list -> editor -> templates list -> editor', function () {
+    cy.intercept('GET', '*/notification-templates**').as('getNotificationTemplates');
+    cy.intercept('GET', '*/notification-templates/*').as('getNotificationTemplate');
+    cy.visit('/templates');
+    cy.wait('@getNotificationTemplates');
+
+    const template = this.session.templates[0];
+    cy.getByTestId('notifications-template')
+      .get('tbody tr td')
+      .contains(template.name, {
+        matchCase: false,
+      })
+      .click();
+    cy.wait('@getNotificationTemplate');
+    cy.getByTestId(`node-inAppSelector`).should('exist');
+    cy.getByTestId(`node-emailSelector`).should('exist');
+
+    cy.getByTestId('side-nav-templates-link').click();
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId('notifications-template')
+      .get('tbody tr td')
+      .contains(template.name, {
+        matchCase: false,
+      })
+      .click();
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId(`node-inAppSelector`).should('exist');
+    cy.getByTestId(`node-emailSelector`).should('exist');
+  });
 });

--- a/apps/web/cypress/tests/notification-editor/steps-actions.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/steps-actions.spec.ts
@@ -2,7 +2,7 @@ import { clickWorkflow, dragAndDrop, editChannel, goBack } from '.';
 
 describe('Workflow Editor - Steps Actions', function () {
   beforeEach(function () {
-    cy.initializeSession().as('session');
+    cy.initializeSession({ showOnBoardingTour: false }).as('session');
   });
 
   const interceptEditTemplateRequests = () => {

--- a/apps/web/cypress/tests/start-from-scratch-tour.spec.ts
+++ b/apps/web/cypress/tests/start-from-scratch-tour.spec.ts
@@ -1,6 +1,6 @@
 describe('Start from scratch tour hints', function () {
   beforeEach(function () {
-    cy.initializeSession().as('session');
+    cy.initializeSession({ showOnBoardingTour: true }).as('session');
   });
 
   it('should show the start from scratch intro step', function () {

--- a/apps/web/src/pages/templates/components/TemplateEditorFormProvider.tsx
+++ b/apps/web/src/pages/templates/components/TemplateEditorFormProvider.tsx
@@ -19,7 +19,7 @@ import { mapNotificationTemplateToForm, mapFormToCreateNotificationTemplate } fr
 import { errorMessage, successMessage } from '../../../utils/notifications';
 import { schema } from './notificationTemplateSchema';
 import { v4 as uuid4 } from 'uuid';
-import { useNotificationGroup } from '../../../hooks';
+import { useEffectOnce, useNotificationGroup } from '../../../hooks';
 import { useCreate } from '../hooks/useCreate';
 import { stepNames } from '../constants';
 
@@ -164,16 +164,18 @@ const TemplateEditorFormProvider = ({ children }) => {
     }
   }, [name]);
 
-  const { template, isLoading, isCreating, isUpdating, isDeleting, updateNotificationTemplate } = useTemplateController(
-    templateId,
-    {
-      onFetchSuccess: (fetchedTemplate) => {
-        setTrigger(fetchedTemplate.triggers[0]);
-        const form = mapNotificationTemplateToForm(fetchedTemplate);
-        reset(form);
-      },
-    }
-  );
+  const { template, isLoading, isCreating, isUpdating, isDeleting, updateNotificationTemplate } =
+    useTemplateController(templateId);
+
+  useEffectOnce(() => {
+    if (!template) return;
+
+    // we don't call this on success because the templates might be fetched before
+    setTrigger(template.triggers[0]);
+    const form = mapNotificationTemplateToForm(template);
+    reset(form);
+  }, !!template);
+
   const { groups, loading: loadingGroups } = useNotificationGroup();
 
   useCreate(templateId, groups, setTrigger, methods.getValues);

--- a/apps/web/src/pages/templates/components/useTemplateController.ts
+++ b/apps/web/src/pages/templates/components/useTemplateController.ts
@@ -9,7 +9,11 @@ export function useTemplateController(
   templateId?: string,
   { onFetchSuccess }: { onFetchSuccess?: (template: INotificationTemplate) => void } = {}
 ) {
-  const { template, isInitialLoading: isLoading } = useTemplateFetcher({ templateId }, { onSuccess: onFetchSuccess });
+  const {
+    template,
+    refetch,
+    isInitialLoading: isLoading,
+  } = useTemplateFetcher({ templateId }, { onSuccess: onFetchSuccess });
   const client = useQueryClient();
 
   const { isLoading: isCreating, mutateAsync: createNotificationTemplate } = useMutation<
@@ -28,6 +32,7 @@ export function useTemplateController(
     { id: string; data: Partial<IUpdateNotificationTemplateDto> }
   >(({ id, data }) => updateTemplate(id, data), {
     onSuccess: async () => {
+      refetch();
       await client.refetchQueries([QueryKeys.changesCount]);
     },
   });

--- a/libs/testing/src/user.service.ts
+++ b/libs/testing/src/user.service.ts
@@ -40,6 +40,7 @@ export class UserService {
       password: passwordHash,
       profilePicture: `https://randomuser.me/api/portraits/men/${Math.floor(Math.random() * 60) + 1}.jpg`,
       tokens: [],
+      showOnBoardingTour: userEntity.showOnBoardingTour,
     });
 
     return user;

--- a/libs/testing/src/user.session.ts
+++ b/libs/testing/src/user.session.ts
@@ -74,7 +74,14 @@ export class UserSession {
     this.jobsService = new JobsService();
   }
 
-  async initialize(options: { noOrganization?: boolean; noEnvironment?: boolean; noIntegrations?: boolean } = {}) {
+  async initialize(
+    options: {
+      noOrganization?: boolean;
+      noEnvironment?: boolean;
+      noIntegrations?: boolean;
+      showOnBoardingTour?: boolean;
+    } = {}
+  ) {
     const card = {
       firstName: faker.name.firstName(),
       lastName: faker.name.lastName(),
@@ -89,6 +96,7 @@ export class UserSession {
       tokens: [],
       password: '123Qwe!@#',
       showOnBoarding: true,
+      showOnBoardingTour: options.showOnBoardingTour ? 0 : 2,
     };
 
     this.user = await userService.createUser(userEntity);


### PR DESCRIPTION
### What change does this PR introduce?

This PR fixes the issue that happens when visiting the template editor twice for the same template. Currently, the form state is not "set", which results in the template steps not being loaded into the workflow. 

Also, there is another issue, like when the template is updated and the user navigates to the templates list page and back, then the old template state is shown.

This PR fixes both issues.

### Why was this change needed?

Fixes the above issue.

### Other information (Screenshots)

https://github.com/novuhq/novu/assets/2607232/c3d460b3-e78b-4e85-afb7-8b4b802c6631


https://github.com/novuhq/novu/assets/2607232/0b3891ab-49cc-498c-a72e-f7237b4348f2


