### PR TITLE
NV-1959B - 🐛 Bug Report: The Notification Center isn't mobile responsive

### DIFF
--- a/packages/notification-center/src/components/notification-center/components/AppContent.tsx
+++ b/packages/notification-center/src/components/notification-center/components/AppContent.tsx
@@ -20,8 +20,10 @@ export function AppContent() {
 
   return (
     <MantineProvider theme={themeConfig}>
-      <div className={wrapperClassName(primaryColor, fontFamily, dir)}>
-        <Layout />
+      <div className={wrapperStyle}>
+        <div className={wrapperClassName(primaryColor, fontFamily, dir)}>
+          <Layout />
+        </div>
       </div>
     </MantineProvider>
   );
@@ -32,8 +34,9 @@ const wrapperClassName = (primaryColor: string, fontFamily: string, dir: string)
   font-family: ${fontFamily === 'inherit' ? fontFamily : `${fontFamily}, Helvetica, sans-serif`};
   color: #333737;
   direction: ${dir};
-  width: 420px;
   z-index: 999;
+  width: auto;
+  max-width: 420px;
 
   ::-moz-selection {
     background: ${primaryColor};
@@ -42,4 +45,12 @@ const wrapperClassName = (primaryColor: string, fontFamily: string, dir: string)
   *::selection {
     background: ${primaryColor};
   }
+
+  @media (max-width: 480px) {
+    padding: 0 10% 0 2%;
+  }
+`;
+
+const wrapperStyle = css`
+  width: 100%;
 `;


### PR DESCRIPTION
 ### What change does this PR introduce?
Fix the notification popup which would overflow to one side on mobile screens.

 ### Why was this change needed?
closes https://github.com/novuhq/novu/issues/3125

### Other information

#### After Fix:
![image](https://github.com/GitStartHQ/client-novu/assets/58044533/4b439b40-dd85-483d-9c89-307b6ccb6fce)

![image](https://github.com/GitStartHQ/client-novu/assets/58044533/546eb481-2b7d-4639-ae57-88e6d0f6acd1)

![image](https://github.com/GitStartHQ/client-novu/assets/58044533/0e2e1d86-272d-4d24-b834-7873fb09b2a3)


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
