### PR TITLE
fix: remove undefined ip pool name

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -452,6 +452,7 @@ export const createMailData = (options: IEmailOptions, overrides: Record<string,
   let to = Array.isArray(options.to) ? options.to : [options.to];
   to = [...to, ...(overrides?.to || [])];
   to = to.reduce(filterDuplicate, []);
+  const ipPoolName = overrides?.ipPoolName ? { ipPoolName: overrides?.ipPoolName } : {};
 
   return {
     ...options,
@@ -460,7 +461,7 @@ export const createMailData = (options: IEmailOptions, overrides: Record<string,
     text: overrides?.text,
     cc: overrides?.cc || [],
     bcc: overrides?.bcc || [],
-    ipPoolName: overrides?.ipPoolName,
+    ...ipPoolName,
   };
 };
 

--- a/providers/sendgrid/src/lib/sendgrid.provider.ts
+++ b/providers/sendgrid/src/lib/sendgrid.provider.ts
@@ -70,7 +70,7 @@ export class SendgridEmailProvider implements IEmailProvider {
         email: options.from || this.config.from,
         name: this.config.senderName,
       },
-      ipPoolName: options.ipPoolName || this.config.ipPoolName,
+      ...this.getIpPoolObject(options),
       to: options.to.map((email) => ({ email })),
       cc: options.cc?.map((ccItem) => ({ email: ccItem })),
       bcc: options.bcc?.map((ccItem) => ({ email: ccItem })),
@@ -99,6 +99,12 @@ export class SendgridEmailProvider implements IEmailProvider {
     }
 
     return mailData as MailDataRequired;
+  }
+
+  private getIpPoolObject(options: IEmailOptions) {
+    const ipPoolNameValue = options.ipPoolName || this.config.ipPoolName;
+
+    return ipPoolNameValue ? { ipPoolName: ipPoolNameValue } : {};
   }
 
   getMessageId(body: any | any[]): string[] {


### PR DESCRIPTION
### What change does this PR introduce?

remove the option to set ip pool name with an undefined/empty string.

### Why was this change needed?

send grid does not support nulish value for the ip pool name and throws an exception.
my mistake in adding the support and not validating the full flow properly.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
