### PR TITLE
feat(api): notifications feed filtering by partial payload object

### DIFF
--- a/apps/api/src/app/subscribers/dtos/get-in-app-notification-feed-for-subscriber.dto.ts
+++ b/apps/api/src/app/subscribers/dtos/get-in-app-notification-feed-for-subscriber.dto.ts
@@ -26,4 +26,12 @@ export class GetInAppNotificationsFeedForSubscriberDto extends PaginationRequest
 
   @ApiPropertyOptional({ required: false, type: Boolean })
   seen: boolean;
+
+  @ApiPropertyOptional({
+    required: false,
+    type: 'string',
+    description: 'Base64 encoded string of the partial payload JSON object',
+    example: 'btoa(JSON.stringify({ foo: 123 })) results in base64 encoded string like eyJmb28iOjEyM30=',
+  })
+  payload?: string;
 }

--- a/apps/api/src/app/subscribers/e2e/get-notifications-feed.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/get-notifications-feed.e2e.ts
@@ -38,6 +38,53 @@ describe('Get Notifications feed - /:subscriberId/notifications/feed (GET)', fun
       );
     }
   });
+
+  it('should throw exception when invalid payload query param is passed', async function () {
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId);
+
+    await session.awaitRunningJobs(template._id);
+
+    try {
+      await getNotificationsFeed(subscriberId, session.apiKey, { limit: 5, payload: 'invalid' });
+    } catch (err) {
+      expect(err.response.status).to.equals(400);
+      expect(err.response.data.message).to.eq(`Invalid payload, the JSON object should be encoded to base64 string.`);
+    }
+  });
+
+  it('should allow filtering by custom data from the payload', async function () {
+    const partialPayload = { foo: 123 };
+    const payload = { ...partialPayload, bar: 'bar' };
+
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId);
+    await session.awaitRunningJobs(template._id);
+
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId, payload);
+    await session.awaitRunningJobs(template._id);
+
+    const payloadQueryValue = Buffer.from(JSON.stringify(partialPayload)).toString('base64');
+    const { data } = await getNotificationsFeed(subscriberId, session.apiKey, { limit: 5, payload: payloadQueryValue });
+
+    expect(data.length).to.equal(1);
+    expect(data[0].payload).to.deep.equal(payload);
+  });
+
+  it('should allow filtering by custom nested data from the payload', async function () {
+    const partialPayload = { foo: { bar: 123 } };
+    const payload = { ...partialPayload, baz: 'baz' };
+
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId);
+    await session.awaitRunningJobs(template._id);
+
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId, payload);
+    await session.awaitRunningJobs(template._id);
+
+    const payloadQueryValue = Buffer.from(JSON.stringify(partialPayload)).toString('base64');
+    const { data } = await getNotificationsFeed(subscriberId, session.apiKey, { limit: 5, payload: payloadQueryValue });
+
+    expect(data.length).to.equal(1);
+    expect(data[0].payload).to.deep.equal(payload);
+  });
 });
 
 async function getNotificationsFeed(subscriberId: string, apiKey: string, query = {}) {

--- a/apps/api/src/app/subscribers/e2e/get-notifications-feed.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/get-notifications-feed.e2e.ts
@@ -49,7 +49,11 @@ describe('Get Notifications feed - /:subscriberId/notifications/feed (GET)', fun
     } catch (err) {
       expect(err.response.status).to.equals(400);
       expect(err.response.data.message).to.eq(`Invalid payload, the JSON object should be encoded to base64 string.`);
+
+      return;
     }
+
+    expect.fail('Should have thrown an bad request exception');
   });
 
   it('should allow filtering by custom data from the payload', async function () {

--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -371,6 +371,7 @@ export class SubscribersController {
       feedId: feedsQuery,
       query: { seen: query.seen, read: query.read },
       limit: query.limit != null ? parseInt(query.limit) : 10,
+      payload: query.payload,
     });
 
     return await this.getNotificationsFeedUsecase.execute(command);

--- a/apps/api/src/app/widgets/e2e/get-notification-feed.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/get-notification-feed.e2e.ts
@@ -157,6 +157,53 @@ describe('GET /widget/notifications/feed', function () {
     expect(feed.hasMore).to.be.equal(true);
   });
 
+  it('should throw exception when invalid payload query param is passed', async function () {
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId);
+
+    await session.awaitRunningJobs(template._id);
+
+    try {
+      await getSubscriberFeed({ payload: 'invalid' });
+    } catch (err) {
+      expect(err.response.status).to.equals(400);
+      expect(err.response.data.message).to.eq(`Invalid payload, the JSON object should be encoded to base64 string.`);
+    }
+  });
+
+  it('should allow filtering by custom data from the payload', async function () {
+    const partialPayload = { foo: 123 };
+    const payload = { ...partialPayload, bar: 'bar' };
+
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId);
+    await session.awaitRunningJobs(template._id);
+
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId, payload);
+    await session.awaitRunningJobs(template._id);
+
+    const payloadQueryValue = Buffer.from(JSON.stringify(partialPayload)).toString('base64');
+    const { data } = await getSubscriberFeed({ payload: payloadQueryValue });
+
+    expect(data.length).to.equal(1);
+    expect(data[0].payload).to.deep.equal(payload);
+  });
+
+  it('should allow filtering by custom nested data from the payload', async function () {
+    const partialPayload = { foo: { bar: 123 } };
+    const payload = { ...partialPayload, baz: 'baz' };
+
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId);
+    await session.awaitRunningJobs(template._id);
+
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId, payload);
+    await session.awaitRunningJobs(template._id);
+
+    const payloadQueryValue = Buffer.from(JSON.stringify(partialPayload)).toString('base64');
+    const { data } = await getSubscriberFeed({ payload: payloadQueryValue });
+
+    expect(data.length).to.equal(1);
+    expect(data[0].payload).to.deep.equal(payload);
+  });
+
   async function getSubscriberFeed(query = {}) {
     const response = await axios.get(`http://localhost:${process.env.PORT}/v1/widgets/notifications/feed`, {
       params: {

--- a/apps/api/src/app/widgets/e2e/get-notification-feed.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/get-notification-feed.e2e.ts
@@ -167,7 +167,11 @@ describe('GET /widget/notifications/feed', function () {
     } catch (err) {
       expect(err.response.status).to.equals(400);
       expect(err.response.data.message).to.eq(`Invalid payload, the JSON object should be encoded to base64 string.`);
+
+      return;
     }
+
+    expect.fail('Should have thrown an bad request exception');
   });
 
   it('should allow filtering by custom data from the payload', async function () {

--- a/apps/api/src/app/widgets/usecases/get-notifications-feed/get-notifications-feed.command.ts
+++ b/apps/api/src/app/widgets/usecases/get-notifications-feed/get-notifications-feed.command.ts
@@ -1,7 +1,7 @@
-import { IsArray, IsNumber, IsOptional, Max, Min } from 'class-validator';
+import { IsArray, IsNumber, IsOptional, IsString } from 'class-validator';
+
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 import { StoreQuery } from '../../queries/store.query';
-import { Transform } from 'class-transformer';
 
 export class GetNotificationsFeedCommand extends EnvironmentWithSubscriber {
   @IsNumber()
@@ -18,4 +18,8 @@ export class GetNotificationsFeedCommand extends EnvironmentWithSubscriber {
 
   @IsOptional()
   query: StoreQuery;
+
+  @IsOptional()
+  @IsString()
+  payload?: string;
 }

--- a/apps/api/src/app/widgets/widgets.controller.ts
+++ b/apps/api/src/app/widgets/widgets.controller.ts
@@ -112,6 +112,7 @@ export class WidgetsController {
       feedId: feedsQuery,
       query: { seen: query.seen, read: query.read },
       limit: query.limit != null ? parseInt(query.limit) : 10,
+      payload: query.payload,
     });
 
     return await this.getNotificationsFeedUsecase.execute(command);

--- a/packages/client/src/api/api.service.ts
+++ b/packages/client/src/api/api.service.ts
@@ -92,13 +92,16 @@ export class ApiService {
 
   async getNotificationsList(
     page: number,
-    query: IStoreQuery = {}
+    { payload, ...rest }: IStoreQuery = {}
   ): Promise<IPaginatedResponse<IMessage>> {
+    const payloadString = payload ? btoa(JSON.stringify(payload)) : undefined;
+
     return await this.httpClient.getFullResponse(
       `/widgets/notifications/feed`,
       {
         page,
-        ...query,
+        payload: payloadString,
+        ...rest,
       }
     );
   }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -20,6 +20,7 @@ export interface IStoreQuery {
   seen?: boolean;
   read?: boolean;
   limit?: number;
+  payload?: Record<string, unknown>;
 }
 
 export interface ITabCountQuery {

--- a/packages/node/src/lib/subscribers/subscriber.interface.ts
+++ b/packages/node/src/lib/subscribers/subscriber.interface.ts
@@ -66,6 +66,7 @@ export interface IGetSubscriberNotificationFeedParams {
   feedIdentifier?: string;
   seen?: boolean;
   read?: boolean;
+  payload?: Record<string, unknown>;
 }
 
 export interface IMarkFields {

--- a/packages/node/src/lib/subscribers/subscribers.ts
+++ b/packages/node/src/lib/subscribers/subscribers.ts
@@ -96,12 +96,19 @@ export class Subscribers extends WithHttp implements ISubscribers {
 
   async getNotificationsFeed(
     subscriberId: string,
-    params: IGetSubscriberNotificationFeedParams
+    { payload, ...rest }: IGetSubscriberNotificationFeedParams = {}
   ) {
+    const payloadString = payload
+      ? Buffer.from(JSON.stringify(payload)).toString('base64')
+      : undefined;
+
     return await this.http.get(
       `/subscribers/${subscriberId}/notifications/feed`,
       {
-        params,
+        params: {
+          payload: payloadString,
+          ...rest,
+        },
       }
     );
   }


### PR DESCRIPTION
### What change does this PR introduce?

Allow filtering of the notifications feed by the custom data from the payload object.

The two endpoints `GET /subscribers/:subscriberId/notifications/feed` and `GET /widgets/notifications/feed` now can take the query param like `?payload=eyJmb28iOjEyM30=`. 

The value is a base64 encoded string of the partial payload JSON object. 

For example, if the payload passed to the trigger event was like `{ foo: 123, bar: 'bar' }`, then you filter notifications by `{ foo: 123 }` by doing `btoa(JSON.stringify({ foo: 123 }))` that results in base64 encoded string `eyJmb28iOjEyM30=` and passing it to the query param.


### Why was this change needed?

Allows building custom notification center experiences.

### Other information (Screenshots)
<img width="1726" alt="Screenshot 2023-08-08 at 18 33 01" src="https://github.com/novuhq/novu/assets/2607232/6ee54f52-0731-4a2d-a3ad-06384fc429af">


<img width="1727" alt="Screenshot 2023-08-08 at 18 33 11" src="https://github.com/novuhq/novu/assets/2607232/f3daa66c-f235-4814-b999-06572997e596">

