### PR TITLE
test: skip failing test until we can control feature flag in worker 

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -57,7 +57,7 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
   const executionDetailsRepository = new ExecutionDetailsRepository();
   const environmentRepository = new EnvironmentRepository();
 
-  describe(`Trigger Event - [IS_MULTI_PROVIDER_CONFIGURATION_ENABLED=${ORIGINAL_IS_MULTI_PROVIDER_CONFIGURATION_ENABLED}]`, function () {
+  describe(`Trigger Event - ${eventTriggerPath} (POST)`, function () {
     beforeEach(async () => {
       session = new UserSession();
       await session.initialize();
@@ -1595,7 +1595,7 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
       });
     });
   });
-  describe('Trigger Event - [IS_MULTI_PROVIDER_CONFIGURATION_ENABLED=true]', function () {
+  describe.skip('Trigger Event - [IS_MULTI_PROVIDER_CONFIGURATION_ENABLED=true]', function () {
     beforeEach(async () => {
       process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = 'true';
       process.env.LAUNCH_DARKLY_SDK_KEY = '';


### PR DESCRIPTION
### What change does this PR introduce?

Skip override integration test that fails because the feature flag is changed on the "API" running instance, but not on the worker service.
So the API runs with the feature flag enabled, but the worker runs without it

 
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
