### PR TITLE
feat(api): update the post, put integration endpoints to allow passing the name, identifier, skip passing credentials

### DIFF
--- a/apps/api/src/app/integrations/dtos/create-integration-request.dto.ts
+++ b/apps/api/src/app/integrations/dtos/create-integration-request.dto.ts
@@ -1,11 +1,27 @@
-import { IsBoolean, IsDefined, IsEnum, IsString, ValidateNested } from 'class-validator';
-import { ChannelTypeEnum, ICreateIntegrationBodyDto } from '@novu/shared';
-import { CredentialsDto } from './credentials.dto';
-import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsDefined, IsEnum, IsMongoId, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
+import { ChannelTypeEnum, ICreateIntegrationBodyDto } from '@novu/shared';
+
+import { CredentialsDto } from './credentials.dto';
 
 export class CreateIntegrationRequestDto implements ICreateIntegrationBodyDto {
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  identifier?: string;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsMongoId()
+  _environmentId?: string;
+
+  @ApiProperty({ type: String })
   @IsDefined()
   @IsString()
   providerId: string;
@@ -17,21 +33,21 @@ export class CreateIntegrationRequestDto implements ICreateIntegrationBodyDto {
   @IsEnum(ChannelTypeEnum)
   channel: ChannelTypeEnum;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: CredentialsDto,
   })
-  @IsDefined()
+  @IsOptional()
   @Type(() => CredentialsDto)
   @ValidateNested()
-  credentials: CredentialsDto;
+  credentials?: CredentialsDto;
 
-  @ApiProperty()
+  @ApiPropertyOptional({ type: Boolean })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+
+  @ApiPropertyOptional({ type: Boolean })
   @IsDefined()
   @IsBoolean()
-  active: boolean;
-
-  @ApiProperty()
-  @IsDefined()
-  @IsBoolean()
-  check: boolean;
+  check?: boolean;
 }

--- a/apps/api/src/app/integrations/dtos/integration-response.dto.ts
+++ b/apps/api/src/app/integrations/dtos/integration-response.dto.ts
@@ -12,6 +12,12 @@ export class IntegrationResponseDto {
   @ApiProperty()
   _organizationId: string;
 
+  @ApiProperty({ type: String })
+  name: string;
+
+  @ApiProperty({ type: String })
+  identifier: string;
+
   @ApiProperty()
   providerId: string;
 

--- a/apps/api/src/app/integrations/dtos/update-integration.dto.ts
+++ b/apps/api/src/app/integrations/dtos/update-integration.dto.ts
@@ -1,25 +1,40 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IUpdateIntegrationBodyDto } from '@novu/shared';
-import { IsBoolean, IsDefined, ValidateNested } from 'class-validator';
+import { IsBoolean, IsDefined, IsMongoId, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { CredentialsDto } from './credentials.dto';
 import { Type } from 'class-transformer';
 
 export class UpdateIntegrationRequestDto implements IUpdateIntegrationBodyDto {
-  @ApiProperty()
-  @IsDefined()
-  @IsBoolean()
-  active: boolean;
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  name?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  identifier?: string;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsMongoId()
+  _environmentId?: string;
+
+  @ApiPropertyOptional({ type: Boolean })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+
+  @ApiPropertyOptional({
     type: CredentialsDto,
   })
-  @IsDefined()
+  @IsOptional()
   @Type(() => CredentialsDto)
   @ValidateNested()
-  credentials: CredentialsDto;
+  credentials?: CredentialsDto;
 
-  @ApiProperty()
+  @ApiPropertyOptional({ type: Boolean })
   @IsDefined()
   @IsBoolean()
-  check: boolean;
+  check?: boolean;
 }

--- a/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
@@ -1,4 +1,4 @@
-import { IntegrationRepository, IntegrationEntity } from '@novu/dal';
+import { IntegrationRepository, EnvironmentRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
 import { ChannelTypeEnum, EmailProviderIdEnum, SmsProviderIdEnum } from '@novu/shared';
 import { expect } from 'chai';
@@ -6,13 +6,14 @@ import { expect } from 'chai';
 describe('Create Integration - /integration (POST)', function () {
   let session: UserSession;
   const integrationRepository = new IntegrationRepository();
+  const envRepository = new EnvironmentRepository();
 
   beforeEach(async () => {
     session = new UserSession();
     await session.initialize();
   });
 
-  it('should create the email integration successfully', async function () {
+  it('should get the email integration successfully', async function () {
     const integrations = (await session.testAgent.get(`/v1/integrations`)).body.data;
 
     const emailIntegrations = integrations.filter(
@@ -30,7 +31,7 @@ describe('Create Integration - /integration (POST)', function () {
     }
   });
 
-  it('should create the sms integration successfully', async function () {
+  it('should get the sms integration successfully', async function () {
     const integrations = (await session.testAgent.get(`/v1/integrations`)).body.data;
 
     const smsIntegrations = integrations.filter(
@@ -48,57 +49,120 @@ describe('Create Integration - /integration (POST)', function () {
     }
   });
 
-  it('should return error on creation of same provider on same environment twice', async function () {
+  it('should allow creating the same provider on same environment twice', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
     const payload = {
-      providerId: 'sendgrid',
-      channel: 'email',
+      name: EmailProviderIdEnum.SendGrid,
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
       credentials: { apiKey: '123', secretKey: 'abc' },
       active: true,
       check: false,
     };
 
-    const secondInsertResponse = await insertIntegrationTwice(session, payload, false);
+    await insertIntegrationTwice(session, payload, false);
 
-    expect(secondInsertResponse.body.message).to.contain('Duplicate key');
+    const integrations = (await session.testAgent.get(`/v1/integrations`)).body.data;
+
+    const sendgridIntegrations = integrations.filter(
+      (integration) =>
+        integration.channel === payload.channel &&
+        integration._environmentId === session.environment._id &&
+        integration.providerId === EmailProviderIdEnum.SendGrid
+    );
+
+    expect(sendgridIntegrations.length).to.eql(2);
+
+    for (const integration of sendgridIntegrations) {
+      expect(integration.name).to.equal(payload.name);
+      expect(integration.identifier).to.exist;
+      expect(integration.providerId).to.equal(EmailProviderIdEnum.SendGrid);
+      expect(integration.channel).to.equal(ChannelTypeEnum.EMAIL);
+      expect(integration.credentials.apiKey).to.equal(payload.credentials.apiKey);
+      expect(integration.credentials.secretKey).to.equal(payload.credentials.secretKey);
+      expect(integration.active).to.equal(payload.active);
+    }
   });
 
-  it('should fail due missing param', async function () {
+  it('should not allow to create integration with same identifier', async function () {
     const payload = {
-      providerId: 'sendgrid',
-      channel: 'email',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      identifier: 'identifier',
+      active: false,
+      check: false,
+    };
+    await integrationRepository.create({
+      name: 'Test',
+      identifier: payload.identifier,
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const { body } = await session.testAgent.post('/v1/integrations').send(payload);
+
+    expect(body.statusCode).to.equal(400);
+    expect(body.message).to.equal('Integration with identifier already exists');
+  });
+
+  it('should not allow to activate the integration without the credentials', async function () {
+    const payload = {
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
       active: true,
       check: false,
     };
 
-    const body = (await session.testAgent.post('/v1/integrations').send(payload)).body.data as IntegrationEntity;
+    const { body } = await session.testAgent.post('/v1/integrations').send(payload);
 
-    expect(body).to.equal(undefined);
+    expect(body.statusCode).to.equal(400);
+    expect(body.message).to.equal('The credentials are required to activate the integration');
   });
 
-  it('should deactivated old providers', async function () {
+  it('should allow creating the integration with minimal data', async function () {
     const payload = {
-      providerId: 'mailgun',
-      channel: 'email',
-      credentials: { apiKey: '123', secretKey: 'abc' },
-      active: true,
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
       check: false,
     };
 
-    const environmentId = (await session.testAgent.get(`/v1/integrations`)).body.data[0]._environmentId;
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
 
-    await session.testAgent.post('/v1/integrations').send(payload);
+    expect(data.name).to.equal('SendGrid');
+    expect(data.identifier).to.exist;
+    expect(data.providerId).to.equal(EmailProviderIdEnum.SendGrid);
+    expect(data.channel).to.equal(ChannelTypeEnum.EMAIL);
+    expect(data.active).to.equal(false);
+  });
 
-    const integrations = await integrationRepository.findByEnvironmentId(environmentId);
+  it('should allow creating the integration for different environment', async function () {
+    const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+    const payload = {
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      _environmentId: prodEnv?._id,
+      check: false,
+    };
 
-    const firstIntegration = integrations.find(
-      (i) => i.providerId.toString() === EmailProviderIdEnum.SendGrid && i._environmentId === session.environment._id
-    );
-    const secondIntegration = integrations.find(
-      (i) => i.providerId.toString() === EmailProviderIdEnum.Mailgun && i._environmentId === session.environment._id
-    );
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
 
-    expect(firstIntegration?.active).to.equal(false);
-    expect(secondIntegration?.active).to.equal(true);
+    expect(data.name).to.equal('SendGrid');
+    expect(data._environmentId).to.equal(prodEnv?._id);
+    expect(data.identifier).to.exist;
+    expect(data.providerId).to.equal(EmailProviderIdEnum.SendGrid);
+    expect(data.channel).to.equal(ChannelTypeEnum.EMAIL);
+    expect(data.active).to.equal(false);
   });
 
   it('should create custom SMTP integration with TLS options successfully', async function () {
@@ -116,27 +180,17 @@ describe('Create Integration - /integration (POST)', function () {
       check: false,
     };
 
-    const environmentId = (await session.testAgent.get(`/v1/integrations`)).body.data[0]._environmentId;
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
 
-    await session.testAgent.post('/v1/integrations').send(payload);
-
-    const integrations = await integrationRepository.findByEnvironmentId(environmentId);
-
-    const sendGridIntegration = integrations.find(
-      (i) => i.providerId.toString() === EmailProviderIdEnum.SendGrid && i._environmentId === session.environment._id
-    );
-    const nodeMailerIntegration = integrations.find(
-      (i) => i.providerId.toString() === EmailProviderIdEnum.CustomSMTP && i._environmentId === session.environment._id
-    );
-
-    expect(sendGridIntegration?.active).to.equal(false);
-    expect(nodeMailerIntegration?.credentials?.host).to.equal(payload.credentials.host);
-    expect(nodeMailerIntegration?.credentials?.port).to.equal(payload.credentials.port);
-    expect(nodeMailerIntegration?.credentials?.secure).to.equal(payload.credentials.secure);
-    expect(nodeMailerIntegration?.credentials?.requireTls).to.equal(payload.credentials.requireTls);
-    expect(nodeMailerIntegration?.credentials?.tlsOptions).to.instanceOf(Object);
-    expect(nodeMailerIntegration?.credentials?.tlsOptions).to.eql(payload.credentials.tlsOptions);
-    expect(nodeMailerIntegration?.active).to.equal(true);
+    expect(data.credentials?.host).to.equal(payload.credentials.host);
+    expect(data.credentials?.port).to.equal(payload.credentials.port);
+    expect(data.credentials?.secure).to.equal(payload.credentials.secure);
+    expect(data.credentials?.requireTls).to.equal(payload.credentials.requireTls);
+    expect(data.credentials?.tlsOptions).to.instanceOf(Object);
+    expect(data.credentials?.tlsOptions).to.eql(payload.credentials.tlsOptions);
+    expect(data.active).to.equal(true);
   });
 });
 

--- a/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
@@ -1,11 +1,12 @@
-import { IntegrationRepository } from '@novu/dal';
+import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
 
 describe('Update Integration - /integrations/:integrationId (PUT)', function () {
   let session: UserSession;
   const integrationRepository = new IntegrationRepository();
+  const envRepository = new EnvironmentRepository();
 
   beforeEach(async () => {
     session = new UserSession();
@@ -36,48 +37,126 @@ describe('Update Integration - /integrations/:integrationId (PUT)', function () 
     expect(integration.credentials.secretKey).to.equal(payload.credentials.secretKey);
   });
 
-  it('should deactivate other providers on the same channel', async function () {
-    const firstProviderPayload = {
-      providerId: 'sendgrid',
+  it('should not allow to update the integration with same identifier', async function () {
+    const identifier2 = 'identifier2';
+    const integrationOne = await integrationRepository.create({
+      name: 'Test1',
+      identifier: 'identifier1',
+      providerId: EmailProviderIdEnum.SendGrid,
       channel: ChannelTypeEnum.EMAIL,
-      credentials: { apiKey: '123', secretKey: 'abc' },
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+    await integrationRepository.create({
+      name: 'Test2',
+      identifier: identifier2,
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+    const payload = {
+      identifier: identifier2,
+      check: false,
+    };
+
+    const { body } = await session.testAgent.put(`/v1/integrations/${integrationOne._id}`).send(payload);
+
+    expect(body.statusCode).to.equal(400);
+    expect(body.message).to.equal('Integration with identifier already exists');
+  });
+
+  it('should not allow to activate the integration without the credentials', async function () {
+    const integrationOne = await integrationRepository.create({
+      name: 'Test1',
+      identifier: 'identifier1',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
       active: true,
       check: false,
     };
-    const secondProviderPayload = {
-      providerId: 'mailgun',
+
+    const { body } = await session.testAgent.put(`/v1/integrations/${integrationOne._id}`).send(payload);
+
+    expect(body.statusCode).to.equal(400);
+    expect(body.message).to.equal('The credentials are required to activate the integration');
+  });
+
+  it('should allow updating the integration with just identifier', async function () {
+    const integrationOne = await integrationRepository.create({
+      name: 'Test',
+      identifier: 'identifier',
+      providerId: EmailProviderIdEnum.SendGrid,
       channel: ChannelTypeEnum.EMAIL,
-      credentials: { apiKey: '123', secretKey: 'abc' },
       active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      identifier: 'identifier2',
       check: false,
     };
 
-    // create integrations
-    await session.testAgent.post('/v1/integrations').send(firstProviderPayload);
-    const mailgunIntegrationId = (await session.testAgent.post('/v1/integrations').send(secondProviderPayload)).body
-      .data._id;
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${integrationOne._id}`).send(payload);
 
-    // create irrelevant channel -> should not be affected by the update
-    firstProviderPayload.channel = ChannelTypeEnum.SMS;
-    await session.testAgent.post('/v1/integrations').send(firstProviderPayload);
+    expect(data.identifier).to.eq(payload.identifier);
+  });
 
-    // update second integration
-    secondProviderPayload.active = true;
-    await session.testAgent.put(`/v1/integrations/${mailgunIntegrationId}`).send(secondProviderPayload);
+  it('should allow updating the integration with just name', async function () {
+    const integrationOne = await integrationRepository.create({
+      name: 'Test',
+      identifier: 'identifier',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
 
-    const integrations = await integrationRepository.findByEnvironmentId(session.environment._id);
+    const payload = {
+      name: 'Test2',
+      check: false,
+    };
 
-    const firstProviderIntegration = integrations.find(
-      (i) => i.providerId.toString() === 'sendgrid' && i.channel.toString() === ChannelTypeEnum.EMAIL
-    );
-    const secondProviderIntegration = integrations.find((i) => i.providerId.toString() === 'mailgun');
-    const irrelevantProviderIntegration = integrations.find(
-      (i) => i.providerId.toString() === 'sendgrid' && i.channel.toString() === ChannelTypeEnum.SMS
-    );
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${integrationOne._id}`).send(payload);
 
-    expect(firstProviderIntegration.active).to.equal(false);
-    expect(secondProviderIntegration.active).to.equal(true);
-    expect(irrelevantProviderIntegration.active).to.equal(true);
+    expect(data.name).to.eq(payload.name);
+  });
+
+  it('should allow updating the integration with just environment', async function () {
+    const integrationOne = await integrationRepository.create({
+      name: 'Test',
+      identifier: 'identifier',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+    const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+    const payload = {
+      _environmentId: prodEnv?._id,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${integrationOne._id}`).send(payload);
+
+    expect(data._environmentId).to.equal(prodEnv?._id);
   });
 
   it('should update custom SMTP integration with TLS options successfully', async function () {

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -134,13 +134,15 @@ export class IntegrationsController {
     return await this.createIntegrationUsecase.execute(
       CreateIntegrationCommand.create({
         userId: user._id,
-        environmentId: user.environmentId,
+        name: body.name,
+        identifier: body.identifier,
+        environmentId: body._environmentId ?? user.environmentId,
         organizationId: user.organizationId,
         providerId: body.providerId,
         channel: body.channel,
         credentials: body.credentials,
-        active: body.active,
-        check: body.check,
+        active: body.active ?? false,
+        check: body.check ?? true,
       })
     );
   }
@@ -163,12 +165,14 @@ export class IntegrationsController {
     return this.updateIntegrationUsecase.execute(
       UpdateIntegrationCommand.create({
         userId: user._id,
-        environmentId: user.environmentId,
+        name: body.name,
+        identifier: body.identifier,
+        environmentId: body._environmentId,
         organizationId: user.organizationId,
         integrationId,
         credentials: body.credentials,
         active: body.active,
-        check: body.check,
+        check: body.check ?? true,
       })
     );
   }

--- a/apps/api/src/app/integrations/usecases/check-integration/check-integration-email.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/check-integration/check-integration-email.usecase.ts
@@ -10,10 +10,10 @@ export class CheckIntegrationEMail {
     const mailHandler = mailFactory.getHandler(
       {
         channel: command.channel,
-        credentials: command.credentials,
+        credentials: command.credentials ?? {},
         providerId: command.providerId,
       },
-      command.credentials.from
+      command.credentials?.from
     );
 
     return await mailHandler.check();

--- a/apps/api/src/app/integrations/usecases/check-integration/check-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/check-integration/check-integration.command.ts
@@ -6,8 +6,10 @@ export class CheckIntegrationCommand extends EnvironmentCommand {
   @IsDefined()
   @IsString()
   providerId: string;
+
   @IsDefined()
   channel: ChannelTypeEnum;
+
   @IsDefined()
-  credentials: ICredentials;
+  credentials?: ICredentials;
 }

--- a/apps/api/src/app/integrations/usecases/create-integration/create-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/create-integration/create-integration.command.ts
@@ -1,22 +1,32 @@
-import { IsDefined } from 'class-validator';
+import { IsDefined, IsEnum, IsOptional, IsString } from 'class-validator';
 import { ChannelTypeEnum, ICredentialsDto } from '@novu/shared';
 
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class CreateIntegrationCommand extends EnvironmentCommand {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  identifier?: string;
+
   @IsDefined()
+  @IsString()
   providerId: string;
 
   @IsDefined()
+  @IsEnum(ChannelTypeEnum)
   channel: ChannelTypeEnum;
 
-  @IsDefined()
-  credentials: ICredentialsDto;
+  @IsOptional()
+  credentials?: ICredentialsDto;
 
-  @IsDefined()
+  @IsOptional()
   active: boolean;
 
-  @IsDefined()
+  @IsOptional()
   check: boolean;
 
   @IsDefined()

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
@@ -1,19 +1,29 @@
-import { IsDefined } from 'class-validator';
+import { IsDefined, IsMongoId, IsOptional, IsString } from 'class-validator';
 import { ICredentialsDto } from '@novu/shared';
-import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
-export class UpdateIntegrationCommand extends EnvironmentCommand {
-  @IsDefined()
-  userId: string;
+import { OrganizationCommand } from '../../../shared/commands/organization.command';
+
+export class UpdateIntegrationCommand extends OrganizationCommand {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  identifier?: string;
+
+  @IsOptional()
+  @IsMongoId()
+  environmentId?: string;
 
   @IsDefined()
   integrationId: string;
 
-  @IsDefined()
-  credentials: ICredentialsDto;
+  @IsOptional()
+  credentials?: ICredentialsDto;
 
-  @IsDefined()
-  active: boolean;
+  @IsOptional()
+  active?: boolean;
 
   @IsDefined()
   check: boolean;

--- a/libs/dal/src/repositories/integration/integration.entity.ts
+++ b/libs/dal/src/repositories/integration/integration.entity.ts
@@ -19,9 +19,9 @@ export class IntegrationEntity {
 
   active: boolean;
 
-  name?: string;
+  name: string;
 
-  identifier?: string;
+  identifier: string;
 
   deleted: boolean;
 

--- a/libs/dal/src/repositories/integration/integration.repository.ts
+++ b/libs/dal/src/repositories/integration/integration.repository.ts
@@ -33,15 +33,6 @@ export class IntegrationRepository extends BaseRepository<IntegrationDBModel, In
   }
 
   async create(data: IntegrationQuery): Promise<IntegrationEntity> {
-    const existingIntegration = await this.findOne({
-      _environmentId: data._environmentId,
-      providerId: data.providerId,
-      channel: data.channel,
-    });
-    if (existingIntegration) {
-      throw new DalException('Duplicate key - One environment may not have two providers of the same channel type');
-    }
-
     return await super.create(data);
   }
 

--- a/libs/shared/src/consts/providers/channels/in-app.ts
+++ b/libs/shared/src/consts/providers/channels/in-app.ts
@@ -8,7 +8,7 @@ import { ChannelTypeEnum } from '../../../types';
 export const inAppProviders: IProviderConfig[] = [
   {
     id: InAppProviderIdEnum.Novu,
-    displayName: 'Notification Center',
+    displayName: 'Novu In-App',
     channel: ChannelTypeEnum.IN_APP,
     credentials: novuInAppConfig,
     docReference: 'https://docs.novu.co/notification-center/getting-started',

--- a/libs/shared/src/dto/integration/construct-integration.interface.ts
+++ b/libs/shared/src/dto/integration/construct-integration.interface.ts
@@ -1,9 +1,13 @@
 import { ICredentials } from '../../entities/integration';
+import type { EnvironmentId } from '../../types';
 
 export type ICredentialsDto = ICredentials;
 
 export interface IConstructIntegrationDto {
-  credentials: ICredentialsDto;
-
-  active: boolean;
+  name?: string;
+  identifier?: string;
+  _environmentId?: EnvironmentId;
+  credentials?: ICredentialsDto;
+  active?: boolean;
+  check?: boolean;
 }

--- a/libs/shared/src/dto/integration/create-integration.dto.ts
+++ b/libs/shared/src/dto/integration/create-integration.dto.ts
@@ -4,6 +4,5 @@ import { ChannelTypeEnum } from '../../types';
 
 export interface ICreateIntegrationBodyDto extends IConstructIntegrationDto {
   providerId: string;
-
   channel: ChannelTypeEnum;
 }


### PR DESCRIPTION
### What change does this PR introduce?

Updated the `POST /v1/integrations` endpoint: 
- to allow passing individually `name, identifier, environmentId`
- skipping `credentials`
- inactive by default
- the only required fields are: `providerId, channel`

Updated the `PUT /v1/integrations` endpoint: 
- to allow passing individually `name, identifier, environmentId`
- skipping `credentials`

Added e2e tests that are covering the current state.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
