### PR TITLE
feat: get execution details endpoint by external subscriber id

### DIFF
--- a/apps/api/src/app/execution-details/dtos/execution-details-request.dto.ts
+++ b/apps/api/src/app/execution-details/dtos/execution-details-request.dto.ts
@@ -1,4 +1,4 @@
-import { IsDefined, IsMongoId } from 'class-validator';
+import { IsDefined, IsMongoId, IsString } from 'class-validator';
 
 export class ExecutionDetailsRequestDto {
   @IsDefined()
@@ -6,6 +6,6 @@ export class ExecutionDetailsRequestDto {
   notificationId: string;
 
   @IsDefined()
-  @IsMongoId()
+  @IsString()
   subscriberId: string;
 }

--- a/apps/api/src/app/execution-details/e2e/get-execution-details.e2e.ts
+++ b/apps/api/src/app/execution-details/e2e/get-execution-details.e2e.ts
@@ -1,6 +1,6 @@
-import { ExecutionDetailsRepository } from '@novu/dal';
+import { ExecutionDetailsRepository, SubscriberEntity } from '@novu/dal';
 import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
-import { UserSession } from '@novu/testing';
+import { UserSession, SubscribersService } from '@novu/testing';
 import axios from 'axios';
 import { expect } from 'chai';
 
@@ -9,10 +9,14 @@ const axiosInstance = axios.create();
 describe('Execution details - Get execution details by notification id - /v1/execution-details/notification/:notificationId (GET)', function () {
   let session: UserSession;
   const executionDetailsRepository: ExecutionDetailsRepository = new ExecutionDetailsRepository();
+  let subscriber: SubscriberEntity;
+  let subscriberService: SubscribersService;
 
   beforeEach(async () => {
     session = new UserSession();
     await session.initialize();
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+    subscriber = await subscriberService.createSubscriber();
   });
 
   it('should get execution details', async function () {
@@ -23,7 +27,7 @@ describe('Execution details - Get execution details by notification id - /v1/exe
       _organizationId: session.organization._id,
       _notificationId: notificationId,
       _notificationTemplateId: ExecutionDetailsRepository.createObjectId(),
-      _subscriberId: session.subscriberId,
+      _subscriberId: subscriber._id,
       providerId: '',
       transactionId: 'transactionId',
       channel: StepTypeEnum.EMAIL,
@@ -37,7 +41,7 @@ describe('Execution details - Get execution details by notification id - /v1/exe
     const {
       data: { data },
     } = await axiosInstance.get(
-      `${session.serverUrl}/v1/execution-details?notificationId=${notificationId}&subscriberId=${session.subscriberId}`,
+      `${session.serverUrl}/v1/execution-details?notificationId=${notificationId}&subscriberId=${subscriber.subscriberId}`,
       {
         headers: {
           authorization: `ApiKey ${session.apiKey}`,

--- a/apps/api/src/app/execution-details/usecases/get-execution-details/get-execution-details.usecase.ts
+++ b/apps/api/src/app/execution-details/usecases/get-execution-details/get-execution-details.usecase.ts
@@ -1,16 +1,45 @@
-import { Injectable } from '@nestjs/common';
-import { ExecutionDetailsEntity, ExecutionDetailsRepository } from '@novu/dal';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ExecutionDetailsEntity, ExecutionDetailsRepository, SubscriberEntity, SubscriberRepository } from '@novu/dal';
+import { buildSubscriberKey, CachedEntity } from '@novu/application-generic';
 import { GetExecutionDetailsCommand } from './get-execution-details.command';
 
 @Injectable()
 export class GetExecutionDetails {
-  constructor(private executionDetailsRepository: ExecutionDetailsRepository) {}
+  constructor(
+    private executionDetailsRepository: ExecutionDetailsRepository,
+    private subscriberRepository: SubscriberRepository
+  ) {}
 
   async execute(command: GetExecutionDetailsCommand): Promise<ExecutionDetailsEntity[]> {
+    const subscriber = await this.fetchSubscriber({
+      _environmentId: command.environmentId,
+      subscriberId: command.subscriberId,
+    });
+    if (!subscriber) {
+      throw new NotFoundException(`Subscriber not found for id ${command.subscriberId}`);
+    }
+
     return this.executionDetailsRepository.find({
       _notificationId: command.notificationId,
       _environmentId: command.environmentId,
-      _subscriberId: command.subscriberId,
+      _subscriberId: subscriber?._id,
     });
+  }
+
+  @CachedEntity({
+    builder: (command: { subscriberId: string; _environmentId: string }) =>
+      buildSubscriberKey({
+        _environmentId: command._environmentId,
+        subscriberId: command.subscriberId,
+      }),
+  })
+  private async fetchSubscriber({
+    subscriberId,
+    _environmentId,
+  }: {
+    subscriberId: string;
+    _environmentId: string;
+  }): Promise<SubscriberEntity | null> {
+    return await this.subscriberRepository.findBySubscriberId(_environmentId, subscriberId, true);
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

https://docs.novu.co/api/get-execution-details/ API expects two things notificationId and subscriberId. In implementation, it is MongoDBId generated by Novu. But the endpoint should accepts the user's subscriberId
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
