### PR TITLE
[Tenants] - Add Tenants Analytics

### DIFF
--- a/apps/api/src/app/tenant/tenant.controller.ts
+++ b/apps/api/src/app/tenant/tenant.controller.ts
@@ -9,7 +9,6 @@ import {
   Param,
   Patch,
   Post,
-  Put,
   Query,
   UseGuards,
   UseInterceptors,
@@ -125,6 +124,7 @@ export class TenantController {
   ): Promise<CreateTenantResponseDto> {
     return await this.createTenantUsecase.execute(
       CreateTenantCommand.create({
+        userId: user._id,
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         identifier: body.identifier,
@@ -151,6 +151,7 @@ export class TenantController {
   ): Promise<UpdateTenantResponseDto> {
     return await this.updateTenantUsecase.execute(
       UpdateTenantCommand.create({
+        userId: user._id,
         identifier: identifier,
         environmentId: user.environmentId,
         organizationId: user.organizationId,
@@ -178,6 +179,7 @@ export class TenantController {
   async removeTenant(@UserSession() user: IJwtPayload, @Param('identifier') identifier: string): Promise<void> {
     return await this.deleteTenantUsecase.execute(
       DeleteTenantCommand.create({
+        userId: user._id,
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         identifier: identifier,

--- a/apps/api/src/app/tenant/usecases/create-tenant/create-tenant.command.ts
+++ b/apps/api/src/app/tenant/usecases/create-tenant/create-tenant.command.ts
@@ -1,8 +1,8 @@
 import { TenantCustomData } from '@novu/shared';
-import { EnvironmentCommand } from '@novu/application-generic';
+import { EnvironmentWithUserCommand } from '@novu/application-generic';
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
-export class CreateTenantCommand extends EnvironmentCommand {
+export class CreateTenantCommand extends EnvironmentWithUserCommand {
   @IsString()
   @IsNotEmpty()
   identifier: string;

--- a/apps/api/src/app/tenant/usecases/create-tenant/create-tenant.usecase.ts
+++ b/apps/api/src/app/tenant/usecases/create-tenant/create-tenant.usecase.ts
@@ -1,10 +1,11 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { TenantRepository } from '@novu/dal';
 import { CreateTenantCommand } from './create-tenant.command';
+import { AnalyticsService } from '@novu/application-generic';
 
 @Injectable()
 export class CreateTenant {
-  constructor(private tenantRepository: TenantRepository) {}
+  constructor(private tenantRepository: TenantRepository, private analyticsService: AnalyticsService) {}
 
   async execute(command: CreateTenantCommand) {
     const tenantExist = await this.tenantRepository.findOne({
@@ -17,6 +18,11 @@ export class CreateTenant {
         `Tenant with identifier: ${command.identifier} already exists under environment ${command.environmentId}`
       );
     }
+
+    this.analyticsService.track('Create Tenant - [Tenants]', command.userId, {
+      _environmentId: command.environmentId,
+      _organization: command.organizationId,
+    });
 
     return await this.tenantRepository.create({
       _environmentId: command.environmentId,

--- a/apps/api/src/app/tenant/usecases/delete-tenant/delete-tenant.command.ts
+++ b/apps/api/src/app/tenant/usecases/delete-tenant/delete-tenant.command.ts
@@ -1,7 +1,7 @@
-import { EnvironmentCommand } from '@novu/application-generic';
+import { EnvironmentWithUserCommand } from '@novu/application-generic';
 import { IsNotEmpty, IsString } from 'class-validator';
 
-export class DeleteTenantCommand extends EnvironmentCommand {
+export class DeleteTenantCommand extends EnvironmentWithUserCommand {
   @IsString()
   @IsNotEmpty()
   identifier: string;

--- a/apps/api/src/app/tenant/usecases/update-tenant/update-tenant.command.ts
+++ b/apps/api/src/app/tenant/usecases/update-tenant/update-tenant.command.ts
@@ -1,9 +1,9 @@
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
-import { EnvironmentCommand } from '@novu/application-generic';
+import { EnvironmentWithUserCommand } from '@novu/application-generic';
 import { TenantCustomData } from '@novu/shared';
 
-export class UpdateTenantCommand extends EnvironmentCommand {
+export class UpdateTenantCommand extends EnvironmentWithUserCommand {
   @IsString()
   @IsNotEmpty()
   identifier: string;

--- a/apps/web/src/pages/tenants/TenantsPage.tsx
+++ b/apps/web/src/pages/tenants/TenantsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { Row } from 'react-table';
 import { ITenantEntity } from '@novu/shared';
@@ -7,9 +7,15 @@ import PageContainer from '../../components/layout/components/PageContainer';
 import PageHeader from '../../components/layout/components/PageHeader';
 import { TenantsList } from './components/list/TenantsList';
 import { ROUTES } from '../../constants/routes.enum';
+import { useSegment } from '../../components/providers/SegmentProvider';
 
 export function TenantsPage() {
+  const segment = useSegment();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    segment.track('Page Visit - [Tenants]');
+  }, []);
 
   const onAddTenantClickCallback = useCallback(() => {
     navigate(ROUTES.TENANTS_CREATE);


### PR DESCRIPTION
### What change does this PR introduce?

I was not sure what analytics we could want to track at the moment, at the moment I added `tenant page visit` and `tenant creation`

### Why was this change needed?

In order to track if a user that enters to the tenant's page creates new tenants.

---

Would love to hear if you think this one is redundant or if we would like to track other events on this feature as well.
