### PR TITLE
fix: workflow table edit icon padding, active icon sizes, and changes…

### DIFF
--- a/apps/web/src/design-system/table/Table.styles.ts
+++ b/apps/web/src/design-system/table/Table.styles.ts
@@ -22,10 +22,10 @@ export default createStyles((theme: MantineTheme, _params, getRef) => {
         paddingLeft: 24,
       },
       'tr td:last-child': {
-        paddingRight: 10,
+        paddingRight: 24,
       },
       'tr th:last-child': {
-        paddingRight: 10,
+        paddingRight: 24,
       },
       '& thead tr': {
         borderBottom: `1px solid ${dark ? colors.B30 : colors.B98}`,

--- a/apps/web/src/pages/changes/components/ChangesTableLayout.tsx
+++ b/apps/web/src/pages/changes/components/ChangesTableLayout.tsx
@@ -109,10 +109,9 @@ export const ChangesTable = ({
     {
       accessor: '_id',
       Header: '',
-      maxWidth: 50,
       Cell: withCellLoading(({ row: { original } }) => {
         return (
-          <div style={{ textAlign: 'right' }}>
+          <div style={{ textAlign: 'right', paddingRight: '20px' }}>
             <Button
               variant="outline"
               data-test-id="promote-btn"

--- a/apps/web/src/pages/templates/WorkflowListPage.tsx
+++ b/apps/web/src/pages/templates/WorkflowListPage.tsx
@@ -84,16 +84,16 @@ const columns: IExtendedColumn<INotificationTemplateExtended>[] = [
       <>
         {!original.active ? (
           <Group spacing={0} data-test-id="disabled-status-label">
-            <BoltOffFilled color={colors.B40} width="16px" height="16px" />
-            <Text rows={1} size="sm" color={colors.B40}>
+            <BoltOffFilled color={colors.B40} />
+            <Text rows={1} color={colors.B40}>
               Disabled
             </Text>
           </Group>
         ) : null}{' '}
         {original.active ? (
           <Group spacing={0} data-test-id="active-status-label">
-            <BoltFilled color={colors.success} width="16px" height="16px" />
-            <Text rows={1} size="sm" color={colors.success}>
+            <BoltFilled color={colors.success} />
+            <Text rows={1} color={colors.success}>
               Active
             </Text>
           </Group>
@@ -104,7 +104,7 @@ const columns: IExtendedColumn<INotificationTemplateExtended>[] = [
   {
     accessor: '_id',
     Header: '',
-    maxWidth: 50,
+    maxWidth: 75,
     Cell: withCellLoading(({ row: { original } }) => {
       const theme = useMantineTheme();
 
@@ -266,7 +266,7 @@ export default WorkflowListPage;
 
 const ActionButtonWrapper = styled.div`
   text-align: right;
-
+  padding-right: 8px;
   a {
     display: inline-block;
     opacity: 0;


### PR DESCRIPTION
… table padding

### What change does this PR introduce?
fix
- workflow edit icon padding for scrollbars
- active icons size
- changes table promote button scrollbar padding
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
<img width="1511" alt="image" src="https://github.com/novuhq/novu/assets/29251776/555f4a2a-f1f5-463a-8118-575c977c398f">
