### PR TITLE
test: fix failing test because of a run on same day

### DIFF
--- a/apps/web/src/pages/templates/workflow/DigestMetadata.cy.tsx
+++ b/apps/web/src/pages/templates/workflow/DigestMetadata.cy.tsx
@@ -46,9 +46,8 @@ describe('Digest', function () {
     cy.getByTestId('time-at').should('have.value', '16:00');
     cy.getByTestId('digest-unit').get('.mantine-SegmentedControl-control').last().click();
     cy.getByTestId('day-select').get('button').last().click();
-    cy.getByTestId('day-select').get('button').last().should('have.class', 'active-day');
     cy.get('[data-test-id=day-select] button').eq(0).click();
-    cy.get('.active-day').should('have.lengthOf.at.least', 2);
+    cy.get('.active-day').should('have.lengthOf.at.least', 1);
     cy.get('.active-day').should('have.lengthOf.at.most', 3);
   });
 


### PR DESCRIPTION
### What change does this PR introduce?

This test would fail every time we run it on the 31th or the 1th of every month. 
Because today's value is already selected by default and in the test we click on the 31 and 1 -> so if the run is on that day we de-select them. 
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
