### PR TITLE
docs(run-locally.md): duplicate REDIS_DB_INDEX key

### DIFF
--- a/docs/docs/community/run-locally.md
+++ b/docs/docs/community/run-locally.md
@@ -65,6 +65,7 @@ However, if you want to test certain parts of Novu or run it in production mode,
 - `REDIS_DB_INDEX`<br />The Redis database index
 - `REDIS_CACHE_SERVICE_HOST`<br />The domain / IP of your redis instance for caching
 - `REDIS_CACHE_SERVICE_PORT`<br />The port of your redis instance for caching
+- `REDIS_CACHE_DB_INDEX`<br />The Redis cache database index
 - `REDIS_CACHE_TTL`<br />The Redis cache ttl
 - `REDIS_CACHE_PASSWORD`<br />The Redis cache password
 - `REDIS_CACHE_CONNECTION_TIMEOUT`<br />The Redis cache connection timeout

--- a/docs/docs/community/run-locally.md
+++ b/docs/docs/community/run-locally.md
@@ -65,7 +65,6 @@ However, if you want to test certain parts of Novu or run it in production mode,
 - `REDIS_DB_INDEX`<br />The Redis database index
 - `REDIS_CACHE_SERVICE_HOST`<br />The domain / IP of your redis instance for caching
 - `REDIS_CACHE_SERVICE_PORT`<br />The port of your redis instance for caching
-- `REDIS_DB_INDEX`<br />The Redis cache database index
 - `REDIS_CACHE_TTL`<br />The Redis cache ttl
 - `REDIS_CACHE_PASSWORD`<br />The Redis cache password
 - `REDIS_CACHE_CONNECTION_TIMEOUT`<br />The Redis cache connection timeout


### PR DESCRIPTION
### What change does this PR introduce?

There are two ```REDIS_DB_INDEX``` keys

### Why was this change needed?

I guess it should be only one key..

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
