### PR TITLE
fix(web): templates store - update the workflow editor position when selecting the blueprint template

### DIFF
--- a/apps/web/src/pages/templates/components/templates-store/TemplatesStoreModal.tsx
+++ b/apps/web/src/pages/templates/components/templates-store/TemplatesStoreModal.tsx
@@ -106,6 +106,7 @@ export const TemplatesStoreModal = ({ general, isOpened, onClose }: ITemplatesSt
           <CanvasHolder>
             <ReactFlowProvider>
               <FlowEditor
+                key={selectedTemplate._id}
                 steps={selectedTemplate.steps}
                 nodeTypes={nodeTypes}
                 zoomOnScroll={false}


### PR DESCRIPTION
### What change does this PR introduce?

In this PR:
- update the Workflow Editor position when selecting the template from the Templates Store modal
- fixed the issue with wrong-positioned tree nodes when the new node is added (check screenshot)

### Why was this change needed?

Templates Store PRD.

### Other information (Screenshots)

1. Wrong-positioned nodes
![Screenshot 2023-05-23 at 20 31 19](https://github.com/novuhq/novu/assets/2607232/f35b5201-b29e-434d-b946-9072737d0c47)

2. Fixes
 

https://github.com/novuhq/novu/assets/2607232/51f3052b-a4e4-49b2-9550-5cffef0bb59e


https://github.com/novuhq/novu/assets/2607232/27ca0c54-4613-4f97-8257-b65ed7dbee43


