### PR TITLE
NV-3541 - 🐛 Bug Report: Novu Notification Center Closing Issue on iFrame Embed

### DIFF
--- a/libs/embed/src/embed.ts
+++ b/libs/embed/src/embed.ts
@@ -143,7 +143,12 @@ class Novu {
         const elem = document.querySelector('.wrapper-novu-widget') as HTMLBodyElement;
 
         if (elem) {
-          elem.style.display = 'inline-block';
+          const elemNotVisible = elem.style.display === 'none';
+          if (elemNotVisible) {
+            elem.style.display = 'inline-block';
+          } else {
+            hideWidget();
+          }
         }
 
         _scope.iframe?.contentWindow?.postMessage(


### PR DESCRIPTION
 ### What change does this PR introduce?
Fix Novu notification center not closing on iframe when the notification bell icon is clicked. 

 ### Why was this change needed?
closes https://github.com/novuhq/novu/issues/3541

### Other information

[Loom video](https://www.loom.com/share/2eb2e47c99984826aff91a35ebdfa68d)


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
