### PR TITLE
fix: discord link correction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ To ensure consistency throughout the source code, please keep these rules in min
 
 ## Need help? Questions and suggestions
 
-Questions, suggestions, and thoughts are most welcome. Feel free to open a [GitHub Discussion](https://github.com/novuhq/novu/discussions/new). We can also be reached in our [Discord Server](https://discord.novu.co).
+Questions, suggestions, and thoughts are most welcome. Feel free to open a [GitHub Discussion](https://github.com/novuhq/novu/discussions/new). We can also be reached in our [Discord Server](https://discord.gg/novu).
 
 ## Ways to contribute
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The ultimate service for managing multi-channel notifications with a single API.
     ·
     <a href="https://github.com/novuhq/novu/issues/new?assignees=&labels=feature&template=feature_request.yml&title=%F0%9F%9A%80+Feature%3A+">Request Feature</a>
     ·
-  <a href="https://discord.novu.co">Join Our Discord</a>
+  <a href="https://discord.gg/novu">Join Our Discord</a>
     ·
     <a href="https://roadmap.novu.co">Roadmap</a>
     ·
@@ -201,7 +201,7 @@ Before you begin coding and collaborating, please read our [Code of Conduct](htt
 
 ## 💻 Need Help?
 
-We are more than happy to help you. If you are getting any errors or facing problems while working on this project, join our [Discord server](https://discord.novu.co) and ask for help. We are open to discussing anything related to the project.
+We are more than happy to help you. If you are getting any errors or facing problems while working on this project, join our [Discord server](https://discord.gg/novu) and ask for help. We are open to discussing anything related to the project.
 
 ## ⚡ Immediate working space with Gitpod
 

--- a/apps/web/cypress/tests/layout/side-menu.spec.ts
+++ b/apps/web/cypress/tests/layout/side-menu.spec.ts
@@ -14,7 +14,7 @@ describe('Side Menu', function () {
 
   it('should show bottom support, docs and share feedback', function () {
     cy.getByTestId('side-nav-bottom-links').scrollIntoView().should('be.visible');
-    cy.getByTestId('side-nav-bottom-link-support').should('have.attr', 'href').should('eq', 'https://discord.novu.co');
+    cy.getByTestId('side-nav-bottom-link-support').should('have.attr', 'href').should('eq', 'https://discord.gg/novu');
     cy.getByTestId('side-nav-bottom-link-documentation')
       .should('have.attr', 'href')
       .should('eq', 'https://docs.novu.co');

--- a/apps/web/src/components/layout/components/SideNav.tsx
+++ b/apps/web/src/components/layout/components/SideNav.tsx
@@ -198,7 +198,7 @@ export function SideNav({}: Props) {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://discord.novu.co"
+            href="https://discord.gg/novu"
             data-test-id="side-nav-bottom-link-support"
           >
             Support

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -97,7 +97,7 @@ const codeTheme = require('./src/utils/prism');
               position: 'right',
             },
             {
-              href: 'https://discord.novu.co',
+              href: 'https://discord.gg/novu',
               label: 'Community',
               position: 'right',
             },
@@ -130,7 +130,7 @@ const codeTheme = require('./src/utils/prism');
                 },
                 {
                   label: 'Contact Us',
-                  href: 'https://discord.novu.co',
+                  href: 'https://discord.gg/novu',
                 },
               ],
             },

--- a/packages/cli/README.MD
+++ b/packages/cli/README.MD
@@ -26,7 +26,7 @@ The ultimate service for managing multi-channel notifications with a single API.
     ·
     <a href="https://github.com/novuhq/novu/issues/new?assignees=&labels=feature&template=feature_request.yml&title=%F0%9F%9A%80+Feature%3A+">Request Feature</a>
     ·
-  <a href="https://discord.novu.co">Join Our Discord</a>
+  <a href="https://discord.gg/novu">Join Our Discord</a>
     ·
     <a href="https://github.com/orgs/novuhq/projects/2">Roadmap</a>
     ·
@@ -151,7 +151,7 @@ Novu provides a single API to manage providers across multiple channels with a s
 
 We are more than happy to help you. Don't worry if you are getting some errors or problems while working with the project. Or just want to discuss something related to the project.
 
-Just <a href="https://discord.novu.co">Join Our Discord</a> server and ask for help.
+Just <a href="https://discord.gg/novu">Join Our Discord</a> server and ask for help.
 
 ## 🔗 Links
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -23,7 +23,7 @@ The ultimate service for managing multi-channel notifications with a single API.
     ·
     <a href="https://github.com/novuhq/novu/issues/new?assignees=&labels=feature&template=feature_request.yml&title=%F0%9F%9A%80+Feature%3A+">Request Feature</a>
     ·
-  <a href="https://discord.novu.co">Join Our Discord</a>
+  <a href="https://discord.gg/novu">Join Our Discord</a>
     ·
     <a href="https://github.com/orgs/novuhq/projects/10">Roadmap</a>
     ·


### PR DESCRIPTION
### What change does this PR introduce?

Updates the Discord invite link. The current link ("https://discord.novu.co") is no longer valid on **_desktop_**. When the current link is clicked **_on a desktop_**, the following Discord error message appears: _This invite may be expired, or you might not have permission to join._

Please note that the invite link appears to be valid for mobile devices, it's just desktop that has an issue. I tried on multiple different browsers (Chrome, Firefox, Edge) and on different PCs and they all have issues with the current invite link.

However, the Discord link provided on Novu's website https://novu.co/ does appear to be valid for desktop: "https://discord.gg/novu"

### Why was this change needed?
To have a valid Discord link for desktop users. 

### Other information (Screenshots)
#### Error Message

![Screenshot 2023-08-25 014447 (2)](https://github.com/novuhq/novu/assets/107815790/2c227510-8701-4780-b489-27d575cd8bb9)

#### Where I Found A Valid Discord Link

![Screenshot 2023-08-25 015459_2](https://github.com/novuhq/novu/assets/107815790/9dbdcc96-f754-4b6b-9391-676e298a224e)
