### PR TITLE
Docs overhaul

### DIFF
--- a/docs/docs/overview/quickstart/get-started-with-angular.md
+++ b/docs/docs/overview/quickstart/get-started-with-angular.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-sidebar_label: Get started with Angular
+sidebar_label: Angular
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/docs/overview/quickstart/get-started-with-kotlin.md
+++ b/docs/docs/overview/quickstart/get-started-with-kotlin.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 9
-sidebar_label: Get started with Kotlin
+sidebar_label: Kotlin
 ---
 
 # Kotlin Quickstart
@@ -9,12 +9,18 @@ Learn how to integrate Novu into your Kotlin project on the fly and send notific
 
 In this Quickstart, you will learn how to:
 
-- [Install and Set up the Novu Kotlin SDK.](#install-and-set-up-the-novu-kotlin-sdk-in-your-project)
-- [Configure a Notification Channel Provider.](#set-up-a-channel-provider)
-- [Set up a Notification Workflow.](#create-a-notification-workflow)
-- [Create a Subscriber and update a Subscriber's information.](#create-a-subscriber-and-update-a-subscribers-information)
-- [Send your first Notification to a Subscriber.](#trigger-a-notification)
-- [Send Notifications via Topics.](#topics)
+- [Kotlin Quickstart](#kotlin-quickstart)
+  - [Requirements](#requirements)
+  - [Install and Set up the Novu Kotlin SDK in your project](#install-and-set-up-the-novu-kotlin-sdk-in-your-project)
+  - [Set up a Channel Provider](#set-up-a-channel-provider)
+  - [Create a Notification Workflow](#create-a-notification-workflow)
+  - [Create a Subscriber and Update a Subscriber's information](#create-a-subscriber-and-update-a-subscribers-information)
+  - [Trigger a Notification](#trigger-a-notification)
+  - [Topics](#topics)
+    - [Create a Topic](#create-a-topic)
+    - [Add subscribers to a Topic](#add-subscribers-to-a-topic)
+    - [Sending a Notification to a Topic](#sending-a-notification-to-a-topic)
+  - [Next Steps](#next-steps)
 
 Let's get started! :muscle:
 

--- a/docs/docs/overview/quickstart/get-started-with-nextjs.md
+++ b/docs/docs/overview/quickstart/get-started-with-nextjs.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 6
-sidebar_label: Get started with NextJS
+sidebar_label: NextJS
 ---
 
 # NextJS Quickstart

--- a/docs/docs/overview/quickstart/get-started-with-node.js.md
+++ b/docs/docs/overview/quickstart/get-started-with-node.js.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 7
-sidebar_label: Get started with Node.js
+sidebar_label: Node.js
 ---
 
 # Node.js Quickstart

--- a/docs/docs/overview/quickstart/get-started-with-php.md
+++ b/docs/docs/overview/quickstart/get-started-with-php.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-sidebar_label: Get started with PHP
+sidebar_label: PHP
 ---
 
 # PHP Quickstart
@@ -9,12 +9,19 @@ Learn how to use Novu to quickly send multi-channel (SMS, Email, Chat, Push) not
 
 In this Quickstart, you’ll learn how to:
 
-- [Install and use the Novu PHP SDK via Composer.](#install-novu-php-sdk)
-- [Configure a Notification Channel Provider.](#set-up-a-channel-provider)
-- [Set up a notification workflow.](#create-a-notification-workflow)
-- [Create subscribers and update subscriber information.](#create-a-subscriber)
-- [Send your first notification.](#trigger-a-notification)
-- [Send notifications via topics.](#topics)
+- [PHP Quickstart](#php-quickstart)
+  - [Requirements](#requirements)
+  - [Install Novu PHP SDK](#install-novu-php-sdk)
+    - [Initialize \& Configure the Novu SDK](#initialize--configure-the-novu-sdk)
+  - [Set Up A Channel Provider](#set-up-a-channel-provider)
+  - [Create A Notification Workflow](#create-a-notification-workflow)
+  - [Create A Subscriber](#create-a-subscriber)
+  - [Trigger A Notification](#trigger-a-notification)
+  - [Topics](#topics)
+    - [Create a Topic](#create-a-topic)
+    - [Add subscribers to a Topic](#add-subscribers-to-a-topic)
+    - [Sending a notification to a Topic](#sending-a-notification-to-a-topic)
+  - [Next Steps](#next-steps)
 
 ## Requirements
 

--- a/docs/docs/overview/quickstart/get-started-with-react.md
+++ b/docs/docs/overview/quickstart/get-started-with-react.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-sidebar_label: Get started with React
+sidebar_label: React
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/docs/overview/quickstart/get-started-with-ruby.md
+++ b/docs/docs/overview/quickstart/get-started-with-ruby.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 10
-sidebar_label: Get started with Ruby
+sidebar_label: Ruby
 ---
 
 # Ruby Quickstart
@@ -9,12 +9,19 @@ Learn how to use Novu to quickly send multi-channel (SMS, Email, Chat, Push) not
 
 In this Quickstart guide, you’ll learn how to:
 
-- [Install and use the Novu Ruby SDK via RubyGems or Bundle.](#install-novu-ruby-sdk) 
-- [Configure a Notification Channel Provider.](#set-up-a-channel-provider)
-- [Set up a notification workflow.](#create-a-workflow)
-- [Create subscribers and update subscriber information.](#create-a-subscriber)
-- [Send your first notification.](#trigger-a-notification)
-- [Send notifications via topics.](#topics)
+- [Ruby Quickstart](#ruby-quickstart)
+  - [Requirements](#requirements)
+  - [Install Novu Ruby SDK](#install-novu-ruby-sdk)
+  - [Initialize \& Configure the Novu Ruby SDK](#initialize--configure-the-novu-ruby-sdk)
+  - [Set Up A Channel Provider](#set-up-a-channel-provider)
+  - [Create A workflow](#create-a-workflow)
+  - [Create A Subscriber](#create-a-subscriber)
+  - [Trigger A Notification](#trigger-a-notification)
+  - [Topics](#topics)
+    - [Create a Topic](#create-a-topic)
+    - [Add and Remove subscribers to a Topic](#add-and-remove-subscribers-to-a-topic)
+    - [Sending a notification to a Topic](#sending-a-notification-to-a-topic)
+  - [Next Steps](#next-steps)
 
 ## Requirements
 

--- a/docs/docs/overview/quickstart/get-started-with-vanilla-js.md
+++ b/docs/docs/overview/quickstart/get-started-with-vanilla-js.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 8
-sidebar_label: Get started with Vanilla JS
+sidebar_label: Vanilla JS
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/docs/overview/quickstart/get-started-with-vue.md
+++ b/docs/docs/overview/quickstart/get-started-with-vue.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-sidebar_label: Get started with Vue
+sidebar_label: Vue
 ---
 
 # Vue Quickstart


### PR DESCRIPTION
### What change does this PR introduce?

This PR changes the headings of all our quickstart from 'get started with xyz' to 'xyz'. 

### Why was this change needed?

This was suggested as a quality-of-life improvement on our Slack by Pixelpoint. (DM me on Discord for the exact conversation link).

### Other information (Screenshots)

<img width="1340" alt="SCR-20230721-ovyr" src="https://github.com/novuhq/novu/assets/62152915/6415908a-ee6f-482a-93e9-d16c60628bb9">
