### PR TITLE
NV-3571 - 🐛 Bug Report: tls options should be hidden when ignore tls has been selected and default value should be {}.

### DIFF
--- a/apps/web/src/pages/integrations/components/ConnectIntegrationForm.tsx
+++ b/apps/web/src/pages/integrations/components/ConnectIntegrationForm.tsx
@@ -155,20 +155,22 @@ export function ConnectIntegrationForm({
         } catch (err) {
           throw new Error('Invalid JSON format for TLS Options');
         }
-      }
-      if (createModel) {
-        await createIntegrationApi({
-          providerId: provider?.providerId ? provider?.providerId : '',
-          channel: provider?.channel ? provider?.channel : null,
-          credentials,
-          active: isActive,
-          check: checkIntegrationState.check,
-        });
       } else {
-        await updateIntegrationApi({
-          integrationId: provider?.integrationId ? provider?.integrationId : '',
-          data: { credentials, active: isActive, check: checkIntegrationState.check },
-        });
+        credentials.tlsOptions = undefined;
+        if (createModel) {
+          await createIntegrationApi({
+            providerId: provider?.providerId ? provider?.providerId : '',
+            channel: provider?.channel ? provider?.channel : null,
+            credentials,
+            active: isActive,
+            check: checkIntegrationState.check,
+          });
+        } else {
+          await updateIntegrationApi({
+            integrationId: provider?.integrationId ? provider?.integrationId : '',
+            data: { credentials, active: isActive, check: checkIntegrationState.check },
+          });
+        }
       }
     } catch (e: any) {
       dispatch({
@@ -241,7 +243,13 @@ export function ConnectIntegrationForm({
                 name={credential.key}
                 control={control}
                 render={({ field }) => (
-                  <IntegrationInput credential={credential} errors={errors} field={field} register={register} />
+                  <IntegrationInput
+                    credential={credential}
+                    ignoreTls={watch('ignoreTls')}
+                    errors={errors}
+                    field={field}
+                    register={register}
+                  />
                 )}
               />
             </InputWrapper>

--- a/apps/web/src/pages/integrations/components/IntegrationInput.tsx
+++ b/apps/web/src/pages/integrations/components/IntegrationInput.tsx
@@ -7,11 +7,13 @@ export function IntegrationInput({
   errors,
   field,
   register,
+  ignoreTls,
 }: {
   credential: IConfigCredentials;
   errors: any;
   field: any;
   register?: any;
+  ignoreTls?: boolean;
 }) {
   if (isNeededToHide(credential.key)) {
     if (credential.type === 'text') {
@@ -96,18 +98,22 @@ export function IntegrationInput({
   }
 
   return (
-    <Input
-      label={credential.displayName}
-      required={credential.required}
-      placeholder={credential.displayName}
-      description={credential.description ?? ''}
-      data-test-id={credential.key}
-      error={errors[credential.key]?.message}
-      {...field}
-      {...register?.(credential.key, {
-        required: credential.required && `Please enter a ${credential.displayName.toLowerCase()}`,
-      })}
-    />
+    <>
+      {credential.key === 'tlsOptions' && ignoreTls ? null : (
+        <Input
+          label={credential.displayName}
+          required={credential.required}
+          placeholder={credential.displayName}
+          description={credential.description ?? ''}
+          data-test-id={credential.key}
+          error={errors[credential.key]?.message}
+          {...field}
+          {...register(credential.key, {
+            required: credential.required && `Please enter a ${credential.displayName.toLowerCase()}`,
+          })}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
### What Change Does this PR introduce?

`tlsOptions` field will be disabled when the `ignoreTls` switch is true. Also the error `credentials.tlsOptions must be an object` is resolved by making `tlsOptions` field's value `undefined` when the field's value is falsy  

### Why was this change needed?
Closes: https://github.com/novuhq/novu/issues/3571

### Additional Information
https://www.loom.com/share/bb4d767f95f449d6be57338b1d523e99?sid=a14d36ef-3b4c-43c7-8b1a-4de05abd6d7a

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
