### PR TITLE
NV-2409 - 🐛 Bug Report: Querying by non-existent subscriberId returns all messages

### DIFF
--- a/apps/api/src/app/messages/usecases/get-messages/get-messages.usecase.ts
+++ b/apps/api/src/app/messages/usecases/get-messages/get-messages.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { MessageEntity, MessageRepository, SubscriberRepository, SubscriberEntity } from '@novu/dal';
 import { CachedEntity, buildSubscriberKey } from '@novu/application-generic';
 import { ActorTypeEnum } from '@novu/shared';
@@ -29,6 +29,8 @@ export class GetMessages {
 
       if (subscriber) {
         query._subscriberId = subscriber._id;
+      } else {
+        throw new NotFoundException('Subscriber not found');
       }
     }
 


### PR DESCRIPTION
 ### What change does this PR introduce?
This fix prevents returning all messages when querying with non-existent subscriberId

 ### Why was this change needed?
closes https://github.com/novuhq/novu/issues/3581

### Other information

Happy hacking! 🎉

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
