### PR TITLE
fix: flaky test because first sms step was not being added

### DIFF
--- a/apps/web/cypress/tests/notification-editor/create-notification.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/create-notification.spec.ts
@@ -181,6 +181,8 @@ describe('Creation functionality', function () {
       cy.visit('/workflows/create');
     });
 
+    cy.waitForNetworkIdle(500);
+
     dragAndDrop('email');
     cy.waitForNetworkIdle(500);
 

--- a/apps/web/cypress/tests/notification-editor/steps-actions.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/steps-actions.spec.ts
@@ -360,13 +360,15 @@ describe('Workflow Editor - Steps Actions', function () {
     cy.waitLoadTemplatePage(() => {
       cy.visit('/workflows/create');
     });
+    cy.waitForNetworkIdle(500);
 
     dragAndDrop('sms');
-    cy.waitForNetworkIdle(500);
 
     dragAndDrop('delay');
 
     dragAndDrop('sms');
+
+    cy.waitForNetworkIdle(500);
 
     const firstContent = 'first content for sms';
     const lastContent = 'last content for sms';


### PR DESCRIPTION
### What change does this PR introduce?

Flaky test - needed a wait after loading the template as sometimes only 1 sms step was added. 
Same for a flaky test that the first email step was not added.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
<img width="1045" alt="Screen Shot 2023-07-19 at 17 04 35" src="https://github.com/novuhq/novu/assets/7778680/ab84e3ce-43e6-4593-a0f0-c367025c628c">


<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
