### PR TITLE
fix: aggregation of events by digest key, fix nested digest key

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events-backoff.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events-backoff.usecase.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { JobStatusEnum } from '@novu/dal';
-import { StepTypeEnum } from '@novu/shared';
-import { InstrumentUsecase } from '@novu/application-generic';
+import { IDigestRegularMetadata, StepTypeEnum } from '@novu/shared';
+import { DigestFilterSteps, InstrumentUsecase } from '@novu/application-generic';
 
 import { SendMessageCommand } from '../send-message.command';
 import { GetDigestEvents } from './get-digest-events.usecase';
@@ -14,6 +14,10 @@ export class GetDigestEventsBackoff extends GetDigestEvents {
     const currentJob = await this.jobRepository.findOne({ _environmentId: command.environmentId, _id: command.jobId });
     if (!currentJob) throw new PlatformException('Digest job is not found');
 
+    const digestMeta = currentJob.digest as IDigestRegularMetadata | undefined;
+    const digestKey = digestMeta?.digestKey;
+    const digestValue = DigestFilterSteps.getNestedValue(currentJob.payload, digestKey);
+
     const jobs = await this.jobRepository.find({
       createdAt: {
         $gte: currentJob.createdAt,
@@ -22,6 +26,7 @@ export class GetDigestEventsBackoff extends GetDigestEvents {
       status: JobStatusEnum.COMPLETED,
       type: StepTypeEnum.TRIGGER,
       _environmentId: command.environmentId,
+      ...(digestKey && { [`payload.${digestKey}`]: digestValue }),
       // backward compatibility - ternary needed to be removed once the queue renewed
       _subscriberId: command._subscriberId ? command._subscriberId : command.subscriberId,
     });

--- a/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events-regular.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events-regular.usecase.ts
@@ -2,7 +2,7 @@
 import { Injectable } from '@nestjs/common';
 import { sub } from 'date-fns';
 import { IDigestRegularMetadata } from '@novu/shared';
-import { InstrumentUsecase } from '@novu/application-generic';
+import { DigestFilterSteps, InstrumentUsecase } from '@novu/application-generic';
 
 import { PlatformException } from '../../../../shared/utils';
 import { SendMessageCommand } from '../send-message.command';
@@ -29,12 +29,17 @@ export class GetDigestEventsRegular extends GetDigestEvents {
       [digestMeta?.unit]: amount,
     });
 
+    const digestKey = digestMeta?.digestKey;
+    const digestValue = DigestFilterSteps.getNestedValue(currentJob.payload, digestKey);
+
     const jobs = await this.jobRepository.findJobsToDigest(
       earliest,
       currentJob._templateId,
       command.environmentId,
       // backward compatibility - ternary needed to be removed once the queue renewed
-      command._subscriberId ? command._subscriberId : command.subscriberId
+      command._subscriberId ? command._subscriberId : command.subscriberId,
+      digestKey,
+      digestValue
     );
 
     return this.filterJobs(currentJob, command.transactionId, jobs);

--- a/libs/dal/src/repositories/job/job.repository.ts
+++ b/libs/dal/src/repositories/job/job.repository.ts
@@ -74,7 +74,14 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
     }
   }
 
-  public async findJobsToDigest(from: Date, templateId: string, environmentId: string, subscriberId: string) {
+  public async findJobsToDigest(
+    from: Date,
+    templateId: string,
+    environmentId: string,
+    subscriberId: string,
+    digestKey?: string,
+    digestValue?: string | number
+  ) {
     /**
      * Remove digest jobs that have been completed and currently delayed jobs that have a digest pending.
      */
@@ -101,6 +108,7 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
       type: StepTypeEnum.TRIGGER,
       _environmentId: environmentId,
       _subscriberId: subscriberId,
+      ...(digestKey && { [`payload.${digestKey}`]: digestValue }),
       transactionId: {
         $nin: transactionIds,
       },

--- a/packages/application-generic/src/usecases/digest-filter-steps/digest-filter-steps.usecase.ts
+++ b/packages/application-generic/src/usecases/digest-filter-steps/digest-filter-steps.usecase.ts
@@ -74,11 +74,11 @@ export class DigestFilterSteps {
     }
 
     try {
-      let result;
+      let result = payload;
       const keys = path.split('.');
 
       for (const key of keys) {
-        result = payload[key];
+        result = result[key];
       }
 
       return result;


### PR DESCRIPTION
### What change does this PR introduce?

1. **Fix - digestKey events don't aggregate the digested payloads**:
The digested events were added only for the first digestKey runs. All other digestKeys had the first event payload but marked all the others as digested.

For example: 
digestKey: 1 , trigger 3 times. get one email with the payload of all 3 triggers (as expected) 
digestKey: 2 , trigger 3 times. get only one email with the payload of only the first trigger

2. **Fix - no digestKey functionality for a nested digestKey path**
Giving a nested path for the digestKey value resulted in the normal digest behaviour, ignores the digest key values


Fix bug of digestKey 
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
