### PR TITLE
fix: web deployment using wrong NODE_ENV

### DIFF
--- a/docker/kubernetes/helm/templates/web/deployment.yaml
+++ b/docker/kubernetes/helm/templates/web/deployment.yaml
@@ -92,7 +92,7 @@ spec:
           {{- end }}
           env:
             - name: REACT_APP_ENVIRONMENT
-              value : {{ print .Values.api.env.NODE_ENV | quote }}
+              value : {{ print .Values.web.env.NODE_ENV | quote }}
             - name: REACT_APP_DOCKER_HOSTED_ENV
               value : "true"
             - name: API_ROOT_URL


### PR DESCRIPTION
### What change does this PR introduce?

### Why was this change needed?
The web deployment accesses the node_env variable of the api and not its own.

