### PR TITLE
fix(worker): fixed the fcm data message issue with payload messed with additional data

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
@@ -24,6 +24,7 @@ import {
   CompileTemplateCommand,
   PushFactory,
 } from '@novu/application-generic';
+import type { IPushOptions } from '@novu/stateless';
 
 import { CreateLog } from '../../../shared/logs';
 import { SendMessageCommand } from './send-message.command';
@@ -59,13 +60,14 @@ export class SendMessagePush extends SendMessageBase {
 
     const pushChannel: NotificationStepEntity = command.step;
 
+    const stepData: IPushOptions['step'] = {
+      digest: !!command.events?.length,
+      events: command.events,
+      total_count: command.events?.length,
+    };
     const data = {
       subscriber: subscriber,
-      step: {
-        digest: !!command.events?.length,
-        events: command.events,
-        total_count: command.events?.length,
-      },
+      step: stepData,
       ...command.payload,
     };
     let content = '';
@@ -147,7 +149,17 @@ export class SendMessagePush extends SendMessageBase {
 
       const overrides = command.overrides[integration.providerId] || {};
 
-      await this.sendMessage(integration, channel.credentials.deviceTokens, title, content, command, data, overrides);
+      await this.sendMessage(
+        subscriber,
+        integration,
+        channel.credentials.deviceTokens,
+        title,
+        content,
+        command,
+        command.payload,
+        overrides,
+        stepData
+      );
     }
   }
 
@@ -165,13 +177,15 @@ export class SendMessagePush extends SendMessageBase {
   }
 
   private async sendMessage(
+    subscriber: IPushOptions['subscriber'],
     integration: IntegrationEntity,
     target: string[],
     title: string,
     content: string,
     command: SendMessageCommand,
     payload: object,
-    overrides: object
+    overrides: object,
+    step: IPushOptions['step']
   ) {
     const message: MessageEntity = await this.messageRepository.create({
       _notificationId: command.notificationId,
@@ -217,6 +231,8 @@ export class SendMessagePush extends SendMessageBase {
         content,
         payload,
         overrides,
+        subscriber,
+        step,
       });
 
       await this.createExecutionDetails.execute(

--- a/packages/stateless/src/lib/provider/provider.interface.ts
+++ b/packages/stateless/src/lib/provider/provider.interface.ts
@@ -68,6 +68,12 @@ export interface IPushOptions {
     };
     fcmOptions?: { analyticsLabel?: string };
   };
+  subscriber: object;
+  step: {
+    digest: boolean;
+    events: object[] | undefined;
+    total_count: number | undefined;
+  };
 }
 
 export interface IChatOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3001,7 +3001,7 @@ importers:
   providers/one-signal:
     specifiers:
       '@istanbuljs/nyc-config-typescript': ~1.0.1
-      '@novu/stateless': ^0.13.0
+      '@novu/stateless': ^0.16.2
       '@types/jest': ~29.5.0
       cspell: ~6.19.2
       cz-conventional-changelog: ~3.3.0
@@ -3015,7 +3015,7 @@ importers:
       ts-node: ~10.9.1
       typescript: 4.9.5
     dependencies:
-      '@novu/stateless': 0.13.0
+      '@novu/stateless': link:../../packages/stateless
       onesignal-node: 3.4.0
     devDependencies:
       '@istanbuljs/nyc-config-typescript': 1.0.2_nyc@15.1.0
@@ -14921,15 +14921,6 @@ packages:
       lodash.merge: 4.6.2
     dev: false
 
-  /@novu/stateless/0.13.0:
-    resolution: {integrity: sha512-2MFsqJbFX4LL/4hPHavg2t/8YpTjLDw8AuP6hlzuHO4qKpFOw4A8509oM6wo9PMV4+z6W37itrbuXj9fbUb0AA==}
-    engines: {node: '>=10'}
-    dependencies:
-      handlebars: 4.7.7
-      lodash.get: 4.4.2
-      lodash.merge: 4.6.2
-    dev: false
-
   /@novu/stateless/0.15.0:
     resolution: {integrity: sha512-NS7n34dlEB48EthLek0NWZXh+nJtbOUVkWdyprGF2f/WCCG/wT+yUtYLOauMffrySpnXEjY9zimyGgIWJQRl0g==}
     engines: {node: '>=10'}
@@ -22382,7 +22373,7 @@ packages:
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
-      semver: 7.5.0
+      semver: 7.5.2
       tsutils: 3.21.0_typescript@4.9.5
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -22514,7 +22505,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.0
+      semver: 7.5.2
       tsutils: 3.21.0_typescript@4.9.5
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -30531,7 +30522,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
-      schema-utils: 3.1.2
+      schema-utils: 3.1.1
       webpack: 4.46.0
     dev: true
 
@@ -30542,7 +30533,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
-      schema-utils: 3.1.2
+      schema-utils: 3.1.1
       webpack: 5.78.0
 
   /file-loader/6.2.0_webpack@5.82.1:
@@ -34465,7 +34456,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_j6r65ghnzvzk7vhdh4hyogrm4a
+      ts-node: 10.9.1_wh2cnrlliuuxb2etxm2m3ttgna
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -44719,7 +44710,7 @@ packages:
       neo-async: 2.6.2
       sass: 1.61.0
       schema-utils: 3.1.1
-      semver: 7.5.0
+      semver: 7.5.2
       webpack: 5.82.1
     dev: false
 
@@ -45045,6 +45036,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: false
 
   /semver/7.5.2:
     resolution: {integrity: sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==}
@@ -46600,7 +46592,7 @@ packages:
       mime: 2.6.0
       qs: 6.11.1
       readable-stream: 3.6.2
-      semver: 7.5.0
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -48969,7 +48961,7 @@ packages:
       espree: 9.5.1
       esquery: 1.5.0
       lodash: 4.17.21
-      semver: 7.5.0
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/providers/expo/src/lib/expo.provider.spec.ts
+++ b/providers/expo/src/lib/expo.provider.spec.ts
@@ -21,6 +21,12 @@ test('should trigger expo correctly', async () => {
     payload: {
       sound: 'test_sound',
     },
+    subscriber: {},
+    step: {
+      digest: false,
+      events: [{}],
+      total_count: 1,
+    },
   });
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error

--- a/providers/fcm/src/lib/fcm.provider.spec.ts
+++ b/providers/fcm/src/lib/fcm.provider.spec.ts
@@ -1,8 +1,16 @@
+import { IPushOptions } from '@novu/stateless';
 import app from 'firebase-admin/app';
+
 import { FcmPushProvider } from './fcm.provider';
 
 let provider: FcmPushProvider;
 let spy: jest.SpyInstance;
+const subscriber = {};
+const step: IPushOptions['step'] = {
+  digest: false,
+  events: [{}],
+  total_count: 1,
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -32,6 +40,8 @@ test('should trigger fcm correctly', async () => {
     payload: {
       sound: 'test_sound',
     },
+    subscriber,
+    step,
   });
   expect(app.initializeApp).toHaveBeenCalledTimes(1);
   expect(app.cert).toHaveBeenCalledTimes(1);
@@ -59,6 +69,8 @@ test('should trigger fcm with fcm options override', async () => {
         analyticsLabel: 'my-label',
       },
     },
+    subscriber,
+    step,
   });
   expect(app.initializeApp).toHaveBeenCalledTimes(1);
   expect(app.cert).toHaveBeenCalledTimes(1);
@@ -96,6 +108,8 @@ test('should trigger fcm with android override', async () => {
         },
       },
     },
+    subscriber,
+    step,
   });
   expect(app.initializeApp).toHaveBeenCalledTimes(1);
   expect(app.cert).toHaveBeenCalledTimes(1);
@@ -142,6 +156,8 @@ test('should trigger fcm with apns (ios) override', async () => {
         },
       },
     },
+    subscriber,
+    step,
   });
   expect(app.initializeApp).toHaveBeenCalledTimes(1);
   expect(app.cert).toHaveBeenCalledTimes(1);
@@ -194,6 +210,8 @@ test('should trigger fcm data for ios with headers options', async () => {
         },
       },
     },
+    subscriber,
+    step,
   });
   expect(app.initializeApp).toHaveBeenCalledTimes(1);
   expect(app.cert).toHaveBeenCalledTimes(1);
@@ -239,6 +257,8 @@ test('should trigger fcm data for android with priority option', async () => {
         priority: 'high',
       },
     },
+    subscriber,
+    step,
   });
   expect(app.initializeApp).toHaveBeenCalledTimes(1);
   expect(app.cert).toHaveBeenCalledTimes(1);
@@ -255,5 +275,51 @@ test('should trigger fcm data for android with priority option', async () => {
       key_1: 'val_1',
       key_2: 'val_2',
     },
+  });
+});
+
+test('should clean the payload for the FCM data message', async () => {
+  const payload = {
+    foo: 'bar',
+    one: 1,
+    isActive: true,
+    object: { asd: 'asd' },
+  };
+  const cleanPayload = {
+    foo: 'bar',
+    one: '1',
+    isActive: 'true',
+    object: '{"asd":"asd"}',
+  };
+
+  await provider.sendMessage({
+    title: 'Test',
+    content: 'Test push',
+    target: ['tester'],
+    payload,
+    overrides: {
+      type: 'data',
+      android: {
+        data: {
+          for_android: 'only',
+        },
+        priority: 'high',
+      },
+    },
+    subscriber,
+    step,
+  });
+  expect(app.initializeApp).toHaveBeenCalledTimes(1);
+  expect(app.cert).toHaveBeenCalledTimes(1);
+  expect(spy).toHaveBeenCalled();
+  expect(spy).toHaveBeenCalledWith({
+    tokens: ['tester'],
+    android: {
+      data: {
+        for_android: 'only',
+      },
+      priority: 'high',
+    },
+    data: cleanPayload,
   });
 });

--- a/providers/fcm/src/lib/fcm.provider.spec.ts
+++ b/providers/fcm/src/lib/fcm.provider.spec.ts
@@ -235,6 +235,8 @@ test('should trigger fcm data for ios with headers options', async () => {
     data: {
       key_1: 'val_1',
       key_2: 'val_2',
+      title: 'Test',
+      body: 'Test push',
     },
   });
 });
@@ -274,6 +276,8 @@ test('should trigger fcm data for android with priority option', async () => {
     data: {
       key_1: 'val_1',
       key_2: 'val_2',
+      title: 'Test',
+      body: 'Test push',
     },
   });
 });
@@ -290,6 +294,8 @@ test('should clean the payload for the FCM data message', async () => {
     one: '1',
     isActive: 'true',
     object: '{"asd":"asd"}',
+    title: 'Test',
+    body: 'Test push',
   };
 
   await provider.sendMessage({

--- a/providers/fcm/src/lib/fcm.provider.ts
+++ b/providers/fcm/src/lib/fcm.provider.ts
@@ -49,6 +49,7 @@ export class FcmPushProvider implements IPushProvider {
     delete (options.overrides as { deviceTokens?: string[] })?.deviceTokens;
 
     const overridesData = options.overrides || ({} as any);
+    const payload = this.cleanPayload(options.payload);
 
     const androidData: AndroidConfig = overridesData.android;
     const apnsData: ApnsConfig = overridesData.apns;
@@ -65,7 +66,7 @@ export class FcmPushProvider implements IPushProvider {
       delete (options.overrides as { type?: string })?.type;
       res = await this.messaging.sendMulticast({
         tokens: options.target,
-        data: options.payload as { [key: string]: string },
+        data: payload,
         ...(androidData ? { android: androidData } : {}),
         ...(apnsData ? { apns: apnsData } : {}),
         ...(fcmOptionsData ? { fcmOptions: fcmOptionsData } : {}),
@@ -108,5 +109,19 @@ export class FcmPushProvider implements IPushProvider {
       ),
       date: new Date().toISOString(),
     };
+  }
+
+  private cleanPayload(payload: object): Record<string, string> {
+    const cleanedPayload: Record<string, string> = {};
+
+    Object.keys(payload).forEach((key) => {
+      if (typeof payload[key] === 'string') {
+        cleanedPayload[key] = payload[key];
+      } else {
+        cleanedPayload[key] = JSON.stringify(payload[key]);
+      }
+    });
+
+    return cleanedPayload;
   }
 }

--- a/providers/fcm/src/lib/fcm.provider.ts
+++ b/providers/fcm/src/lib/fcm.provider.ts
@@ -26,7 +26,7 @@ export class FcmPushProvider implements IPushProvider {
       projectId: string;
       email: string;
       secretKey: string;
-    }
+    },
   ) {
     this.config = config;
     this.appName = crypto.randomBytes(32).toString();
@@ -38,13 +38,13 @@ export class FcmPushProvider implements IPushProvider {
           privateKey: this.config.secretKey,
         }),
       },
-      this.appName
+      this.appName,
     );
     this.messaging = getMessaging(firebase);
   }
 
   async sendMessage(
-    options: IPushOptions
+    options: IPushOptions,
   ): Promise<ISendMessageSuccessResponse> {
     delete (options.overrides as { deviceTokens?: string[] })?.deviceTokens;
 
@@ -94,7 +94,7 @@ export class FcmPushProvider implements IPushProvider {
       throw new Error(
         `Sending message failed due to "${
           res.responses.find((i) => i.success === false).error.message
-        }"`
+        }"`,
       );
     }
 
@@ -105,7 +105,7 @@ export class FcmPushProvider implements IPushProvider {
       ids: res?.responses?.map((response, index) =>
         response.success
           ? response.messageId
-          : `${response.error.message}. Invalid token:- ${options.target[index]}`
+          : `${response.error.message}. Invalid token:- ${options.target[index]}`,
       ),
       date: new Date().toISOString(),
     };

--- a/providers/fcm/src/lib/fcm.provider.ts
+++ b/providers/fcm/src/lib/fcm.provider.ts
@@ -26,7 +26,7 @@ export class FcmPushProvider implements IPushProvider {
       projectId: string;
       email: string;
       secretKey: string;
-    },
+    }
   ) {
     this.config = config;
     this.appName = crypto.randomBytes(32).toString();
@@ -38,13 +38,13 @@ export class FcmPushProvider implements IPushProvider {
           privateKey: this.config.secretKey,
         }),
       },
-      this.appName,
+      this.appName
     );
     this.messaging = getMessaging(firebase);
   }
 
   async sendMessage(
-    options: IPushOptions,
+    options: IPushOptions
   ): Promise<ISendMessageSuccessResponse> {
     delete (options.overrides as { deviceTokens?: string[] })?.deviceTokens;
 
@@ -66,7 +66,7 @@ export class FcmPushProvider implements IPushProvider {
       delete (options.overrides as { type?: string })?.type;
       res = await this.messaging.sendMulticast({
         tokens: options.target,
-        data: payload,
+        data: { ...payload, title: options.title, body: options.content },
         ...(androidData ? { android: androidData } : {}),
         ...(apnsData ? { apns: apnsData } : {}),
         ...(fcmOptionsData ? { fcmOptions: fcmOptionsData } : {}),
@@ -94,7 +94,7 @@ export class FcmPushProvider implements IPushProvider {
       throw new Error(
         `Sending message failed due to "${
           res.responses.find((i) => i.success === false).error.message
-        }"`,
+        }"`
       );
     }
 
@@ -105,7 +105,7 @@ export class FcmPushProvider implements IPushProvider {
       ids: res?.responses?.map((response, index) =>
         response.success
           ? response.messageId
-          : `${response.error.message}. Invalid token:- ${options.target[index]}`,
+          : `${response.error.message}. Invalid token:- ${options.target[index]}`
       ),
       date: new Date().toISOString(),
     };

--- a/providers/one-signal/package.json
+++ b/providers/one-signal/package.json
@@ -34,7 +34,7 @@
     "pnpm": "^7.26.0"
   },
   "dependencies": {
-    "@novu/stateless": "^0.13.0",
+    "@novu/stateless": "^0.16.2",
     "onesignal-node": "^3.4.0"
   },
   "devDependencies": {

--- a/providers/one-signal/src/lib/one-signal.provider.spec.ts
+++ b/providers/one-signal/src/lib/one-signal.provider.spec.ts
@@ -22,6 +22,12 @@ test('should trigger OneSignal library correctly', async () => {
     payload: {
       sound: 'test_sound',
     },
+    subscriber: {},
+    step: {
+      digest: false,
+      events: [{}],
+      total_count: 1,
+    },
   });
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error

--- a/providers/push-webhook/src/lib/push-webhook.provider.spec.ts
+++ b/providers/push-webhook/src/lib/push-webhook.provider.spec.ts
@@ -17,6 +17,9 @@ test('should trigger push-webhook library correctly', async () => {
     hmacSecretKey: 'super-secret-key',
   });
 
+  const subscriber = {};
+  const step = { digest: false, events: [{}], total_count: 1 };
+
   await provider.sendMessage({
     title: 'Test',
     content: 'Test push',
@@ -24,6 +27,8 @@ test('should trigger push-webhook library correctly', async () => {
     payload: {
       sound: 'test_sound',
     },
+    subscriber,
+    step,
   });
 
   expect(fakePost).toHaveBeenCalled();
@@ -35,13 +40,15 @@ test('should trigger push-webhook library correctly', async () => {
       target: ['tester'],
       payload: {
         sound: 'test_sound',
+        subscriber,
+        step,
       },
     }),
     {
       headers: {
         'content-type': 'application/json',
         'X-Novu-Signature':
-          '39350928c49e8a2bde72d29f43325e5d99291a756ced0f9034f7659cfd2c5d34',
+          'ebb2ff6420df59a863a6ddfa64ca8721cbbce038d5432c441cde83dee43b70d9',
       },
     }
   );

--- a/providers/push-webhook/src/lib/push-webhook.provider.ts
+++ b/providers/push-webhook/src/lib/push-webhook.provider.ts
@@ -15,18 +15,19 @@ export class PushWebhookPushProvider implements IPushProvider {
     private config: {
       hmacSecretKey?: string;
       webhookUrl: string;
-    },
+    }
   ) {}
 
   async sendMessage(
-    options: IPushOptions,
+    options: IPushOptions
   ): Promise<ISendMessageSuccessResponse> {
+    const { subscriber, step, payload, ...rest } = options;
     const bodyData = this.createBody({
-      ...options,
+      ...rest,
       payload: {
-        ...options.payload,
-        subscriber: options.subscriber,
-        step: options.step,
+        ...payload,
+        subscriber,
+        step,
       },
     });
     const hmacValue = this.computeHmac(bodyData);
@@ -44,7 +45,7 @@ export class PushWebhookPushProvider implements IPushProvider {
     };
   }
 
-  createBody(options: IPushOptions): string {
+  createBody(options: object): string {
     return JSON.stringify(options);
   }
 

--- a/providers/push-webhook/src/lib/push-webhook.provider.ts
+++ b/providers/push-webhook/src/lib/push-webhook.provider.ts
@@ -15,11 +15,11 @@ export class PushWebhookPushProvider implements IPushProvider {
     private config: {
       hmacSecretKey?: string;
       webhookUrl: string;
-    }
+    },
   ) {}
 
   async sendMessage(
-    options: IPushOptions
+    options: IPushOptions,
   ): Promise<ISendMessageSuccessResponse> {
     const bodyData = this.createBody({
       ...options,

--- a/providers/push-webhook/src/lib/push-webhook.provider.ts
+++ b/providers/push-webhook/src/lib/push-webhook.provider.ts
@@ -21,7 +21,14 @@ export class PushWebhookPushProvider implements IPushProvider {
   async sendMessage(
     options: IPushOptions
   ): Promise<ISendMessageSuccessResponse> {
-    const bodyData = this.createBody(options);
+    const bodyData = this.createBody({
+      ...options,
+      payload: {
+        ...options.payload,
+        subscriber: options.subscriber,
+        step: options.step,
+      },
+    });
     const hmacValue = this.computeHmac(bodyData);
 
     const response = await axios.post(this.config.webhookUrl, bodyData, {


### PR DESCRIPTION
### What change does this PR introduce?

The FCM data message `data` field should be a type of `Record<string, string>` otherwise the FCM platform will raise an error.

FCM docs:
https://firebase.google.com/docs/cloud-messaging/concept-options

https://firebase.google.com/docs/reference/admin/node/firebase-admin.messaging.basemessage.md#basemessage_interface

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

![Screenshot 2023-07-08 at 00 31 19](https://github.com/novuhq/novu/assets/2607232/44fa885a-b0da-4b72-b8be-0db8d41e2841)
![Screenshot 2023-07-08 at 00 31 08](https://github.com/novuhq/novu/assets/2607232/b05249f3-8f27-4d8b-85dd-e95eb69d7ede)


