### PR TITLE
fix: fix update of digest jobs only for current subscriber

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event-topic.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event-topic.e2e.ts
@@ -17,6 +17,8 @@ import {
   TriggerRecipients,
   TriggerRecipientsTypeEnum,
   ExternalSubscriberId,
+  DigestUnitEnum,
+  DigestTypeEnum,
 } from '@novu/shared';
 import { SubscribersService, UserSession } from '@novu/testing';
 import axios from 'axios';
@@ -308,6 +310,7 @@ describe('Topic Trigger Event', () => {
     let fourthSubscriber: SubscriberEntity;
     let fifthSubscriber: SubscriberEntity;
     let sixthSubscriber: SubscriberEntity;
+    let firstTopicSubscribers: SubscriberEntity[];
     let subscribers: SubscriberEntity[];
     let subscriberService: SubscribersService;
     let firstTopicDto: { _id: TopicId; key: TopicKey };
@@ -330,7 +333,7 @@ describe('Topic Trigger Event', () => {
       subscriberService = new SubscribersService(session.organization._id, session.environment._id);
       firstSubscriber = await subscriberService.createSubscriber();
       secondSubscriber = await subscriberService.createSubscriber();
-      const firstTopicSubscribers = [firstSubscriber, secondSubscriber];
+      firstTopicSubscribers = [firstSubscriber, secondSubscriber];
 
       const firstTopicKey = 'topic-key-1-trigger-event';
       const firstTopicName = 'topic-name-1-trigger-event';
@@ -491,6 +494,65 @@ describe('Topic Trigger Event', () => {
         expect(message?.phone).to.equal(subscriber.phone);
       }
     });
+
+    it('should not contain events from a different digestKey ', async () => {
+      template = await session.createTemplate({
+        steps: [
+          {
+            type: StepTypeEnum.DIGEST,
+            content: '',
+            metadata: {
+              unit: DigestUnitEnum.SECONDS,
+              amount: 5,
+              digestKey: 'id',
+              type: DigestTypeEnum.REGULAR,
+            },
+          },
+          {
+            type: StepTypeEnum.IN_APP,
+            content: '{{#each step.events}}{{id}} {{/each}}' as string,
+          },
+        ],
+      });
+
+      const toFirstTopic: TriggerRecipients = [{ type: TriggerRecipientsTypeEnum.TOPIC, topicKey: firstTopicDto.key }];
+
+      await Promise.all([
+        triggerEvent(session, template, toFirstTopic, {
+          id: 'key-1',
+        }),
+        triggerEvent(session, template, toFirstTopic, {
+          id: 'key-1',
+        }),
+        triggerEvent(session, template, toFirstTopic, {
+          id: 'key-1',
+        }),
+        triggerEvent(session, template, toFirstTopic, {
+          id: 'key-2',
+        }),
+        triggerEvent(session, template, toFirstTopic, {
+          id: 'key-2',
+        }),
+        triggerEvent(session, template, toFirstTopic, {
+          id: 'key-2',
+        }),
+      ]);
+
+      await session.awaitRunningJobs(template?._id, false, 8);
+
+      for (const subscriber of firstTopicSubscribers) {
+        const messages = await messageRepository.findBySubscriberChannel(
+          session.environment._id,
+          subscriber._id,
+          ChannelTypeEnum.IN_APP
+        );
+        expect(messages.length).to.equal(2);
+        for (const message of messages) {
+          const digestKey = message.payload.id;
+          expect(message.content).to.equal(`${digestKey} ${digestKey} ${digestKey} `);
+        }
+      }
+    });
   });
 });
 
@@ -570,3 +632,24 @@ const buildTriggerRequestHeaders = (session: UserSession) => ({
     authorization: `ApiKey ${session.apiKey}`,
   },
 });
+
+const triggerEvent = async (
+  session: UserSession,
+  template: NotificationTemplateEntity,
+  to: (string | ITopic | ISubscribersDefine)[],
+  payload: Record<string, unknown> = {}
+): Promise<void> => {
+  await axiosInstance.post(
+    `${session.serverUrl}/v1/events/trigger`,
+    {
+      name: template.triggers[0].identifier,
+      to,
+      payload,
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+};

--- a/apps/worker/src/app/workflow/usecases/send-message/digest/digest.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/digest.usecase.ts
@@ -78,6 +78,7 @@ export class Digest extends SendMessageType {
     const nextJobs = await this.jobRepository.find({
       _environmentId: command.environmentId,
       transactionId: command.transactionId,
+      _subscriberId: command._subscriberId,
       _id: {
         $ne: command.jobId,
       },


### PR DESCRIPTION
### What change does this PR introduce?

When concurrently triggering a workflow with a digest + digest key for multiple subscribers in same trigger, some events contained did not belong to the correct digest key. 


When getting the jobs to update the digest field with the events we save on job, we didn't filter it with the subscriberId (🤦‍♀️ ). Meaning that when we trigger for multiple subscribers ( they have the same transactionId ) we update all the "next jobs" - all the not completed jobs of all the subscribers with the same transaction -  with the digest: {events }. And by that we are overriding the other settings we had in that digest object, like the digest key. So, when later, in the execution of that job we accidentally updated he doesn't have the digestKey and so he aggregates all the events. As if there was no digestKey.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
