### PR TITLE
refactor: marked the old notification-temlates controller, usecases a…

### DIFF
--- a/apps/api/src/app/notification-template/notification-template.controller.ts
+++ b/apps/api/src/app/notification-template/notification-template.controller.ts
@@ -43,7 +43,7 @@ import { CreateNotificationTemplateQuery } from './queries';
 @Controller('/notification-templates')
 @UseInterceptors(ClassSerializerInterceptor)
 @UseGuards(JwtAuthGuard)
-@ApiTags('Workflows')
+@ApiTags('Notification Templates')
 export class NotificationTemplateController {
   constructor(
     private getNotificationTemplatesUsecase: GetNotificationTemplates,
@@ -59,6 +59,7 @@ export class NotificationTemplateController {
   @ApiOperation({
     summary: 'Get workflows',
     description: `Workflows were previously named notification templates`,
+    deprecated: true,
   })
   @ExternalApiAccessible()
   getNotificationTemplates(
@@ -81,6 +82,7 @@ export class NotificationTemplateController {
   @ApiOperation({
     summary: 'Update workflow',
     description: `Workflow was previously named notification template`,
+    deprecated: true,
   })
   @ExternalApiAccessible()
   async updateTemplateById(
@@ -115,6 +117,7 @@ export class NotificationTemplateController {
   @ApiOperation({
     summary: 'Delete workflow',
     description: `Workflow was previously named notification template`,
+    deprecated: true,
   })
   @ExternalApiAccessible()
   deleteTemplateById(@UserSession() user: IJwtPayload, @Param('templateId') templateId: string): Promise<boolean> {
@@ -133,6 +136,7 @@ export class NotificationTemplateController {
   @ApiOperation({
     summary: 'Get workflow',
     description: `Workflow was previously named notification template`,
+    deprecated: true,
   })
   @ExternalApiAccessible()
   getNotificationTemplateById(
@@ -156,6 +160,7 @@ export class NotificationTemplateController {
   @ApiOperation({
     summary: 'Create workflow',
     description: `Workflow was previously named notification template`,
+    deprecated: true,
   })
   @Roles(MemberRoleEnum.ADMIN)
   createNotificationTemplates(
@@ -190,6 +195,7 @@ export class NotificationTemplateController {
   @ApiOperation({
     summary: 'Update workflow status',
     description: `Workflow was previously named notification template`,
+    deprecated: true,
   })
   @ExternalApiAccessible()
   changeActiveStatus(

--- a/apps/api/src/app/notification-template/notification-template.controller.ts
+++ b/apps/api/src/app/notification-template/notification-template.controller.ts
@@ -57,8 +57,8 @@ export class NotificationTemplateController {
   @Get('')
   @ApiResponse(NotificationTemplateResponse)
   @ApiOperation({
-    summary: 'Get workflows',
-    description: `Workflows were previously named notification templates`,
+    summary: 'Get Notification templates',
+    description: `Notification templates have been renamed to Workflows, Please use the new workflows controller`,
     deprecated: true,
   })
   @ExternalApiAccessible()
@@ -80,8 +80,8 @@ export class NotificationTemplateController {
   @Put('/:templateId')
   @ApiResponse(NotificationTemplateResponse)
   @ApiOperation({
-    summary: 'Update workflow',
-    description: `Workflow was previously named notification template`,
+    summary: 'Update Notification template',
+    description: `Notification templates have been renamed to Workflows, Please use the new workflows controller`,
     deprecated: true,
   })
   @ExternalApiAccessible()
@@ -115,8 +115,8 @@ export class NotificationTemplateController {
     type: DataBooleanDto,
   })
   @ApiOperation({
-    summary: 'Delete workflow',
-    description: `Workflow was previously named notification template`,
+    summary: 'Delete Notification template',
+    description: `Notification templates have been renamed to Workflows, Please use the new workflows controller`,
     deprecated: true,
   })
   @ExternalApiAccessible()
@@ -134,8 +134,8 @@ export class NotificationTemplateController {
   @Get('/:templateId')
   @ApiResponse(NotificationTemplateResponse)
   @ApiOperation({
-    summary: 'Get workflow',
-    description: `Workflow was previously named notification template`,
+    summary: 'Get Notification template',
+    description: `Notification templates have been renamed to Workflows, Please use the new workflows controller`,
     deprecated: true,
   })
   @ExternalApiAccessible()
@@ -158,8 +158,8 @@ export class NotificationTemplateController {
   @UseGuards(RootEnvironmentGuard)
   @ApiResponse(NotificationTemplateResponse, 201)
   @ApiOperation({
-    summary: 'Create workflow',
-    description: `Workflow was previously named notification template`,
+    summary: 'Create Notification template',
+    description: `Notification templates have been renamed to Workflows, Please use the new workflows controller`,
     deprecated: true,
   })
   @Roles(MemberRoleEnum.ADMIN)
@@ -193,8 +193,8 @@ export class NotificationTemplateController {
   @Roles(MemberRoleEnum.ADMIN)
   @ApiResponse(NotificationTemplateResponse)
   @ApiOperation({
-    summary: 'Update workflow status',
-    description: `Workflow was previously named notification template`,
+    summary: 'Update Notification template status',
+    description: `Notification templates have been renamed to Workflows, Please use the new workflows controller`,
     deprecated: true,
   })
   @ExternalApiAccessible()

--- a/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.command.ts
+++ b/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.command.ts
@@ -1,6 +1,11 @@
 import { IsBoolean, IsDefined, IsMongoId } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
+/**
+ * DEPRECATED:
+ * This command is deprecated and will be removed in the future.
+ * Please use the ChangeWorkflowActiveStatusCommand instead.
+ */
 export class ChangeTemplateActiveStatusCommand extends EnvironmentWithUserCommand {
   @IsBoolean()
   @IsDefined()

--- a/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/change-template-active-status/change-template-active-status.usecase.ts
@@ -10,6 +10,11 @@ import {
 import { ChangeTemplateActiveStatusCommand } from './change-template-active-status.command';
 import { CreateChange, CreateChangeCommand } from '../../../change/usecases';
 
+/**
+ * DEPRECATED:
+ * This usecase is deprecated and will be removed in the future.
+ * Please use the ChangeWorkflowActiveStatus usecase instead.
+ */
 @Injectable()
 export class ChangeTemplateActiveStatus {
   constructor(

--- a/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.command.ts
+++ b/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.command.ts
@@ -21,6 +21,11 @@ import {
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { MessageTemplate } from '../../../shared/dtos/message-template';
 
+/**
+ * DEPRECATED:
+ * This command is deprecated and will be removed in the future.
+ * Please use the CreateWorkflowCommand instead.
+ */
 export class CreateNotificationTemplateCommand extends EnvironmentWithUserCommand {
   @IsMongoId()
   @IsDefined()

--- a/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/create-notification-template/create-notification-template.usecase.ts
@@ -18,6 +18,11 @@ import { CreateMessageTemplate, CreateMessageTemplateCommand } from '../../../me
 import { CreateChange, CreateChangeCommand } from '../../../change/usecases';
 import { ApiException } from '../../../shared/exceptions/api.exception';
 
+/**
+ * DEPRECATED:
+ * This usecase is deprecated and will be removed in the future.
+ * Please use the CreateWorkflow usecase instead.
+ */
 @Injectable()
 export class CreateNotificationTemplate {
   constructor(

--- a/apps/api/src/app/notification-template/usecases/delete-notification-template/delete-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/delete-notification-template/delete-notification-template.usecase.ts
@@ -15,6 +15,11 @@ import { DeleteMessageTemplateCommand } from '../../../message-template/usecases
 import { DeleteMessageTemplate } from '../../../message-template/usecases/delete-message-template/delete-message-template.usecase';
 import { GetNotificationTemplateCommand } from '../get-notification-template/get-notification-template.command';
 
+/**
+ * DEPRECATED:
+ * This usecase is deprecated and will be removed in the future.
+ * Please use the DeleteWorkflow usecase instead.
+ */
 @Injectable()
 export class DeleteNotificationTemplate {
   constructor(

--- a/apps/api/src/app/notification-template/usecases/get-notification-template/get-notification-template.command.ts
+++ b/apps/api/src/app/notification-template/usecases/get-notification-template/get-notification-template.command.ts
@@ -1,6 +1,11 @@
 import { IsDefined, IsMongoId } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
+/**
+ * DEPRECATED:
+ * This command is deprecated and will be removed in the future.
+ * Please use the GetWorkflowCommand instead.
+ */
 export class GetNotificationTemplateCommand extends EnvironmentWithUserCommand {
   @IsDefined()
   @IsMongoId()

--- a/apps/api/src/app/notification-template/usecases/get-notification-template/get-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/get-notification-template/get-notification-template.usecase.ts
@@ -2,6 +2,11 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { NotificationTemplateEntity, NotificationTemplateRepository } from '@novu/dal';
 import { GetNotificationTemplateCommand } from './get-notification-template.command';
 
+/**
+ * DEPRECATED:
+ * This usecase is deprecated and will be removed in the future.
+ * Please use the GetWorkflow usecase instead.
+ */
 @Injectable()
 export class GetNotificationTemplate {
   constructor(private notificationTemplateRepository: NotificationTemplateRepository) {}

--- a/apps/api/src/app/notification-template/usecases/get-notification-templates/get-notification-templates.command.ts
+++ b/apps/api/src/app/notification-template/usecases/get-notification-templates/get-notification-templates.command.ts
@@ -2,6 +2,11 @@ import { IsNumber } from 'class-validator';
 
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
+/**
+ * DEPRECATED:
+ * This command is deprecated and will be removed in the future.
+ * Please use the GetWorkflowsCommand instead.
+ */
 export class GetNotificationTemplatesCommand extends EnvironmentWithUserCommand {
   @IsNumber()
   page: number;

--- a/apps/api/src/app/notification-template/usecases/get-notification-templates/get-notification-templates.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/get-notification-templates/get-notification-templates.usecase.ts
@@ -2,6 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { NotificationTemplateRepository } from '@novu/dal';
 import { GetNotificationTemplatesCommand } from './get-notification-templates.command';
 import { NotificationTemplatesResponseDto } from '../../dto/notification-templates.response.dto';
+/**
+ * DEPRECATED:
+ * This usecase is deprecated and will be removed in the future.
+ * Please use the GetWorkflows usecase instead.
+ */
 @Injectable()
 export class GetNotificationTemplates {
   constructor(private notificationTemplateRepository: NotificationTemplateRepository) {}

--- a/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.command.ts
+++ b/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.command.ts
@@ -4,6 +4,11 @@ import { IPreferenceChannels } from '@novu/shared';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { NotificationStep } from '../create-notification-template';
 
+/**
+ * DEPRECATED:
+ * This command is deprecated and will be removed in the future.
+ * Please use the UpdateWorkflowCommand instead.
+ */
 export class UpdateNotificationTemplateCommand extends EnvironmentWithUserCommand {
   @IsDefined()
   @IsMongoId()

--- a/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.usecase.ts
+++ b/apps/api/src/app/notification-template/usecases/update-notification-template/update-notification-template.usecase.ts
@@ -30,6 +30,11 @@ import { NotificationStep } from '../create-notification-template';
 import { DeleteMessageTemplate } from '../../../message-template/usecases/delete-message-template/delete-message-template.usecase';
 import { DeleteMessageTemplateCommand } from '../../../message-template/usecases/delete-message-template/delete-message-template.command';
 
+/**
+ * DEPRECATED:
+ * This usecase is deprecated and will be removed in the future.
+ * Please use the UpdateWorkflow usecase instead.
+ */
 @Injectable()
 export class UpdateNotificationTemplate {
   constructor(


### PR DESCRIPTION

### What change does this PR introduce?
- Marked the old files inside the old notification-templates controller as `deprecated`
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
<img width="1511" alt="image" src="https://github.com/novuhq/novu/assets/29251776/49d8c3f3-22ea-42b8-9c3d-239c40e46c88">


This PR is a part of stacked PRs
- https://github.com/novuhq/novu/pull/3704
- https://github.com/novuhq/novu/pull/3703
- https://github.com/novuhq/novu/pull/3702
- https://github.com/novuhq/novu/pull/3701
