### PR TITLE
fix: export TriggerRecipientsTypeEnum in Node.js SDK

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -12,6 +12,7 @@ export {
   TextAlignEnum,
   EmailBlockTypeEnum,
   ChannelTypeEnum,
+  TriggerRecipientsTypeEnum,
 } from '@novu/shared';
 
 export * from './lib/novu';

--- a/packages/node/src/lib/events/events.interface.ts
+++ b/packages/node/src/lib/events/events.interface.ts
@@ -1,10 +1,11 @@
 import {
   DigestUnitEnum,
-  IAttachmentOptions,
   ITriggerPayload,
   TriggerRecipientSubscriber,
   TriggerRecipientsPayload,
 } from '@novu/shared';
+
+export { TriggerRecipientsTypeEnum } from '@novu/shared';
 
 export interface IBroadcastPayloadOptions {
   payload: ITriggerPayload;

--- a/packages/node/src/lib/events/events.interface.ts
+++ b/packages/node/src/lib/events/events.interface.ts
@@ -5,8 +5,6 @@ import {
   TriggerRecipientsPayload,
 } from '@novu/shared';
 
-export { TriggerRecipientsTypeEnum } from '@novu/shared';
-
 export interface IBroadcastPayloadOptions {
   payload: ITriggerPayload;
   overrides?: ITriggerOverrides;

--- a/packages/node/src/lib/topics/topic.interface.ts
+++ b/packages/node/src/lib/topics/topic.interface.ts
@@ -1,10 +1,4 @@
-import {
-  ExternalSubscriberId,
-  ITopic,
-  TopicKey,
-  TopicName,
-  TriggerRecipientsTypeEnum,
-} from '@novu/shared';
+import { ExternalSubscriberId, TopicKey, TopicName } from '@novu/shared';
 
 export interface ITopics {
   addSubscribers(topicKey: TopicKey, data: ITopicSubscribersPayload);


### PR DESCRIPTION
### What change does this PR introduce?
Exports `TriggerRecipientsTypeEnum` and remove some random unused imports inside SDK.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
Because I was unable to use Novu Node.js SDK inside TypeScript project (without `//@ts-ignore` what I want avoid for sure in my apps)
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

Closes #3786

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
