### PR TITLE
NV 2418 - Integration Selection Caching

### DIFF
--- a/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
@@ -49,7 +49,7 @@ export class CreateIntegration {
 
       await this.invalidateCache.invalidateQuery({
         key: buildIntegrationKey().invalidate({
-          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
         }),
       });
 

--- a/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.usecase.ts
@@ -15,7 +15,7 @@ export class RemoveIntegration {
     try {
       await this.invalidateCache.invalidateQuery({
         key: buildIntegrationKey().invalidate({
-          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
         }),
       });
 

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
@@ -41,7 +41,7 @@ export class UpdateIntegration {
 
     await this.invalidateCache.invalidateQuery({
       key: buildIntegrationKey().invalidate({
-        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
       }),
     });
 

--- a/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
@@ -3,9 +3,17 @@ import { ChannelTypeEnum, InAppProviderIdEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import { createHash } from '../../shared/helpers/hmac.service';
+import {
+  buildIntegrationKey,
+  CacheService,
+  InMemoryProviderService,
+  InvalidateCacheService,
+} from '@novu/application-generic';
 
 describe('Initialize Session - /widgets/session/initialize (POST)', async () => {
   let session: UserSession;
+  const inMemoryProviderService = new InMemoryProviderService();
+  const invalidateCache = new InvalidateCacheService(new CacheService(inMemoryProviderService));
 
   before(async () => {
     session = new UserSession();
@@ -46,7 +54,7 @@ describe('Initialize Session - /widgets/session/initialize (POST)', async () => 
   });
 
   it('should pass the test with valid HMAC hash', async function () {
-    await setHmacConfig(session);
+    await setHmacConfig(session, invalidateCache);
     const subscriberId = '12345';
     const secretKey = session.environment.apiKeys[0].key;
 
@@ -57,7 +65,7 @@ describe('Initialize Session - /widgets/session/initialize (POST)', async () => 
   });
 
   it('should fail the test with invalid subscriber id or invalid secret key', async function () {
-    await setHmacConfig(session);
+    await setHmacConfig(session, invalidateCache);
     const validSubscriberId = '12345';
     const validSecretKey = session.environment.apiKeys[0].key;
     let hmacHash;
@@ -88,8 +96,14 @@ async function initWidgetSession(subscriberId: string, session, hmacHash?: strin
   });
 }
 
-async function setHmacConfig(session: UserSession) {
+async function setHmacConfig(session: UserSession, invalidateCache: InvalidateCacheService) {
   const integrationRepository = new IntegrationRepository();
+
+  await invalidateCache.invalidateQuery({
+    key: buildIntegrationKey().invalidate({
+      _organizationId: session.organization._id,
+    }),
+  });
 
   await integrationRepository.update(
     {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.base.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.base.ts
@@ -48,13 +48,6 @@ export abstract class SendMessageBase extends SendMessageType {
     });
   }
 
-  @CachedQuery({
-    builder: ({ environmentId, ...command }: GetDecryptedIntegrationsCommand) =>
-      buildIntegrationKey().cache({
-        _environmentId: environmentId,
-        ...command,
-      }),
-  })
   protected async getIntegration(
     selectIntegrationCommand: SelectIntegrationCommand
   ): Promise<IntegrationEntity | undefined> {

--- a/packages/application-generic/src/services/cache/key-builders/queries.ts
+++ b/packages/application-generic/src/services/cache/key-builders/queries.ts
@@ -84,22 +84,26 @@ const buildMessageCountKey = () => {
 
 const buildIntegrationKey = () => {
   const cache = (
-    command: Record<string, unknown> & { _environmentId: string }
+    command: Record<string, unknown> & { _organizationId: string }
   ): string =>
-    buildQueryByEnvironmentKey({
+    buildQueryByOrganizationKey({
       type: CacheKeyTypeEnum.QUERY,
       keyEntity: CacheKeyPrefixEnum.INTEGRATION,
-      environmentId: command._environmentId,
-      environmentIdPrefix: OrgScopePrefixEnum.ENVIRONMENT_ID,
+      organizationId: command._organizationId,
+      organizationIdPrefix: OrgScopePrefixEnum.ORGANIZATION_ID,
       query: command,
     });
 
-  const invalidate = ({ _environmentId }: { _environmentId: string }): string =>
-    buildKeyByEnvironment({
+  const invalidate = ({
+    _organizationId,
+  }: {
+    _organizationId: string;
+  }): string =>
+    buildKeyByOrganization({
       type: CacheKeyTypeEnum.QUERY,
       keyEntity: CacheKeyPrefixEnum.INTEGRATION,
-      environmentId: _environmentId,
-      environmentIdPrefix: OrgScopePrefixEnum.ENVIRONMENT_ID,
+      organizationId: _organizationId,
+      organizationIdPrefix: OrgScopePrefixEnum.ORGANIZATION_ID,
     });
 
   return {
@@ -134,38 +138,40 @@ export const buildQueryKey = ({
     identifier,
   })}:${QUERY_PREFIX}=${JSON.stringify(query)}`;
 
-export const buildQueryByEnvironmentKey = ({
+export const buildQueryByOrganizationKey = ({
   type,
   keyEntity,
-  environmentIdPrefix = OrgScopePrefixEnum.ENVIRONMENT_ID,
-  environmentId,
+  organizationIdPrefix = OrgScopePrefixEnum.ORGANIZATION_ID,
+  organizationId,
   query,
 }: {
   type: CacheKeyTypeEnum;
   keyEntity: CacheKeyPrefixEnum;
-  environmentIdPrefix?: OrgScopePrefixEnum;
-  environmentId: string;
+  organizationIdPrefix?: OrgScopePrefixEnum;
+  organizationId: string;
   query: Record<string, unknown>;
 }): string =>
-  `${buildKeyByEnvironment({
+  `${buildKeyByOrganization({
     type,
     keyEntity,
-    environmentIdPrefix,
-    environmentId,
+    organizationIdPrefix,
+    organizationId,
   })}:${QUERY_PREFIX}=${JSON.stringify(query)}`;
 
-const buildKeyByEnvironment = ({
+const buildKeyByOrganization = ({
   type,
   keyEntity,
-  environmentIdPrefix = OrgScopePrefixEnum.ENVIRONMENT_ID,
-  environmentId,
+  organizationIdPrefix = OrgScopePrefixEnum.ORGANIZATION_ID,
+  organizationId,
 }: {
   type: CacheKeyTypeEnum;
   keyEntity: CacheKeyPrefixEnum;
-  environmentIdPrefix?: OrgScopePrefixEnum;
-  environmentId: string;
+  organizationIdPrefix?: OrgScopePrefixEnum;
+  organizationId: string;
 }): string =>
-  prefixWrapper(`${type}:${keyEntity}:${environmentIdPrefix}=${environmentId}`);
+  prefixWrapper(
+    `${type}:${keyEntity}:${organizationIdPrefix}=${organizationId}`
+  );
 
 export interface IBuildNotificationTemplateByIdentifier {
   _environmentId: string;

--- a/packages/application-generic/src/usecases/select-integration/select-integration.usecase.ts
+++ b/packages/application-generic/src/usecases/select-integration/select-integration.usecase.ts
@@ -7,6 +7,7 @@ import {
 } from '../get-novu-integration';
 import { SelectIntegrationCommand } from './select-integration.command';
 import { decryptCredentials } from '../../encryption';
+import { buildIntegrationKey, CachedQuery } from '../../services';
 
 @Injectable()
 export class SelectIntegration {
@@ -15,6 +16,13 @@ export class SelectIntegration {
     private getNovuIntegration: GetNovuIntegration
   ) {}
 
+  @CachedQuery({
+    builder: ({ organizationId, ...command }: SelectIntegrationCommand) =>
+      buildIntegrationKey().cache({
+        _organizationId: organizationId,
+        ...command,
+      }),
+  })
   async execute(
     command: SelectIntegrationCommand
   ): Promise<IntegrationEntity | undefined> {


### PR DESCRIPTION
### What change does this PR introduce?

We would like to apply the caching mechanism over the Integration Selection use-case. The rationale is that the integration configurations should not be changing really often.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
