### PR TITLE
fix: helm values.yaml missing web endpoints

### DIFF
--- a/docker/kubernetes/helm/values.yaml
+++ b/docker/kubernetes/helm/values.yaml
@@ -1560,6 +1560,13 @@ web:
   ##
   port: 4200
 
+  ## @param web.apiExternalEndpoint The external endpoint of the API
+  ##
+  apiExternalEndpoint: http://localhost:3000
+
+  ## @param web.wsExternalEndpoint The external websocket endpoint of the API
+  wsExternalEndpoint: ws://localhost:3002
+  
 ## @section Persistence Parameters
 ##
 


### PR DESCRIPTION
### What change does this PR introduce?

In the values.yaml, the configuration for the points that are used by the web deployment is missing.

### Why was this change needed?

Due to its absence, the API cannot always be accessed from the web component.

