### PR TITLE
feat(infra): consolidate usage of redis instance by bull-mq

### DIFF
--- a/apps/api/src/app/inbound-parse/services/inbound-parse.queue.service.ts
+++ b/apps/api/src/app/inbound-parse/services/inbound-parse.queue.service.ts
@@ -1,28 +1,14 @@
-import { Queue, QueueBaseOptions, Worker } from 'bullmq';
+import { Queue, Worker, WorkerOptions } from 'bullmq';
+import { BullMqService } from '@novu/application-generic';
 import { Injectable } from '@nestjs/common';
-import { getRedisPrefix } from '@novu/shared';
+
 import { InboundEmailParse } from '../usecases/inbound-email-parse/inbound-email-parse.usecase';
 import { InboundEmailParseCommand } from '../usecases/inbound-email-parse/inbound-email-parse.command';
-import { ConnectionOptions } from 'tls';
-import { BullMqService } from '@novu/application-generic';
 
 @Injectable()
 export class InboundParseQueueService {
   readonly QUEUE_NAME = 'inbound-parse-mail';
 
-  private bullConfig: QueueBaseOptions = {
-    connection: {
-      db: Number(process.env.REDIS_DB_INDEX),
-      port: Number(process.env.REDIS_PORT),
-      host: process.env.REDIS_HOST,
-      password: process.env.REDIS_PASSWORD,
-      connectTimeout: 50000,
-      keepAlive: 30000,
-      family: 4,
-      keyPrefix: getRedisPrefix(),
-      tls: process.env.REDIS_TLS as ConnectionOptions,
-    },
-  };
   public readonly queue: Queue;
   public readonly worker: Worker;
   private readonly bullMqService: BullMqService;
@@ -30,7 +16,6 @@ export class InboundParseQueueService {
   constructor(private emailParseUsecase: InboundEmailParse) {
     this.bullMqService = new BullMqService();
     this.queue = this.bullMqService.createQueue(this.QUEUE_NAME, {
-      ...this.bullConfig,
       defaultJobOptions: {
         removeOnComplete: true,
       },
@@ -39,9 +24,8 @@ export class InboundParseQueueService {
     this.worker = this.bullMqService.createWorker(this.QUEUE_NAME, this.getWorkerProcessor(), this.getWorkerOpts());
   }
 
-  private getWorkerOpts() {
+  private getWorkerOpts(): WorkerOptions {
     return {
-      ...this.bullConfig,
       lockDuration: 90000,
       concurrency: 200,
     };

--- a/apps/inbound-mail/src/server/queue-service.ts
+++ b/apps/inbound-mail/src/server/queue-service.ts
@@ -9,14 +9,8 @@ export class QueueService {
   private bullConfig: QueueBaseOptions = {
     connection: {
       db: Number(process.env.REDIS_DB_INDEX) ?? 2,
-      host: process.env.REDIS_HOST,
       port: Number(process.env.REDIS_PORT) ?? 6379,
-      password: process.env.REDIS_PASSWORD,
-      connectTimeout: 50000,
-      keepAlive: 30000,
-      family: 4,
       keyPrefix: process.env.REDIS_PREFIX ?? '',
-      tls: process.env.REDIS_TLS as ConnectionOptions,
     },
   };
   public readonly bullMqService: BullMqService;

--- a/apps/inbound-mail/src/server/queue-service.ts
+++ b/apps/inbound-mail/src/server/queue-service.ts
@@ -1,6 +1,5 @@
 import { BullMqService } from '@novu/application-generic';
-import { Queue, QueueBaseOptions } from 'bullmq';
-import { ConnectionOptions } from 'tls';
+import { QueueBaseOptions } from 'bullmq';
 
 export class QueueService {
   readonly DEFAULT_ATTEMPTS = 5;

--- a/apps/worker/src/app/workflow/services/metric-queue.service.ts
+++ b/apps/worker/src/app/workflow/services/metric-queue.service.ts
@@ -79,11 +79,10 @@ export class MetricQueueService extends QueueService<Record<string, never>> {
 
   private getWorkerOpts(): WorkerOptions {
     return {
-      ...this.bullConfig,
       lockDuration: 500,
       concurrency: 1,
       settings: {},
-    } as WorkerOptions;
+    };
   }
 
   private getWorkerProcessor() {

--- a/apps/worker/src/app/workflow/services/trigger-processor-queue.service.ts
+++ b/apps/worker/src/app/workflow/services/trigger-processor-queue.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { WorkerOptions } from 'bullmq';
 const nr = require('newrelic');
 import {
   INovuWorker,
@@ -19,9 +20,8 @@ export class TriggerProcessorQueueService extends TriggerQueueService implements
     this.bullMqService.createWorker(this.name, this.getWorkerProcessor(), this.getWorkerOpts());
   }
 
-  private getWorkerOpts() {
+  private getWorkerOpts(): WorkerOptions {
     return {
-      ...this.bullConfig,
       lockDuration: 90000,
       concurrency: 200,
     };

--- a/apps/worker/src/app/workflow/services/workflow-queue.service.spec.ts
+++ b/apps/worker/src/app/workflow/services/workflow-queue.service.spec.ts
@@ -92,7 +92,7 @@ describe('Workflow Queue service', () => {
 
   it('should be initialised properly', async () => {
     expect(queueService).to.be.ok;
-    expect(queueService).to.have.all.keys('DEFAULT_ATTEMPTS', 'bullConfig', 'bullMqService', 'name');
+    expect(queueService).to.have.all.keys('DEFAULT_ATTEMPTS', 'bullMqService', 'name');
     expect(queueService.DEFAULT_ATTEMPTS).to.eql(3);
     expect(queueService.bullMqService.queue).to.deep.include({
       _events: {},

--- a/apps/worker/src/app/workflow/services/workflow-queue.service.ts
+++ b/apps/worker/src/app/workflow/services/workflow-queue.service.ts
@@ -1,7 +1,7 @@
 const nr = require('newrelic');
 import { Job, WorkerOptions } from 'bullmq';
 import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
-import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, getRedisPrefix, IJobData } from '@novu/shared';
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, IJobData } from '@novu/shared';
 import { QueueService, PinoLogger, storage, Store, INovuWorker } from '@novu/application-generic';
 
 import {
@@ -43,13 +43,12 @@ export class WorkflowQueueService extends QueueService<IJobData> implements INov
 
   private getWorkerOpts(): WorkerOptions {
     return {
-      ...this.bullConfig,
       lockDuration: 90000,
       concurrency: 200,
       settings: {
         backoffStrategy: this.getBackoffStrategies(),
       },
-    } as WorkerOptions;
+    };
   }
 
   private getWorkerProcessor() {

--- a/apps/ws/src/socket/socket.module.ts
+++ b/apps/ws/src/socket/socket.module.ts
@@ -26,17 +26,6 @@ export class SocketModule implements OnModuleInit {
       {
         lockDuration: 90000,
         concurrency: 5,
-        connection: {
-          db: Number(process.env.REDIS_DB_INDEX),
-          port: Number(process.env.REDIS_PORT),
-          host: process.env.REDIS_HOST,
-          password: process.env.REDIS_PASSWORD,
-          connectTimeout: 50000,
-          keepAlive: 30000,
-          family: 4,
-          keyPrefix: getRedisPrefix(),
-          tls: process.env.REDIS_TLS as any,
-        },
       }
     );
   }

--- a/packages/application-generic/src/services/index.ts
+++ b/packages/application-generic/src/services/index.ts
@@ -1,4 +1,8 @@
-export { BullMqService } from './bull-mq.service';
+export {
+  bullMqBaseOptions,
+  BullMqConnectionOptions,
+  BullMqService,
+} from './bull-mq.service';
 export { AnalyticsService } from './analytics.service';
 export { QueueService } from './queue.service';
 export { WsQueueService } from './ws-queue.service';

--- a/packages/application-generic/src/services/queue.service.ts
+++ b/packages/application-generic/src/services/queue.service.ts
@@ -1,6 +1,5 @@
-import { JobsOptions, QueueBaseOptions } from 'bullmq';
-import { ConnectionOptions } from 'tls';
-import { getRedisPrefix, IJobData } from '@novu/shared';
+import { JobsOptions } from 'bullmq';
+import { IJobData } from '@novu/shared';
 import { Logger } from '@nestjs/common';
 
 import { BullMqService } from './bull-mq.service';
@@ -8,26 +7,12 @@ import { BullMqService } from './bull-mq.service';
 const LOG_CONTEXT = 'QueueService';
 
 export class QueueService<T = unknown> {
-  protected bullConfig: QueueBaseOptions = {
-    connection: {
-      db: Number(process.env.REDIS_DB_INDEX),
-      port: Number(process.env.REDIS_PORT),
-      host: process.env.REDIS_HOST,
-      password: process.env.REDIS_PASSWORD,
-      connectTimeout: 50000,
-      keepAlive: 30000,
-      family: 4,
-      keyPrefix: getRedisPrefix(),
-      tls: process.env.REDIS_TLS as ConnectionOptions,
-    },
-  };
   public readonly bullMqService: BullMqService;
   public readonly DEFAULT_ATTEMPTS = 3;
 
   constructor(public name = 'standard') {
     this.bullMqService = new BullMqService();
     this.bullMqService.createQueue(name, {
-      ...this.bullConfig,
       defaultJobOptions: {
         removeOnComplete: true,
       },

--- a/packages/application-generic/src/services/trigger-queue.service.ts
+++ b/packages/application-generic/src/services/trigger-queue.service.ts
@@ -1,7 +1,4 @@
 import { Logger } from '@nestjs/common';
-import { QueueBaseOptions } from 'bullmq';
-import { getRedisPrefix } from '@novu/shared';
-import { ConnectionOptions } from 'tls';
 
 const LOG_CONTEXT = 'TriggerQueueService';
 
@@ -9,26 +6,12 @@ import { BullMqService } from './bull-mq.service';
 
 export class TriggerQueueService {
   public readonly name = 'trigger-handler';
-  protected bullConfig: QueueBaseOptions = {
-    connection: {
-      db: Number(process.env.REDIS_DB_INDEX),
-      port: Number(process.env.REDIS_PORT),
-      host: process.env.REDIS_HOST,
-      password: process.env.REDIS_PASSWORD,
-      connectTimeout: 50000,
-      keepAlive: 30000,
-      family: 4,
-      keyPrefix: getRedisPrefix(),
-      tls: process.env.REDIS_TLS as ConnectionOptions,
-    },
-  };
   public readonly bullMqService: BullMqService;
 
   constructor() {
     this.bullMqService = new BullMqService();
 
     this.bullMqService.createQueue(this.name, {
-      ...this.bullConfig,
       defaultJobOptions: {
         removeOnComplete: true,
       },


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Consolidates the usage and instantiation of the Redis instance used by BullMQ for the queues and workers of Novu.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
It is needed in preparation of the move in the Cloud offering to support MemoryDB for our solution.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
Haven't yet touched:
- `libs/testing/src/queue.service.ts`: as it is used by `@novu/application-generic` and we should think if we want to reuse the Redis instance / MemoryDB instance for the testing Queue. In Test environment we use the same DB index for the testing Queue service and for the apps.
- `apps/ws/src/shared/framework/redis.adapter.ts`: it shares the configuration of the Redis instance used by BullMQ, even using the same DB, so I am tempted (I think we should) to implement it there.


