### PR TITLE
fix: remove github discussion link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for showing an interest in contributing to Novu! All kinds of contribu
 ## Submitting an issue
 
 
-Before submitting a new issue, please search the [issues](https://github.com/novuhq/novu/issues) and [discussion](https://github.com/novuhq/novu/discussions) tabs. Maybe an issue or discussion already exists and might inform you of workarounds. Otherwise, you can give new information.
+Before submitting a new issue, please search the existing [issues](https://github.com/novuhq/novu/issues). Maybe an issue already exists and might inform you of workarounds. Otherwise, you can give new information.
 
 While we want to fix all the [issues](https://github.com/novuhq/novu/issues), before fixing a bug we need to be able to reproduce and confirm it. Please provide us with a minimal reproduction scenario using a repository or [Gist](https://gist.github.com/). Having a live, reproducible scenario gives us the information without asking questions back & forth with additional questions like:
 
@@ -53,7 +53,7 @@ To ensure consistency throughout the source code, please keep these rules in min
 
 ## Need help? Questions and suggestions
 
-Questions, suggestions, and thoughts are most welcome. Feel free to open a [GitHub Discussion](https://github.com/novuhq/novu/discussions/new). We can also be reached in our [Discord Server](https://discord.novu.co).
+Questions, suggestions, and thoughts are most welcome. Feel free to open a [GitHub Issue](https://github.com/novuhq/novu/issues/new/choose). We can also be reached in our [Discord Server](https://discord.novu.co).
 
 ## Ways to contribute
 

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -59,4 +59,4 @@ We strongly recommend that you decouple your database before deploying.
 
 ## Next steps
 
-- Got a question? [Ask here](https://github.com/novuhq/novu/discussions).
+- Got a question? [Ask here](https://discord.gg/novu).

--- a/docs/docs/overview/docker-deploy.md
+++ b/docs/docs/overview/docker-deploy.md
@@ -108,4 +108,4 @@ we can improve performance in the near future.
 
 ## Next steps
 
-- Got a question? [Ask here](https://github.com/novuhq/novu/discussions).
+- Got a question? [Ask here](https://discord.gg/novu).


### PR DESCRIPTION
### What change does this PR introduce?
closes #3995 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

Removed or replaced github discussion links from repo and docs with discord server link

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
