### PR TITLE
fix: digest and delay values are reset to default values on update

### DIFF
--- a/apps/web/cypress/tests/notification-editor/create-notification.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/create-notification.spec.ts
@@ -225,6 +225,39 @@ describe('Creation functionality', function () {
     cy.getByTestId('trigger-code-snippet').contains('customVariable:');
   });
 
+  it('should not reset action steps values on update', function () {
+    cy.waitLoadTemplatePage(() => {
+      cy.visit('/workflows/create');
+    });
+
+    dragAndDrop('digest');
+    cy.waitForNetworkIdle(500);
+
+    cy.clickWorkflowNode('node-digestSelector');
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId('digest-send-options').click();
+    cy.getByTestId('time-amount').clear().type('30');
+    cy.getByTestId('time-unit').click();
+    cy.get('.mantine-Select-item').contains('sec (s)').click();
+
+    cy.getByTestId('digest-group-by-options').click();
+
+    cy.getByTestId('batch-key').type('id');
+
+    cy.getByTestId('digest-send-options').click();
+
+    cy.clickWorkflowNode('node-digestSelector');
+    cy.getByTestId('notification-template-submit-btn').click();
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId('digest-send-options').click();
+
+    cy.getByTestId('time-amount').should('have.value', '30');
+    cy.getByTestId('batch-key').should('have.value', 'id');
+    cy.getByTestId('time-unit').should('have.value', 'sec (s)');
+  });
+
   it('should add digest node', function () {
     cy.waitLoadTemplatePage(() => {
       cy.visit('/workflows/create');

--- a/apps/web/src/pages/templates/components/TemplateEditorFormProvider.tsx
+++ b/apps/web/src/pages/templates/components/TemplateEditorFormProvider.tsx
@@ -192,10 +192,8 @@ const TemplateEditorFormProvider = ({ children }) => {
           },
         });
         setTrigger(response.triggers[0]);
-        reset({
-          ...form,
-          steps: response.steps,
-        });
+        reset(mapNotificationTemplateToForm(response));
+
         if (showMessage) {
           successMessage('Trigger code is updated successfully', 'workflowSaved');
         }


### PR DESCRIPTION
### What change does this PR introduce?

fix - update resets to default values of digest or delay metadata.

Reproducing steps: 
1. add digest step
2. change any value of regular digest
3. click update 

https://www.loom.com/share/038f03d3f7ab4695b70636e69c5be858
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

The problem was that we reset the steps in the form from the response we got from the update. We have different field names for the digest metadata in the backend vs the frontend. 
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
