### PR TITLE
feat(headless): add listen to notification_received in headless service

### DIFF
--- a/docs/docs/notification-center/headless/api-reference.md
+++ b/docs/docs/notification-center/headless/api-reference.md
@@ -120,6 +120,27 @@ interface IFetchUnreadCount {
 }
 ```
 
+## listenNotificationReceive
+
+Listens to the changes of the unseen count.
+Can be used to get real time count of the unseen messages.
+
+```ts
+headlessService.listenNotificationReceive({
+  listener: (message: IMessage) => {
+    console.log(JSON.stringify(message));
+  },
+});
+```
+
+### method args interface
+
+```ts
+interface IListenNotificationReceive {
+  listener: (message: IMessage) => void;
+}
+```
+
 ## listenUnseenCountChange
 
 Listens to the changes of the unseen count.

--- a/packages/headless/src/lib/headless.service.ts
+++ b/packages/headless/src/lib/headless.service.ts
@@ -309,6 +309,34 @@ export class HeadlessService {
     return unsubscribe;
   }
 
+  public listenNotificationReceive({
+    listener,
+  }: {
+    listener: (message: IMessage) => void;
+  }) {
+    this.assertSessionInitialized();
+
+    if (this.socket) {
+      this.socket.on(
+        'notification_received',
+        (data?: { message: IMessage }) => {
+          if (data?.message) {
+            this.queryClient.removeQueries(NOTIFICATIONS_QUERY_KEY, {
+              exact: false,
+            });
+            listener(data.message);
+          }
+        }
+      );
+    }
+
+    return () => {
+      if (this.socket) {
+        this.socket.off('notification_received');
+      }
+    };
+  }
+
   public listenUnseenCountChange({
     listener,
   }: {


### PR DESCRIPTION
### What change does this PR introduce?

When the headless package [was introduced](https://github.com/novuhq/novu/pull/2178), the `notification_received` event did not yet exist ([it was added two weeks later](https://github.com/novuhq/novu/pull/2336)), a corresponding method to listen to that event hasn't been added to headlessService yet.

This PR introduces the method listenNotificationReceive (following the same naming scheme as listenUnseenCountChange for the event `unseen_count_changed`).

### Why was this change needed?

Use cases that may require this method include :

- Updating the UI in real-time when a new notification is received, with more than just a global unread/unseen count (e.g. having multiple unread counts, categorized by topic)
- Displaying a toast with details about the notification when the notification is received

### Other information (Screenshots)

![image](https://github.com/novuhq/novu/assets/73177874/01c1ae0c-a2ae-43b9-886f-e3a12a171051)
![image](https://github.com/novuhq/novu/assets/73177874/4307bcef-63b8-4bc0-97e7-d0cb159c687b)

Jest test is successful

