### PR TITLE
fix: add mark message read method in node sdk

### DIFF
--- a/packages/node/src/lib/subscribers/subscriber.interface.ts
+++ b/packages/node/src/lib/subscribers/subscriber.interface.ts
@@ -35,6 +35,7 @@ export interface ISubscribers {
   );
   getUnseenCount(subscriberId: string, seen: boolean);
   markMessageSeen(subscriberId: string, messageId: string);
+  markMessageRead(subscriberId: string, messageId: string);
   markMessageActionSeen(subscriberId: string, messageId: string, type: string);
 }
 

--- a/packages/node/src/lib/subscribers/subscribers.spec.ts
+++ b/packages/node/src/lib/subscribers/subscribers.spec.ts
@@ -224,6 +224,18 @@ describe('test use of novus node package - Subscribers class', () => {
     );
   });
 
+  test('should mark subscriber feed message as read', async () => {
+    mockedAxios.post.mockResolvedValue({});
+
+    await novu.subscribers.markMessageRead('test-message-read', 'message-123');
+
+    expect(mockedAxios.post).toHaveBeenCalled();
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      '/subscribers/test-message-read/messages/markAs',
+      { mark: { read: true }, messageId: 'message-123' }
+    );
+  });
+
   test('should mark message action as seen', async () => {
     mockedAxios.post.mockResolvedValue({});
 

--- a/packages/node/src/lib/subscribers/subscribers.ts
+++ b/packages/node/src/lib/subscribers/subscribers.ts
@@ -117,6 +117,13 @@ export class Subscribers extends WithHttp implements ISubscribers {
     );
   }
 
+  async markMessageRead(subscriberId: string, messageId: string) {
+    return await this.http.post(
+      `/subscribers/${subscriberId}/messages/markAs`,
+      { messageId, mark: { read: true } }
+    );
+  }
+
   async markMessageActionSeen(
     subscriberId: string,
     messageId: string,


### PR DESCRIPTION
### What change does this PR introduce?
Add `markMessageRead `method in node SDK similar to `markMessageSeen`
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
