### PR TITLE
fix(web): general app layout updates for small and bigger screens

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -45,7 +45,7 @@ import { TemplateSettings } from './pages/templates/components/TemplateSettings'
 import { UserPreference } from './pages/templates/components/UserPreference';
 import { TestWorkflowPage } from './pages/templates/components/TestWorkflowPage';
 import { SnippetPage } from './pages/templates/components/SnippetPage';
-import { TemplateEditor } from './pages/templates/components/TemplateEditor';
+import { ChannelStepEditor } from './pages/templates/components/ChannelStepEditor';
 import { ProvidersPage } from './pages/templates/components/ProvidersPage';
 import { InAppSuccess } from './pages/quick-start/steps/InAppSuccess';
 import { IntegrationsListPage } from './pages/integrations/IntegrationsListPage';
@@ -200,7 +200,7 @@ function App() {
                     <Route path="test-workflow" element={<TestWorkflowPage />} />
                     <Route path="snippet" element={<SnippetPage />} />
                     <Route path="providers" element={<ProvidersPage />} />
-                    <Route path=":channel/:stepUuid" element={<TemplateEditor />} />
+                    <Route path=":channel/:stepUuid" element={<ChannelStepEditor />} />
                   </Route>
                   <Route path={ROUTES.WORKFLOWS} element={<WorkflowListPage />} />
                   <Route path={ROUTES.TENANTS} element={<TenantsPage />}>

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -1,18 +1,30 @@
 import { useState } from 'react';
-import { AppShell } from '@mantine/core';
 import * as Sentry from '@sentry/react';
 import { Outlet } from 'react-router-dom';
+import styled from '@emotion/styled';
 
 import { ThemeProvider } from '../../design-system/ThemeProvider';
 import { HeaderNav } from './components/HeaderNav';
 import { SideNav } from './components/SideNav';
-import { colors } from '../../design-system';
 import { IntercomProvider } from 'react-use-intercom';
 import { INTERCOM_APP_ID } from '../../config';
-import { HEADER_HEIGHT } from './constants';
 import { RequiredAuth } from './RequiredAuth';
 import { SpotLight } from '../utils/Spotlight';
 import { SpotLightProvider } from '../providers/SpotlightProvider';
+
+const AppShellNew = styled.div`
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  min-width: 1024px;
+`;
+
+const ContentShell = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  overflow: hidden; // for appropriate scroll
+`;
 
 export function AppLayout() {
   const [isIntercomOpened, setIsIntercomOpened] = useState(false);
@@ -26,49 +38,32 @@ export function AppLayout() {
             onShow={() => setIsIntercomOpened(true)}
             onHide={() => setIsIntercomOpened(false)}
           >
-            <AppShell
-              padding="lg"
-              navbar={<SideNav />}
-              styles={(theme) => ({
-                root: { minHeight: '100vh', position: 'relative', zIndex: 1 },
-                body: {
-                  minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
-                  '@media (max-width: 768px)': {
-                    flexDirection: 'column',
-                    height: 'auto',
-                  },
-                },
-                main: {
-                  backgroundColor: theme.colorScheme === 'dark' ? colors.BGDark : colors.BGLight,
-                  minHeight: 'auto',
-                  padding: 0,
-                  overflowX: 'hidden',
-                  borderRadius: 0,
-                },
-              })}
+            <Sentry.ErrorBoundary
+              fallback={({ error, resetError, eventId }) => (
+                <>
+                  Sorry, but something went wrong. <br />
+                  Our team been notified about it and we will look at it asap.
+                  <br />
+                  <code>
+                    <small style={{ color: 'lightGrey' }}>
+                      Event Id: {eventId}.
+                      <br />
+                      {error.toString()}
+                    </small>
+                  </code>
+                </>
+              )}
             >
-              <Sentry.ErrorBoundary
-                fallback={({ error, resetError, eventId }) => (
-                  <>
-                    Sorry, but something went wrong. <br />
-                    Our team been notified about it and we will look at it asap.
-                    <br />
-                    <code>
-                      <small style={{ color: 'lightGrey' }}>
-                        Event Id: {eventId}.
-                        <br />
-                        {error.toString()}
-                      </small>
-                    </code>
-                  </>
-                )}
-              >
-                <SpotLight>
-                  <HeaderNav isIntercomOpened={isIntercomOpened} />
-                  <Outlet />
-                </SpotLight>
-              </Sentry.ErrorBoundary>
-            </AppShell>
+              <SpotLight>
+                <AppShellNew>
+                  <SideNav />
+                  <ContentShell>
+                    <HeaderNav isIntercomOpened={isIntercomOpened} />
+                    <Outlet />
+                  </ContentShell>
+                </AppShellNew>
+              </SpotLight>
+            </Sentry.ErrorBoundary>
           </IntercomProvider>
         </ThemeProvider>
       </SpotLightProvider>

--- a/apps/web/src/components/layout/components/AuthContainer.tsx
+++ b/apps/web/src/components/layout/components/AuthContainer.tsx
@@ -18,14 +18,14 @@ export default function AuthContainer({
       sx={{
         display: 'flex',
         alignItems: 'center',
+        justifyContent: 'center',
         margin: 0,
-        '@media (max-width: 1100px)': {
-          justifyContent: 'center',
-        },
+        overflowY: 'auto',
+        height: '100vh',
       }}
     >
       <PageMeta title={title} />
-      <div style={{ margin: '30px 0', width: '100%', maxWidth: 550 }}>
+      <div style={{ margin: 'auto', padding: '40px 20px', width: '100%', maxWidth: 550 }}>
         <Title data-test-id="auth-container-title">{title}</Title>
         {customDescription || (
           <Text size="lg" color={colors.B60} mb={60} mt={20}>

--- a/apps/web/src/components/layout/components/HeaderNav.tsx
+++ b/apps/web/src/components/layout/components/HeaderNav.tsx
@@ -165,6 +165,7 @@ export function HeaderNav({ isIntercomOpened }: Props) {
         position: 'sticky',
         top: 0,
         borderBottom: 'none',
+        zIndex: 199,
       }}
     >
       <Container

--- a/apps/web/src/components/layout/components/OrganizationSelect.tsx
+++ b/apps/web/src/components/layout/components/OrganizationSelect.tsx
@@ -105,6 +105,8 @@ export default function OrganizationSelect() {
 }
 
 const SelectWrapper = styled.div`
+  margin-top: 16px;
+
   input {
     background: transparent;
   }

--- a/apps/web/src/components/layout/components/PageContainer.tsx
+++ b/apps/web/src/components/layout/components/PageContainer.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import React, { CSSProperties } from 'react';
 import { Container } from '../../../design-system';
-import { HEADER_HEIGHT } from '../constants';
 import PageMeta from './PageMeta';
 
 function PageContainer({
@@ -19,7 +18,7 @@ function PageContainer({
   };
 
   return (
-    <StyledContainer pl={0} pr={0} fluid style={containerStyle} h={`calc(100vh - ${HEADER_HEIGHT}px)`}>
+    <StyledContainer fluid style={containerStyle} h={`100%`}>
       <PageMeta title={title} />
       {children}
     </StyledContainer>
@@ -33,4 +32,5 @@ const StyledContainer = styled(Container)`
   border-radius: 0;
   padding-left: 0;
   padding-right: 0;
+  margin: 0;
 `;

--- a/apps/web/src/components/layout/components/SideNav.tsx
+++ b/apps/web/src/components/layout/components/SideNav.tsx
@@ -137,17 +137,16 @@ export function SideNav({}: Props) {
 
   return (
     <Navbar
-      p={24}
-      pt={16}
       sx={{
         position: 'sticky',
         top: 0,
         zIndex: 'auto',
         backgroundColor: 'transparent',
         borderRight: 'none',
-        paddingRight: 0,
         width: '300px',
-        height: 'max-content',
+        minHeight: '100vh',
+        padding: '16px 24px',
+        paddingBottom: '0px',
         '@media (max-width: 768px)': {
           width: '100%',
         },
@@ -158,7 +157,7 @@ export function SideNav({}: Props) {
           <NovuLogo />
         </Link>
       </Navbar.Section>
-      <Navbar.Section>
+      <Navbar.Section sx={{ overflowY: 'auto', flex: 1 }}>
         <Popover
           classNames={classes}
           withArrow
@@ -180,6 +179,7 @@ export function SideNav({}: Props) {
               onChange={async (value) => {
                 await setEnvironment(value);
               }}
+              sx={{ marginBottom: '16px' }}
               data-test-id="environment-switch"
             />
           </Popover.Target>
@@ -193,45 +193,39 @@ export function SideNav({}: Props) {
           </Popover.Dropdown>
         </Popover>
         <NavMenu menuItems={menuItems} />
-      </Navbar.Section>
-      <Navbar.Section mt={15}>
-        <Navbar.Section>
-          <OrganizationSelect />
-        </Navbar.Section>
-        <Navbar.Section>
-          <BottomNav dark={dark} data-test-id="side-nav-bottom-links">
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://discord.novu.co"
-              data-test-id="side-nav-bottom-link-support"
-            >
-              Support
-            </a>
-            <p>
-              <b>&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;</b>
-            </p>
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://docs.novu.co"
-              data-test-id="side-nav-bottom-link-documentation"
-            >
-              Docs
-            </a>
-            <p>
-              <b>&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;</b>
-            </p>
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://github.com/novuhq/novu/issues/new/choose"
-              data-test-id="side-nav-bottom-link-share-feedback"
-            >
-              Share Feedback
-            </a>
-          </BottomNav>
-        </Navbar.Section>
+        <OrganizationSelect />
+        <BottomNav dark={dark} data-test-id="side-nav-bottom-links">
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://discord.novu.co"
+            data-test-id="side-nav-bottom-link-support"
+          >
+            Support
+          </a>
+          <p>
+            <b>&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;</b>
+          </p>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://docs.novu.co"
+            data-test-id="side-nav-bottom-link-documentation"
+          >
+            Docs
+          </a>
+          <p>
+            <b>&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;</b>
+          </p>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/novuhq/novu/issues/new/choose"
+            data-test-id="side-nav-bottom-link-share-feedback"
+          >
+            Share Feedback
+          </a>
+        </BottomNav>
       </Navbar.Section>
     </Navbar>
   );
@@ -258,5 +252,4 @@ const BottomNav = styled.div<{ dark: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 5px;
 `;

--- a/apps/web/src/design-system/ThemeProvider.tsx
+++ b/apps/web/src/design-system/ThemeProvider.tsx
@@ -115,6 +115,7 @@ export function ThemeProvider({ children }: { children: JSX.Element; dark?: Bool
               backgroundColor: theme.colorScheme === 'dark' ? colors.BGDark : colors.BGLight,
               color: theme.colorScheme === 'dark' ? colors.white : colors.B40,
               marginRight: `calc(-1 * var(--removed-scroll-width, 0))`,
+              overflow: 'hidden',
             },
             a: {
               textDecoration: 'none',

--- a/apps/web/src/design-system/navigation/NavMenu.styles.ts
+++ b/apps/web/src/design-system/navigation/NavMenu.styles.ts
@@ -20,9 +20,9 @@ export default createStyles((theme: MantineTheme) => {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'space-between',
-      height: '50px',
+      height: '44px',
       width: '100%',
-      margin: '15px 0px',
+      margin: '8px 0px',
       position: 'relative',
       padding: theme.spacing.xs,
       boxSizing: 'border-box',
@@ -39,6 +39,15 @@ export default createStyles((theme: MantineTheme) => {
       '&:first-of-type': {
         marginTop: '0px',
       },
+
+      '&:last-of-type': {
+        marginBottom: '0px',
+      },
+
+      '@media (min-width: 1440px)': {
+        margin: '15px 0px',
+        height: '50px',
+      },
     },
     linkActive: {
       '&, &:hover': {
@@ -46,7 +55,7 @@ export default createStyles((theme: MantineTheme) => {
         alignItems: 'center',
         justifyContent: 'space-between',
         width: '100%',
-        height: '50px',
+        height: '44px',
         position: 'relative',
         padding: theme.spacing.xs,
         boxSizing: 'border-box',
@@ -66,6 +75,10 @@ export default createStyles((theme: MantineTheme) => {
           left: 0,
           borderRadius: '7px 0px 0px 7px',
           background: colors.vertical,
+        },
+
+        '@media (min-width: 1440px)': {
+          height: '50px',
         },
       },
     },

--- a/apps/web/src/design-system/segmented-control/SegmentedControl.tsx
+++ b/apps/web/src/design-system/segmented-control/SegmentedControl.tsx
@@ -40,7 +40,7 @@ export const SegmentedControl = React.forwardRef<HTMLDivElement, ISegmentedContr
     } as SegmentedControlProps;
 
     return (
-      <ControlWrapper style={{ position: 'relative', marginBottom: 24 }}>
+      <ControlWrapper style={{ position: 'relative', marginBottom: 0 }}>
         <LoadingOverlay
           visible={loading}
           overlayColor={theme.colorScheme === 'dark' ? colors.B30 : colors.B98}

--- a/apps/web/src/design-system/sidebar/Sidebar.tsx
+++ b/apps/web/src/design-system/sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { ActionIcon, createStyles, Drawer, Loader, MantineTheme, Stack } from '@mantine/core';
 import { ReactNode } from 'react';
+import { HEADER_HEIGHT } from '../../components/layout/constants';
 
 import { When } from '../../components/utils/When';
 import { useKeyDown } from '../../hooks';
@@ -37,7 +38,6 @@ const FooterHolder = styled.div`
 `;
 
 const COLLAPSED_WIDTH = 480;
-const HEADER_HEIGHT = 65;
 const NAVIGATION_WIDTH = 300;
 const PAGE_MARGIN = 30;
 const INTEGRATION_SETTING_TOP = HEADER_HEIGHT;
@@ -108,7 +108,7 @@ export const Sidebar = ({
       position="right"
       styles={{
         drawer: {
-          width: isExpanded ? `calc(100% - ${NAVIGATION_WIDTH + PAGE_MARGIN}px)` : COLLAPSED_WIDTH,
+          width: isExpanded ? `calc(100% - ${NAVIGATION_WIDTH}px)` : COLLAPSED_WIDTH,
           transition: 'all 300ms ease !important',
           '@media screen and (max-width: 768px)': {
             width: isExpanded ? `100%` : COLLAPSED_WIDTH,

--- a/apps/web/src/pages/activities/components/ActivityGraph.tsx
+++ b/apps/web/src/pages/activities/components/ActivityGraph.tsx
@@ -73,6 +73,7 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   flex-direction: column;
+  position: relative;
 `;
 
 function fillDateGaps(data: IActivityGraphStats[]): IActivityGraphStats[] {

--- a/apps/web/src/pages/activities/services/chart-bar/option.service.ts
+++ b/apps/web/src/pages/activities/services/chart-bar/option.service.ts
@@ -83,6 +83,7 @@ function getTooltipConfiguration() {
         tooltipEl.id = 'chartjs-tooltip';
         tooltipEl.innerHTML = '<table></table>';
         document.body.appendChild(tooltipEl);
+        tooltipEl.style.position = 'absolute';
       }
 
       // Hide if no tooltip

--- a/apps/web/src/pages/integrations/IntegrationsList.tsx
+++ b/apps/web/src/pages/integrations/IntegrationsList.tsx
@@ -79,13 +79,7 @@ export const IntegrationsList = ({
   }, [integrations, environments]);
 
   return (
-    <PageContainer
-      style={{
-        position: 'relative',
-        overflow: 'hidden',
-      }}
-      title="Integrations"
-    >
+    <PageContainer title="Integrations">
       <PageHeader title="Integrations Store" />
       <Container fluid sx={{ padding: '0 30px 8px 30px' }}>
         <IntegrationsListToolbar onAddProviderClick={onAddProviderClick} areIntegrationsLoading={isLoading} />

--- a/apps/web/src/pages/quick-start/components/layout/BodyLayout.tsx
+++ b/apps/web/src/pages/quick-start/components/layout/BodyLayout.tsx
@@ -7,14 +7,13 @@ import { colors } from '../../../../design-system';
 import { getStartedSteps, OnBoardingAnalyticsEnum } from '../../consts';
 import { useSegment } from '../../../../components/providers/SegmentProvider';
 import { ROUTES } from '../../../../constants/routes.enum';
-import { FOOTER_HEIGHT } from './FooterLayout';
 
 const BULLET_TOP_MARGIN = 20;
 
 export function BodyLayout({ children }: { children: React.ReactNode }) {
   return (
     <StyledBody>
-      <Grid columns={24}>
+      <Grid columns={24} m={0}>
         <Grid.Col span={7}>
           <BodyNavigation />
         </Grid.Col>
@@ -25,11 +24,10 @@ export function BodyLayout({ children }: { children: React.ReactNode }) {
 }
 
 const StyledBody = styled.div`
-  display: block;
-  flex: auto;
-  margin-bottom: ${FOOTER_HEIGHT}px;
+  height: calc(100vh - 180px);
   padding-top: 25px;
   padding-bottom: 25px;
+  overflow-y: auto;
 `;
 
 function BodyNavigation() {

--- a/apps/web/src/pages/quick-start/components/layout/FooterLayout.tsx
+++ b/apps/web/src/pages/quick-start/components/layout/FooterLayout.tsx
@@ -31,7 +31,7 @@ export function FooterLayout({ leftSide, rightSide }: IFooterLayoutProps) {
 
   return (
     <FooterWrapper>
-      <Grid justify={'space-between'} style={{ width: '100%' }}>
+      <Grid justify={'space-between'} style={{ width: '100%' }} m={0} mx={12}>
         <LeftCol span={4}>{leftSide} </LeftCol>
         <MiddleCol span={4}>
           <DotsNavigation selectedIndex={selectedIndex} size={2} onClick={handleOnNavigationClick} />
@@ -63,23 +63,13 @@ const RightCol = styled(Grid.Col)`
 `;
 
 const FooterWrapper = styled.div`
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  left: 0;
+  width: 100%;
   height: ${FOOTER_HEIGHT}px;
-  z-index: 100;
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-direction: row;
-
-  padding: 20px 24px;
   box-shadow: inset 0 1px 0 #000000;
-
-  @media screen and (min-width: 1369px) {
-    padding: 32px 80px;
-  }
 
   background-color: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.B15 : colors.white)};
 

--- a/apps/web/src/pages/quick-start/components/layout/GetStartedLayout.tsx
+++ b/apps/web/src/pages/quick-start/components/layout/GetStartedLayout.tsx
@@ -8,6 +8,7 @@ import { currentOnboardingStep } from '../route/store';
 import { BodyLayout } from './BodyLayout';
 import { FooterLayout } from './FooterLayout';
 import { HeaderLayout } from './HeaderLayout';
+import { Title } from '../../../../design-system';
 
 interface IGetStartedLayoutProps {
   children?: React.ReactNode;
@@ -15,10 +16,9 @@ interface IGetStartedLayoutProps {
     leftSide: React.ReactNode;
     rightSide: React.ReactNode;
   };
-  header: React.ReactNode;
 }
 
-export function GetStartedLayout({ children, footer, header }: IGetStartedLayoutProps) {
+export function GetStartedLayout({ children, footer }: IGetStartedLayoutProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -48,7 +48,9 @@ export function GetStartedLayout({ children, footer, header }: IGetStartedLayout
     <>
       <PageContainer style={{ display: 'flex' }}>
         <PageWrapper>
-          <HeaderLayout>{header}</HeaderLayout>
+          <HeaderLayout>
+            <Title>Get started</Title>
+          </HeaderLayout>
           <BodyLayout>{children}</BodyLayout>
           <FooterLayout leftSide={footer.leftSide} rightSide={footer.rightSide} />
         </PageWrapper>
@@ -59,7 +61,6 @@ export function GetStartedLayout({ children, footer, header }: IGetStartedLayout
 
 const PageWrapper = styled.div`
   display: flex;
-  justify-content: space-between;
   flex-direction: column;
   width: 100%;
   position: relative;

--- a/apps/web/src/pages/quick-start/components/layout/HeaderLayout.tsx
+++ b/apps/web/src/pages/quick-start/components/layout/HeaderLayout.tsx
@@ -34,5 +34,4 @@ const StyledHeader = styled.div`
   display: flex;
   justify-content: center;
   flex-direction: column;
-  margin-bottom: 10px;
 `;

--- a/apps/web/src/pages/quick-start/steps/DigestPreview.tsx
+++ b/apps/web/src/pages/quick-start/steps/DigestPreview.tsx
@@ -15,7 +15,6 @@ import { Label } from '../../../design-system/typography/label';
 import { NavButton } from '../components/NavButton';
 import useStyles from '../components/OnboardingSteps.styles';
 import { getStartedSteps, OnBoardingAnalyticsEnum } from '../consts';
-import { HeaderSecondaryTitle, HeaderTitle } from '../components/layout/HeaderLayout';
 
 export function DigestPreview() {
   const segment = useSegment();
@@ -26,12 +25,6 @@ export function DigestPreview() {
 
   return (
     <GetStartedLayout
-      header={
-        <>
-          <HeaderTitle>Set-up steps to get started</HeaderTitle>
-          <HeaderSecondaryTitle>Quick Start Guide</HeaderSecondaryTitle>
-        </>
-      }
       footer={{
         leftSide: <FooterLeftSide />,
         rightSide: <FooterRightSide />,
@@ -103,7 +96,7 @@ const DigestDemoFlowStyled = styled(DigestDemoFlow)`
 
 const ButtonsHolder = styled.div`
   display: flex;
-  gap: 40px;
+  gap: 20px;
 `;
 
 const DemoContainer = styled.div`

--- a/apps/web/src/pages/quick-start/steps/GetStarted.tsx
+++ b/apps/web/src/pages/quick-start/steps/GetStarted.tsx
@@ -3,7 +3,6 @@ import { ChannelTypeEnum } from '@novu/shared';
 import { useEffect, useState } from 'react';
 
 import { useSegment } from '../../../components/providers/SegmentProvider';
-import { Title } from '../../../design-system';
 import { ArrowRight } from '../../../design-system/icons/arrows/ArrowRight';
 import { useIsMultiProviderConfigurationEnabled } from '../../../hooks';
 import { IntegrationsListModal } from '../../integrations/IntegrationsListModal';
@@ -46,7 +45,6 @@ export function GetStarted() {
 
   return (
     <GetStartedLayout
-      header={<Title>Get started</Title>}
       footer={{
         leftSide: <LearnMoreRef />,
         rightSide: (

--- a/apps/web/src/pages/templates/components/ChannelStepEditor.tsx
+++ b/apps/web/src/pages/templates/components/ChannelStepEditor.tsx
@@ -17,7 +17,7 @@ import { useBasePath } from '../hooks/useBasePath';
 import { StepName } from './StepName';
 import { DeleteStepRow } from './DeleteStepRow';
 
-export const TemplateEditor = () => {
+export const ChannelStepEditor = () => {
   const { readonly } = useEnvController();
   const { channel, stepUuid = '' } = useParams<{
     channel: StepTypeEnum | undefined;
@@ -60,8 +60,7 @@ export const TemplateEditor = () => {
           width: '100%',
           borderTopLeftRadius: 7,
           borderBottomLeftRadius: 7,
-          paddingBottom: 96,
-          overflowY: 'auto',
+          paddingBottom: 24,
         }}
       >
         <TemplateInAppEditor errors={errors} control={control} index={index} />
@@ -80,8 +79,7 @@ export const TemplateEditor = () => {
           width: '100%',
           borderTopLeftRadius: 7,
           borderBottomLeftRadius: 7,
-          paddingBottom: 96,
-          overflowY: 'auto',
+          paddingBottom: 24,
         }}
       >
         <EmailMessagesCards
@@ -99,7 +97,7 @@ export const TemplateEditor = () => {
         key={index}
         color={colors.white}
         title={<StepName index={index} color={colors.B60} channel={channel} />}
-        style={{ paddingBottom: 96 }}
+        style={{ paddingBottom: 24 }}
       >
         {channel === StepTypeEnum.SMS && (
           <TemplateSMSEditor

--- a/apps/web/src/pages/templates/components/DeleteStepRow.tsx
+++ b/apps/web/src/pages/templates/components/DeleteStepRow.tsx
@@ -20,15 +20,7 @@ export const DeleteStepRow = () => {
   }
 
   return (
-    <Group
-      position="apart"
-      sx={{
-        position: 'absolute',
-        bottom: 24,
-        left: 24,
-        right: 24,
-      }}
-    >
+    <Group position="apart" mt={'auto'}>
       <When truthy={![StepTypeEnum.DELAY, StepTypeEnum.DIGEST].includes(channel)}>
         <div />
       </When>

--- a/apps/web/src/pages/templates/components/ProvidersPage.tsx
+++ b/apps/web/src/pages/templates/components/ProvidersPage.tsx
@@ -41,7 +41,7 @@ export function ProvidersPage() {
         }}
       >
         <WorkflowSettingsTabs />
-        <ScrollArea h="100%" offsetScrollbars>
+        <ScrollArea h="calc(100vh - 220px)" offsetScrollbars mr={-12}>
           <ListProviders
             channel={ChannelTypeEnum.IN_APP}
             setProvider={setProvider}

--- a/apps/web/src/pages/templates/components/SnippetPage.tsx
+++ b/apps/web/src/pages/templates/components/SnippetPage.tsx
@@ -11,7 +11,7 @@ export function SnippetPage() {
 
   return (
     <SubPageWrapper title="Trigger">
-      <Text color={colors.B60} mt={-16} mb={24}>
+      <Text color={colors.B60} mt={-16}>
         Test trigger as if you sent it from your API or implement it by copy/pasting it into the codebase of your
         application.
       </Text>

--- a/apps/web/src/pages/templates/components/SubPageWrapper.tsx
+++ b/apps/web/src/pages/templates/components/SubPageWrapper.tsx
@@ -1,6 +1,7 @@
 import { Stack, Title, UnstyledButton, useMantineColorScheme } from '@mantine/core';
 import { CSSProperties } from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import { colors } from '../../../design-system';
 import { Close } from '../../../design-system/icons/actions/Close';
 import { useBasePath } from '../hooks/useBasePath';
@@ -23,17 +24,19 @@ export const SubPageWrapper = ({
   return (
     <div
       style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 24,
         padding: '24px',
         backgroundColor: colorScheme === 'dark' ? colors.B17 : colors.white,
         borderRadius: '0 7px 7px 0 ',
-        height: '100%',
         width: 460,
         position: 'relative',
         ...style,
       }}
       data-test-id="step-page-wrapper"
     >
-      <div style={{ display: 'flex', marginBottom: 24 }}>
+      <div style={{ display: 'flex' }}>
         <Stack
           style={{
             flex: '1 1 auto',

--- a/apps/web/src/pages/templates/components/TemplatePushEditor.tsx
+++ b/apps/web/src/pages/templates/components/TemplatePushEditor.tsx
@@ -38,8 +38,6 @@ export function TemplatePushEditor({
         control={control}
         render={({ field }) => (
           <Textarea
-            mt={24}
-            mb={24}
             {...field}
             data-test-id="pushNotificationTitle"
             error={errors?.steps ? errors.steps[index]?.template?.title?.message : undefined}

--- a/apps/web/src/pages/templates/components/TemplateSMSEditor.tsx
+++ b/apps/web/src/pages/templates/components/TemplateSMSEditor.tsx
@@ -43,7 +43,6 @@ export function TemplateSMSEditor({
             error={errors?.steps ? errors.steps[index]?.template?.content?.message : undefined}
             disabled={readonly}
             minRows={4}
-            mt={24}
             value={field.value || ''}
             label="SMS message content"
             placeholder="Add notification content here..."

--- a/apps/web/src/pages/templates/components/TemplateSettings.tsx
+++ b/apps/web/src/pages/templates/components/TemplateSettings.tsx
@@ -56,10 +56,8 @@ export const TemplateSettings = () => {
     <SubPageWrapper title="Workflow Settings">
       <WorkflowSettingsTabs />
       <NotificationSettingsForm trigger={trigger} />
-
-      <Group position="right">
+      <Group position="right" mt={'auto'}>
         <DeleteNotificationButton
-          mt={48}
           variant="outline"
           disabled={readonly}
           data-test-id="delete-notification-button"

--- a/apps/web/src/pages/templates/components/TestWorkflow.tsx
+++ b/apps/web/src/pages/templates/components/TestWorkflow.tsx
@@ -103,7 +103,7 @@ export function TestWorkflow({ trigger }) {
   return (
     <>
       <SubPageWrapper title="Trigger">
-        <Text color={colors.B60} mt={-16} mb={24}>
+        <Text color={colors.B60} mt={-16}>
           Test trigger as if you sent it from your API or implement it by copy/pasting it into the codebase of your
           application.
         </Text>
@@ -117,7 +117,6 @@ export function TestWorkflow({ trigger }) {
           label="To"
           {...form.getInputProps('toValue')}
           minRows={3}
-          mb={15}
           validationError="Invalid JSON"
         />
         <JsonInput
@@ -129,7 +128,6 @@ export function TestWorkflow({ trigger }) {
           {...form.getInputProps('payloadValue')}
           minRows={3}
           validationError="Invalid JSON"
-          mb={15}
         />
         <JsonInput
           data-test-id="test-trigger-overrides-param"
@@ -141,7 +139,7 @@ export function TestWorkflow({ trigger }) {
           minRows={3}
           validationError="Invalid JSON"
         />
-        <Group mt={30} position="right">
+        <Group position="right" mt={'auto'}>
           <div data-test-id="test-workflow-btn">
             <Button
               sx={{

--- a/apps/web/src/pages/templates/components/WorkflowSettingsTabs.tsx
+++ b/apps/web/src/pages/templates/components/WorkflowSettingsTabs.tsx
@@ -15,7 +15,6 @@ export const WorkflowSettingsTabs = () => {
 
   return (
     <Tabs
-      mb={24}
       orientation="horizontal"
       keepMounted={true}
       onTabChange={(tabValue) => {

--- a/apps/web/src/pages/templates/components/chat-editor/TemplateChatEditor.tsx
+++ b/apps/web/src/pages/templates/components/chat-editor/TemplateChatEditor.tsx
@@ -38,7 +38,6 @@ export function TemplateChatEditor({
         control={control}
         render={({ field }) => (
           <Textarea
-            mt={24}
             {...field}
             data-test-id="chatNotificationContent"
             error={errors?.steps ? errors.steps[index]?.template?.content?.message : undefined}

--- a/apps/web/src/pages/templates/components/email-editor/EmailMessagesCards.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/EmailMessagesCards.tsx
@@ -67,7 +67,7 @@ export function EmailMessagesCards({ index, isIntegrationActive }: { index: numb
         }}
       >
         <StepSettings index={index} />
-        <Grid m={0} mb={24} mt={24}>
+        <Grid m={0} mt={24}>
           <Grid.Col p={0} mr={20} span={7}>
             <EditorPreviewSwitch view={view} setView={setView} />
           </Grid.Col>

--- a/apps/web/src/pages/templates/components/email-editor/TestSendEmail.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/TestSendEmail.tsx
@@ -72,7 +72,7 @@ export function TestSendEmail({ index, isIntegrationActive }: { index: number; i
 
   return (
     <div>
-      <Text my={30} color={colors.B60}>
+      <Text mb={30} color={colors.B60}>
         Fill in the required variables and send a test to your desired address.
       </Text>
 
@@ -114,7 +114,6 @@ export function TestSendEmail({ index, isIntegrationActive }: { index: number; i
           value={payloadValue}
           onChange={setPayloadValue}
           minRows={12}
-          mb={15}
           validationError="Invalid JSON"
           rightSectionWidth={50}
           rightSectionProps={{ style: { alignItems: 'start', padding: '5px' } }}

--- a/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
@@ -1,9 +1,10 @@
-import { colors, Text, Tooltip } from '../../../../../design-system';
 import { useWatch } from 'react-hook-form';
+import { UnstyledButton } from '@mantine/core';
 import { SystemVariablesWithTypes } from '@novu/shared';
+
+import { Text, Tooltip } from '../../../../../design-system';
 import { VarItemsDropdown } from './VarItemsDropdown';
 import { VarLabel } from './VarLabel';
-import { UnstyledButton, useMantineTheme } from '@mantine/core';
 import { EditGradient } from '../../../../../design-system/icons/gradient/EditGradient';
 import { useProcessVariables } from '../../../../../hooks';
 import { VarItemTooltip } from './VarItemTooltip';
@@ -20,7 +21,6 @@ export const VariablesManagement = ({
   control?: any;
   path?: string;
 }) => {
-  const theme = useMantineTheme();
   const variableArray = useWatch({
     name: path ?? `steps.${index}.template.variables`,
     control,
@@ -32,7 +32,6 @@ export const VariablesManagement = ({
       style={{
         width: '100%',
         height: '100%',
-        background: theme.colorScheme === 'dark' ? colors.B17 : colors.B98,
         borderRadius: 7,
         padding: 15,
       }}

--- a/apps/web/src/pages/templates/components/in-app-editor/InAppContentCard.tsx
+++ b/apps/web/src/pages/templates/components/in-app-editor/InAppContentCard.tsx
@@ -69,7 +69,7 @@ export function InAppContentCard({ index, openVariablesModal }: { index: number;
         radius={'xl'}
       />
       <When truthy={activeTab === PREVIEW}>
-        <Grid mt={24} mb={24}>
+        <Grid mt={24} mb={0}>
           <Grid.Col span={9} p={0}>
             <div style={{ margin: '0 10px' }}>
               <InAppEditorBlock
@@ -116,7 +116,6 @@ export function InAppContentCard({ index, openVariablesModal }: { index: number;
           </Grid.Col>
           <Grid.Col
             span={3}
-            mb={20}
             style={{
               maxWidth: '350px',
             }}

--- a/apps/web/src/pages/templates/components/in-app-editor/TemplateInAppEditor.tsx
+++ b/apps/web/src/pages/templates/components/in-app-editor/TemplateInAppEditor.tsx
@@ -36,7 +36,7 @@ export function TemplateInAppEditor({ control, index }: { control: Control<IForm
   return (
     <>
       <StepSettings index={index} />
-      <Stack mt={24} spacing={24}>
+      <Stack spacing={24}>
         <Controller
           name={`steps.${index}.template.cta.data.url` as any}
           defaultValue=""

--- a/apps/web/src/pages/templates/components/notification-setting-form/NotificationSettingsForm.tsx
+++ b/apps/web/src/pages/templates/components/notification-setting-form/NotificationSettingsForm.tsx
@@ -62,7 +62,7 @@ export const NotificationSettingsForm = ({ trigger }: { trigger?: INotificationT
 
   return (
     <>
-      <Grid gutter={0}>
+      <Grid gutter={0} mt={-8} mb={-8}>
         <Grid.Col span={6}>
           <Stack
             justify="center"

--- a/apps/web/src/pages/templates/components/notification-setting-form/TemplatePreference.tsx
+++ b/apps/web/src/pages/templates/components/notification-setting-form/TemplatePreference.tsx
@@ -1,11 +1,9 @@
 import { FunctionComponent } from 'react';
 import { Group, Input, InputWrapperProps, Text } from '@mantine/core';
-import styled from '@emotion/styled';
 import { useFormContext, Controller } from 'react-hook-form';
 
 import { useEnvController } from '../../../../hooks';
 import { Checkbox, colors, Switch } from '../../../../design-system';
-import { channels } from '../../../../utils/channels';
 import type { IForm } from '../formTypes';
 import { LabelWithTooltip } from '../../workflow/LabelWithTooltip';
 import { ChannelTitle } from '../ChannelTitle';
@@ -39,9 +37,7 @@ export function ChannelPreference() {
 
         return (
           <>
-            <Text mb={16} color={colors.B60}>
-              Default Channels On:
-            </Text>
+            <Text color={colors.B60}>Default Channels On:</Text>
             {Object.keys(preferences).map((key) => {
               const checked = preferences[key] || false;
 
@@ -52,7 +48,6 @@ export function ChannelPreference() {
                     border: `1px dashed ${colors.B40}`,
                     borderRadius: 8,
                   }}
-                  mb={24}
                   position="apart"
                 >
                   <Text>{<ChannelTitle channel={key as ChannelTypeEnum} />}</Text>
@@ -85,7 +80,7 @@ export function CriticalPreference() {
       control={control}
       render={({ field }) => {
         return (
-          <Group mb={24} align="center" position="apart">
+          <Group align="center" position="apart">
             <LabelWithTooltip
               label="Users will be able to manage subscriptions"
               tooltip="Allow opting out of the specific channel. Users will receive notifications in the active channels."
@@ -101,21 +96,6 @@ export function CriticalPreference() {
 export const InputWrapperProxy: FunctionComponent<InputWrapperProps> = ({ children, ...props }) => {
   return <Input.Wrapper {...props}>{children}</Input.Wrapper>;
 };
-
-const InputBackground = styled(InputWrapperProxy)`
-  background: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.B17 : colors.B98)};
-  border-radius: 7px;
-`;
-
-const StyledCheckbox = styled(CheckboxProxy)<{ checked: boolean }>`
-  label {
-    ${({ checked }) =>
-      !checked &&
-      `
-    color: ${colors.B60}
-  `}
-  }
-`;
 
 export function CheckboxProxy({ ...props }) {
   return <Checkbox {...props} />;

--- a/apps/web/src/pages/templates/components/templates-store/ChannelNode.tsx
+++ b/apps/web/src/pages/templates/components/templates-store/ChannelNode.tsx
@@ -1,11 +1,6 @@
 import { NodeProps, Handle, Position, getOutgoers, useReactFlow } from 'react-flow-renderer';
-import styled from '@emotion/styled';
 
 import { NodeStep } from '../../../../components/workflow';
-
-const NodeStepStyled = styled(NodeStep)`
-  width: 200px;
-`;
 
 export const ChannelNode = ({ id, data }: NodeProps) => {
   const { getNode, getEdges, getNodes } = useReactFlow();
@@ -14,7 +9,7 @@ export const ChannelNode = ({ id, data }: NodeProps) => {
   const noChildStyle = isParent ? {} : { border: 'none', background: 'transparent' };
 
   return (
-    <NodeStepStyled
+    <NodeStep
       data={data}
       Icon={data.Icon}
       Handlers={() => {

--- a/apps/web/src/pages/templates/components/templates-store/TriggerNode.tsx
+++ b/apps/web/src/pages/templates/components/templates-store/TriggerNode.tsx
@@ -1,16 +1,11 @@
 import { Handle, NodeProps, Position } from 'react-flow-renderer';
-import styled from '@emotion/styled';
 
 import { NodeStep } from '../../../../components/workflow';
 import { TurnOnGradient } from '../../../../design-system/icons';
 
-const NodeStepStyled = styled(NodeStep)`
-  width: 200px;
-`;
-
 export const TriggerNode = ({ data }: NodeProps) => {
   return (
-    <NodeStepStyled
+    <NodeStep
       data={data}
       Icon={TurnOnGradient}
       Handlers={() => {

--- a/apps/web/src/pages/templates/editor/DigestWorkflowTourTooltip.tsx
+++ b/apps/web/src/pages/templates/editor/DigestWorkflowTourTooltip.tsx
@@ -25,11 +25,30 @@ const DESCRIPTION = [
 const TooltipHolder = styled.div`
   display: flex;
   flex-direction: column;
-  width: 300px;
-  padding: 32px;
+  padding: 20px;
+  width: 280px;
   background-color: ${({ theme }) => (theme.colorScheme === 'dark' ? colors.B30 : colors.B98)};
   filter: drop-shadow(0px 5px 20px rgba(0, 0, 0, 0.1));
   border-radius: 8px;
+
+  [data-tooltip-icon] {
+    width: 80px;
+    height: 80px;
+    align-self: center;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  @media screen and (min-width: 1440px) {
+    padding: 32px;
+
+    [data-tooltip-icon] {
+      width: 120px;
+      height: 120px;
+      margin-top: 40px;
+      margin-bottom: 40px;
+    }
+  }
 `;
 
 const Title = styled.p`
@@ -116,7 +135,7 @@ export const DigestWorkflowTourTooltip = ({
 
   return (
     <TooltipHolder ref={tooltipProps.ref} data-test-id="digest-workflow-tooltip">
-      <Icon width={120} height={120} style={{ alignSelf: 'center', marginTop: '40px', marginBottom: '40px' }} />
+      <Icon data-tooltip-icon />
       <Title>{TITLE[index]}</Title>
       <Description>{DESCRIPTION[index]}</Description>
       <ButtonsHolder>

--- a/apps/web/src/pages/templates/editor/Mobile.tsx
+++ b/apps/web/src/pages/templates/editor/Mobile.tsx
@@ -5,7 +5,7 @@ const useStyles = createStyles((theme) => ({
   phone: {
     display: 'block',
     margin: 'auto',
-    width: '390px',
+    width: '400px',
     height: '740px',
     position: 'relative',
     borderColor: theme.colorScheme === 'dark' ? colors.B20 : colors.B85,

--- a/apps/web/src/pages/templates/editor/PreviewMobile.tsx
+++ b/apps/web/src/pages/templates/editor/PreviewMobile.tsx
@@ -50,9 +50,6 @@ const useStyles = createStyles((theme) => ({
     padding: '15px',
     textAlign: 'center',
   },
-  bottom: {
-    height: '30px',
-  },
 }));
 
 export const PreviewMobile = ({
@@ -135,7 +132,6 @@ export const PreviewMobile = ({
           </ErrorBoundary>
         </When>
       </Mobile>
-      <div className={classes.bottom}></div>
     </>
   );
 };

--- a/apps/web/src/pages/templates/editor/PreviewWeb.tsx
+++ b/apps/web/src/pages/templates/editor/PreviewWeb.tsx
@@ -66,9 +66,6 @@ const useStyles = createStyles((theme) => ({
     padding: '15px',
     textAlign: 'center',
   },
-  bottom: {
-    height: '30px',
-  },
 }));
 
 export const PreviewWeb = ({
@@ -163,7 +160,6 @@ export const PreviewWeb = ({
           </div>
         </When>
       </div>
-      <div className={classes.bottom}></div>
     </>
   );
 };

--- a/apps/web/src/pages/templates/editor/TemplateEditorPage.tsx
+++ b/apps/web/src/pages/templates/editor/TemplateEditorPage.tsx
@@ -74,7 +74,7 @@ function BaseTemplateEditorPage() {
           name="template-form"
           noValidate
           onSubmit={handleSubmit(onSubmitHandler, onInvalid)}
-          style={{ minHeight: '100%', height: '100%' }}
+          style={{ height: '100%', display: 'grid', gridTemplateColumns: '1fr' }}
         >
           <ReactFlowProvider>
             <WorkflowEditor />

--- a/apps/web/src/pages/templates/editor/TourProvider.tsx
+++ b/apps/web/src/pages/templates/editor/TourProvider.tsx
@@ -74,7 +74,7 @@ export const TourProvider = React.memo(() => {
         styles={{
           options: {
             arrowColor: colorScheme === 'dark' ? colors.B30 : colors.B98,
-            zIndex: 99,
+            zIndex: 200,
           },
           tooltipFooter: {
             flexDirection: 'row-reverse',

--- a/apps/web/src/pages/templates/editor/useDigestWorkflowTour.tsx
+++ b/apps/web/src/pages/templates/editor/useDigestWorkflowTour.tsx
@@ -20,9 +20,9 @@ const digestTourSteps: Step[] = [
     offset: 0,
   },
   {
-    target: '[data-test-id="email-step-settings-edit"]',
+    target: '#codeEditor',
     content: '',
-    placement: 'left',
+    placement: 'right',
     disableBeacon: true,
     hideBackButton: true,
     locale: { skip: 'Skip tour' },
@@ -32,7 +32,7 @@ const digestTourSteps: Step[] = [
   {
     target: '[data-test-id="test-workflow-btn"]',
     content: '',
-    placement: 'bottom',
+    placement: 'top',
     disableBeacon: true,
     hideBackButton: true,
     tooltipComponent: DigestWorkflowTourTooltip,

--- a/apps/web/src/pages/templates/workflow/DelayMetadata.tsx
+++ b/apps/web/src/pages/templates/workflow/DelayMetadata.tsx
@@ -21,48 +21,34 @@ export const DelayMetadata = ({ control, index }) => {
 
   return (
     <>
-      <div
-        style={{
-          marginBottom: '15px',
+      <Controller
+        control={control}
+        defaultValue={DelayTypeEnum.REGULAR}
+        name={`steps.${index}.delayMetadata.type`}
+        render={({ field }) => {
+          return (
+            <SegmentedControl
+              {...field}
+              sx={{
+                maxWidth: '100% !important',
+              }}
+              fullWidth
+              disabled={readonly}
+              data={[
+                { value: DelayTypeEnum.REGULAR, label: 'Regular' },
+                { value: DelayTypeEnum.SCHEDULED, label: 'Scheduled' },
+              ]}
+              onChange={async (segmentValue) => {
+                field.onChange(segmentValue);
+                await trigger(`steps.${index}.delayMetadata`);
+              }}
+              data-test-id="delay-type"
+            />
+          );
         }}
-      >
-        <Controller
-          control={control}
-          defaultValue={DelayTypeEnum.REGULAR}
-          name={`steps.${index}.delayMetadata.type`}
-          render={({ field }) => {
-            return (
-              <SegmentedControl
-                {...field}
-                sx={{
-                  maxWidth: '100% !important',
-                }}
-                fullWidth
-                disabled={readonly}
-                data={[
-                  { value: DelayTypeEnum.REGULAR, label: 'Regular' },
-                  { value: DelayTypeEnum.SCHEDULED, label: 'Scheduled' },
-                ]}
-                onChange={async (segmentValue) => {
-                  field.onChange(segmentValue);
-                  await trigger(`steps.${index}.delayMetadata`);
-                }}
-                data-test-id="delay-type"
-              />
-            );
-          }}
-        />
-      </div>
+      />
       <When truthy={type === DelayTypeEnum.REGULAR}>
-        <LabelWithTooltip
-          label="Time Interval"
-          tooltip="Once triggered, for how long should delay before next step execution."
-        />
-        <Grid
-          sx={{
-            marginBottom: '2px',
-          }}
-        >
+        <Grid>
           <Grid.Col span={4}>
             <Controller
               control={control}
@@ -76,6 +62,12 @@ export const DelayMetadata = ({ control, index }) => {
                     error={showErrors && fieldState.error?.message}
                     min={0}
                     max={100}
+                    label={
+                      <LabelWithTooltip
+                        label="Time Interval"
+                        tooltip="Once triggered, for how long should delay before next step execution."
+                      />
+                    }
                     type="number"
                     data-test-id="time-amount"
                     placeholder="0"
@@ -92,7 +84,7 @@ export const DelayMetadata = ({ control, index }) => {
               }}
             />
           </Grid.Col>
-          <Grid.Col span={8}>
+          <Grid.Col span={8} mt={20}>
             <IntervalRadios
               control={control}
               name={`steps.${index}.delayMetadata.${DelayTypeEnum.REGULAR}.unit`}

--- a/apps/web/src/pages/templates/workflow/DigestMetadata.tsx
+++ b/apps/web/src/pages/templates/workflow/DigestMetadata.tsx
@@ -26,7 +26,7 @@ export const DigestMetadata = ({ index, readonly }: { index: number; readonly: b
 
   return (
     <div data-test-id="digest-step-settings-interval">
-      <Accordion>
+      <Accordion styles={{ item: { '&:last-of-type': { marginBottom: 0 } } }}>
         <Tooltip
           position="left"
           width={227}

--- a/apps/web/src/pages/templates/workflow/WorkflowEditor.tsx
+++ b/apps/web/src/pages/templates/workflow/WorkflowEditor.tsx
@@ -141,7 +141,7 @@ const WorkflowEditor = () => {
 
   if (readonly && pathname === basePath) {
     return (
-      <div style={{ minHeight: '600px', display: 'flex', flexFlow: 'row', height: '100%' }}>
+      <div style={{ display: 'flex', flexFlow: 'row' }}>
         <div
           style={{
             flex: '1 1 auto',
@@ -200,9 +200,8 @@ const WorkflowEditor = () => {
           }}
         />
       </When>
-      <When truthy={readonly && pathname === basePath}>{null}</When>
       <When truthy={!channel || ![StepTypeEnum.EMAIL, StepTypeEnum.IN_APP].includes(channel)}>
-        <div style={{ minHeight: '600px', display: 'flex', flexFlow: 'row', height: '100%' }}>
+        <div style={{ display: 'flex', flexFlow: 'row' }}>
           <div
             style={{
               flex: '1 1 auto',
@@ -241,19 +240,12 @@ const WorkflowEditor = () => {
             />
           </div>
 
-          <div
-            style={{
-              width: 'auto',
-              minHeight: '600px',
+          <Outlet
+            context={{
+              setDragging,
+              onDelete,
             }}
-          >
-            <Outlet
-              context={{
-                setDragging,
-                onDelete,
-              }}
-            />
-          </div>
+          />
         </div>
       </When>
       <DeleteConfirmModal

--- a/apps/web/src/pages/tenants/components/list/TenantsList.tsx
+++ b/apps/web/src/pages/tenants/components/list/TenantsList.tsx
@@ -30,13 +30,7 @@ export const TenantsList = ({
   }
 
   return (
-    <PageContainer
-      style={{
-        position: 'relative',
-        overflow: 'hidden',
-      }}
-      title="Tenants"
-    >
+    <>
       <Container fluid sx={{ padding: '0 30px 8px 30px' }}>
         <Toolbar onAddTenantClick={onAddTenantClick} tenantLoading={loading} />
       </Container>
@@ -59,6 +53,6 @@ export const TenantsList = ({
       <When truthy={noTenants}>
         <TenantsListNoData />
       </When>
-    </PageContainer>
+    </>
   );
 };


### PR DESCRIPTION
### What change does this PR introduce?

**Sorry about the big PR, but I've noticed so many small issues...**

**Also want to ask you to do the local dev testing for this PR, because it might be hard to understand from the code why I've changed something.**

In this PR I've fixed:
- the header was not sticky at the top
- the double scrollbar was shown on smaller screens
- the side nav was too big on smaller screens, which created layout problems
- the get started footer was not sticky to the bottom of the page
- the digest tour component was not visible on smaller screens
- many more

### Why was this change needed?

### Other information (Screenshots)

I've touched too many places in the app so it's hard to put all the screenshots.
