### PR TITLE
Docs: Add Uml flow to Cookbook & Architecture pages

### DIFF
--- a/docs/docs/cookbook/introduction.md
+++ b/docs/docs/cookbook/introduction.md
@@ -10,6 +10,8 @@ import TabItem from '@theme/TabItem';
 
 This cookbook contains recipes and code samples demonstrating how to accomplish everyday tasks with Novu in your application. Each code example uses our libraries and SDKs.
 
+![UML flow](https://res.cloudinary.com/dxc6bnman/image/upload/v1690181515/flow-2x-straight-white-bg_l8elfm.png)
+
 ## Fetch Subscriber Feed
 
 A subscriber feed is a list of all In-App messages for a single subscriber. It's a continuous stream of messages displayed in a list that subscribers can scroll through on the frontend via the Notification Center.

--- a/docs/docs/overview/architecture.md
+++ b/docs/docs/overview/architecture.md
@@ -44,6 +44,12 @@ The trigger is responsible to let the engine know what happened and what workflo
 
 The trigger should only be responsible to let the system know that something has happened, but not where and when the message will be delivered.
 
+
+## The workflow-trigger-event-notification flow
+
+![Novu Architecture](https://res.cloudinary.com/dxc6bnman/image/upload/v1690181294/flow-2x-white-bg_igzccb.png)
+
+
 ## Communication API
 
 This is the unit that is responsible for reading the configurations of the workflows, finding the relevant channels, locating the providers, and doing the heavy lifting of sending the notifications. All logical rules such as priority, timing, channel selection, and others are managed by the engine.


### PR DESCRIPTION
### What change does this PR introduce?

Introduces a visual model of workflow/trigger/event/notification flow to Cookbook & Architecture pages.

### Why was this change needed?

To help readers understand how Novu workflows and notifications work.

### Other information (Screenshots)

![Screenshot 2023-07-24 at 08 40 47](https://github.com/novuhq/novu/assets/2946769/c28418a9-e2e9-4fcd-ae1d-90adab34feeb)

