### PR TITLE
feat: Export additional types and enums from sdk

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,4 +1,17 @@
-export { ChatProviderIdEnum, PushProviderIdEnum } from '@novu/shared';
+export {
+  ChatProviderIdEnum,
+  PushProviderIdEnum,
+  ChannelCTATypeEnum,
+  TemplateVariableTypeEnum,
+  IMessageTemplate,
+  SystemAvatarIconEnum,
+  INotificationTemplate,
+  INotificationTemplateStep,
+  ITemplateVariable,
+  IEmailBlock,
+  TextAlignEnum,
+  EmailBlockTypeEnum,
+} from '@novu/shared';
 
 export * from './lib/novu';
 export * from './lib/subscribers/subscriber.interface';


### PR DESCRIPTION
### What change does this PR introduce?
This PR exports additional enums and types that are important when building programmatic resource generation as these types facilitate the type-safety.

I'm open to suggestions if this doesn't feel like the right thing to do but I would like to access as much as possible the underlying types references

### Why was this change needed?
Closes #3442 


### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
