### PR TITLE
Add Python to the list of available SDKs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The ultimate service for managing multi-channel notifications with a single API.
   · <a href="https://github.com/novuhq/novu-kotlin">Kotlin</a>
   · <a href="https://github.com/novuhq/elixir">Elixir</a>
   · <a href="https://github.com/novuhq/rust">Rust</a>
+  · <a href="https://github.com/novuhq/novu-python">Python</a>
   </p>
 
 ## ⭐️ Why Novu?


### PR DESCRIPTION
### What change does this PR introduce?

A hyperlink to the Python SDK

### Why was this change needed?

There appears to be an SDK that supports Python. Initially I avoided using Novu because of the lack of Python support but now that I found it I will give it a try and do what I can to support the Python SDK.
