### PR TITLE
feat(app-generic): add log for subscriber not processed when trigger

### DIFF
--- a/packages/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
@@ -174,6 +174,20 @@ export class TriggerEvent {
           organizationId: command.organizationId,
         });
         await this.storeSubscriberJobs.execute(storeSubscriberJobsCommand);
+      } else {
+        /**
+         * TODO: Potentially add a CreateExecutionDetails entry. Right now we
+         * have the limitation we need a job to be created for that. Here there
+         * is no job at this point.
+         */
+        Logger.warn(
+          `Subscriber ${JSON.stringify(subscriber._id)} of organization ${
+            command.organizationId
+          } in transaction ${
+            command.transactionId
+          } was not processed. No jobs are created.`,
+          LOG_CONTEXT
+        );
       }
     }
 


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Adds log if subscriber is not processed before creating jobs when an event is triggered for a subscriber.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
We received a report of a trigger event successfully executed but no notification triggered. Checking the flow we can see we have no feedback when a subscriber for any reason is not processed as the exit is clean in the loop. Worth to have an observable notice in New Relic to help to find out what could have gone wrong.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
