### PR TITLE
feat(api): implement mappers for the different contexts in feature flags

### DIFF
--- a/apps/api/src/app/feature-flags/services/feature-flags.service.ts
+++ b/apps/api/src/app/feature-flags/services/feature-flags.service.ts
@@ -49,7 +49,8 @@ export class FeatureFlagsService {
     }
   }
 
-  public async get<T>(key: FeatureFlagKey, context: IFeatureFlagContext, defaultValue: T): Promise<T> {
-    return await this.service.get(key, context, defaultValue);
+  public async get<T>(key: FeatureFlagKey, defaultValue: T, context: IFeatureFlagContext): Promise<T> {
+    // TODO: Select here which context we will need in the future
+    return await this.service.getWithUserContext(key, defaultValue, context.userId);
   }
 }

--- a/apps/api/src/app/feature-flags/services/launch-darkly.service.ts
+++ b/apps/api/src/app/feature-flags/services/launch-darkly.service.ts
@@ -1,7 +1,14 @@
-import { init, LDClient, LDContext, LDFlagValue, LDUser } from 'launchdarkly-node-server-sdk';
+import { init, LDClient, LDContext, LDFlagValue, LDSingleKindContext } from 'launchdarkly-node-server-sdk';
 import { Injectable, Logger } from '@nestjs/common';
 
-import { FeatureFlagKey, IFeatureFlagContext, IFeatureFlagsService } from '../types';
+import {
+  EnvironmentId,
+  FeatureFlagKey,
+  IFeatureFlagContext,
+  IFeatureFlagsService,
+  OrganizationId,
+  UserId,
+} from '../types';
 
 const LOG_CONTEXT = 'LaunchDarklyService';
 
@@ -17,12 +24,34 @@ export class LaunchDarklyService implements IFeatureFlagsService {
     }
   }
 
-  public async get<T>(key: FeatureFlagKey, context: IFeatureFlagContext, defaultValue: T): Promise<T> {
-    const launchDarklyContext = this.mapToLaunchDarklyContext(key, context);
+  private async get<T>(key: FeatureFlagKey, context: LDSingleKindContext, defaultValue: T): Promise<T> {
+    return await this.client.variation(key, context, defaultValue);
+  }
 
-    const value = await this.client.variation(key, launchDarklyContext, defaultValue);
+  public async getWithEnvironmentContext<T>(
+    key: FeatureFlagKey,
+    defaultValue: T,
+    environmentId: EnvironmentId
+  ): Promise<T> {
+    const context = this.mapToEnvironmentContext(environmentId);
 
-    return value satisfies T;
+    return await this.get(key, context, defaultValue);
+  }
+
+  public async getWithOrganizationContext<T>(
+    key: FeatureFlagKey,
+    defaultValue: T,
+    organizationId: OrganizationId
+  ): Promise<T> {
+    const context = this.mapToOrganizationContext(organizationId);
+
+    return await this.get(key, context, defaultValue);
+  }
+
+  public async getWithUserContext<T>(key: FeatureFlagKey, defaultValue: T, userId: UserId): Promise<T> {
+    const context = this.mapToUserContext(userId);
+
+    return await this.get(key, context, defaultValue);
   }
 
   public async gracefullyShutdown(): Promise<void> {
@@ -48,10 +77,30 @@ export class LaunchDarklyService implements IFeatureFlagsService {
     }
   }
 
-  private mapToLaunchDarklyContext(key: FeatureFlagKey, context: IFeatureFlagContext): LDContext {
-    const launchDarklyContext: LDUser = {
-      ...context,
-      key,
+  // TODO: Unused for now.
+  private mapToEnvironmentContext(environmentId: EnvironmentId): LDSingleKindContext {
+    const launchDarklyContext = {
+      kind: 'environment',
+      key: environmentId,
+    };
+
+    return launchDarklyContext;
+  }
+
+  // TODO: Unused for now
+  private mapToOrganizationContext(organizationId: OrganizationId): LDSingleKindContext {
+    const launchDarklyContext = {
+      kind: 'organization',
+      key: organizationId,
+    };
+
+    return launchDarklyContext;
+  }
+
+  private mapToUserContext(userId: UserId): LDSingleKindContext {
+    const launchDarklyContext = {
+      kind: 'user',
+      key: userId,
     };
 
     return launchDarklyContext;

--- a/apps/api/src/app/feature-flags/types/index.ts
+++ b/apps/api/src/app/feature-flags/types/index.ts
@@ -1,5 +1,7 @@
 import { EnvironmentId, OrganizationId, UserId } from '@novu/shared';
 
+export { EnvironmentId, OrganizationId, UserId };
+
 // This will become an enum with the keys.
 export type FeatureFlagKey = string;
 
@@ -10,7 +12,9 @@ export interface IFeatureFlagContext {
 }
 
 export interface IFeatureFlagsService {
-  initialize: () => Promise<void>;
-  get: <T>(key: FeatureFlagKey, context: IFeatureFlagContext, defaultValue: T) => Promise<T>;
+  getWithEnvironmentContext: <T>(key: FeatureFlagKey, defaultValue: T, environmentId: EnvironmentId) => Promise<T>;
+  getWithOrganizationContext: <T>(key: FeatureFlagKey, defaultValue: T, organizationId: OrganizationId) => Promise<T>;
+  getWithUserContext: <T>(key: FeatureFlagKey, defaultValue: T, userId: UserId) => Promise<T>;
   gracefullyShutdown: () => Promise<void>;
+  initialize: () => Promise<void>;
 }

--- a/apps/api/src/app/feature-flags/use-cases/get-feature-flag/get-feature-flag.command.ts
+++ b/apps/api/src/app/feature-flags/use-cases/get-feature-flag/get-feature-flag.command.ts
@@ -3,7 +3,10 @@ import { IsDefined } from 'class-validator';
 
 import { FeatureFlagKey } from '../../types';
 
-export class GetFeatureFlagCommand extends EnvironmentWithUserCommand {
+export class GetFeatureFlagCommand<T> extends EnvironmentWithUserCommand {
   @IsDefined()
   key: FeatureFlagKey;
+
+  @IsDefined()
+  defaultValue: T;
 }

--- a/apps/api/src/app/feature-flags/use-cases/get-feature-flag/get-feature-flag.use-case.ts
+++ b/apps/api/src/app/feature-flags/use-cases/get-feature-flag/get-feature-flag.use-case.ts
@@ -8,8 +8,8 @@ import { FeatureFlagsService } from '../../services';
 export class GetFeatureFlag {
   constructor(private featureFlagsService: FeatureFlagsService) {}
 
-  async execute(command: GetFeatureFlagCommand): Promise<void> {
-    const { key, environmentId, organizationId, userId } = command;
+  async execute<T>(command: GetFeatureFlagCommand<T>): Promise<T> {
+    const { defaultValue, key, environmentId, organizationId, userId } = command;
 
     const context = {
       environmentId,
@@ -17,7 +17,6 @@ export class GetFeatureFlag {
       userId,
     };
 
-    // TODO: The type needs to be dynamic. String so far by default
-    await this.featureFlagsService.get(key, context, '');
+    return await this.featureFlagsService.get(key, defaultValue, context);
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Adds mapping for the different potential contexts we might have for the feature flags (organization, environment, user).

### Why was this change needed?

We need to adapt Novu's context to Launch Darkly's one.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

I am missing for now adding other contexts such as version and region that were discussed but we still don't have the implementation for them in the apps. The implementation of the contexts in this PR should be enough to give an idea how to implement them in the future.
<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
