### PR TITLE
fix: add missing tls param to redis provider config

### DIFF
--- a/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.spec.ts
+++ b/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.spec.ts
@@ -34,6 +34,7 @@ describe('In-memory Provider Service', () => {
         expect(inMemoryProviderConfig.keyPrefix).toEqual('');
         expect(inMemoryProviderConfig.password).toEqual('');
         expect(inMemoryProviderConfig.ttl).toEqual(7_200);
+        expect(inMemoryProviderConfig.tls).toEqual(undefined);
       });
 
       it('should instantiate the provider properly', async () => {

--- a/packages/application-generic/src/services/in-memory-provider/redis-provider.ts
+++ b/packages/application-generic/src/services/in-memory-provider/redis-provider.ts
@@ -62,6 +62,7 @@ export const getRedisProviderConfig = (): IRedisProviderConfig => {
     : DEFAULT_KEEP_ALIVE;
   const keyPrefix = redisConfig.keyPrefix ?? DEFAULT_KEY_PREFIX;
   const ttl = redisConfig.ttl ? Number(redisConfig.ttl) : DEFAULT_TTL_SECONDS;
+  const tls = redisConfig.tls;
 
   return {
     host,
@@ -72,6 +73,7 @@ export const getRedisProviderConfig = (): IRedisProviderConfig => {
     keepAlive,
     keyPrefix,
     ttl,
+    tls,
   };
 };
 


### PR DESCRIPTION
### What change does this PR introduce?

adding missing tls param
