### PR TITLE
Release Helm Chart to charts branch

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -11,9 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: stefanprodan/helm-gh-pages@master
+      - uses: stefanprodan/helm-gh-pages@v1.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: "docker/kubernetes"
           branch: charts
-          dependencies: bitnami=oci://registry-1.docker.io/bitnamicharts;localstack=https://localstack.github.io/helm-charts

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -1,0 +1,19 @@
+name: Release Helm Chart
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: "docker/kubernetes"
+          branch: charts
+          dependencies: bitnami=oci://registry-1.docker.io/bitnamicharts;localstack=https://localstack.github.io/helm-charts


### PR DESCRIPTION

### What change does this PR introduce?

Use the branch charts as a helm repo.

### Why was this change needed?

This is how to install nuvo via helmet without cloning the github repo

### Other information (Screenshots)

The branch could additionally be published via github pages.
