### PR TITLE
[WIP] 🚧 feat(api): set integration as primary and priority system

### DIFF
--- a/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
@@ -1,6 +1,13 @@
 import { IntegrationRepository, EnvironmentRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
-import { ChannelTypeEnum, EmailProviderIdEnum, SmsProviderIdEnum } from '@novu/shared';
+import {
+  ChannelTypeEnum,
+  ChatProviderIdEnum,
+  EmailProviderIdEnum,
+  InAppProviderIdEnum,
+  PushProviderIdEnum,
+  SmsProviderIdEnum,
+} from '@novu/shared';
 import { expect } from 'chai';
 
 const ORIGINAL_IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED;
@@ -186,6 +193,262 @@ describe('Create Integration - /integration (POST)', function () {
     expect(data.credentials?.tlsOptions).to.instanceOf(Object);
     expect(data.credentials?.tlsOptions).to.eql(payload.credentials.tlsOptions);
     expect(data.active).to.equal(true);
+  });
+
+  it('should not calculate primary and priority fields when is not active', async function () {
+    const payload = {
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(false);
+  });
+
+  it('should not calculate primary and priority fields for in-app channel', async function () {
+    const payload = {
+      providerId: InAppProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.IN_APP,
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+  });
+
+  it('should not calculate primary and priority fields for push channel', async function () {
+    const payload = {
+      providerId: PushProviderIdEnum.FCM,
+      channel: ChannelTypeEnum.PUSH,
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+  });
+
+  it('should not calculate primary and priority fields for chat channel', async function () {
+    const payload = {
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+  });
+
+  it('should set the integration as primary when its active and there are no other active integrations', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
+
+    expect(data.priority).to.equal(1);
+    expect(data.primary).to.equal(true);
+    expect(data.active).to.equal(true);
+  });
+
+  it(
+    'should set the integration as primary when its active ' +
+      'and there are no other active integrations excluding Novu',
+    async function () {
+      await integrationRepository.deleteMany({
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+      });
+
+      const novuEmail = await integrationRepository.create({
+        name: 'novuEmail',
+        identifier: 'novuEmail',
+        providerId: EmailProviderIdEnum.Novu,
+        channel: ChannelTypeEnum.EMAIL,
+        active: true,
+        primary: false,
+        priority: 1,
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+      });
+
+      const payload = {
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: true,
+        check: false,
+      };
+
+      const {
+        body: { data },
+      } = await session.testAgent.post('/v1/integrations').send(payload);
+
+      expect(data.priority).to.equal(2);
+      expect(data.primary).to.equal(true);
+      expect(data.active).to.equal(true);
+
+      const [first, second] = await await integrationRepository.find(
+        {
+          _organizationId: session.organization._id,
+          _environmentId: session.environment._id,
+          channel: ChannelTypeEnum.EMAIL,
+        },
+        undefined,
+        { sort: { priority: -1 } }
+      );
+
+      expect(first._id).to.equal(data._id);
+      expect(first.primary).to.equal(true);
+      expect(first.active).to.equal(true);
+      expect(first.priority).to.equal(2);
+
+      expect(second._id).to.equal(novuEmail._id);
+      expect(second.primary).to.equal(false);
+      expect(second.active).to.equal(true);
+      expect(second.priority).to.equal(1);
+    }
+  );
+
+  it('should not set the integration as primary when there is primary integration', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const primaryIntegration = await integrationRepository.create({
+      name: 'primaryIntegration',
+      identifier: 'primaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
+
+    expect(data.priority).to.equal(1);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+
+    const [first, second] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(primaryIntegration._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(data._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
+  });
+
+  it('should calculate the highest priority but not set primary if there is another active integration', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegration = await integrationRepository.create({
+      name: 'activeIntegration',
+      identifier: 'activeIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.post('/v1/integrations').send(payload);
+
+    expect(data.priority).to.equal(2);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+
+    const [first, second] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(data._id);
+    expect(first.primary).to.equal(false);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(activeIntegration._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
   });
 });
 

--- a/apps/api/src/app/integrations/e2e/get-active-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/get-active-integration.e2e.ts
@@ -50,7 +50,7 @@ describe('Get Active Integrations [IS_MULTI_PROVIDER_CONFIGURATION_ENABLED=true]
     expect(chatIntegration.length).to.equal(4);
 
     const selectedInAppIntegrations = filterEnvIntegrations(inAppIntegration, session.environment._id);
-    expect(selectedInAppIntegrations.length).to.equal(1);
+    expect(selectedInAppIntegrations.length).to.equal(0);
 
     const selectedEmailIntegrations = filterEnvIntegrations(emailIntegration, session.environment._id);
     expect(selectedEmailIntegrations.length).to.equal(1);
@@ -59,13 +59,10 @@ describe('Get Active Integrations [IS_MULTI_PROVIDER_CONFIGURATION_ENABLED=true]
     expect(selectedSmsIntegrations.length).to.equal(1);
 
     const selectedPushIntegrations = filterEnvIntegrations(pushIntegration, session.environment._id);
-    expect(selectedPushIntegrations.length).to.equal(1);
+    expect(selectedPushIntegrations.length).to.equal(0);
 
-    const selected = chatIntegration.filter((integration) => integration.selected);
-    const notSelected = chatIntegration.filter((integration) => !integration.selected);
-
-    expect(selected.length).to.equal(2);
-    expect(notSelected.length).to.equal(2);
+    const selectedChatIntegrations = filterEnvIntegrations(chatIntegration, session.environment._id);
+    expect(selectedChatIntegrations.length).to.equal(0);
 
     for (const integration of activeIntegrations) {
       expect(integration.active).to.equal(true);

--- a/apps/api/src/app/integrations/e2e/remove-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/remove-integration.e2e.ts
@@ -1,8 +1,16 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import { IntegrationRepository } from '@novu/dal';
-import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
+import {
+  ChannelTypeEnum,
+  EmailProviderIdEnum,
+  InAppProviderIdEnum,
+  ChatProviderIdEnum,
+  PushProviderIdEnum,
+} from '@novu/shared';
 import { HttpStatus } from '@nestjs/common';
+
+const ORIGINAL_IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED;
 
 describe('Delete Integration - /integration/:integrationId (DELETE)', function () {
   let session: UserSession;
@@ -11,6 +19,277 @@ describe('Delete Integration - /integration/:integrationId (DELETE)', function (
   beforeEach(async () => {
     session = new UserSession();
     await session.initialize();
+    process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = 'true';
+  });
+
+  afterEach(async () => {
+    process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = ORIGINAL_IS_MULTI_PROVIDER_CONFIGURATION_ENABLED;
+  });
+
+  it('should throw not found exception when integration is not found', async function () {
+    const integrationId = IntegrationRepository.createObjectId();
+    const { body } = await session.testAgent.delete(`/v1/integrations/${integrationId}`).send();
+
+    expect(body.statusCode).to.equal(404);
+    expect(body.message).to.equal(`Entity with id ${integrationId} not found`);
+  });
+
+  it('should not recalculate primary and priority fields for in-app channel', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const primaryIntegration = await integrationRepository.create({
+      name: 'primaryIntegration',
+      identifier: 'primaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integration = await integrationRepository.create({
+      name: 'integration',
+      identifier: 'integration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const inAppIntegration = await integrationRepository.create({
+      name: 'Novu In-App',
+      identifier: 'identifier1',
+      providerId: InAppProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.IN_APP,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const { statusCode } = await session.testAgent.delete(`/v1/integrations/${inAppIntegration._id}`).send();
+    expect(statusCode).to.equal(200);
+
+    const [first, second] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(primaryIntegration._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(integration._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
+  });
+
+  it('should not recalculate primary and priority fields for push channel', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const primaryIntegration = await integrationRepository.create({
+      name: 'primaryIntegration',
+      identifier: 'primaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integration = await integrationRepository.create({
+      name: 'integration',
+      identifier: 'integration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const pushIntegration = await integrationRepository.create({
+      name: 'FCM',
+      identifier: 'identifier1',
+      providerId: PushProviderIdEnum.FCM,
+      channel: ChannelTypeEnum.PUSH,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const { statusCode } = await session.testAgent.delete(`/v1/integrations/${pushIntegration._id}`).send();
+    expect(statusCode).to.equal(200);
+
+    const [first, second] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(primaryIntegration._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(integration._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
+  });
+
+  it('should not recalculate primary and priority fields for chat channel', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const primaryIntegration = await integrationRepository.create({
+      name: 'primaryIntegration',
+      identifier: 'primaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integration = await integrationRepository.create({
+      name: 'integration',
+      identifier: 'integration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const chatIntegration = await integrationRepository.create({
+      name: 'Slack',
+      identifier: 'identifier1',
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const { statusCode } = await session.testAgent.delete(`/v1/integrations/${chatIntegration._id}`).send();
+    expect(statusCode).to.equal(200);
+
+    const [first, second] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(primaryIntegration._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(integration._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
+  });
+
+  it('should recalculate primary and priority fields for email channel', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const primaryIntegration = await integrationRepository.create({
+      name: 'primaryIntegration',
+      identifier: 'primaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 3,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integrationOne = await integrationRepository.create({
+      name: 'integrationOne',
+      identifier: 'integrationOne',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integrationTwo = await integrationRepository.create({
+      name: 'integrationTwo',
+      identifier: 'integrationTwo',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const { statusCode } = await session.testAgent.delete(`/v1/integrations/${integrationOne._id}`).send();
+    expect(statusCode).to.equal(200);
+
+    const [first, second] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(primaryIntegration._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(integrationTwo._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
   });
 
   it('should remove existing integration', async function () {
@@ -43,7 +322,7 @@ describe('Delete Integration - /integration/:integrationId (DELETE)', function (
     expect(deletedIntegration.deleted).to.equal(true);
   });
 
-  it.skip('should remove a newly created integration', async function () {
+  it('should remove a newly created integration', async function () {
     const payload = {
       providerId: EmailProviderIdEnum.SendGrid,
       channel: ChannelTypeEnum.EMAIL,
@@ -71,12 +350,5 @@ describe('Delete Integration - /integration/:integrationId (DELETE)', function (
     )[0];
 
     expect(deletedIntegration.deleted).to.equal(true);
-  });
-
-  it('fail remove none existing integration', async function () {
-    const dummyId = '012345678912';
-    const response = await session.testAgent.delete(`/v1/integrations/${dummyId}`).send();
-
-    expect(response.body.message).to.contains('Could not find integration with id');
   });
 });

--- a/apps/api/src/app/integrations/e2e/set-itegration-as-primary.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/set-itegration-as-primary.e2e.ts
@@ -1,0 +1,454 @@
+import { IntegrationEntity, IntegrationRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+import {
+  ChannelTypeEnum,
+  ChatProviderIdEnum,
+  EmailProviderIdEnum,
+  InAppProviderIdEnum,
+  PushProviderIdEnum,
+} from '@novu/shared';
+
+const ORIGINAL_IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED;
+
+describe('Set Integration As Primary - /integrations/:integrationId/set-primary (POST)', function () {
+  let session: UserSession;
+  const integrationRepository = new IntegrationRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = 'true';
+  });
+
+  afterEach(async () => {
+    process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = ORIGINAL_IS_MULTI_PROVIDER_CONFIGURATION_ENABLED;
+  });
+
+  it('when integration id is not valid should throw bad request exception', async () => {
+    const fakeIntegrationId = 'fakeIntegrationId';
+
+    const { body } = await session.testAgent.post(`/v1/integrations/${fakeIntegrationId}/set-primary`).send({});
+
+    expect(body.statusCode).to.equal(400);
+    expect(body.message[0]).to.equal(`integrationId must be a mongodb id`);
+  });
+
+  it('when integration does not exist should throw not found exception', async () => {
+    const fakeIntegrationId = IntegrationRepository.createObjectId();
+
+    const { body } = await session.testAgent.post(`/v1/integrations/${fakeIntegrationId}/set-primary`).send({});
+
+    expect(body.statusCode).to.equal(404);
+    expect(body.message).to.equal(`Integration with id ${fakeIntegrationId} not found`);
+  });
+
+  it('in-app channel does not support primary flag, then for integration it should throw bad request exception', async () => {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const inAppIntegration = await integrationRepository.create({
+      name: 'Novu In-App',
+      identifier: 'identifier1',
+      providerId: InAppProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.IN_APP,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const { body } = await session.testAgent.post(`/v1/integrations/${inAppIntegration._id}/set-primary`).send({});
+
+    expect(body.statusCode).to.equal(400);
+    expect(body.message).to.equal(`Channel ${inAppIntegration.channel} does not support primary`);
+  });
+
+  it('push channel does not support primary flag, then for integration it should throw bad request exception', async () => {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const pushIntegration = await integrationRepository.create({
+      name: 'FCM',
+      identifier: 'identifier1',
+      providerId: PushProviderIdEnum.FCM,
+      channel: ChannelTypeEnum.PUSH,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const { body } = await session.testAgent.post(`/v1/integrations/${pushIntegration._id}/set-primary`).send({});
+
+    expect(body.statusCode).to.equal(400);
+    expect(body.message).to.equal(`Channel ${pushIntegration.channel} does not support primary`);
+  });
+
+  it('chat channel does not support primary flag, then for integration it should throw bad request exception', async () => {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const chatIntegration = await integrationRepository.create({
+      name: 'Slack',
+      identifier: 'identifier1',
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const { body } = await session.testAgent.post(`/v1/integrations/${chatIntegration._id}/set-primary`).send({});
+
+    expect(body.statusCode).to.equal(400);
+    expect(body.message).to.equal(`Channel ${chatIntegration.channel} does not support primary`);
+  });
+
+  it('should not update the primary integration if already is primary', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integrationOne = await integrationRepository.create({
+      name: 'Test1',
+      identifier: 'identifier1',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: true,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const {
+      body: { data },
+    } = await session.testAgent.post(`/v1/integrations/${integrationOne._id}/set-primary`).send({});
+
+    expect(data.primary).to.equal(true);
+    expect(data.priority).to.equal(1);
+  });
+
+  it('should set primary and active when there are no other active integrations', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integrationOne = await integrationRepository.create({
+      name: 'Test1',
+      identifier: 'identifier1',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const {
+      body: { data },
+    } = await session.testAgent.post(`/v1/integrations/${integrationOne._id}/set-primary`).send({});
+
+    expect(data.primary).to.equal(true);
+    expect(data.active).to.equal(true);
+    expect(data.priority).to.equal(1);
+  });
+
+  it('should set primary and active and update old primary', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const oldPrimaryIntegration = await integrationRepository.create({
+      name: 'Test1',
+      identifier: 'primaryIdentifier',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integrationOne = await integrationRepository.create({
+      name: 'Test1',
+      identifier: 'identifier1',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const {
+      body: { data },
+    } = await session.testAgent.post(`/v1/integrations/${integrationOne._id}/set-primary`).send({});
+
+    expect(data.primary).to.equal(true);
+    expect(data.active).to.equal(true);
+    expect(data.priority).to.equal(2);
+
+    const updatedOldPrimary = (await integrationRepository.findById(oldPrimaryIntegration._id)) as IntegrationEntity;
+
+    expect(updatedOldPrimary.primary).to.equal(false);
+    expect(updatedOldPrimary.active).to.equal(true);
+    expect(updatedOldPrimary.priority).to.equal(1);
+  });
+
+  it('should set primary and active and update priority for other active integrations', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const oldPrimaryIntegration = await integrationRepository.create({
+      name: 'oldPrimaryIntegration',
+      identifier: 'oldPrimaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegration = await integrationRepository.create({
+      name: 'activeIntegration',
+      identifier: 'activeIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const inactiveIntegration = await integrationRepository.create({
+      name: 'inactiveIntegration',
+      identifier: 'inactiveIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integrationToSetPrimary = await integrationRepository.create({
+      name: 'integrationToSetPrimary',
+      identifier: 'identifier1',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const {
+      body: { data },
+    } = await session.testAgent.post(`/v1/integrations/${integrationToSetPrimary._id}/set-primary`).send({});
+
+    expect(data.primary).to.equal(true);
+    expect(data.active).to.equal(true);
+    expect(data.priority).to.equal(3);
+
+    const [first, second, third, fourth] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(data._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(3);
+
+    expect(second._id).to.equal(oldPrimaryIntegration._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(2);
+
+    expect(third._id).to.equal(activeIntegration._id);
+    expect(third.primary).to.equal(false);
+    expect(third.active).to.equal(true);
+    expect(third.priority).to.equal(1);
+
+    expect(fourth._id).to.equal(inactiveIntegration._id);
+    expect(fourth.primary).to.equal(false);
+    expect(fourth.active).to.equal(false);
+    expect(fourth.priority).to.equal(0);
+  });
+
+  it('should allow set primary for active and recalculate priority for other', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const oldPrimaryIntegration = await integrationRepository.create({
+      name: 'oldPrimaryIntegration',
+      identifier: 'oldPrimaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 3,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegrationOne = await integrationRepository.create({
+      name: 'activeIntegrationOne',
+      identifier: 'activeIntegrationOne',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegrationTwo = await integrationRepository.create({
+      name: 'activeIntegrationTwo',
+      identifier: 'activeIntegrationTwo',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const {
+      body: { data },
+    } = await session.testAgent.post(`/v1/integrations/${activeIntegrationTwo._id}/set-primary`).send({});
+
+    expect(data.primary).to.equal(true);
+    expect(data.active).to.equal(true);
+    expect(data.priority).to.equal(3);
+
+    const [first, second, third] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(activeIntegrationTwo._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(3);
+
+    expect(second._id).to.equal(oldPrimaryIntegration._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(2);
+
+    expect(third._id).to.equal(activeIntegrationOne._id);
+    expect(third.primary).to.equal(false);
+    expect(third.active).to.equal(true);
+    expect(third.priority).to.equal(1);
+  });
+
+  it('should allow to set primary and do not recalculate priority for all inactive', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const inactiveIntegrationOne = await integrationRepository.create({
+      name: 'inactiveIntegrationOne',
+      identifier: 'inactiveIntegrationOne',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const inactiveIntegrationTwo = await integrationRepository.create({
+      name: 'inactiveIntegrationTwo',
+      identifier: 'inactiveIntegrationTwo',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integrationToSetPrimary = await integrationRepository.create({
+      name: 'integrationToSetPrimary',
+      identifier: 'integrationToSetPrimary',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const {
+      body: { data },
+    } = await session.testAgent.post(`/v1/integrations/${integrationToSetPrimary._id}/set-primary`).send({});
+
+    expect(data.primary).to.equal(true);
+    expect(data.active).to.equal(true);
+    expect(data.priority).to.equal(1);
+
+    const [first, second, third] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(integrationToSetPrimary._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(1);
+
+    expect(second._id).to.equal(inactiveIntegrationOne._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(false);
+    expect(second.priority).to.equal(0);
+
+    expect(third._id).to.equal(inactiveIntegrationTwo._id);
+    expect(third.primary).to.equal(false);
+    expect(third.active).to.equal(false);
+    expect(third.priority).to.equal(0);
+  });
+});

--- a/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
@@ -1,7 +1,13 @@
 import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
-import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
+import {
+  ChannelTypeEnum,
+  ChatProviderIdEnum,
+  EmailProviderIdEnum,
+  InAppProviderIdEnum,
+  PushProviderIdEnum,
+} from '@novu/shared';
 
 const ORIGINAL_IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED;
 
@@ -20,9 +26,25 @@ describe('Update Integration - /integrations/:integrationId (PUT)', function () 
     process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = ORIGINAL_IS_MULTI_PROVIDER_CONFIGURATION_ENABLED;
   });
 
+  it('should throw not found exception when integration is not found', async function () {
+    const integrationId = IntegrationRepository.createObjectId();
+    const payload = {
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      credentials: { apiKey: 'new_key', secretKey: 'new_secret' },
+      active: true,
+      check: false,
+    };
+
+    const { body } = await session.testAgent.put(`/v1/integrations/${integrationId}`).send(payload);
+
+    expect(body.statusCode).to.equal(404);
+    expect(body.message).to.equal(`Entity with id ${integrationId} not found`);
+  });
+
   it('should update newly created integration', async function () {
     const payload = {
-      providerId: 'sendgrid',
+      providerId: EmailProviderIdEnum.SendGrid,
       channel: ChannelTypeEnum.EMAIL,
       credentials: { apiKey: 'new_key', secretKey: 'new_secret' },
       active: true,
@@ -194,5 +216,631 @@ describe('Update Integration - /integrations/:integrationId (PUT)', function () 
       updatedNodeMailerProviderPayload.credentials.tlsOptions
     );
     expect(nodeMailerIntegration?.active).to.equal(true);
+  });
+
+  it('should not calculate primary and priority if active is not defined', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const emailIntegration = await integrationRepository.create({
+      name: 'SendGrid',
+      identifier: 'identifier1',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      name: 'SendGrid Email',
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${emailIntegration._id}`).send(payload);
+
+    expect(data.name).to.equal('SendGrid Email');
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(false);
+  });
+
+  it('should not calculate primary and priority if active not changed', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const emailIntegration = await integrationRepository.create({
+      name: 'SendGrid Email',
+      identifier: 'identifier1',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: false,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${emailIntegration._id}`).send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(false);
+  });
+
+  it('should not calculate primary and priority fields for in-app channel', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const inAppIntegration = await integrationRepository.create({
+      name: 'Novu In-App',
+      identifier: 'identifier1',
+      providerId: InAppProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.IN_APP,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${inAppIntegration._id}`).send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+  });
+
+  it('should not calculate primary and priority fields for push channel', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const pushIntegration = await integrationRepository.create({
+      name: 'FCM',
+      identifier: 'identifier1',
+      providerId: PushProviderIdEnum.FCM,
+      channel: ChannelTypeEnum.PUSH,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${pushIntegration._id}`).send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+  });
+
+  it('should not calculate primary and priority fields for chat channel', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const chatIntegration = await integrationRepository.create({
+      name: 'Slack',
+      identifier: 'identifier1',
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${chatIntegration._id}`).send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+  });
+
+  it('should set the primary if there are no other active integrations', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integration = await integrationRepository.create({
+      name: 'integration',
+      identifier: 'integration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${integration._id}`).send(payload);
+
+    expect(data.priority).to.equal(1);
+    expect(data.primary).to.equal(true);
+    expect(data.active).to.equal(true);
+  });
+
+  it('should set the primary if there are no other active integrations excluding Novu', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const novuEmail = await integrationRepository.create({
+      name: 'novuEmail',
+      identifier: 'novuEmail',
+      providerId: EmailProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integration = await integrationRepository.create({
+      name: 'integration',
+      identifier: 'integration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${integration._id}`).send(payload);
+
+    expect(data.priority).to.equal(2);
+    expect(data.primary).to.equal(true);
+    expect(data.active).to.equal(true);
+
+    const [first, second] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(integration._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(novuEmail._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
+  });
+
+  it('should calculate the highest priority but not set primary if there is another active integration', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const firstActiveIntegration = await integrationRepository.create({
+      name: 'firstActiveIntegration',
+      identifier: 'firstActiveIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const secondActiveIntegration = await integrationRepository.create({
+      name: 'secondActiveIntegration',
+      identifier: 'secondActiveIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${secondActiveIntegration._id}`).send(payload);
+
+    expect(data.priority).to.equal(2);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+
+    const [first, second] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(secondActiveIntegration._id);
+    expect(first.primary).to.equal(false);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(firstActiveIntegration._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
+  });
+
+  it('should calculate the priority but not higher than the primary integration', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const primaryIntegration = await integrationRepository.create({
+      name: 'primaryIntegration',
+      identifier: 'primaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 3,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegrationOne = await integrationRepository.create({
+      name: 'activeIntegrationOne',
+      identifier: 'activeIntegrationOne',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegrationTwo = await integrationRepository.create({
+      name: 'activeIntegrationTwo',
+      identifier: 'activeIntegrationTwo',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const inactiveIntegration = await integrationRepository.create({
+      name: 'inactiveIntegration',
+      identifier: 'inactiveIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const integration = await integrationRepository.create({
+      name: 'integration',
+      identifier: 'integration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${integration._id}`).send(payload);
+
+    expect(data.priority).to.equal(3);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(true);
+
+    const [first, second, third, fourth, fifth] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1 } }
+    );
+
+    expect(first._id).to.equal(primaryIntegration._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(4);
+
+    expect(second._id).to.equal(integration._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(3);
+
+    expect(third._id).to.equal(activeIntegrationOne._id);
+    expect(third.primary).to.equal(false);
+    expect(third.active).to.equal(true);
+    expect(third.priority).to.equal(2);
+
+    expect(fourth._id).to.equal(activeIntegrationTwo._id);
+    expect(fourth.primary).to.equal(false);
+    expect(fourth.active).to.equal(true);
+    expect(fourth.priority).to.equal(1);
+
+    expect(fifth._id).to.equal(inactiveIntegration._id);
+    expect(fifth.primary).to.equal(false);
+    expect(fifth.active).to.equal(false);
+    expect(fifth.priority).to.equal(0);
+  });
+
+  it('should recalculate the priority when integration is deactivated', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const primaryIntegration = await integrationRepository.create({
+      name: 'primaryIntegration',
+      identifier: 'primaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 3,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegrationOne = await integrationRepository.create({
+      name: 'activeIntegrationOne',
+      identifier: 'activeIntegrationOne',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegrationTwo = await integrationRepository.create({
+      name: 'activeIntegrationTwo',
+      identifier: 'activeIntegrationTwo',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const inactiveIntegration = await integrationRepository.create({
+      name: 'inactiveIntegration',
+      identifier: 'inactiveIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: false,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${activeIntegrationOne._id}`).send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(false);
+
+    const [first, second, third, fourth] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1, createdAt: -1 } }
+    );
+
+    expect(first._id).to.equal(primaryIntegration._id);
+    expect(first.primary).to.equal(true);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(activeIntegrationTwo._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
+
+    expect(third._id).to.equal(inactiveIntegration._id);
+    expect(third.primary).to.equal(false);
+    expect(third.active).to.equal(false);
+    expect(third.priority).to.equal(0);
+
+    expect(fourth._id).to.equal(activeIntegrationOne._id);
+    expect(fourth.primary).to.equal(false);
+    expect(fourth.active).to.equal(false);
+    expect(fourth.priority).to.equal(0);
+  });
+
+  it('should recalculate the priority when the primary integration is deactivated', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const primaryIntegration = await integrationRepository.create({
+      name: 'primaryIntegration',
+      identifier: 'primaryIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      priority: 3,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegrationOne = await integrationRepository.create({
+      name: 'activeIntegrationOne',
+      identifier: 'activeIntegrationOne',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 2,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const activeIntegrationTwo = await integrationRepository.create({
+      name: 'activeIntegrationTwo',
+      identifier: 'activeIntegrationTwo',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: false,
+      priority: 1,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const inactiveIntegration = await integrationRepository.create({
+      name: 'inactiveIntegration',
+      identifier: 'inactiveIntegration',
+      providerId: EmailProviderIdEnum.SendGrid,
+      channel: ChannelTypeEnum.EMAIL,
+      active: false,
+      primary: false,
+      priority: 0,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      active: false,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${primaryIntegration._id}`).send(payload);
+
+    expect(data.priority).to.equal(0);
+    expect(data.primary).to.equal(false);
+    expect(data.active).to.equal(false);
+
+    const [first, second, third, fourth] = await await integrationRepository.find(
+      {
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.EMAIL,
+      },
+      undefined,
+      { sort: { priority: -1, createdAt: -1 } }
+    );
+
+    expect(first._id).to.equal(activeIntegrationOne._id);
+    expect(first.primary).to.equal(false);
+    expect(first.active).to.equal(true);
+    expect(first.priority).to.equal(2);
+
+    expect(second._id).to.equal(activeIntegrationTwo._id);
+    expect(second.primary).to.equal(false);
+    expect(second.active).to.equal(true);
+    expect(second.priority).to.equal(1);
+
+    expect(third._id).to.equal(inactiveIntegration._id);
+    expect(third.primary).to.equal(false);
+    expect(third.active).to.equal(false);
+    expect(third.priority).to.equal(0);
+
+    expect(fourth._id).to.equal(primaryIntegration._id);
+    expect(fourth.primary).to.equal(false);
+    expect(fourth.active).to.equal(false);
+    expect(fourth.priority).to.equal(0);
   });
 });

--- a/apps/api/src/app/integrations/usecases/get-active-integration/get-active-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/get-active-integration/get-active-integration.command.ts
@@ -1,8 +1,3 @@
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
-import { IsOptional } from 'class-validator';
-import { ProvidersIdEnum } from '@novu/shared';
 
-export class GetActiveIntegrationsCommand extends EnvironmentWithUserCommand {
-  @IsOptional()
-  providerId?: ProvidersIdEnum;
-}
+export class GetActiveIntegrationsCommand extends EnvironmentWithUserCommand {}

--- a/apps/api/src/app/integrations/usecases/get-active-integration/get-active-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/get-active-integration/get-active-integration.usecase.ts
@@ -3,13 +3,9 @@ import { Injectable } from '@nestjs/common';
 import {
   GetDecryptedIntegrations,
   GetDecryptedIntegrationsCommand,
-  SelectIntegration,
-  SelectIntegrationCommand,
   FeatureFlagCommand,
   GetFeatureFlag,
 } from '@novu/application-generic';
-import { ChannelTypeEnum } from '@novu/shared';
-import { EnvironmentEntity, EnvironmentRepository, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 
 import { GetActiveIntegrationsCommand } from './get-active-integration.command';
 import { GetActiveIntegrationResponseDto } from '../../dtos/get-active-integration-response.dto';
@@ -17,9 +13,6 @@ import { GetActiveIntegrationResponseDto } from '../../dtos/get-active-integrati
 @Injectable()
 export class GetActiveIntegrations {
   constructor(
-    private integrationRepository: IntegrationRepository,
-    private selectIntegration: SelectIntegration,
-    private environmentRepository: EnvironmentRepository,
     private getDecryptedIntegrationsUsecase: GetDecryptedIntegrations,
     private getFeatureFlag: GetFeatureFlag
   ) {}
@@ -50,81 +43,9 @@ export class GetActiveIntegrations {
       return activeIntegrations;
     }
 
-    const environments = await this.environmentRepository.findOrganizationEnvironments(command.organizationId);
-    const activeIntegrationChannelTypes = this.getDistinctChannelTypes(activeIntegrations);
-    const selectedIntegrations = await this.getSelectedIntegrations(
-      command,
-      activeIntegrationChannelTypes,
-      environments
-    );
-
-    return this.mapBySelectedIntegration(activeIntegrations, selectedIntegrations);
-  }
-
-  private getDistinctChannelTypes(activeIntegration: IntegrationEntity[]): ChannelTypeEnum[] {
-    return activeIntegration.map((integration) => integration.channel).filter(this.distinct);
-  }
-
-  distinct = (value, index, self) => {
-    return self.indexOf(value) === index;
-  };
-
-  private mapBySelectedIntegration(
-    activeIntegration: IntegrationEntity[],
-    selectedIntegrations: IntegrationEntity[]
-  ): GetActiveIntegrationResponseDto[] {
-    return activeIntegration.map((integration) => {
-      // novu integrations doesn't have unique id that's why we need to compare by environmentId
-      const selected = selectedIntegrations.find(
-        (selectedIntegration) =>
-          selectedIntegration._id === integration._id &&
-          selectedIntegration._environmentId === integration._environmentId
-      );
-
-      return selected ? { ...integration, selected: true } : { ...integration, selected: false };
+    return activeIntegrations.map((integration) => {
+      return { ...integration, selected: integration.primary };
     });
-  }
-
-  private async getSelectedIntegrations(
-    command: GetActiveIntegrationsCommand,
-    activeIntegrationChannelTypes: ChannelTypeEnum[],
-    environments: EnvironmentEntity[]
-  ) {
-    const integrationPromises = this.selectIntegrationByEnvironment(
-      environments,
-      command,
-      activeIntegrationChannelTypes
-    );
-
-    return (await Promise.all(integrationPromises)).filter(notNullish);
-  }
-
-  private selectIntegrationByEnvironment(
-    environments,
-    command: GetActiveIntegrationsCommand,
-    activeIntegrationChannelTypes: ChannelTypeEnum[]
-  ) {
-    return environments.flatMap((environment) =>
-      this.selectIntegrationByChannelType(environment._id, command, activeIntegrationChannelTypes)
-    );
-  }
-
-  private selectIntegrationByChannelType(
-    environmentId,
-    command: GetActiveIntegrationsCommand,
-    activeIntegrationChannelTypes: ChannelTypeEnum[]
-  ) {
-    return activeIntegrationChannelTypes.map((channelType) =>
-      this.selectIntegration.execute(
-        SelectIntegrationCommand.create({
-          environmentId: environmentId,
-          organizationId: command.organizationId,
-          userId: command.userId,
-          channelType: channelType as ChannelTypeEnum,
-          providerId: command.providerId,
-        })
-      )
-    );
   }
 }
 

--- a/apps/api/src/app/integrations/usecases/index.ts
+++ b/apps/api/src/app/integrations/usecases/index.ts
@@ -15,6 +15,7 @@ import { GetActiveIntegrations } from './get-active-integration/get-active-integ
 import { CheckIntegration } from './check-integration/check-integration.usecase';
 import { CheckIntegrationEMail } from './check-integration/check-integration-email.usecase';
 import { GetInAppActivated } from './get-in-app-activated/get-in-app-activated.usecase';
+import { SetIntegrationAsPrimary } from './set-integration-as-primary/set-integration-as-primary.usecase';
 
 export const USE_CASES = [
   GetInAppActivated,
@@ -31,4 +32,5 @@ export const USE_CASES = [
   CheckIntegrationEMail,
   GetNovuIntegration,
   CalculateLimitNovuIntegration,
+  SetIntegrationAsPrimary,
 ];

--- a/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.command.ts
@@ -1,7 +1,11 @@
-import { IsDefined } from 'class-validator';
+import { IsDefined, IsNotEmpty } from 'class-validator';
+
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class RemoveIntegrationCommand extends EnvironmentCommand {
+  @IsNotEmpty()
+  public readonly userId: string;
+
   @IsDefined()
   integrationId: string;
 }

--- a/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.usecase.ts
@@ -1,6 +1,12 @@
-import { Injectable, Scope } from '@nestjs/common';
+import { Injectable, NotFoundException, Scope } from '@nestjs/common';
 import { IntegrationRepository, DalException } from '@novu/dal';
-import { buildIntegrationKey, InvalidateCacheService } from '@novu/application-generic';
+import { CHANNELS_WITH_PRIMARY } from '@novu/shared';
+import {
+  buildIntegrationKey,
+  FeatureFlagCommand,
+  GetFeatureFlag,
+  InvalidateCacheService,
+} from '@novu/application-generic';
 
 import { RemoveIntegrationCommand } from './remove-integration.command';
 import { ApiException } from '../../../shared/exceptions/api.exception';
@@ -9,18 +15,48 @@ import { ApiException } from '../../../shared/exceptions/api.exception';
   scope: Scope.REQUEST,
 })
 export class RemoveIntegration {
-  constructor(private invalidateCache: InvalidateCacheService, private integrationRepository: IntegrationRepository) {}
+  constructor(
+    private invalidateCache: InvalidateCacheService,
+    private integrationRepository: IntegrationRepository,
+    private getFeatureFlag: GetFeatureFlag
+  ) {}
 
   async execute(command: RemoveIntegrationCommand) {
     try {
-      // TODO: We should check first if the Integration exists in the database
+      const existingIntegration = await this.integrationRepository.findById(command.integrationId);
+      if (!existingIntegration) {
+        throw new NotFoundException(`Entity with id ${command.integrationId} not found`);
+      }
+
       await this.invalidateCache.invalidateQuery({
         key: buildIntegrationKey().invalidate({
           _organizationId: command.organizationId,
         }),
       });
 
-      await this.integrationRepository.delete({ _id: command.integrationId, _organizationId: command.organizationId });
+      await this.integrationRepository.delete({
+        _id: existingIntegration._id,
+        _organizationId: existingIntegration._organizationId,
+      });
+
+      const isMultiProviderConfigurationEnabled = await this.getFeatureFlag.isMultiProviderConfigurationEnabled(
+        FeatureFlagCommand.create({
+          userId: command.userId,
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+        })
+      );
+
+      const isChannelSupportsPrimary = CHANNELS_WITH_PRIMARY.includes(existingIntegration.channel);
+      if (isMultiProviderConfigurationEnabled && isChannelSupportsPrimary) {
+        await this.integrationRepository.recalculatePriorityForAllActive({
+          _id: existingIntegration._id,
+          _organizationId: existingIntegration._organizationId,
+          _environmentId: existingIntegration._environmentId,
+          channel: existingIntegration.channel,
+          exclude: true,
+        });
+      }
     } catch (e) {
       if (e instanceof DalException) {
         throw new ApiException(e.message);

--- a/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.command.ts
+++ b/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.command.ts
@@ -1,0 +1,13 @@
+import { IsDefined, IsMongoId } from 'class-validator';
+
+import { OrganizationCommand } from '../../../shared/commands/organization.command';
+
+export class SetIntegrationAsPrimaryCommand extends OrganizationCommand {
+  @IsDefined()
+  @IsMongoId()
+  integrationId: string;
+
+  @IsDefined()
+  @IsMongoId()
+  environmentId: string;
+}

--- a/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.usecase.ts
@@ -1,0 +1,109 @@
+import { Injectable, NotFoundException, Logger, BadRequestException } from '@nestjs/common';
+import { IntegrationEntity, IntegrationRepository } from '@novu/dal';
+import { CHANNELS_WITH_PRIMARY } from '@novu/shared';
+import {
+  AnalyticsService,
+  buildIntegrationKey,
+  InvalidateCacheService,
+  GetFeatureFlag,
+  FeatureFlagCommand,
+} from '@novu/application-generic';
+
+import { SetIntegrationAsPrimaryCommand } from './set-integration-as-primary.command';
+
+@Injectable()
+export class SetIntegrationAsPrimary {
+  constructor(
+    private invalidateCache: InvalidateCacheService,
+    private integrationRepository: IntegrationRepository,
+    private analyticsService: AnalyticsService,
+    private getFeatureFlag: GetFeatureFlag
+  ) {}
+
+  private async updatePrimaryFlag({ existingIntegration }: { existingIntegration: IntegrationEntity }) {
+    await this.integrationRepository.update(
+      {
+        _organizationId: existingIntegration._organizationId,
+        _environmentId: existingIntegration._environmentId,
+        channel: existingIntegration.channel,
+        active: true,
+        primary: true,
+      },
+      {
+        $set: {
+          primary: false,
+        },
+      }
+    );
+
+    await this.integrationRepository.update(
+      {
+        _id: existingIntegration._id,
+        _organizationId: existingIntegration._organizationId,
+        _environmentId: existingIntegration._environmentId,
+      },
+      {
+        $set: {
+          active: true,
+          primary: true,
+        },
+      }
+    );
+  }
+
+  async execute(command: SetIntegrationAsPrimaryCommand): Promise<IntegrationEntity> {
+    Logger.verbose('Executing Set Integration As Primary Usecase');
+
+    const existingIntegration = await this.integrationRepository.findById(command.integrationId);
+    if (!existingIntegration) {
+      throw new NotFoundException(`Integration with id ${command.integrationId} not found`);
+    }
+
+    if (!CHANNELS_WITH_PRIMARY.includes(existingIntegration.channel)) {
+      throw new BadRequestException(`Channel ${existingIntegration.channel} does not support primary`);
+    }
+
+    const { _organizationId, _environmentId, channel, providerId } = existingIntegration;
+    const isMultiProviderConfigurationEnabled = await this.getFeatureFlag.isMultiProviderConfigurationEnabled(
+      FeatureFlagCommand.create({
+        userId: command.userId,
+        organizationId: _organizationId,
+        environmentId: _environmentId,
+      })
+    );
+    if (!isMultiProviderConfigurationEnabled || existingIntegration.primary) {
+      return existingIntegration;
+    }
+
+    this.analyticsService.track('Set Integration As Primary - [Integrations]', command.userId, {
+      providerId,
+      channel,
+      _organizationId,
+      _environmentId,
+    });
+
+    await this.invalidateCache.invalidateQuery({
+      key: buildIntegrationKey().invalidate({
+        _organizationId,
+      }),
+    });
+
+    await this.updatePrimaryFlag({ existingIntegration });
+
+    await this.integrationRepository.recalculatePriorityForAllActive({
+      _id: existingIntegration._id,
+      _organizationId,
+      _environmentId,
+      channel,
+    });
+
+    const updatedIntegration = await this.integrationRepository.findOne({
+      _id: command.integrationId,
+      _organizationId,
+      _environmentId,
+    });
+    if (!updatedIntegration) throw new NotFoundException(`Integration with id ${command.integrationId} is not found`);
+
+    return updatedIntegration;
+  }
+}

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -40,7 +40,8 @@ export const WIDGET_EMBED_PATH =
 export const IS_DOCKER_HOSTED =
   window._env_.REACT_APP_DOCKER_HOSTED_ENV === 'true' || process.env.REACT_APP_DOCKER_HOSTED_ENV === 'true';
 
-export const INTERCOM_APP_ID = window._env_.REACT_APP_INTERCOM_APP_ID || process.env.REACT_APP_INTERCOM_APP_ID;
+export const INTERCOM_APP_ID =
+  'fqe0apnx' || window._env_.REACT_APP_INTERCOM_APP_ID || process.env.REACT_APP_INTERCOM_APP_ID;
 
 export const CONTEXT_PATH = getContextPath(NovuComponentEnum.WEB);
 
@@ -54,7 +55,9 @@ export const MAIL_SERVER_DOMAIN =
   window._env_.REACT_APP_MAIL_SERVER_DOMAIN || process.env.REACT_APP_MAIL_SERVER_DOMAIN || 'dev.inbound-mail.novu.co';
 
 export const LAUNCH_DARKLY_CLIENT_SIDE_ID =
-  window._env_.REACT_APP_LAUNCH_DARKLY_CLIENT_SIDE_ID || process.env.REACT_APP_LAUNCH_DARKLY_CLIENT_SIDE_ID;
+  '64708935336dd81236770db7' ||
+  window._env_.REACT_APP_LAUNCH_DARKLY_CLIENT_SIDE_ID ||
+  process.env.REACT_APP_LAUNCH_DARKLY_CLIENT_SIDE_ID;
 
 export const IS_TEMPLATE_STORE_ENABLED = isCypress
   ? window._env_.IS_TEMPLATE_STORE_ENABLED || process.env.IS_TEMPLATE_STORE_ENABLED || 'true'

--- a/libs/dal/src/repositories/integration/integration.entity.ts
+++ b/libs/dal/src/repositories/integration/integration.entity.ts
@@ -23,6 +23,10 @@ export class IntegrationEntity {
 
   identifier: string;
 
+  priority: number;
+
+  primary: boolean;
+
   deleted: boolean;
 
   deletedAt: string;

--- a/libs/dal/src/repositories/integration/integration.repository.ts
+++ b/libs/dal/src/repositories/integration/integration.repository.ts
@@ -1,5 +1,6 @@
 import { FilterQuery } from 'mongoose';
 import { SoftDeleteModel } from 'mongoose-delete';
+import { NOVU_PROVIDERS } from '@novu/shared';
 
 import { IntegrationEntity, IntegrationDBModel } from './integration.entity';
 import { Integration } from './integration.schema';
@@ -8,7 +9,7 @@ import { BaseRepository } from '../base-repository';
 import { DalException } from '../../shared';
 import type { EnforceEnvOrOrgIds, IDeleteResult } from '../../types';
 
-type IntegrationQuery = FilterQuery<IntegrationDBModel> & EnforceEnvOrOrgIds;
+export type IntegrationQuery = FilterQuery<IntegrationDBModel> & EnforceEnvOrOrgIds;
 
 export class IntegrationRepository extends BaseRepository<IntegrationDBModel, IntegrationEntity, EnforceEnvOrOrgIds> {
   private integration: SoftDeleteModel;
@@ -29,6 +30,39 @@ export class IntegrationRepository extends BaseRepository<IntegrationDBModel, In
   async findByEnvironmentId(environmentId: string): Promise<IntegrationEntity[]> {
     return await this.find({
       _environmentId: environmentId,
+    });
+  }
+
+  async findHighestPriorityIntegration({
+    _organizationId,
+    _environmentId,
+    channel,
+  }: Pick<IntegrationEntity, '_environmentId' | '_organizationId' | 'channel'>) {
+    return await this.findOne(
+      {
+        _organizationId,
+        _environmentId,
+        channel,
+        active: true,
+      },
+      undefined,
+      { query: { sort: { priority: -1 } } }
+    );
+  }
+
+  async countActiveExcludingNovu({
+    _organizationId,
+    _environmentId,
+    channel,
+  }: Pick<IntegrationEntity, '_environmentId' | '_organizationId' | 'channel'>) {
+    return await this.count({
+      _organizationId,
+      _environmentId,
+      channel,
+      active: true,
+      providerId: {
+        $nin: NOVU_PROVIDERS,
+      },
     });
   }
 
@@ -69,5 +103,50 @@ export class IntegrationRepository extends BaseRepository<IntegrationDBModel, In
     const res: IntegrationEntity = await this.integration.findDeleted(query);
 
     return this.mapEntity(res);
+  }
+
+  async recalculatePriorityForAllActive({
+    _id,
+    _organizationId,
+    _environmentId,
+    channel,
+    exclude = false,
+  }: Pick<IntegrationEntity, '_id' | '_environmentId' | '_organizationId' | 'channel'> & {
+    exclude?: boolean;
+  }) {
+    const otherActiveIntegrations = await this.find(
+      {
+        _organizationId,
+        _environmentId,
+        channel,
+        active: true,
+        _id: {
+          $nin: [_id],
+        },
+      },
+      '_id',
+      { sort: { priority: -1 } }
+    );
+
+    let ids = [_id, ...otherActiveIntegrations.map((integration) => integration._id)];
+    if (exclude) {
+      ids = otherActiveIntegrations.map((integration) => integration._id);
+    }
+
+    const promises = ids.map((id, index) =>
+      this.update(
+        {
+          _id: id,
+          _organizationId,
+          _environmentId,
+        },
+        {
+          $set: {
+            priority: ids.length - index,
+          },
+        }
+      )
+    );
+    await Promise.all(promises);
   }
 }

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -52,6 +52,14 @@ const integrationSchema = new Schema<IntegrationDBModel>(
     },
     name: Schema.Types.String,
     identifier: Schema.Types.String,
+    priority: {
+      type: Schema.Types.Number,
+      default: 0,
+    },
+    primary: {
+      type: Schema.Types.Boolean,
+      default: false,
+    },
   },
   schemaOptions
 );

--- a/libs/shared/src/consts/providers/provider.enum.ts
+++ b/libs/shared/src/consts/providers/provider.enum.ts
@@ -92,6 +92,12 @@ export enum InAppProviderIdEnum {
   Novu = 'novu',
 }
 
+export const NOVU_PROVIDERS: ProvidersIdEnum[] = [
+  InAppProviderIdEnum.Novu,
+  SmsProviderIdEnum.Novu,
+  EmailProviderIdEnum.Novu,
+];
+
 export type ProvidersIdEnum =
   | EmailProviderIdEnum
   | SmsProviderIdEnum

--- a/libs/shared/src/types/channel/index.ts
+++ b/libs/shared/src/types/channel/index.ts
@@ -50,3 +50,5 @@ export enum SystemAvatarIconEnum {
   UP = 'up',
   QUESTION = 'question',
 }
+
+export const CHANNELS_WITH_PRIMARY = [ChannelTypeEnum.EMAIL, ChannelTypeEnum.SMS];

--- a/libs/testing/src/integration.service.ts
+++ b/libs/testing/src/integration.service.ts
@@ -87,6 +87,8 @@ export class IntegrationService {
       channel: ChannelTypeEnum.EMAIL,
       credentials: { apiKey: 'SG.123', secretKey: 'abc' },
       active: true,
+      primary: true,
+      priority: 1,
     };
 
     await this.integrationRepository.create(mailPayload);
@@ -98,6 +100,8 @@ export class IntegrationService {
       channel: ChannelTypeEnum.SMS,
       credentials: { accountSid: 'AC123', token: '123', from: 'me' },
       active: true,
+      primary: true,
+      priority: 1,
     };
     await this.integrationRepository.create(smsPayload);
 

--- a/packages/application-generic/src/usecases/select-integration/select-integration.spec.ts
+++ b/packages/application-generic/src/usecases/select-integration/select-integration.spec.ts
@@ -37,6 +37,8 @@ const testIntegration: IntegrationEntity = {
   deleted: false,
   identifier: 'test-integration-identifier',
   name: 'test-integration-name',
+  primary: true,
+  priority: 1,
   deletedAt: null,
   deletedBy: null,
 };
@@ -52,6 +54,8 @@ const novuIntegration: IntegrationEntity = {
   deleted: false,
   identifier: 'test-novu-integration-identifier',
   name: 'test-novu-integration-name',
+  primary: true,
+  priority: 1,
   deletedAt: null,
   deletedBy: null,
 };
@@ -100,6 +104,7 @@ describe('select integration', function () {
       // @ts-ignore
       new GetDecryptedIntegrations()
     );
+    jest.clearAllMocks();
   });
 
   it('should select the integration', async function () {
@@ -131,4 +136,47 @@ describe('select integration', function () {
     expect(integration).not.toBeNull();
     expect(integration?.providerId).toEqual(EmailProviderIdEnum.Novu);
   });
+
+  it.each`
+    channel                   | shouldUsePrimary
+    ${ChannelTypeEnum.PUSH}   | ${false}
+    ${ChannelTypeEnum.CHAT}   | ${false}
+    ${ChannelTypeEnum.IN_APP} | ${false}
+    ${ChannelTypeEnum.EMAIL}  | ${true}
+    ${ChannelTypeEnum.SMS}    | ${true}
+  `(
+    'for channel $channel it should select integration by primary: $shouldUsePrimary',
+    async ({ channel, shouldUsePrimary }) => {
+      const environmentId = 'environmentId';
+      const organizationId = 'organizationId';
+      const userId = 'userId';
+      findOneMock.mockImplementation(() => ({
+        ...testIntegration,
+        channel,
+      }));
+
+      const integration = await useCase.execute(
+        SelectIntegrationCommand.create({
+          channelType: channel,
+          environmentId,
+          organizationId,
+          userId,
+        })
+      );
+
+      expect(findOneMock).toHaveBeenCalledWith(
+        {
+          _organizationId: organizationId,
+          _environmentId: environmentId,
+          channel,
+          active: true,
+          ...(shouldUsePrimary && {
+            primary: true,
+          }),
+        },
+        undefined,
+        { query: { sort: { createdAt: -1 } } }
+      );
+    }
+  );
 });

--- a/packages/application-generic/src/usecases/select-integration/select-integration.usecase.ts
+++ b/packages/application-generic/src/usecases/select-integration/select-integration.usecase.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { IntegrationEntity, IntegrationRepository } from '@novu/dal';
+import { CHANNELS_WITH_PRIMARY } from '@novu/shared';
 
 import {
   GetNovuIntegration,
@@ -57,6 +58,10 @@ export class SelectIntegration {
       return integrations[0];
     }
 
+    const isChannelSupportsPrimary = CHANNELS_WITH_PRIMARY.includes(
+      command.channelType
+    );
+
     let query: Partial<IntegrationEntity> & { _organizationId: string } = {
       ...(command.id ? { id: command.id } : {}),
       _organizationId: command.organizationId,
@@ -64,6 +69,9 @@ export class SelectIntegration {
       channel: command.channelType,
       ...(command.providerId ? { providerId: command.providerId } : {}),
       active: true,
+      ...(isChannelSupportsPrimary && {
+        primary: true,
+      }),
     };
 
     if (command.identifier) {


### PR DESCRIPTION
### What change does this PR introduce?

Set integration as "primary" endpoint and priority system logic:
1. One integration per channel could be marked as primary.
2. Only Email and SMS integrations could be marked as primary and will apply priority to the integrations. For the Chat and Push integrations messages are delivered for each channel, potentially different integrations, meaning that we can't have a "primary" integration concept or priority system. For In-App we only have one provider rn, but in future, we might have many per application, so there also we can't apply these concepts.
3. When we do create or update the first active integration (excluding Novu providers) for the Email or SMS channel, that integration will become automatically primary.
4. I will describe all the other logic in comments on the code.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
