### PR TITLE
fix: k8s component labels hard coded

### DIFF
--- a/docker/kubernetes/helm/templates/api/deployment.yaml
+++ b/docker/kubernetes/helm/templates/api/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ printf "%s-%s" .Release.Name "api"  }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: novu-api
+    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "api"  }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -20,14 +20,14 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: novu-api
+      app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "api"  }}
   template:
     metadata:
       {{- if .Values.api.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.api.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: novu-api
+        app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "api"  }}
         {{- if .Values.api.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.api.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/docker/kubernetes/helm/templates/web/deployment.yaml
+++ b/docker/kubernetes/helm/templates/web/deployment.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ printf "%s-%s" .Release.Name "web"  }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: novu-web
+    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "web"  }}
+
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -20,14 +21,14 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: novu-web
+      app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "web"  }}
   template:
     metadata:
       {{- if .Values.web.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.web.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: novu-web
+        app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "web"  }}
         {{- if .Values.web.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.web.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/docker/kubernetes/helm/templates/worker/deployment.yaml
+++ b/docker/kubernetes/helm/templates/worker/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ printf "%s-%s" .Release.Name "worker"  }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: novu-worker
+    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "worker"  }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -20,14 +20,14 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: novu-worker
+      app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "worker"  }}
   template:
     metadata:
       {{- if .Values.worker.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: novu-worker
+        app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "worker"  }}
         {{- if .Values.worker.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/docker/kubernetes/helm/templates/ws/deployment.yaml
+++ b/docker/kubernetes/helm/templates/ws/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ printf "%s-%s" .Release.Name "ws"  }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: novu-ws
+    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "ws"  }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -20,14 +20,14 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: novu-ws
+      app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "ws"  }}
   template:
     metadata:
       {{- if .Values.ws.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.ws.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: novu-ws
+        app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "ws"  }}
         {{- if .Values.ws.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.ws.podLabels "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
### What change does this PR introduce?

In the k8s chart, the labels "app.kubernetes.io/component" are now generated, taking into account the ".Release.Name". 

### Why was this change needed?

If the release name did not correspond to "novu", the selector labels of the services were wrong.
