### PR TITLE
Add IP Pool Name In Integration

### DIFF
--- a/apps/api/src/app/integrations/dtos/credentials.dto.ts
+++ b/apps/api/src/app/integrations/dtos/credentials.dto.ts
@@ -123,7 +123,7 @@ export class CredentialsDto implements ICredentials {
   redirectUrl?: string;
 
   @ApiPropertyOptional()
-  @IsString()
+  @IsBoolean()
   @IsOptional()
   hmac?: boolean;
 

--- a/apps/api/src/app/integrations/dtos/credentials.dto.ts
+++ b/apps/api/src/app/integrations/dtos/credentials.dto.ts
@@ -1,8 +1,9 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsBoolean, IsObject, IsOptional, IsString } from 'class-validator';
 import { TransformToBoolean } from '../../shared/transformers/to-boolean';
+import { ICredentials } from '@novu/shared';
 
-export class CredentialsDto {
+export class CredentialsDto implements ICredentials {
   @ApiPropertyOptional()
   @IsString()
   @IsOptional()
@@ -115,4 +116,24 @@ export class CredentialsDto {
   @IsString()
   @IsOptional()
   webhookUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  redirectUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  hmac?: boolean;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  serviceAccount?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  ipPoolName?: string;
 }

--- a/apps/api/src/app/integrations/usecases/check-integration/check-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/check-integration/check-integration.command.ts
@@ -1,7 +1,6 @@
-import { IsDefined, IsOptional, IsString, IsBoolean } from 'class-validator';
-import { ICredentials } from '@novu/dal';
+import { IsDefined, IsString } from 'class-validator';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 
 export class CheckIntegrationCommand extends EnvironmentCommand {
   @IsDefined()

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { ChannelTypeEnum } from '@novu/stateless';
-import { IntegrationEntity, IntegrationRepository, EnvironmentRepository, ICredentials } from '@novu/dal';
+import { IntegrationEntity, IntegrationRepository, EnvironmentRepository, ICredentialsEntity } from '@novu/dal';
 
 import { ChatOauthCommand } from './chat-oauth.command';
 import { createHash } from '../../../shared/helpers/hmac.service';
@@ -60,7 +60,7 @@ export class ChatOauth {
     return `${this.SLACK_OAUTH_URL}client_id=${clientId}&scope=incoming-webhook&user_scope=&redirect_uri=${redirectUri}`;
   }
 
-  private async getCredentials(command: ChatOauthCommand): Promise<ICredentials> {
+  private async getCredentials(command: ChatOauthCommand): Promise<ICredentialsEntity> {
     const query: Partial<IntegrationEntity> & { _environmentId: string } = {
       _environmentId: command.environmentId,
       channel: ChannelTypeEnum.CHAT,

--- a/apps/web/src/pages/integrations/IntegrationsStoreModal.tsx
+++ b/apps/web/src/pages/integrations/IntegrationsStoreModal.tsx
@@ -9,6 +9,7 @@ import {
   InAppProviderIdEnum,
   ProvidersIdEnum,
   SmsProviderIdEnum,
+  ICredentials,
 } from '@novu/shared';
 
 import { useAuthController, useEnvController } from '../../hooks';
@@ -18,7 +19,7 @@ import { NovuInAppProviderModal } from './components/NovuInAppProviderModal';
 import { ChannelGroup } from './components/Modal/ChannelGroup';
 import { colors, shadows, Title } from '../../design-system';
 import { ConnectIntegrationForm } from './components/Modal/ConnectIntegrationForm';
-import { Close } from '../../design-system/icons/actions/Close';
+import { Close } from '../../design-system/icons';
 import { useProviders } from './useProviders';
 import { useSegment } from '../../components/providers/SegmentProvider';
 import { IntegrationsStoreModalAnalytics } from './constants';
@@ -326,32 +327,6 @@ export interface IIntegratedProvider {
   logoFileName: ILogoFileName;
   betaVersion: boolean;
   novu?: boolean;
-}
-
-export interface ICredentials {
-  apiKey?: string;
-  user?: string;
-  secretKey?: string;
-  domain?: string;
-  password?: string;
-  host?: string;
-  port?: string;
-  secure?: boolean;
-  region?: string;
-  accountSid?: string;
-  messageProfileId?: string;
-  token?: string;
-  from?: string;
-  senderName?: string;
-  applicationId?: string;
-  clientId?: string;
-  projectName?: string;
-  serviceAccount?: string;
-  baseUrl?: string;
-  webhookUrl?: string;
-  requireTls?: boolean;
-  ignoreTls?: boolean;
-  tlsOptions?: Record<string, unknown>;
 }
 
 export interface IntegrationEntity {

--- a/apps/web/src/pages/integrations/IntegrationsStorePage.tsx
+++ b/apps/web/src/pages/integrations/IntegrationsStorePage.tsx
@@ -12,6 +12,7 @@ import {
   InAppProviderIdEnum,
   ProvidersIdEnum,
   SmsProviderIdEnum,
+  ICredentials,
 } from '@novu/shared';
 
 import PageHeader from '../../components/layout/components/PageHeader';
@@ -150,34 +151,6 @@ export interface IIntegratedProvider {
   logoFileName: ILogoFileName;
   betaVersion: boolean;
   novu?: boolean;
-}
-
-export interface ICredentials {
-  apiKey?: string;
-  user?: string;
-  secretKey?: string;
-  domain?: string;
-  password?: string;
-  host?: string;
-  port?: string;
-  secure?: boolean;
-  region?: string;
-  accountSid?: string;
-  messageProfileId?: string;
-  token?: string;
-  from?: string;
-  senderName?: string;
-  applicationId?: string;
-  clientId?: string;
-  projectName?: string;
-  serviceAccount?: string;
-  baseUrl?: string;
-  webhookUrl?: string;
-  requireTls?: boolean;
-  ignoreTls?: boolean;
-  tlsOptions?: Record<string, unknown>;
-  redirectUrl?: string;
-  hmac?: boolean;
 }
 
 export interface IntegrationEntity {

--- a/apps/web/src/pages/integrations/components/ConnectIntegrationForm.tsx
+++ b/apps/web/src/pages/integrations/components/ConnectIntegrationForm.tsx
@@ -11,7 +11,7 @@ import { ChannelTypeEnum, ICredentialsDto, IConfigCredentials } from '@novu/shar
 import { Button, colors, Input, Switch, Text } from '../../../design-system';
 import { IIntegratedProvider } from '../IntegrationsStorePage';
 import { createIntegration, getWebhookSupportStatus, updateIntegration } from '../../../api/integration';
-import { Close } from '../../../design-system/icons/actions/Close';
+import { Close } from '../../../design-system/icons';
 import { IntegrationInput } from './IntegrationInput';
 import { IS_DOCKER_HOSTED, WEBHOOK_URL } from '../../../config';
 import { useEnvController, useAuthController } from '../../../hooks';

--- a/libs/dal/src/repositories/integration/integration.entity.ts
+++ b/libs/dal/src/repositories/integration/integration.entity.ts
@@ -1,37 +1,8 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 
 import type { EnvironmentId } from '../environment';
 import type { OrganizationId } from '../organization';
 import { ChangePropsValueType } from '../../types/helpers';
-
-export interface ICredentials {
-  apiKey?: string;
-  user?: string;
-  secretKey?: string;
-  domain?: string;
-  password?: string;
-  host?: string;
-  port?: string;
-  secure?: boolean;
-  region?: string;
-  accountSid?: string;
-  messageProfileId?: string;
-  token?: string;
-  from?: string;
-  senderName?: string;
-  applicationId?: string;
-  clientId?: string;
-  projectName?: string;
-  serviceAccount?: string;
-  baseUrl?: string;
-  webhookUrl?: string;
-  ipPoolName?: string;
-  requireTls?: boolean;
-  ignoreTls?: boolean;
-  tlsOptions?: Record<string, unknown>;
-  redirectUrl?: string;
-  hmac?: boolean;
-}
 
 export class IntegrationEntity {
   _id: string;
@@ -44,7 +15,7 @@ export class IntegrationEntity {
 
   channel: ChannelTypeEnum;
 
-  credentials: ICredentials;
+  credentials: ICredentialsEntity;
 
   active: boolean;
 
@@ -58,5 +29,7 @@ export class IntegrationEntity {
 
   deletedBy: string;
 }
+
+export type ICredentialsEntity = ICredentials;
 
 export type IntegrationDBModel = ChangePropsValueType<IntegrationEntity, '_environmentId' | '_organizationId'>;

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -44,6 +44,7 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       tlsOptions: Schema.Types.Mixed,
       redirectUrl: Schema.Types.String,
       hmac: Schema.Types.Boolean,
+      ipPoolName: Schema.Types.String,
     },
     active: {
       type: Schema.Types.Boolean,

--- a/libs/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/libs/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -201,6 +201,12 @@ export const sendgridConfig: IConfigCredentials[] = [
     type: 'string',
     required: true,
   },
+  {
+    key: CredentialsKeyEnum.IpPoolName,
+    displayName: 'IP Pool Name',
+    type: 'string',
+    required: false,
+  },
   ...mailConfigBase,
 ];
 

--- a/libs/shared/src/consts/providers/provider.enum.ts
+++ b/libs/shared/src/consts/providers/provider.enum.ts
@@ -26,6 +26,7 @@ export enum CredentialsKeyEnum {
   TlsOptions = 'tlsOptions',
   RedirectUrl = 'redirectUrl',
   Hmac = 'hmac',
+  IpPoolName = 'ipPoolName',
 }
 
 export enum EmailProviderIdEnum {

--- a/libs/shared/src/dto/integration/construct-integration.interface.ts
+++ b/libs/shared/src/dto/integration/construct-integration.interface.ts
@@ -1,30 +1,6 @@
-export interface ICredentialsDto {
-  apiKey?: string;
-  user?: string;
-  secretKey?: string;
-  domain?: string;
-  password?: string;
-  host?: string;
-  port?: string;
-  secure?: boolean;
-  hmac?: boolean;
-  region?: string;
-  accountSid?: string;
-  messageProfileId?: string;
-  token?: string;
-  from?: string;
-  senderName?: string;
-  applicationId?: string;
-  clientId?: string;
-  projectName?: string;
-  serviceAccount?: string;
-  baseUrl?: string;
-  requireTls?: boolean;
-  ignoreTls?: boolean;
-  tlsOptions?: Record<string, unknown>;
-  webhookUrl?: string;
-  redirectUrl?: string;
-}
+import { ICredentials } from '../../entities/integration';
+
+export type ICredentialsDto = ICredentials;
 
 export interface IConstructIntegrationDto {
   credentials: ICredentialsDto;

--- a/libs/shared/src/entities/integration/credential.interface.ts
+++ b/libs/shared/src/entities/integration/credential.interface.ts
@@ -1,0 +1,28 @@
+export interface ICredentials {
+  apiKey?: string;
+  user?: string;
+  secretKey?: string;
+  domain?: string;
+  password?: string;
+  host?: string;
+  port?: string;
+  secure?: boolean;
+  region?: string;
+  accountSid?: string;
+  messageProfileId?: string;
+  token?: string;
+  from?: string;
+  senderName?: string;
+  applicationId?: string;
+  clientId?: string;
+  projectName?: string;
+  serviceAccount?: string;
+  baseUrl?: string;
+  webhookUrl?: string;
+  requireTls?: boolean;
+  ignoreTls?: boolean;
+  tlsOptions?: Record<string, unknown>;
+  redirectUrl?: string;
+  hmac?: boolean;
+  ipPoolName?: string;
+}

--- a/libs/shared/src/entities/integration/index.ts
+++ b/libs/shared/src/entities/integration/index.ts
@@ -1,0 +1,1 @@
+export * from './credential.interface';

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -15,6 +15,7 @@ export * from './entities/subscriber-preference';
 export * from './entities/subscriber';
 export * from './entities/layout';
 export * from './entities/notification-group';
+export * from './entities/integration';
 export * from './types';
 export * from './dto';
 export * from './consts';

--- a/packages/application-generic/src/factories/chat/handlers/discord.handler.ts
+++ b/packages/application-generic/src/factories/chat/handlers/discord.handler.ts
@@ -1,4 +1,4 @@
-import { ICredentials } from '@novu/dal';
+import { ICredentials } from '@novu/shared';
 import { ChannelTypeEnum } from '@novu/stateless';
 import { BaseChatHandler } from './base.handler';
 import { DiscordProvider } from '@novu/discord';

--- a/packages/application-generic/src/factories/chat/handlers/mattermost.handler.ts
+++ b/packages/application-generic/src/factories/chat/handlers/mattermost.handler.ts
@@ -1,4 +1,4 @@
-import { ICredentials } from '@novu/dal';
+import { ICredentials } from '@novu/shared';
 import { ChannelTypeEnum } from '@novu/stateless';
 import { BaseChatHandler } from './base.handler';
 import { MattermostProvider } from '@novu/mattermost';

--- a/packages/application-generic/src/factories/chat/handlers/msteams.handler.ts
+++ b/packages/application-generic/src/factories/chat/handlers/msteams.handler.ts
@@ -1,4 +1,4 @@
-import { ICredentials } from '@novu/dal';
+import { ICredentials } from '@novu/shared';
 import { ChannelTypeEnum } from '@novu/stateless';
 import { BaseChatHandler } from './base.handler';
 import { MsTeamsProvider } from '@novu/ms-teams';

--- a/packages/application-generic/src/factories/chat/handlers/slack.handler.ts
+++ b/packages/application-generic/src/factories/chat/handlers/slack.handler.ts
@@ -1,4 +1,4 @@
-import { ICredentials } from '@novu/dal';
+import { ICredentials } from '@novu/shared';
 import { ChannelTypeEnum } from '@novu/stateless';
 import { SlackProvider } from '@novu/slack';
 

--- a/packages/application-generic/src/factories/chat/interfaces/index.ts
+++ b/packages/application-generic/src/factories/chat/interfaces/index.ts
@@ -1,6 +1,6 @@
 import { IChatOptions, ISendMessageSuccessResponse } from '@novu/stateless';
-import { ICredentials, IntegrationEntity } from '@novu/dal';
-import { ChannelTypeEnum } from '@novu/shared';
+import { IntegrationEntity } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 
 export interface IChatHandler {
   canHandle(providerId: string, channelType: ChannelTypeEnum);

--- a/packages/application-generic/src/factories/mail/handlers/email-webhook.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/email-webhook.handler.ts
@@ -1,6 +1,5 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { EmailWebhookProvider } from '@novu/email-webhook';
-import { ICredentials } from '@novu/dal';
 import { BaseHandler } from './base.handler';
 export class EmailWebhookHandler extends BaseHandler {
   constructor() {

--- a/packages/application-generic/src/factories/mail/handlers/emailjs.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/emailjs.handler.ts
@@ -1,7 +1,6 @@
 import { IEmailJsConfig } from '@novu/emailjs/build/main/lib/emailjs.config';
 import { EmailJsProvider } from '@novu/emailjs';
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseHandler } from './base.handler';
 
 /**

--- a/packages/application-generic/src/factories/mail/handlers/infobip.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/infobip.handler.ts
@@ -1,6 +1,5 @@
 import { InfobipEmailProvider } from '@novu/infobip';
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseHandler } from './base.handler';
 
 export class InfobipEmailHandler extends BaseHandler {

--- a/packages/application-generic/src/factories/mail/handlers/mailersend.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/mailersend.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { MailersendEmailProvider } from '@novu/mailersend';
 
 import { BaseHandler } from './base.handler';

--- a/packages/application-generic/src/factories/mail/handlers/mailgun.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/mailgun.handler.ts
@@ -1,6 +1,5 @@
 import { MailgunEmailProvider } from '@novu/mailgun';
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseHandler } from './base.handler';
 
 export class MailgunHandler extends BaseHandler {

--- a/packages/application-generic/src/factories/mail/handlers/mailjet.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/mailjet.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { MailjetEmailProvider } from '@novu/mailjet';
 import { BaseHandler } from './base.handler';
 

--- a/packages/application-generic/src/factories/mail/handlers/mandrill.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/mandrill.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { MandrillProvider } from '@novu/mandrill';
 import { BaseHandler } from './base.handler';
 

--- a/packages/application-generic/src/factories/mail/handlers/nodemailer.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/nodemailer.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { NodemailerProvider } from '@novu/nodemailer';
 import { BaseHandler } from './base.handler';
 

--- a/packages/application-generic/src/factories/mail/handlers/outlook365.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/outlook365.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { Outlook365Provider } from '@novu/outlook365';
 import { BaseHandler } from './base.handler';
 

--- a/packages/application-generic/src/factories/mail/handlers/postmark.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/postmark.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { PostmarkEmailProvider } from '@novu/postmark';
 import { BaseHandler } from './base.handler';
 

--- a/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { ResendEmailProvider } from '@novu/resend';
 import { BaseHandler } from './base.handler';
 

--- a/packages/application-generic/src/factories/mail/handlers/sendinblue.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/sendinblue.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { SendinblueEmailProvider } from '@novu/sendinblue';
 import { BaseHandler } from './base.handler';
 

--- a/packages/application-generic/src/factories/mail/handlers/ses.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/ses.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { SESConfig } from '@novu/ses/build/module/lib/ses.config';
 import { SESEmailProvider } from '@novu/ses';
 import { BaseHandler } from './base.handler';

--- a/packages/application-generic/src/factories/mail/handlers/sparkpost.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/sparkpost.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { SparkPostEmailProvider } from '@novu/sparkpost';
 
 import { BaseHandler } from './base.handler';

--- a/packages/application-generic/src/factories/mail/interfaces/send.handler.interface.ts
+++ b/packages/application-generic/src/factories/mail/interfaces/send.handler.interface.ts
@@ -4,8 +4,7 @@ import {
   ISendMessageSuccessResponse,
   ICheckIntegrationResponse,
 } from '@novu/stateless';
-import { ICredentials } from '@novu/dal';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 
 export interface IMailHandler {
   canHandle(providerId: string, channelType: ChannelTypeEnum);

--- a/packages/application-generic/src/factories/push/handlers/apns.handler.ts
+++ b/packages/application-generic/src/factories/push/handlers/apns.handler.ts
@@ -1,7 +1,6 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { APNSPushProvider } from '@novu/apns';
 import { BasePushHandler } from './base.handler';
-import { ICredentials } from '@novu/dal';
 
 export class APNSHandler extends BasePushHandler {
   constructor() {

--- a/packages/application-generic/src/factories/push/handlers/base.handler.ts
+++ b/packages/application-generic/src/factories/push/handlers/base.handler.ts
@@ -1,6 +1,6 @@
 import { IPushOptions, IPushProvider } from '@novu/stateless';
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
+import {} from '@novu/dal';
 import { IPushHandler } from '../interfaces';
 
 export abstract class BasePushHandler implements IPushHandler {

--- a/packages/application-generic/src/factories/push/handlers/expo.handler.ts
+++ b/packages/application-generic/src/factories/push/handlers/expo.handler.ts
@@ -1,7 +1,6 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { ExpoPushProvider } from '@novu/expo';
 import { BasePushHandler } from './base.handler';
-import { ICredentials } from '@novu/dal';
 
 export class ExpoHandler extends BasePushHandler {
   constructor() {

--- a/packages/application-generic/src/factories/push/handlers/fcm.handler.ts
+++ b/packages/application-generic/src/factories/push/handlers/fcm.handler.ts
@@ -1,7 +1,6 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { FcmPushProvider } from '@novu/fcm';
 import { BasePushHandler } from './base.handler';
-import { ICredentials } from '@novu/dal';
 
 export class FCMHandler extends BasePushHandler {
   constructor() {

--- a/packages/application-generic/src/factories/push/handlers/one-signal.handler.ts
+++ b/packages/application-generic/src/factories/push/handlers/one-signal.handler.ts
@@ -1,7 +1,6 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { OneSignalPushProvider } from '@novu/one-signal';
 import { BasePushHandler } from './base.handler';
-import { ICredentials } from '@novu/dal';
 
 export class OneSignalHandler extends BasePushHandler {
   constructor() {

--- a/packages/application-generic/src/factories/push/handlers/push-webhook.handler.ts
+++ b/packages/application-generic/src/factories/push/handlers/push-webhook.handler.ts
@@ -1,7 +1,6 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { PushWebhookPushProvider } from '@novu/push-webhook';
 import { BasePushHandler } from './base.handler';
-import { ICredentials } from '@novu/dal';
 
 export class PushWebhookHandler extends BasePushHandler {
   constructor() {

--- a/packages/application-generic/src/factories/push/interfaces/push.handler.interface.ts
+++ b/packages/application-generic/src/factories/push/interfaces/push.handler.interface.ts
@@ -1,6 +1,5 @@
 import { IPushOptions, ISendMessageSuccessResponse } from '@novu/stateless';
-import { ICredentials } from '@novu/dal';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 
 export interface IPushHandler {
   canHandle(providerId: string, channelType: ChannelTypeEnum);

--- a/packages/application-generic/src/factories/sms/handlers/africas-talking.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/africas-talking.handler.ts
@@ -1,6 +1,5 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { AfricasTalkingSmsProvider } from '@novu/africas-talking';
-import { ICredentials } from '@novu/dal';
 import { BaseSmsHandler } from './base.handler';
 
 export class AfricasTalkingSmsHandler extends BaseSmsHandler {

--- a/packages/application-generic/src/factories/sms/handlers/base.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/base.handler.ts
@@ -1,6 +1,5 @@
 import { ISmsOptions, ISmsProvider } from '@novu/stateless';
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { ISmsHandler } from '../interfaces';
 
 export abstract class BaseSmsHandler implements ISmsHandler {

--- a/packages/application-generic/src/factories/sms/handlers/burst-sms.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/burst-sms.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseSmsHandler } from './base.handler';
 import { BurstSmsProvider } from '@novu/burst-sms';
 

--- a/packages/application-generic/src/factories/sms/handlers/clickatell.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/clickatell.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { ClickatellSmsProvider } from '@novu/clickatell';
 import { BaseSmsHandler } from './base.handler';
 

--- a/packages/application-generic/src/factories/sms/handlers/firetext.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/firetext.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseSmsHandler } from './base.handler';
 import { FiretextSmsProvider } from '@novu/firetext';
 

--- a/packages/application-generic/src/factories/sms/handlers/forty-six-elks.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/forty-six-elks.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseSmsHandler } from './base.handler';
 import { FortySixElksSmsProvider } from '@novu/forty-six-elks';
 

--- a/packages/application-generic/src/factories/sms/handlers/gupshup.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/gupshup.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseSmsHandler } from './base.handler';
 import { GupshupSmsProvider } from '@novu/gupshup';
 

--- a/packages/application-generic/src/factories/sms/handlers/infobip.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/infobip.handler.ts
@@ -1,6 +1,5 @@
 import { InfobipSmsProvider } from '@novu/infobip';
-import { ChannelTypeEnum, SmsProviderIdEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, SmsProviderIdEnum, ICredentials } from '@novu/shared';
 import { BaseSmsHandler } from './base.handler';
 export class InfobipSmsHandler extends BaseSmsHandler {
   constructor() {

--- a/packages/application-generic/src/factories/sms/handlers/kannel.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/kannel.handler.ts
@@ -1,6 +1,5 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { KannelSmsProvider } from '@novu/kannel';
-import { ICredentials } from '@novu/dal';
 import { BaseSmsHandler } from './base.handler';
 
 export class KannelSmsHandler extends BaseSmsHandler {

--- a/packages/application-generic/src/factories/sms/handlers/maqsam.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/maqsam.handler.ts
@@ -1,6 +1,5 @@
 import { MaqsamSmsProvider } from '@novu/maqsam';
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseSmsHandler } from './base.handler';
 
 export class MaqsamHandler extends BaseSmsHandler {

--- a/packages/application-generic/src/factories/sms/handlers/plivo.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/plivo.handler.ts
@@ -1,6 +1,5 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { PlivoSmsProvider } from '@novu/plivo';
-import { ICredentials } from '@novu/dal';
 import { BaseSmsHandler } from './base.handler';
 
 export class PlivoHandler extends BaseSmsHandler {

--- a/packages/application-generic/src/factories/sms/handlers/sms-central.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/sms-central.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseSmsHandler } from './base.handler';
 import { SmsCentralSmsProvider } from '@novu/sms-central';
 

--- a/packages/application-generic/src/factories/sms/handlers/sms77.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/sms77.handler.ts
@@ -1,5 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { Sms77SmsProvider } from '@novu/sms77';
 import { BaseSmsHandler } from './base.handler';
 

--- a/packages/application-generic/src/factories/sms/handlers/sns.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/sns.handler.ts
@@ -1,7 +1,6 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { SNSSmsProvider } from '@novu/sns';
 import { SNSConfig } from '@novu/sns/build/main/lib/sns.config';
-import { ICredentials } from '@novu/dal';
 import { BaseSmsHandler } from './base.handler';
 
 export class SnsHandler extends BaseSmsHandler {

--- a/packages/application-generic/src/factories/sms/handlers/telnyx.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/telnyx.handler.ts
@@ -1,6 +1,5 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { TelnyxSmsProvider } from '@novu/telnyx';
-import { ICredentials } from '@novu/dal';
 import { BaseSmsHandler } from './base.handler';
 
 export class TelnyxHandler extends BaseSmsHandler {

--- a/packages/application-generic/src/factories/sms/handlers/termii.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/termii.handler.ts
@@ -1,6 +1,5 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { TermiiSmsProvider } from '@novu/termii';
-import { ICredentials } from '@novu/dal';
 import { BaseSmsHandler } from './base.handler';
 
 export class TermiiSmsHandler extends BaseSmsHandler {

--- a/packages/application-generic/src/factories/sms/handlers/twilio.handler.ts
+++ b/packages/application-generic/src/factories/sms/handlers/twilio.handler.ts
@@ -1,6 +1,5 @@
 import { TwilioSmsProvider } from '@novu/twilio';
-import { ChannelTypeEnum } from '@novu/shared';
-import { ICredentials } from '@novu/dal';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 import { BaseSmsHandler } from './base.handler';
 
 export class TwilioHandler extends BaseSmsHandler {

--- a/packages/application-generic/src/factories/sms/interfaces/sms.handler.interface.ts
+++ b/packages/application-generic/src/factories/sms/interfaces/sms.handler.interface.ts
@@ -3,8 +3,7 @@ import {
   ISmsOptions,
   ISmsProvider,
 } from '@novu/stateless';
-import { ICredentials } from '@novu/dal';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ICredentials } from '@novu/shared';
 
 export interface ISmsHandler {
   canHandle(providerId: string, channelType: ChannelTypeEnum);


### PR DESCRIPTION
### What change does this PR introduce?

Add ip pool name into the send grid integration.

### Why was this change needed?

in order to provide the user the ability to add/update it.

### Other information (Screenshots)

i refactored(moved to shared) the ICredentials by mistake we had too many duplications of it mostly mine fult.
i created an ICredentials in shared.
deleted some of the duplications.
currently created `type` of the interface because they were the same, it this type will need to change we change to update it to interface and `implement` the shared ICredentials.
