### PR TITLE
feat(tests): add tests for worker and queue services

### DIFF
--- a/apps/api/src/app/events/services/workflow-queue/trigger-handler-queue.service.spec.ts
+++ b/apps/api/src/app/events/services/workflow-queue/trigger-handler-queue.service.spec.ts
@@ -1,0 +1,83 @@
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+
+import { TriggerHandlerQueueService } from './trigger-handler-queue.service';
+
+let triggerHandlerQueueService: TriggerHandlerQueueService;
+
+describe('TriggerHandlerQueue service', () => {
+  beforeEach(async () => {
+    triggerHandlerQueueService = new TriggerHandlerQueueService();
+    await triggerHandlerQueueService.bullMqService.queue.obliterate();
+  });
+
+  afterEach(async () => {
+    await triggerHandlerQueueService.gracefulShutdown();
+  });
+
+  it('should be initialised properly', async () => {
+    expect(triggerHandlerQueueService).to.exist;
+    expect(Object.keys(triggerHandlerQueueService)).to.include.members(['name', 'bullMqService']);
+    expect(triggerHandlerQueueService.name).to.equal('trigger-handler');
+    expect(await triggerHandlerQueueService.bullMqService.getRunningStatus()).to.deep.equal({
+      queueIsPaused: false,
+      queueName: 'trigger-handler',
+      workerName: undefined,
+      workerIsRunning: undefined,
+    });
+    expect(triggerHandlerQueueService.bullMqService.queue).to.deep.include({
+      _events: {},
+      _eventsCount: 0,
+      _maxListeners: undefined,
+      name: 'trigger-handler',
+      jobsOpts: {
+        removeOnComplete: true,
+      },
+    });
+    expect(triggerHandlerQueueService.bullMqService.queue.opts).to.deep.include({
+      blockingConnection: false,
+      connection: {
+        connectTimeout: 50000,
+        db: 1,
+        family: 4,
+        host: 'localhost',
+        keepAlive: 30000,
+        keyPrefix: '',
+        password: undefined,
+        port: 6379,
+        tls: undefined,
+      },
+      defaultJobOptions: {
+        removeOnComplete: true,
+      },
+      prefix: 'bull',
+      sharedConnection: false,
+    });
+    expect(triggerHandlerQueueService.bullMqService.queue.opts.connection).to.deep.include({
+      host: 'localhost',
+      port: 6379,
+    });
+  });
+
+  it('should add a job in the queue', async () => {
+    const jobId = 'trigger-queue-job-id';
+    const organizationId = 'trigger-queue-organization-id';
+    const jobData = {
+      test: 'trigger-queue-job-data',
+    };
+    await triggerHandlerQueueService.add(jobId, jobData, organizationId);
+
+    expect(await triggerHandlerQueueService.bullMqService.queue.getActiveCount()).to.equal(0);
+    expect(await triggerHandlerQueueService.bullMqService.queue.getWaitingCount()).to.equal(1);
+
+    const triggerHandlerQueueJobs = await triggerHandlerQueueService.bullMqService.queue.getJobs();
+    expect(triggerHandlerQueueJobs.length).to.equal(1);
+    const [triggerHandlerQueueJob] = triggerHandlerQueueJobs;
+    expect(triggerHandlerQueueJob).to.deep.include({
+      id: '1',
+      name: jobId,
+      data: jobData,
+      attemptsMade: 0,
+    });
+  });
+});

--- a/apps/worker/src/app/workflow/services/metric-queue.service.spec.ts
+++ b/apps/worker/src/app/workflow/services/metric-queue.service.spec.ts
@@ -1,0 +1,39 @@
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+
+import { MetricQueueService } from './metric-queue.service';
+
+import { WorkflowModule } from '../workflow.module';
+
+let metricQueueService: MetricQueueService;
+
+describe('Metric Queue service', () => {
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [WorkflowModule],
+    }).compile();
+
+    metricQueueService = moduleRef.get<MetricQueueService>(MetricQueueService);
+  });
+
+  afterEach(async () => {
+    await metricQueueService.gracefulShutdown();
+  });
+
+  it('should be initialised properly', async () => {
+    expect(metricQueueService).to.be.ok;
+    expect(metricQueueService).to.have.all.keys('DEFAULT_ATTEMPTS', 'bullMqService', 'name', 'token_list');
+    expect(await metricQueueService.bullMqService.getRunningStatus()).to.deep.include({
+      queueName: 'metric',
+      workerName: 'metric',
+    });
+    expect(metricQueueService.bullMqService.worker.opts).to.deep.include({
+      concurrency: 1,
+      lockDuration: 500,
+    });
+    expect(metricQueueService.bullMqService.worker.opts.connection).to.deep.include({
+      host: 'localhost',
+      port: 6379,
+    });
+  });
+});

--- a/apps/worker/src/app/workflow/services/trigger-processor-queue.service.spec.ts
+++ b/apps/worker/src/app/workflow/services/trigger-processor-queue.service.spec.ts
@@ -1,0 +1,92 @@
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import { setTimeout } from 'timers/promises';
+
+import { TriggerProcessorQueueService } from './trigger-processor-queue.service';
+
+import { WorkflowModule } from '../workflow.module';
+
+let triggerProcessorQueueService: TriggerProcessorQueueService;
+
+describe('Trigger Processor Queue service', () => {
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [WorkflowModule],
+    }).compile();
+
+    triggerProcessorQueueService = moduleRef.get<TriggerProcessorQueueService>(TriggerProcessorQueueService);
+    await triggerProcessorQueueService.bullMqService.queue.obliterate();
+  });
+
+  afterEach(async () => {
+    await triggerProcessorQueueService.gracefulShutdown();
+  });
+
+  it('should be initialised properly', async () => {
+    expect(triggerProcessorQueueService).to.be.ok;
+    expect(triggerProcessorQueueService).to.have.all.keys('bullMqService', 'name', 'triggerEventUsecase');
+    expect(await triggerProcessorQueueService.bullMqService.getRunningStatus()).to.deep.equal({
+      queueIsPaused: false,
+      queueName: 'trigger-handler',
+      workerName: 'trigger-handler',
+      workerIsRunning: true,
+    });
+    expect(triggerProcessorQueueService.bullMqService.worker.opts).to.deep.include({
+      concurrency: 200,
+      lockDuration: 90000,
+    });
+    expect(triggerProcessorQueueService.bullMqService.worker.opts.connection).to.deep.include({
+      host: 'localhost',
+      port: 6379,
+    });
+  });
+
+  it('should be able to automatically pull a job from the queue that will error', async () => {
+    const existingJobs = await triggerProcessorQueueService.bullMqService.queue.getJobs();
+    expect(existingJobs.length).to.equal(0);
+
+    const jobId = 'trigger-processor-queue-job-id';
+    const _environmentId = 'trigger-processor-queue-environment-id';
+    const _organizationId = 'trigger-processor-queue-organization-id';
+    const _userId = 'trigger-processor-queue-user-id';
+    const jobData = {
+      _id: jobId,
+      test: 'trigger-processor-queue-job-data',
+      _environmentId,
+      _organizationId,
+      _userId,
+    };
+
+    await triggerProcessorQueueService.bullMqService.add(jobId, jobData, _organizationId);
+
+    expect(await triggerProcessorQueueService.bullMqService.queue.getActiveCount()).to.equal(1);
+    expect(await triggerProcessorQueueService.bullMqService.queue.getWaitingCount()).to.equal(0);
+
+    const timestamp = Date.now();
+
+    // When we arrive to pull the job it has been already pulled by the worker
+    const nextJob = await triggerProcessorQueueService.bullMqService.worker.getNextJob(jobId);
+    expect(nextJob).to.equal(undefined);
+
+    await setTimeout(100);
+
+    const queueJobs = await triggerProcessorQueueService.bullMqService.queue.getJobs();
+    expect(queueJobs.length).to.equal(1);
+    const [queueJob] = queueJobs;
+
+    expect(queueJob).to.deep.include({
+      attemptsMade: 1,
+      data: jobData,
+      delay: 0,
+      failedReason: 'Notification template could not be found',
+      id: '1',
+      name: jobId,
+      progress: 0,
+    });
+    const [stackTrace] = queueJob.stacktrace;
+    expect(stackTrace)
+      .to.be.a('string')
+      .and.satisfy((str) => str.startsWith('ApiException: Notification template could not be found'));
+    expect(timestamp).to.be.greaterThanOrEqual(Number(queueJob.processedOn));
+  });
+});

--- a/packages/application-generic/src/services/bull-mq.service.spec.ts
+++ b/packages/application-generic/src/services/bull-mq.service.spec.ts
@@ -1,0 +1,160 @@
+import {
+  BullMqService,
+  QueueBaseOptions,
+  WorkerOptions,
+} from './bull-mq.service';
+
+let bullMqService: BullMqService;
+
+describe('BullMQ Service', () => {
+  describe('Non cluster mode', () => {
+    beforeEach(() => {
+      bullMqService = new BullMqService();
+    });
+
+    afterEach(async () => {
+      await bullMqService.gracefulShutdown();
+    });
+
+    describe('Set up', () => {
+      it('should be able to instantiate it correctly', async () => {
+        expect(bullMqService.queue).toBeUndefined();
+        expect(bullMqService.worker).toBeUndefined();
+        expect(BullMqService.haveProInstalled()).toBeFalsy();
+        expect(await bullMqService.getRunningStatus()).toEqual({
+          queueIsPaused: undefined,
+          queueName: undefined,
+          workerIsRunning: undefined,
+          workerName: undefined,
+        });
+      });
+
+      it('should create a queue properly with the default configuration', async () => {
+        const queueName = 'test-queue';
+        const queueOptions: QueueBaseOptions = {};
+        await bullMqService.createQueue(queueName, queueOptions);
+
+        expect(bullMqService.queue.name).toEqual(queueName);
+        expect(bullMqService.queue.opts.connection).toEqual({
+          connectTimeout: 50000,
+          db: 1,
+          family: 4,
+          host: 'localhost',
+          keepAlive: 30000,
+          keyPrefix: '',
+          password: undefined,
+          port: 6379,
+          tls: undefined,
+        });
+
+        expect(await bullMqService.getRunningStatus()).toEqual({
+          queueIsPaused: false,
+          queueName,
+          workerIsRunning: undefined,
+          workerName: undefined,
+        });
+      });
+
+      it('should create a queue properly with a chosen configuration', async () => {
+        const queueName = 'test-queue';
+        const queueOptions: QueueBaseOptions = {
+          connection: {
+            connectTimeout: 10000,
+            db: 10,
+            family: 6,
+            keepAlive: 1000,
+            keyPrefix: 'test',
+          },
+        };
+        await bullMqService.createQueue(queueName, queueOptions);
+
+        expect(bullMqService.queue.name).toEqual(queueName);
+        expect(bullMqService.queue.opts.connection).toEqual({
+          connectTimeout: 10000,
+          db: 10,
+          family: 6,
+          host: 'localhost',
+          keepAlive: 1000,
+          keyPrefix: 'test',
+          password: undefined,
+          port: 6379,
+          tls: undefined,
+        });
+
+        expect(await bullMqService.getRunningStatus()).toEqual({
+          queueIsPaused: false,
+          queueName,
+          workerIsRunning: undefined,
+          workerName: undefined,
+        });
+      });
+
+      it('should create a worker properly with the default configuration', async () => {
+        const workerName = 'test-worker';
+        await bullMqService.createWorker(workerName, undefined, {});
+
+        expect(bullMqService.worker.name).toEqual(workerName);
+        expect(bullMqService.worker.opts.connection).toEqual({
+          connectTimeout: 50000,
+          db: 1,
+          family: 4,
+          host: 'localhost',
+          keepAlive: 30000,
+          keyPrefix: '',
+          password: undefined,
+          port: 6379,
+          tls: undefined,
+        });
+
+        expect(await bullMqService.getRunningStatus()).toEqual({
+          queueIsPaused: undefined,
+          queueName: undefined,
+          workerIsRunning: false,
+          workerName,
+        });
+      });
+
+      it('should create a worker properly with a chosen configuration', async () => {
+        const workerName = 'test-worker';
+        const workerOptions: WorkerOptions = {
+          connection: {
+            connectTimeout: 10000,
+            db: 10,
+            family: 6,
+            keepAlive: 1000,
+            keyPrefix: 'test',
+          },
+          lockDuration: 90000,
+          concurrency: 200,
+        };
+        await bullMqService.createWorker(workerName, undefined, workerOptions);
+
+        expect(bullMqService.worker.name).toEqual(workerName);
+        /*
+         * TODO: This test if executed shows we have a bug. As we are not running this
+         * in the CI is not going to block. I am fixing it in MemoryDB feature.
+         */
+        expect(bullMqService.worker.opts.connection).toEqual({
+          connectTimeout: 10000,
+          db: 10,
+          family: 6,
+          host: 'localhost',
+          keepAlive: 1000,
+          keyPrefix: 'test',
+          password: undefined,
+          port: 6379,
+          tls: undefined,
+        });
+        expect(bullMqService.worker.opts.concurrency).toEqual(200);
+        expect(bullMqService.worker.opts.lockDuration).toEqual(90000);
+
+        expect(await bullMqService.getRunningStatus()).toEqual({
+          queueIsPaused: undefined,
+          queueName: undefined,
+          workerIsRunning: false,
+          workerName,
+        });
+      });
+    });
+  });
+});

--- a/packages/application-generic/src/services/bull-mq.service.ts
+++ b/packages/application-generic/src/services/bull-mq.service.ts
@@ -29,7 +29,11 @@ interface IEventJobData {
 
 type BullMqJobData = undefined | IJobData | IEventJobData;
 
-export { QueueBaseOptions, RedisConnectionOptions as BullMqConnectionOptions };
+export {
+  QueueBaseOptions,
+  RedisConnectionOptions as BullMqConnectionOptions,
+  WorkerOptions,
+};
 
 export const bullMqBaseOptions = {
   connection: {

--- a/packages/application-generic/src/services/queue.service.spec.ts
+++ b/packages/application-generic/src/services/queue.service.spec.ts
@@ -1,0 +1,100 @@
+import { Test } from '@nestjs/testing';
+
+import { QueueService } from './queue.service';
+
+let queueService: QueueService;
+
+describe('Queue service', () => {
+  beforeEach(async () => {
+    queueService = new QueueService();
+    await queueService.bullMqService.queue.obliterate();
+  });
+
+  afterEach(async () => {
+    await queueService.gracefulShutdown();
+  });
+
+  it('should be initialised properly', async () => {
+    expect(queueService).toBeDefined();
+    expect(Object.keys(queueService)).toEqual([
+      'name',
+      'DEFAULT_ATTEMPTS',
+      'bullMqService',
+    ]);
+    expect(queueService.name).toEqual('standard');
+    expect(await queueService.bullMqService.getRunningStatus()).toStrictEqual({
+      queueIsPaused: false,
+      queueName: 'standard',
+      workerName: undefined,
+      workerIsRunning: undefined,
+    });
+    expect(queueService.DEFAULT_ATTEMPTS).toEqual(3);
+    expect(queueService.bullMqService.queue).toMatchObject({
+      _events: {},
+      _eventsCount: 0,
+      _maxListeners: undefined,
+      name: 'standard',
+      jobsOpts: {
+        removeOnComplete: true,
+      },
+    });
+    expect(queueService.bullMqService.queue.opts).toMatchObject({
+      blockingConnection: false,
+      connection: {
+        connectTimeout: 50000,
+        db: 1,
+        family: 4,
+        host: 'localhost',
+        keepAlive: 30000,
+        keyPrefix: '',
+        password: undefined,
+        port: 6379,
+        tls: undefined,
+      },
+      defaultJobOptions: {
+        removeOnComplete: true,
+      },
+      prefix: 'bull',
+      sharedConnection: false,
+    });
+    expect(queueService.bullMqService.queue.opts.connection).toMatchObject({
+      host: 'localhost',
+      port: 6379,
+    });
+  });
+
+  it('should add a job in the queue', async () => {
+    const jobId = 'queue-job-id';
+    const _environmentId = 'queue-environment-id';
+    const _organizationId = 'queue-organization-id';
+    const _userId = 'queue-user-id';
+    const jobData = {
+      _id: jobId,
+      test: 'queue-job-data',
+      _environmentId,
+      _organizationId,
+      _userId,
+    };
+    await queueService.addToQueue(jobId, jobData);
+
+    expect(await queueService.bullMqService.queue.getActiveCount()).toEqual(0);
+    expect(await queueService.bullMqService.queue.getWaitingCount()).toEqual(1);
+
+    const queueJobs = await queueService.bullMqService.queue.getJobs();
+    expect(queueJobs.length).toEqual(1);
+    const [queueJob] = queueJobs;
+    expect(queueJob).toMatchObject(
+      expect.objectContaining({
+        id: '1',
+        name: jobId,
+        data: {
+          _id: jobId,
+          _environmentId,
+          _organizationId,
+          _userId,
+        },
+        attemptsMade: 0,
+      })
+    );
+  });
+});

--- a/packages/application-generic/src/services/trigger-queue.service.spec.ts
+++ b/packages/application-generic/src/services/trigger-queue.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test } from '@nestjs/testing';
+
+import { TriggerQueueService } from './trigger-queue.service';
+
+let triggerQueueService: TriggerQueueService;
+
+describe('TriggerQueue service', () => {
+  beforeEach(async () => {
+    triggerQueueService = new TriggerQueueService();
+    await triggerQueueService.bullMqService.queue.obliterate();
+  });
+
+  afterEach(async () => {
+    await triggerQueueService.gracefulShutdown();
+  });
+
+  it('should be initialised properly', async () => {
+    expect(triggerQueueService).toBeDefined();
+    expect(Object.keys(triggerQueueService)).toEqual(['name', 'bullMqService']);
+    expect(triggerQueueService.name).toEqual('trigger-handler');
+    expect(
+      await triggerQueueService.bullMqService.getRunningStatus()
+    ).toStrictEqual({
+      queueIsPaused: false,
+      queueName: 'trigger-handler',
+      workerName: undefined,
+      workerIsRunning: undefined,
+    });
+    expect(triggerQueueService.bullMqService.queue).toMatchObject({
+      _events: {},
+      _eventsCount: 0,
+      _maxListeners: undefined,
+      name: 'trigger-handler',
+      jobsOpts: {
+        removeOnComplete: true,
+      },
+    });
+    expect(triggerQueueService.bullMqService.queue.opts).toMatchObject({
+      blockingConnection: false,
+      connection: {
+        connectTimeout: 50000,
+        db: 1,
+        family: 4,
+        host: 'localhost',
+        keepAlive: 30000,
+        keyPrefix: '',
+        password: undefined,
+        port: 6379,
+        tls: undefined,
+      },
+      defaultJobOptions: {
+        removeOnComplete: true,
+      },
+      prefix: 'bull',
+      sharedConnection: false,
+    });
+    expect(
+      triggerQueueService.bullMqService.queue.opts.connection
+    ).toMatchObject({
+      host: 'localhost',
+      port: 6379,
+    });
+  });
+
+  it('should add a job in the queue', async () => {
+    const jobId = 'trigger-queue-job-id';
+    const organizationId = 'trigger-queue-organization-id';
+    const jobData = {
+      test: 'trigger-queue-job-data',
+    };
+    await triggerQueueService.add(jobId, jobData, organizationId);
+
+    expect(
+      await triggerQueueService.bullMqService.queue.getActiveCount()
+    ).toEqual(0);
+    expect(
+      await triggerQueueService.bullMqService.queue.getWaitingCount()
+    ).toEqual(1);
+
+    const triggerQueueJobs =
+      await triggerQueueService.bullMqService.queue.getJobs();
+    expect(triggerQueueJobs.length).toEqual(1);
+    const [triggerQueueJob] = triggerQueueJobs;
+    expect(triggerQueueJob).toMatchObject({
+      id: '1',
+      name: jobId,
+      data: jobData,
+      attemptsMade: 0,
+    });
+  });
+});

--- a/packages/application-generic/src/services/ws-queue.service.spec.ts
+++ b/packages/application-generic/src/services/ws-queue.service.spec.ts
@@ -1,0 +1,105 @@
+import { Test } from '@nestjs/testing';
+
+import { WsQueueService } from './ws-queue.service';
+
+let wsQueueService: WsQueueService;
+
+describe('WebSocket Queue service', () => {
+  beforeEach(async () => {
+    wsQueueService = new WsQueueService();
+    await wsQueueService.bullMqService.queue.obliterate();
+  });
+
+  afterEach(async () => {
+    await wsQueueService.gracefulShutdown();
+  });
+
+  it('should be initialised properly', async () => {
+    expect(wsQueueService).toBeDefined();
+    expect(Object.keys(wsQueueService)).toEqual([
+      'name',
+      'DEFAULT_ATTEMPTS',
+      'bullMqService',
+    ]);
+    expect(wsQueueService.DEFAULT_ATTEMPTS).toEqual(3);
+    expect(wsQueueService.name).toEqual('ws_socket_queue');
+    expect(await wsQueueService.getJobStats('ws_socket_queue')).toMatchObject({
+      active: 0,
+    });
+    expect(await wsQueueService.bullMqService.getRunningStatus()).toStrictEqual(
+      {
+        queueIsPaused: false,
+        queueName: 'ws_socket_queue',
+        workerName: undefined,
+        workerIsRunning: undefined,
+      }
+    );
+    expect(wsQueueService.bullMqService.queue).toMatchObject({
+      _events: {},
+      _eventsCount: 0,
+      _maxListeners: undefined,
+      name: 'ws_socket_queue',
+      jobsOpts: {
+        removeOnComplete: true,
+      },
+    });
+    expect(wsQueueService.bullMqService.queue.opts).toMatchObject({
+      blockingConnection: false,
+      connection: {
+        connectTimeout: 50000,
+        db: 1,
+        family: 4,
+        host: 'localhost',
+        keepAlive: 30000,
+        keyPrefix: '',
+        password: undefined,
+        port: 6379,
+        tls: undefined,
+      },
+      defaultJobOptions: {
+        removeOnComplete: true,
+      },
+      prefix: 'bull',
+      sharedConnection: false,
+    });
+    expect(wsQueueService.bullMqService.queue.opts.connection).toMatchObject({
+      host: 'localhost',
+      port: 6379,
+    });
+  });
+
+  it('should add a job in the queue', async () => {
+    const jobId = 'ws-queue-job-id';
+    const _environmentId = 'ws-queue-environment-id';
+    const _organizationId = 'ws-queue-organization-id';
+    const _userId = 'ws-queue-user-id';
+    const jobData = {
+      _id: jobId,
+      test: 'ws-queue-job-data',
+      _environmentId,
+      _organizationId,
+      _userId,
+    };
+    await wsQueueService.addToQueue(jobId, jobData);
+
+    expect(await wsQueueService.getJobStats('ws_socket_queue')).toStrictEqual({
+      active: 0,
+      waiting: 1,
+    });
+
+    const wsQueueJobs = await wsQueueService.bullMqService.queue.getJobs();
+    expect(wsQueueJobs.length).toEqual(1);
+    const [wsQueueJob] = wsQueueJobs;
+    expect(wsQueueJob).toMatchObject({
+      id: '1',
+      name: jobId,
+      data: {
+        _id: jobId,
+        _environmentId,
+        _organizationId,
+        _userId,
+      },
+      attemptsMade: 0,
+    });
+  });
+});

--- a/packages/application-generic/src/services/ws-queue.service.ts
+++ b/packages/application-generic/src/services/ws-queue.service.ts
@@ -3,7 +3,6 @@ import { ConnectionOptions } from 'tls';
 import { QueueOptions } from 'bullmq';
 import { Injectable, Logger } from '@nestjs/common';
 
-import { BullMqService } from './bull-mq.service';
 import { QueueService } from './queue.service';
 
 const LOG_CONTEXT = 'WsQueueService';


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Adds unit tests for worker and queue services dependant of BullMqService.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Give extra confidence in the changes for MemoryDB and identify possible migration mistakes.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
