### PR TITLE
fix: allow return 'data' as response prop

### DIFF
--- a/apps/api/src/app/shared/framework/response.interceptor.ts
+++ b/apps/api/src/app/shared/framework/response.interceptor.ts
@@ -33,7 +33,7 @@ export class ResponseInterceptor<T> implements NestInterceptor<T, Response<T>> {
   /**
    * This method is used to determine if the entire object should be returned or just the data property
    *   for paginated results that already contain the data wrapper, true.
-   *   for entity results that *could* contain data object, false.
+   *   for single entity result that *could* contain data object, false.
    * @param data
    * @private
    */

--- a/apps/api/src/app/shared/framework/response.interceptor.ts
+++ b/apps/api/src/app/shared/framework/response.interceptor.ts
@@ -17,7 +17,7 @@ export class ResponseInterceptor<T> implements NestInterceptor<T, Response<T>> {
     return next.handle().pipe(
       map((data) => {
         // For paginated results that already contain the data wrapper, return the whole object
-        if (data?.data) {
+        if (data?.data && !data?._id) {
           return {
             ...data,
             data: isObject(data.data) ? this.transformResponse(data.data) : data.data,

--- a/apps/api/src/app/shared/framework/response.interceptor.ts
+++ b/apps/api/src/app/shared/framework/response.interceptor.ts
@@ -16,8 +16,7 @@ export class ResponseInterceptor<T> implements NestInterceptor<T, Response<T>> {
 
     return next.handle().pipe(
       map((data) => {
-        // For paginated results that already contain the data wrapper, return the whole object
-        if (data?.data && !data?._id) {
+        if (this.returnWholeObject(data)) {
           return {
             ...data,
             data: isObject(data.data) ? this.transformResponse(data.data) : data.data,
@@ -29,6 +28,20 @@ export class ResponseInterceptor<T> implements NestInterceptor<T, Response<T>> {
         };
       })
     );
+  }
+
+  /**
+   * This method is used to determine if the entire object should be returned or just the data property
+   *   for paginated results that already contain the data wrapper, true.
+   *   for entity results that *could* contain data object, false.
+   * @param data
+   * @private
+   */
+  private returnWholeObject(data) {
+    const isPaginatedResult = data?.data;
+    const isEntityObject = data?._id;
+
+    return isPaginatedResult && !isEntityObject;
   }
 
   private transformResponse(response) {

--- a/apps/api/src/app/tenant/e2e/get-tenant.e2e.ts
+++ b/apps/api/src/app/tenant/e2e/get-tenant.e2e.ts
@@ -45,9 +45,11 @@ describe('Get Tenant - /tenants/:identifier (GET)', function () {
 async function getTenant({ session, identifier }: { session; identifier: string }): Promise<AxiosResponse> {
   const axiosInstance = axios.create();
 
-  return await axiosInstance.get(`${session.serverUrl}/v1/tenants/${identifier}`, {
-    headers: {
-      authorization: `ApiKey ${session.apiKey}`,
-    },
-  });
+  return (
+    await axiosInstance.get(`${session.serverUrl}/v1/tenants/${identifier}`, {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    })
+  ).data;
 }


### PR DESCRIPTION
### What change does this PR introduce?

allow return 'data' as response prop

### Why was this change needed?

so we could create entities with a 'data' prop on the root layer and return them properly.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
