### PR TITLE
feat: reduce count 1000 to the db

### DIFF
--- a/apps/ws/src/socket/usecases/external-services-route/external-services-route.usecase.ts
+++ b/apps/ws/src/socket/usecases/external-services-route/external-services-route.usecase.ts
@@ -6,6 +6,7 @@ import { BullMqService } from '@novu/application-generic';
 
 import { ExternalServicesRouteCommand } from './external-services-route.command';
 import { WSGateway } from '../../ws.gateway';
+import { IUnreadCountPaginationIndication, IUnseenCountPaginationIndication } from './types';
 
 @Injectable()
 export class ExternalServicesRoute {
@@ -49,11 +50,15 @@ export class ExternalServicesRoute {
         command.userId,
         ChannelTypeEnum.IN_APP,
         { read: false },
-        { limit: 1000 }
+        { limit: 101 }
       );
     }
+    const paginationIndication: IUnreadCountPaginationIndication =
+      unreadCount > 100 ? { unreadCount: 100, hasMore: true } : { unreadCount: unreadCount, hasMore: false };
+
     await this.wsGateway.sendMessage(command.userId, command.event, {
-      unreadCount,
+      unreadCount: paginationIndication.unreadCount,
+      hasMore: paginationIndication.hasMore,
     });
   }
 
@@ -76,12 +81,16 @@ export class ExternalServicesRoute {
         command.userId,
         ChannelTypeEnum.IN_APP,
         { seen: false },
-        { limit: 1000 }
+        { limit: 101 }
       );
     }
 
+    const paginationIndication: IUnseenCountPaginationIndication =
+      unseenCount > 100 ? { unseenCount: 100, hasMore: true } : { unseenCount: unseenCount, hasMore: false };
+
     await this.wsGateway.sendMessage(command.userId, command.event, {
-      unseenCount,
+      unseenCount: paginationIndication.unseenCount,
+      hasMore: paginationIndication.hasMore,
     });
   }
 

--- a/apps/ws/src/socket/usecases/external-services-route/types.ts
+++ b/apps/ws/src/socket/usecases/external-services-route/types.ts
@@ -1,0 +1,9 @@
+export interface IUnseenCountPaginationIndication {
+  unseenCount: number;
+  hasMore: boolean;
+}
+
+export interface IUnreadCountPaginationIndication {
+  unreadCount: number;
+  hasMore: boolean;
+}


### PR DESCRIPTION
### What change does this PR introduce?

Looks like after updating the API to query by a limit of 100, we still have a query with a limit of 1000.

In this ticket, we need to check why and update it to have a max limit of 100.

### Why was this change needed?

reduce the high count from the db.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
