### PR TITLE
feat(ci): separate the swagger validation in own runner plus improvement

### DIFF
--- a/.github/actions/run-api/action.yml
+++ b/.github/actions/run-api/action.yml
@@ -1,0 +1,22 @@
+name: Run API
+
+description: Starts and waits for an API running instance
+
+inputs:
+  launch_darkly_sdk_key:
+    description: 'The Launch Darkly SDK key to use'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+
+  steps:
+   - name: Start API
+       env:
+        IS_IN_MEMORY_CLUSTER_MODE_ENABLED: true
+        LAUNCH_DARKLY_SDK_KEY: ${{ inputs.launch_darkly_sdk_key }}
+      run: cd apps/api && pnpm start:test &
+
+  - name: Wait on API
+    run: wait-on --timeout=180000 http://localhost:1336/v1/health-check

--- a/.github/actions/validate-swagger/action.yml
+++ b/.github/actions/validate-swagger/action.yml
@@ -1,0 +1,17 @@
+name: Validate Swagger
+
+description: Validates the swagger from the API
+
+runs:
+  using: composite
+
+  steps:
+    - name: Get swagger json as file
+      run: |
+        curl -o swagger.json http://localhost:1336/api-json  
+    - uses: char0n/swagger-editor-validate@v1
+      with:
+        definition-file: swagger.json
+
+    - name: Kill port for api 1336 for unit tests
+      run: sudo kill -9 $(sudo lsof -t -i:1336)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   dependency-review:
+    name: Dependency review
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
@@ -15,7 +16,8 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
 
-  spellcheck: # run the action
+  spellcheck:
+    name: Spell check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -203,6 +205,7 @@ jobs:
       - uses: ./.github/actions/setup-project
       - uses: ./.github/actions/setup-redis-cluster
       - uses: mansagroup/nrwl-nx-action@v3
+        name: Lint and build
         with:
           targets: lint,build
           projects: ${{matrix.projectName}}
@@ -215,6 +218,7 @@ jobs:
           launch_darkly_sdk_key: ${{ secrets.LAUNCH_DARKLY_SDK_KEY }}
 
       - uses: mansagroup/nrwl-nx-action@v3
+        name: Running the E2E tests
         env:
           IN_MEMORY_CLUSTER_MODE_ENABLED: true
           LAUNCH_DARKLY_SDK_KEY: ${{ secrets.LAUNCH_DARKLY_SDK_KEY }}
@@ -222,30 +226,11 @@ jobs:
           targets: test:e2e
           projects: ${{matrix.projectName}}
 
-      - name: Start Api
-        env:
-          IN_MEMORY_CLUSTER_MODE_ENABLED: true
-        run: cd apps/api && pnpm start:test &
-
-      - name: Wait on Api
-        run: wait-on --timeout=180000 http://localhost:1336/v1/health-check
-
-      - name: Get swagger json as file
-        run: |
-          curl -o swagger.json http://localhost:1336/api-json  
-
-      - uses: char0n/swagger-editor-validate@v1
-        with:
-          definition-file: swagger.json
-
-      - name: Kill port for api 1336 for unit tests
-        run: sudo kill -9 $(sudo lsof -t -i:1336)
-
   test_unit:
     name: Unit Test
     runs-on: ubuntu-latest
     needs: [get-affected]
-    if:  ${{ fromJson(needs.get-affected.outputs.test-unit)[0] }}
+    if: ${{ fromJson(needs.get-affected.outputs.test-unit)[0] }}
     timeout-minutes: 80
     strategy:
       # One job for each different project and node version
@@ -265,6 +250,29 @@ jobs:
           slim: ${{ !contains(matrix.projectName, '@novu/api') && !contains(matrix.projectName, '@novu/worker') && !contains(matrix.projectName, '@novu/ws') }}
       - uses: ./.github/actions/setup-redis-cluster
       - uses: mansagroup/nrwl-nx-action@v3
+        name: Lint and build and test
         with:
           targets: lint,build,test
           projects: ${{matrix.projectName}}
+
+  validate_swagger:
+    name: Validate Swagger
+    runs-on: ubuntu-latest
+    needs: [get-affected]
+    if: ${{ fromJson(needs.get-affected.outputs.test-unit)[0] }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+      deployments: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-project
+      - uses: ./.github/actions/setup-redis-cluster
+      - uses: ./.github/actions/run-api
+        with:
+          launch_darkly_sdk_key: ${{ secrets.LAUNCH_DARKLY_SDK_KEY }}
+
+      - uses: ./.github/actions/validate-swagger
+

--- a/scripts/print-affected-array.mjs
+++ b/scripts/print-affected-array.mjs
@@ -3,7 +3,7 @@ import spawn from 'cross-spawn';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import * as fs from 'fs';
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 const processArguments = process.argv.slice(2);
 
 const ALL_FLAG = '--all';
@@ -11,7 +11,7 @@ const TASK_NAME = processArguments[0];
 const BASE_BRANCH_NAME = processArguments[1];
 const GROUP = processArguments[2];
 
-const ROOT_PATH = path.resolve(__dirname, '..');
+const ROOT_PATH = path.resolve(dirname, '..');
 const ENCODING_TYPE = 'utf8';
 const NEW_LINE_CHAR = '\n';
 
@@ -22,7 +22,6 @@ class CliLogs {
   }
 
   log(log) {
-
     const cleanLog = log.trim();
     if (cleanLog.length) {
       this._logs.push(cleanLog);
@@ -135,7 +134,7 @@ async function allProjectsContainingTask(taskName) {
 }
 
 async function printAffectedProjectsContainingTask() {
-  const { providers, packages , libs } = await getPackageFolders(['providers', 'packages', 'libs']);
+  const { providers, packages, libs } = await getPackageFolders(['providers', 'packages', 'libs']);
 
   let projects =
     BASE_BRANCH_NAME === ALL_FLAG
@@ -157,14 +156,13 @@ async function printAffectedProjectsContainingTask() {
     projects = projects.filter((project) => !libs.includes(project));
   }
 
-
   if (GROUP === 'providers') {
     console.log(JSON.stringify(foundProviders));
   } else if (GROUP === 'packages') {
     console.log(JSON.stringify(foundPackages));
   } else if (GROUP === 'libs') {
     console.log(JSON.stringify(foundLibs));
-  }  else {
+  } else {
     console.log(JSON.stringify(projects));
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Separates the Swagger validation in its own runner to avoid interfering in E2E test runners. Also isolates some reusable actions.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Clarify the intention of the Swagger validation.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
