### PR TITLE
fix(worker): set the proper argument order in the logger error function

### DIFF
--- a/apps/worker/src/app/shared/logs/create-log.usecase.ts
+++ b/apps/worker/src/app/shared/logs/create-log.usecase.ts
@@ -15,7 +15,7 @@ export class CreateLog {
       try {
         rawData = JSON.stringify(command.raw);
       } catch (error) {
-        Logger.error('Parsing raw data when creating a log failed', LOG_CONTEXT, error);
+        Logger.error('Parsing raw data when creating a log failed', error, LOG_CONTEXT);
       }
     }
 

--- a/apps/worker/src/app/workflow/services/metric-queue.service.ts
+++ b/apps/worker/src/app/workflow/services/metric-queue.service.ts
@@ -146,6 +146,6 @@ export class MetricQueueService extends QueueService<Record<string, never>> {
   }
 
   private async jobHasFailed(job, error): Promise<void> {
-    Logger.verbose('Metric job failed', LOG_CONTEXT, error);
+    Logger.verbose('Metric job failed', error, LOG_CONTEXT);
   }
 }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
@@ -116,7 +116,7 @@ export class SendMessageChat extends SendMessageBase {
          * Do nothing, one chat channel failed, perhaps another one succeeds
          * The failed message has been created
          */
-        Logger.error(`Sending chat message to the chat channel ${channel.providerId} failed`, LOG_CONTEXT);
+        Logger.error(`Sending chat message to the chat channel ${channel.providerId} failed`, e, LOG_CONTEXT);
       }
     }
 

--- a/packages/application-generic/src/services/analytics.service.ts
+++ b/packages/application-generic/src/services/analytics.service.ts
@@ -112,6 +112,7 @@ export class AnalyticsService {
         });
       } catch (error: any) {
         Logger.error(
+          'There has been an error when tracking',
           {
             eventName: name,
             usedId: userId,

--- a/packages/application-generic/src/services/cache/cache.service.ts
+++ b/packages/application-generic/src/services/cache/cache.service.ts
@@ -122,8 +122,8 @@ export class CacheService implements ICacheService {
     } catch (error) {
       Logger.error(
         `Failed to execute pipeline action ${action} for key ${key}`,
-        LOG_CONTEXT,
-        error
+        error,
+        LOG_CONTEXT
       );
       throw error;
     }

--- a/packages/application-generic/src/services/cache/interceptors/cached-entity.interceptor.ts
+++ b/packages/application-generic/src/services/cache/interceptors/cached-entity.interceptor.ts
@@ -38,8 +38,8 @@ export function CachedEntity({
       } catch (err) {
         Logger.error(
           `An error has occurred when extracting "key: ${cacheKey}" in "method: ${methodName}"`,
-          LOG_CONTEXT,
-          err
+          err,
+          LOG_CONTEXT
         );
       }
 
@@ -51,8 +51,8 @@ export function CachedEntity({
         // eslint-disable-next-line no-console
         Logger.error(
           `An error has occurred when inserting "key: ${cacheKey}" in "method: ${methodName}" with "value: ${response}"`,
-          LOG_CONTEXT,
-          err
+          err,
+          LOG_CONTEXT
         );
       }
 

--- a/packages/application-generic/src/services/cache/interceptors/cached-query.interceptor.ts
+++ b/packages/application-generic/src/services/cache/interceptors/cached-query.interceptor.ts
@@ -33,8 +33,8 @@ export function CachedQuery({ builder }: { builder: (...args) => string }) {
       } catch (err) {
         Logger.error(
           `An error has occurred when extracting "key: ${cacheKey}" in "method: ${methodName}"`,
-          LOG_CONTEXT,
-          err
+          err,
+          LOG_CONTEXT
         );
       }
 
@@ -45,8 +45,8 @@ export function CachedQuery({ builder }: { builder: (...args) => string }) {
       } catch (err) {
         Logger.error(
           `An error has occurred when inserting "key: ${cacheKey}" in "method: ${methodName}" with "value: ${response}"`,
-          LOG_CONTEXT,
-          err
+          err,
+          LOG_CONTEXT
         );
       }
 

--- a/packages/application-generic/src/services/cache/interceptors/cached.interceptor.ts
+++ b/packages/application-generic/src/services/cache/interceptors/cached.interceptor.ts
@@ -43,8 +43,8 @@ export function Cached(storeKeyPrefix: CacheKeyPrefixEnum) {
       } catch (err) {
         Logger.error(
           `An error has occurred when extracting "key: ${cacheKey}" in "method: ${methodName}"`,
-          LOG_CONTEXT,
-          err
+          err,
+          LOG_CONTEXT
         );
       }
 
@@ -55,8 +55,8 @@ export function Cached(storeKeyPrefix: CacheKeyPrefixEnum) {
       } catch (err) {
         Logger.error(
           `An error has occurred when inserting "key: ${cacheKey}" in "method: ${methodName}" with "value: ${response}"`,
-          LOG_CONTEXT,
-          err
+          err,
+          LOG_CONTEXT
         );
       }
 

--- a/packages/application-generic/src/services/cache/invalidate-cache.service.ts
+++ b/packages/application-generic/src/services/cache/invalidate-cache.service.ts
@@ -21,8 +21,8 @@ export class InvalidateCacheService {
     } catch (err) {
       Logger.error(
         `An error has occurred when deleting "key: ${key}",`,
-        LOG_CONTEXT,
-        err
+        err,
+        LOG_CONTEXT
       );
     }
   }
@@ -35,8 +35,8 @@ export class InvalidateCacheService {
     } catch (err) {
       Logger.error(
         `An error has occurred when deleting "key: ${key}",`,
-        LOG_CONTEXT,
-        err
+        err,
+        LOG_CONTEXT
       );
     }
   }
@@ -67,8 +67,8 @@ export class InvalidateCacheService {
     } catch (err) {
       Logger.error(
         `An error has occurred when deleting "key: ${cacheKey}",`,
-        LOG_CONTEXT,
-        err
+        err,
+        LOG_CONTEXT
       );
     }
   }

--- a/packages/application-generic/src/services/distributed-lock/distributed-lock.service.ts
+++ b/packages/application-generic/src/services/distributed-lock/distributed-lock.service.ts
@@ -57,7 +57,11 @@ export class DistributedLockService {
        * when an "error" event is emitted in the absence of listeners.
        */
       this.distributedLock.on('error', (error) => {
-        Logger.error(error, LOG_CONTEXT);
+        Logger.error(
+          'There has been an error in the Distributed Lock service',
+          error,
+          LOG_CONTEXT
+        );
       });
     }
   }

--- a/packages/application-generic/src/services/feature-flags.service.ts
+++ b/packages/application-generic/src/services/feature-flags.service.ts
@@ -45,8 +45,8 @@ export class FeatureFlagsService {
       } catch (error) {
         Logger.error(
           'Feature Flags service has failed when shut down',
-          LOG_CONTEXT,
-          error
+          error,
+          LOG_CONTEXT
         );
       }
     }
@@ -91,8 +91,8 @@ export class FeatureFlagsService {
       } catch (error) {
         Logger.error(
           'Feature Flags service has failed when initialized',
-          LOG_CONTEXT,
-          error
+          error,
+          LOG_CONTEXT
         );
       }
     }

--- a/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.ts
+++ b/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.ts
@@ -161,7 +161,11 @@ export class InMemoryProviderService {
             );
           });
         } catch (e) {
-          Logger.error(e);
+          Logger.error(
+            'Connecting to cluster executing intervals has failed',
+            e,
+            LOG_CONTEXT
+          );
         }
       }, 2000);
 
@@ -186,7 +190,11 @@ export class InMemoryProviderService {
       });
 
       inMemoryProviderClient.on('error', (error) => {
-        Logger.error(error, LOG_CONTEXT);
+        Logger.error(
+          'There has been an error in the InMemory Cluster provider client',
+          error,
+          LOG_CONTEXT
+        );
       });
 
       inMemoryProviderClient.on('ready', () => {
@@ -232,7 +240,11 @@ export class InMemoryProviderService {
       });
 
       inMemoryProviderClient.on('error', (error) => {
-        Logger.error(error, LOG_CONTEXT);
+        Logger.error(
+          'There has been an error in the InMemory provider client',
+          error,
+          LOG_CONTEXT
+        );
       });
 
       inMemoryProviderClient.on('ready', () => {

--- a/packages/application-generic/src/services/launch-darkly.service.ts
+++ b/packages/application-generic/src/services/launch-darkly.service.ts
@@ -82,8 +82,8 @@ export class LaunchDarklyService implements IFeatureFlagsService {
       } catch (error) {
         Logger.error(
           'Launch Darkly SDK has failed when shut down',
-          LOG_CONTEXT,
-          error
+          error,
+          LOG_CONTEXT
         );
         throw error;
       }
@@ -100,8 +100,8 @@ export class LaunchDarklyService implements IFeatureFlagsService {
     } catch (error) {
       Logger.error(
         'Launch Darkly SDK has failed when initialized',
-        LOG_CONTEXT,
-        error
+        error,
+        LOG_CONTEXT
       );
       throw error;
     }

--- a/packages/application-generic/src/services/readiness.service.ts
+++ b/packages/application-generic/src/services/readiness.service.ts
@@ -40,8 +40,8 @@ export class ReadinessService {
     } catch (error) {
       Logger.error(
         'Some health indicator throw an error when checking if queues are enabled',
-        LOG_CONTEXT,
-        error
+        error,
+        LOG_CONTEXT
       );
 
       return false;

--- a/packages/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
+++ b/packages/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
@@ -75,8 +75,9 @@ export class CreateNotificationJobs {
 
     if (!notification) {
       const message = 'Notification could not be created';
-      Logger.error(message, LOG_CONTEXT);
-      throw new PlatformException(message);
+      const error = new PlatformException(message);
+      Logger.error(message, error, LOG_CONTEXT);
+      throw error;
     }
 
     const jobs: NotificationJob[] = [];

--- a/packages/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
@@ -98,8 +98,9 @@ export class TriggerEvent {
      */
     if (!template) {
       const message = 'Notification template could not be found';
-      Logger.error(message, LOG_CONTEXT);
-      throw new ApiException(message);
+      const error = new ApiException(message);
+      Logger.error(message, error, LOG_CONTEXT);
+      throw error;
     }
 
     const templateProviderIds = await this.getProviderIdsForTemplate(


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Sets the proper order of the arguments for the usage of `Logger.error` from NestJS throughout our codebase.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
In a previous PR I spotted mixing order of usage of error and context params in the function. I corrected it after understanding the proper order that makes usage of the context. This will help debugging and error control and fix a bit of tech debt.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
