### PR TITLE
fix: fix update of digest jobs only for current subscriber

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/digest/digest.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/digest.usecase.ts
@@ -78,6 +78,7 @@ export class Digest extends SendMessageType {
     const nextJobs = await this.jobRepository.find({
       _environmentId: command.environmentId,
       transactionId: command.transactionId,
+      _subscriberId: command._subscriberId,
       _id: {
         $ne: command.jobId,
       },


### PR DESCRIPTION
### What change does this PR introduce?
When concurrently triggering a workflow with a digest + digest key for multiple subscribers in same trigger, some events contained did not belong to the correct digest key.

When getting the jobs to update the digest field with the events we save on job, we didn't filter it with the subscriberId (🤦‍♀️ ). Meaning that when we trigger for multiple subscribers ( they have the same transactionId ) we update all the "next jobs" - all the not completed jobs of all the subscribers with the same transaction - with the digest: {events }. And by that we are overriding the other settings we had in that digest object, like the digest key. So, when later, in the execution of that job we accidentally updated he doesn't have the digestKey and so he aggregates all the events. As if there was no digestKey.


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
