### PR TITLE
feat: add name field to update sidebar

### DIFF
--- a/apps/web/src/pages/integrations/UpdateProviderPage.tsx
+++ b/apps/web/src/pages/integrations/UpdateProviderPage.tsx
@@ -227,7 +227,13 @@ export function UpdateProviderPage() {
             }}
             render={({ field }) => (
               <InputWrapper>
-                <Input {...field} required label="Name" error={errors.name?.message} />
+                <Input
+                  {...field}
+                  value={field.value ? field.value : selectedProvider?.displayName}
+                  required
+                  label="Name"
+                  error={errors.name?.message}
+                />
               </InputWrapper>
             )}
           />

--- a/apps/web/src/pages/integrations/UpdateProviderPage.tsx
+++ b/apps/web/src/pages/integrations/UpdateProviderPage.tsx
@@ -220,6 +220,19 @@ export function UpdateProviderPage() {
           />
           <Controller
             control={control}
+            name="name"
+            defaultValue={''}
+            rules={{
+              required: 'Required - Instance name',
+            }}
+            render={({ field }) => (
+              <InputWrapper>
+                <Input {...field} required label="Name" error={errors.name?.message} />
+              </InputWrapper>
+            )}
+          />
+          <Controller
+            control={control}
             name="identifier"
             defaultValue={''}
             rules={{


### PR DESCRIPTION
### What change does this PR introduce?

UX consistency in the product. We display the Input "Name" of a Workflow in the WF settings. 
Input "Name" is displayed in the update integration sidebar
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
<img width="501" alt="Screen Shot 2023-07-04 at 14 59 31" src="https://github.com/novuhq/novu/assets/7778680/c2fc466f-9199-460b-86a4-7c69ed5771a2">

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
