### PR TITLE
Nv 2434 update workflow sets variables to default value

### DIFF
--- a/apps/web/cypress/tests/notification-editor/create-notification.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/create-notification.spec.ts
@@ -176,6 +176,50 @@ describe('Creation functionality', function () {
     cy.get('.mantine-Notification-root').contains('Test sent successfully!');
   });
 
+  it('should not clear the set default values of variables on update', function () {
+    cy.waitLoadTemplatePage(() => {
+      cy.visit('/workflows/create');
+    });
+
+    dragAndDrop('email');
+    cy.waitForNetworkIdle(500);
+
+    cy.clickWorkflowNode('node-emailSelector');
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId('emailSubject').type('this is email subject');
+    cy.getByTestId('email-editor').getByTestId('editor-row').click();
+    cy.getByTestId('editable-text-content').clear().type('This text is written from a test {{firstName}}', {
+      parseSpecialCharSequences: false,
+    });
+
+    cy.getByTestId('open-edit-variables-btn').click();
+    cy.getByTestId('variable-default-value').type('Test Var Value');
+    cy.getByTestId('close-var-manager-modal').click();
+    cy.getByTestId('notification-template-submit-btn').click();
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId('open-edit-variables-btn').click();
+    cy.getByTestId('variable-default-value').should('have.value', 'Test Var Value');
+    cy.getByTestId('close-var-manager-modal').click();
+    goBack();
+    dragAndDrop('sms');
+    cy.waitForNetworkIdle(500);
+
+    cy.clickWorkflowNode('node-smsSelector');
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId('smsNotificationContent').type('This text is written from a test {{var}}', {
+      parseSpecialCharSequences: false,
+    });
+    cy.getByTestId('variable-default-value').type('Test');
+
+    cy.getByTestId('notification-template-submit-btn').click();
+    cy.waitForNetworkIdle(500);
+
+    cy.getByTestId('variable-default-value').should('have.value', 'Test');
+  });
+
   it('should create email notification', function () {
     cy.waitLoadTemplatePage(() => {
       cy.visit('/workflows/create');

--- a/apps/web/src/hooks/useVariablesManager.ts
+++ b/apps/web/src/hooks/useVariablesManager.ts
@@ -8,7 +8,7 @@ import { IForm, ITemplates } from '../pages/templates/components/formTypes';
 export const useVariablesManager = (index: number, contents: string[]) => {
   const { watch, control, getValues } = useFormContext<IForm>();
   const variablesArray = useFieldArray({ control, name: `steps.${index}.template.variables` });
-  const variableArray = watch(`steps.${index}.template.variables`, []);
+  const variableArray = watch(`steps.${index}.template.variables`);
 
   const getTextContent = useCallback(
     ({ templateToParse, fields }: { templateToParse?: ITemplates; fields: string[] }): string => {

--- a/apps/web/src/pages/templates/components/VariableManager.tsx
+++ b/apps/web/src/pages/templates/components/VariableManager.tsx
@@ -77,6 +77,7 @@ export const VariableComponent = ({ index, template, control, path, readonly }: 
                 <Input
                   error={fieldState.error?.message}
                   type="text"
+                  data-test-id="variable-default-value"
                   placeholder="Default Value"
                   value={field.value}
                   onChange={field.onChange}
@@ -94,6 +95,7 @@ export const VariableComponent = ({ index, template, control, path, readonly }: 
             render={({ field }) => {
               return (
                 <Switch
+                  data-test-id="variable-required-value"
                   label={field.value ? 'True' : 'False'}
                   checked={field.value === true}
                   onChange={field.onChange}

--- a/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
@@ -46,6 +46,7 @@ export const VariablesManagement = ({
         >
           <Tooltip label="Add defaults or mark as required">
             <UnstyledButton
+              data-test-id="open-edit-variables-btn"
               onClick={() => {
                 if (openVariablesModal) {
                   openVariablesModal();


### PR DESCRIPTION
### What change does this PR introduce?

Any update workflow click, clears the default values set for the variables. 

to reproduce:
1. open any step that has values for default values/required set 
2. edit any content 
3. click update 
4. the values has been cleared 

https://www.loom.com/share/8ef844b9293c4125aec2508f98231285
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
