### PR TITLE
fix noNewNotification field on russian locale

### DIFF
--- a/packages/notification-center/src/i18n/languages/ru.ts
+++ b/packages/notification-center/src/i18n/languages/ru.ts
@@ -6,7 +6,7 @@ export const RU: ITranslationEntry = {
     markAllAsRead: 'Пометить все как прочитанные',
     poweredBy: 'При поддержке',
     settings: 'Настройки',
-    noNewNotification: 'Все още няма нищо ново за гледане тук',
+    noNewNotification: 'Здесь пока ничего нового',
   },
   lang: 'ru',
 };


### PR DESCRIPTION
### What change does this PR introduce?

This PR fixes ru locale

### Why was this change needed?

Because now it's have a mistake in `noNewNotification` field, it's writtend on bulgarian instead of russian
