### PR TITLE
feat  add organization id index in integration

### DIFF
--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -15,6 +15,7 @@ const integrationSchema = new Schema<IntegrationDBModel>(
     _organizationId: {
       type: Schema.Types.ObjectId,
       ref: 'Organization',
+      index: true,
     },
     providerId: Schema.Types.String,
     channel: Schema.Types.String,


### PR DESCRIPTION
### What change does this PR introduce?

add organization id index in integration.

### Why was this change needed?

in the get decrypted integration usecase there is a possibility to fetch by an organization, therefore we won't have any index by which we could fetch.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
