### PR TITLE
feat(app-generic): refactor in-memory-provider service

### DIFF
--- a/apps/api/src/app/blueprint/e2e/get-grouped-blueprints.e2e.ts
+++ b/apps/api/src/app/blueprint/e2e/get-grouped-blueprints.e2e.ts
@@ -8,6 +8,7 @@ import {
   buildGroupedBlueprintsKey,
   CacheService,
   GetIsInMemoryClusterModeEnabled,
+  InMemoryProviderEnum,
   InMemoryProviderService,
   InvalidateCacheService,
 } from '@novu/application-generic';
@@ -28,7 +29,10 @@ describe('Get grouped notification template blueprints - /blueprints/group-by-ca
 
   before(async () => {
     const getIsInMemoryClusterModeEnabled = new GetIsInMemoryClusterModeEnabled();
-    const inMemoryProviderService = new InMemoryProviderService(getIsInMemoryClusterModeEnabled);
+    const inMemoryProviderService = new InMemoryProviderService(
+      getIsInMemoryClusterModeEnabled,
+      InMemoryProviderEnum.REDIS
+    );
     const cacheService = new CacheService(inMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);

--- a/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
+++ b/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
@@ -16,6 +16,7 @@ import {
   buildNotificationTemplateIdentifierKey,
   buildNotificationTemplateKey,
   InvalidateCacheService,
+  InMemoryProviderEnum,
 } from '@novu/application-generic';
 
 import { UpdateSubscriberPreferenceRequestDto } from '../../widgets/dtos/update-subscriber-preference-request.dto';
@@ -39,7 +40,7 @@ describe('Trigger event - process subscriber /v1/events/trigger (POST)', functio
 
   before(async () => {
     const getIsInMemoryClusterModeEnabled = new GetIsInMemoryClusterModeEnabled();
-    inMemoryProviderService = new InMemoryProviderService(getIsInMemoryClusterModeEnabled);
+    inMemoryProviderService = new InMemoryProviderService(getIsInMemoryClusterModeEnabled, InMemoryProviderEnum.REDIS);
     cacheService = new CacheService(inMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);

--- a/apps/api/src/app/health/e2e/health-check.e2e.ts
+++ b/apps/api/src/app/health/e2e/health-check.e2e.ts
@@ -1,20 +1,30 @@
 import { UserSession } from '@novu/testing';
+import {
+  GetIsInMemoryClusterModeEnabled,
+  InMemoryProviderEnum,
+  InMemoryProviderService,
+} from '@novu/application-generic';
 import { expect } from 'chai';
 
 describe('Health-check', () => {
   const session = new UserSession();
 
   before(async () => {
+    const getIsInMemoryClusterModeEnabled = new GetIsInMemoryClusterModeEnabled();
+    const inMemoryProviderService = new InMemoryProviderService(
+      getIsInMemoryClusterModeEnabled,
+      InMemoryProviderEnum.REDIS
+    );
+
     await session.initialize();
   });
 
   describe('/health-check (GET)', () => {
     it('should correctly return a health check', async () => {
-      const {
-        body: { data },
-      } = await session.testAgent.get('/v1/health-check');
+      const result = await session.testAgent.get('/v1/health-check');
+      const { data } = result.body || {};
 
-      expect(data.status).to.equal('ok');
+      expect(data?.status).to.equal('ok');
     });
   });
 });

--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -43,6 +43,7 @@ import {
   GetIsTopicNotificationEnabled,
   LaunchDarklyService,
   FeatureFlagsService,
+  InMemoryProviderEnum,
 } from '@novu/application-generic';
 
 import * as packageJson from '../../../package.json';
@@ -135,9 +136,10 @@ const inMemoryProviderService = {
   provide: InMemoryProviderService,
   useFactory: (
     getIsInMemoryClusterModeEnabledUseCase: GetIsInMemoryClusterModeEnabled,
+    provider: InMemoryProviderEnum,
     enableAutoPipelining?: boolean
   ): InMemoryProviderService => {
-    return new InMemoryProviderService(getIsInMemoryClusterModeEnabledUseCase, enableAutoPipelining);
+    return new InMemoryProviderService(getIsInMemoryClusterModeEnabledUseCase, provider, enableAutoPipelining);
   },
   inject: [GetIsInMemoryClusterModeEnabled],
 };
@@ -151,6 +153,7 @@ const cacheService = {
     const enableAutoPipelining = process.env.REDIS_CACHE_ENABLE_AUTOPIPELINING === 'true';
     const factoryInMemoryProviderService = inMemoryProviderService.useFactory(
       getIsInMemoryClusterModeEnabledUseCase,
+      InMemoryProviderEnum.ELASTICACHE,
       enableAutoPipelining
     );
 
@@ -165,10 +168,19 @@ const cacheService = {
 
 const distributedLockService = {
   provide: DistributedLockService,
-  useFactory: (getIsInMemoryClusterModeEnabledUseCase: GetIsInMemoryClusterModeEnabled): DistributedLockService => {
-    const factoryInMemoryProviderService = inMemoryProviderService.useFactory(getIsInMemoryClusterModeEnabledUseCase);
+  useFactory: async (
+    getIsInMemoryClusterModeEnabledUseCase: GetIsInMemoryClusterModeEnabled
+  ): Promise<DistributedLockService> => {
+    const factoryInMemoryProviderService = inMemoryProviderService.useFactory(
+      getIsInMemoryClusterModeEnabledUseCase,
+      InMemoryProviderEnum.ELASTICACHE
+    );
 
-    return new DistributedLockService(factoryInMemoryProviderService);
+    const service = new DistributedLockService(factoryInMemoryProviderService);
+
+    await service.initialize();
+
+    return service;
   },
   inject: [GetIsInMemoryClusterModeEnabled],
 };

--- a/apps/api/src/app/widgets/e2e/get-count.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/get-count.e2e.ts
@@ -4,12 +4,13 @@ import { MessageRepository, NotificationTemplateEntity, SubscriberRepository } f
 import { UserSession } from '@novu/testing';
 import { ChannelTypeEnum, InAppProviderIdEnum } from '@novu/shared';
 import {
-  InMemoryProviderService,
   buildFeedKey,
   buildMessageCountKey,
   CacheService,
-  InvalidateCacheService,
   GetIsInMemoryClusterModeEnabled,
+  InMemoryProviderEnum,
+  InMemoryProviderService,
+  InvalidateCacheService,
 } from '@novu/application-generic';
 
 describe('Count - GET /widget/notifications/count', function () {
@@ -27,7 +28,7 @@ describe('Count - GET /widget/notifications/count', function () {
 
   before(async () => {
     const getIsInMemoryClusterModeEnabled = new GetIsInMemoryClusterModeEnabled();
-    inMemoryProviderService = new InMemoryProviderService(getIsInMemoryClusterModeEnabled);
+    inMemoryProviderService = new InMemoryProviderService(getIsInMemoryClusterModeEnabled, InMemoryProviderEnum.REDIS);
     const cacheService = new CacheService(inMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);

--- a/apps/api/src/app/widgets/e2e/get-unseen-count.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/get-unseen-count.e2e.ts
@@ -4,12 +4,13 @@ import { MessageRepository, NotificationTemplateEntity, SubscriberRepository } f
 import { UserSession } from '@novu/testing';
 import { ChannelTypeEnum } from '@novu/shared';
 import {
-  InMemoryProviderService,
   buildFeedKey,
   buildMessageCountKey,
   CacheService,
-  InvalidateCacheService,
   GetIsInMemoryClusterModeEnabled,
+  InMemoryProviderEnum,
+  InMemoryProviderService,
+  InvalidateCacheService,
 } from '@novu/application-generic';
 
 describe('Unseen Count - GET /widget/notifications/unseen', function () {
@@ -27,7 +28,7 @@ describe('Unseen Count - GET /widget/notifications/unseen', function () {
 
   before(async () => {
     const getIsInMemoryClusterModeEnabled = new GetIsInMemoryClusterModeEnabled();
-    inMemoryProviderService = new InMemoryProviderService(getIsInMemoryClusterModeEnabled);
+    inMemoryProviderService = new InMemoryProviderService(getIsInMemoryClusterModeEnabled, InMemoryProviderEnum.REDIS);
     const cacheService = new CacheService(inMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);

--- a/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
@@ -9,6 +9,7 @@ import {
   GetIsInMemoryClusterModeEnabled,
   InMemoryProviderService,
   InvalidateCacheService,
+  InMemoryProviderEnum,
 } from '@novu/application-generic';
 
 const integrationRepository = new IntegrationRepository();
@@ -20,7 +21,10 @@ describe('Initialize Session - /widgets/session/initialize (POST)', async () => 
 
   before(async () => {
     const getIsInMemoryClusterModeEnabled = new GetIsInMemoryClusterModeEnabled();
-    const inMemoryProviderService = new InMemoryProviderService(getIsInMemoryClusterModeEnabled);
+    const inMemoryProviderService = new InMemoryProviderService(
+      getIsInMemoryClusterModeEnabled,
+      InMemoryProviderEnum.REDIS
+    );
     const cacheService = new CacheService(inMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);

--- a/apps/worker/src/app/health/e2e/health-check.e2e.ts
+++ b/apps/worker/src/app/health/e2e/health-check.e2e.ts
@@ -1,3 +1,8 @@
+import {
+  GetIsInMemoryClusterModeEnabled,
+  InMemoryProviderEnum,
+  InMemoryProviderService,
+} from '@novu/application-generic';
 import { expect } from 'chai';
 import * as request from 'supertest';
 import * as defaults from 'superagent-defaults';
@@ -6,6 +11,12 @@ describe('Health-check', () => {
   let testAgent;
 
   before(async () => {
+    const getIsInMemoryClusterModeEnabled = new GetIsInMemoryClusterModeEnabled();
+    const inMemoryProviderService = new InMemoryProviderService(
+      getIsInMemoryClusterModeEnabled,
+      InMemoryProviderEnum.REDIS
+    );
+
     testAgent = defaults(request(`http://localhost:${process.env.PORT}`));
   });
 

--- a/packages/application-generic/src/health/in-memory.health-indicator.ts
+++ b/packages/application-generic/src/health/in-memory.health-indicator.ts
@@ -20,7 +20,7 @@ export class InMemoryProviderServiceHealthIndicator extends HealthIndicator {
    * without blocking self hosted users
    */
   async isHealthy(): Promise<HealthIndicatorResult> {
-    if (this.inMemoryProviderService.isClientReady()) {
+    if (this.inMemoryProviderService?.isClientReady()) {
       return this.getStatus(this.INDICATOR_KEY, true);
     }
 

--- a/packages/application-generic/src/services/cache/cache-service.spec.ts
+++ b/packages/application-generic/src/services/cache/cache-service.spec.ts
@@ -6,7 +6,10 @@ import {
 } from './cache.service';
 
 import { FeatureFlagsService } from '../feature-flags.service';
-import { InMemoryProviderService } from '../in-memory-provider';
+import {
+  InMemoryProviderEnum,
+  InMemoryProviderService,
+} from '../in-memory-provider';
 import { GetIsInMemoryClusterModeEnabled } from '../../usecases';
 
 const enableAutoPipelining =
@@ -28,6 +31,7 @@ describe.skip('Cache Service - Redis Instance - Non Cluster Mode', () => {
 
     inMemoryProviderService = new InMemoryProviderService(
       getIsInMemoryClusterModeEnabled,
+      InMemoryProviderEnum.REDIS,
       enableAutoPipelining
     );
     await inMemoryProviderService.delayUntilReadiness();
@@ -89,6 +93,7 @@ describe('Cache Service - Cluster Mode', () => {
 
     inMemoryProviderService = new InMemoryProviderService(
       getIsInMemoryClusterModeEnabled,
+      InMemoryProviderEnum.REDIS,
       enableAutoPipelining
     );
     await inMemoryProviderService.delayUntilReadiness();

--- a/packages/application-generic/src/services/distributed-lock/distributed-lock.service.spec.ts
+++ b/packages/application-generic/src/services/distributed-lock/distributed-lock.service.spec.ts
@@ -6,6 +6,7 @@ import { DistributedLockService } from './distributed-lock.service';
 import { FeatureFlagsService } from '../feature-flags.service';
 import {
   InMemoryProviderClient,
+  InMemoryProviderEnum,
   InMemoryProviderService,
 } from '../in-memory-provider';
 import { GetIsInMemoryClusterModeEnabled } from '../../usecases';
@@ -45,18 +46,18 @@ describe('Distributed Lock Service', () => {
 
     beforeEach(async () => {
       inMemoryProviderService = new InMemoryProviderService(
-        getIsInMemoryClusterModeEnabled
+        getIsInMemoryClusterModeEnabled,
+        InMemoryProviderEnum.REDIS,
       );
 
       await inMemoryProviderService.delayUntilReadiness();
 
       expect(inMemoryProviderService.getStatus()).toEqual('ready');
-    });
 
-    beforeEach(() => {
       distributedLockService = new DistributedLockService(
         inMemoryProviderService
       );
+      await distributedLockService.initialize();
     });
 
     describe('Set up', () => {
@@ -292,19 +293,21 @@ describe('Distributed Lock Service', () => {
     let inMemoryProviderService: InMemoryProviderService;
     let distributedLockService: DistributedLockService;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       process.env.REDIS_CACHE_SERVICE_HOST = '';
       process.env.REDIS_CACHE_SERVICE_PORT = '0';
       process.env.REDIS_CLUSTER_SERVICE_HOST = '';
       process.env.REDIS_CLUSTER_SERVICE_PORTS = '';
 
       inMemoryProviderService = new InMemoryProviderService(
-        getIsInMemoryClusterModeEnabled
+        getIsInMemoryClusterModeEnabled,
+        InMemoryProviderEnum.REDIS
       );
       expect(inMemoryProviderService.inMemoryProviderConfig.host).toEqual('');
       distributedLockService = new DistributedLockService(
         inMemoryProviderService
       );
+      await distributedLockService.initialize();
     });
 
     afterEach(() => {

--- a/packages/application-generic/src/services/distributed-lock/distributed-lock.service.ts
+++ b/packages/application-generic/src/services/distributed-lock/distributed-lock.service.ts
@@ -2,7 +2,11 @@ import Redlock from 'redlock';
 import { setTimeout } from 'timers/promises';
 import { Injectable, Logger } from '@nestjs/common';
 
-import { InMemoryProviderClient, InMemoryProviderService } from '../index';
+import {
+  InMemoryProviderClient,
+  InMemoryProviderEnum,
+  InMemoryProviderService,
+} from '../index';
 
 const LOG_CONTEXT = 'DistributedLock';
 
@@ -18,8 +22,11 @@ export class DistributedLockService {
   public lockCounter = {};
   public shuttingDown = false;
 
-  constructor(private inMemoryProviderService: InMemoryProviderService) {
-    this.startup(inMemoryProviderService.inMemoryProviderClient);
+  constructor(private inMemoryProviderService: InMemoryProviderService) {}
+
+  async initialize(): Promise<void> {
+    await this.inMemoryProviderService.delayUntilReadiness();
+    this.startup(this.inMemoryProviderService.inMemoryProviderClient);
   }
 
   public startup(

--- a/packages/application-generic/src/services/in-memory-provider/elasticache-cluster-provider.ts
+++ b/packages/application-generic/src/services/in-memory-provider/elasticache-cluster-provider.ts
@@ -115,3 +115,9 @@ export const getElasticacheCluster = (
 
   return undefined;
 };
+
+export const validateElasticacheClusterProviderConfig = (): boolean => {
+  const config = getElasticacheClusterProviderConfig();
+
+  return !!config.host && !!config.port;
+};

--- a/packages/application-generic/src/services/in-memory-provider/redis-cluster-provider.ts
+++ b/packages/application-generic/src/services/in-memory-provider/redis-cluster-provider.ts
@@ -119,3 +119,13 @@ export const getRedisCluster = (
 
   return undefined;
 };
+
+export const validateRedisClusterProviderConfig = (): boolean => {
+  const config = getRedisClusterProviderConfig();
+
+  const validPorts =
+    config.ports.length > 0 &&
+    config.ports.every((port: number) => Number.isInteger(port));
+
+  return !!config.host && validPorts;
+};

--- a/packages/application-generic/src/usecases/create-subscriber/create-subscriber.spec.ts
+++ b/packages/application-generic/src/usecases/create-subscriber/create-subscriber.spec.ts
@@ -7,6 +7,7 @@ import { CreateSubscriberCommand } from './create-subscriber.command';
 
 import {
   CacheService,
+  InMemoryProviderEnum,
   InMemoryProviderService,
   InvalidateCacheService,
 } from '../../services';
@@ -19,7 +20,8 @@ const inMemoryProviderService = {
     const getIsInMemoryClusterModeEnabled =
       new GetIsInMemoryClusterModeEnabled();
     const inMemoryProvider = new InMemoryProviderService(
-      getIsInMemoryClusterModeEnabled
+      getIsInMemoryClusterModeEnabled,
+      InMemoryProviderEnum.REDIS
     );
 
     return inMemoryProvider;

--- a/packages/application-generic/src/usecases/update-subscriber/update-subscriber.spec.ts
+++ b/packages/application-generic/src/usecases/update-subscriber/update-subscriber.spec.ts
@@ -9,6 +9,7 @@ import {
   CacheService,
   InvalidateCacheService,
   InMemoryProviderService,
+  InMemoryProviderEnum,
 } from '../../services';
 
 const inMemoryProviderService = {
@@ -17,7 +18,8 @@ const inMemoryProviderService = {
     const getIsInMemoryClusterModeEnabled =
       new GetIsInMemoryClusterModeEnabled();
     const inMemoryProvider = new InMemoryProviderService(
-      getIsInMemoryClusterModeEnabled
+      getIsInMemoryClusterModeEnabled,
+      InMemoryProviderEnum.REDIS,
     );
 
     return inMemoryProvider;


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Allows to provide the provider choose for any specific InMemoryProviderService instance.
Also it fallbacks to Redis instance if no provider chosen or the configuration validation for the provider chosen fails.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Right now we only have Elasticache as provider implemented with Redis Cluster compatibility. In order to support further Redis Cluster compatible providers we need to refactor InMemoryProviderService.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
