### PR TITLE
Remove attachments on last job execution only

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,6 +9,7 @@ RUN npm --no-update-notifier --no-fund --global install pnpm@7.28.0
 RUN pnpm --version
 
 WORKDIR /usr/src/app
+
 # ------- DEV BUILD ----------
 FROM dev_base AS dev
 ARG PACKAGE_PATH

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -77,7 +77,7 @@ export class RunJob {
       throw new PlatformException(error.message);
     } finally {
       if (shouldQueueNextJob) {
-        await this.queueNextJob.execute(
+        const newJob = await this.queueNextJob.execute(
           QueueNextJobCommand.create({
             parentId: job._id,
             environmentId: job._environmentId,
@@ -85,6 +85,14 @@ export class RunJob {
             userId: job._userId,
           })
         );
+
+        // Only remove the attachments if that is the last job
+        if (!newJob) {
+          await this.storageHelperService.deleteAttachments(job.payload?.attachments);
+        }
+      } else {
+        // Remove the attachments if the job should not be queued
+        await this.storageHelperService.deleteAttachments(job.payload?.attachments);
       }
     }
   }


### PR DESCRIPTION
### What change does this PR introduce?

Only remove attachments on the last job execution phase, or when a failure happened without retry.

### Why was this change needed?

In case of multiple nodes where the email is the last node, it would remove the attachments before the email will be sent. 

