### PR TITLE
patch : remove rows only when steps are truthy

### DIFF
--- a/apps/api/src/app/workflows/usecases/update-notification-template/update-notification-template.usecase.ts
+++ b/apps/api/src/app/workflows/usecases/update-notification-template/update-notification-template.usecase.ts
@@ -208,6 +208,8 @@ export class UpdateNotificationTemplate {
         parentStepId = stepId || null;
       }
       updatePayload.steps = templateMessages;
+
+      await this.deleteRemovedSteps(existingTemplate.steps, command, parentChangeId);
     }
 
     if (command.tags) {
@@ -221,8 +223,6 @@ export class UpdateNotificationTemplate {
     if (!Object.keys(updatePayload).length) {
       throw new BadRequestException('No properties found for update');
     }
-
-    await this.deleteRemovedSteps(existingTemplate.steps, command, parentChangeId);
 
     await this.invalidateCache.invalidateByKey({
       key: buildNotificationTemplateKey({


### PR DESCRIPTION
### What change does this PR introduce?

deleted removed steps only if new steps were provided, or empty array.

### Why was this change needed?

so the client of the api could provide params for update without the steps.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
