### PR TITLE
refactor: so filter logic from message matcher to filter abstract class

### DIFF
--- a/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.spec.ts
@@ -1053,7 +1053,7 @@ describe('Message filter matcher', function () {
     it('should add a passed condition', () => {
       const result = MessageMatcher.sumFilters(
         {
-          stepFilters: [],
+          filters: [],
           failedFilters: [],
           passedFilters: ['payload'],
         },
@@ -1069,14 +1069,14 @@ describe('Message filter matcher', function () {
 
       expect(result.passedFilters).to.contain('payload');
       expect(result.passedFilters.length).to.eq(1);
-      expect(result.stepFilters.length).to.eq(1);
-      expect(result.stepFilters).to.contain('payload');
+      expect(result.filters.length).to.eq(1);
+      expect(result.filters).to.contain('payload');
     });
 
     it('should add a failed condition', () => {
       const result = MessageMatcher.sumFilters(
         {
-          stepFilters: [],
+          filters: [],
           failedFilters: [],
           passedFilters: [],
         },
@@ -1092,14 +1092,14 @@ describe('Message filter matcher', function () {
 
       expect(result.failedFilters).to.contain('payload');
       expect(result.failedFilters.length).to.eq(1);
-      expect(result.stepFilters.length).to.eq(1);
-      expect(result.stepFilters).to.contain('payload');
+      expect(result.filters.length).to.eq(1);
+      expect(result.filters).to.contain('payload');
     });
 
     it('should add online for both cases of online', () => {
       let result = MessageMatcher.sumFilters(
         {
-          stepFilters: [],
+          filters: [],
           failedFilters: [],
           passedFilters: [],
         },
@@ -1115,12 +1115,12 @@ describe('Message filter matcher', function () {
 
       expect(result.passedFilters).to.contain('online');
       expect(result.passedFilters.length).to.eq(1);
-      expect(result.stepFilters.length).to.eq(1);
-      expect(result.stepFilters).to.contain('online');
+      expect(result.filters.length).to.eq(1);
+      expect(result.filters).to.contain('online');
 
       result = MessageMatcher.sumFilters(
         {
-          stepFilters: [],
+          filters: [],
           failedFilters: [],
           passedFilters: [],
         },
@@ -1136,8 +1136,8 @@ describe('Message filter matcher', function () {
 
       expect(result.passedFilters).to.contain('online');
       expect(result.passedFilters.length).to.eq(1);
-      expect(result.stepFilters.length).to.eq(1);
-      expect(result.stepFilters).to.contain('online');
+      expect(result.filters.length).to.eq(1);
+      expect(result.filters).to.contain('online');
     });
   });
 });

--- a/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.ts
@@ -3,7 +3,6 @@ import axios from 'axios';
 import { Injectable } from '@nestjs/common';
 import { parseISO, differenceInMinutes, differenceInHours, differenceInDays } from 'date-fns';
 import {
-  IBaseFieldFilterPart,
   FilterParts,
   IWebhookFilterPart,
   IRealtimeOnlineFilterPart,
@@ -27,11 +26,16 @@ import {
   MessageRepository,
   JobRepository,
 } from '@novu/dal';
-import { DetailEnum, CreateExecutionDetails, CreateExecutionDetailsCommand } from '@novu/application-generic';
+import {
+  DetailEnum,
+  CreateExecutionDetails,
+  CreateExecutionDetailsCommand,
+  Filter,
+  IFilterVariables,
+  FilterProcessingDetails,
+} from '@novu/application-generic';
 import { EmailEventStatusEnum } from '@novu/stateless';
 
-import { IFilterVariables } from './types';
-import { FilterProcessingDetails } from './filter-processing-details';
 import { SendMessageCommand } from '../send-message/send-message.command';
 import { EXCEPTION_MESSAGE_ON_WEBHOOK_FILTER, createHash, PlatformException } from '../../../shared/utils';
 
@@ -48,7 +52,7 @@ const differenceIn = (currentDate: Date, lastDate: Date, timeOperator: TimeOpera
 };
 
 @Injectable()
-export class MessageMatcher {
+export class MessageMatcher extends Filter {
   constructor(
     private subscriberRepository: SubscriberRepository,
     private createExecutionDetails: CreateExecutionDetails,
@@ -56,7 +60,9 @@ export class MessageMatcher {
     private executionDetailsRepository: ExecutionDetailsRepository,
     private messageRepository: MessageRepository,
     private jobRepository: JobRepository
-  ) {}
+  ) {
+    super();
+  }
 
   public async filter(
     command: SendMessageCommand,
@@ -75,7 +81,7 @@ export class MessageMatcher {
     if (step.filters?.length) {
       const details: FilterProcessingDetails[] = [];
 
-      const foundFilter = await findAsync(step.filters, async (filter) => {
+      const foundFilter = await this.findAsync(step.filters, async (filter) => {
         const filterProcessingDetails = new FilterProcessingDetails();
         filterProcessingDetails.addFilter(filter, variables);
 
@@ -141,7 +147,7 @@ export class MessageMatcher {
 
   public static sumFilters(
     summary: {
-      stepFilters: string[];
+      filters: string[];
       failedFilters: string[];
       passedFilters: string[];
     },
@@ -153,19 +159,7 @@ export class MessageMatcher {
       type = 'online';
     }
 
-    if (condition.passed && !summary.passedFilters.includes(type)) {
-      summary.passedFilters.push(type);
-    }
-
-    if (!condition.passed && !summary.failedFilters.includes(type)) {
-      summary.failedFilters.push(type);
-    }
-
-    if (!summary.stepFilters.includes(type)) {
-      summary.stepFilters.push(type);
-    }
-
-    return summary;
+    return Filter.sumFilters(summary, condition, type);
   }
 
   private async handleGroupFilters(
@@ -201,14 +195,14 @@ export class MessageMatcher {
   ): Promise<boolean> {
     const { webhookFilters, otherFilters } = this.splitFilters(filter);
 
-    const matchedOtherFilters = await filterAsync(otherFilters, (i) =>
+    const matchedOtherFilters = await this.filterAsync(otherFilters, (i) =>
       this.processFilter(variables, i, command, filterProcessingDetails)
     );
     if (otherFilters.length !== matchedOtherFilters.length) {
       return false;
     }
 
-    const matchedWebhookFilters = await filterAsync(webhookFilters, (i) =>
+    const matchedWebhookFilters = await this.filterAsync(webhookFilters, (i) =>
       this.processFilter(variables, i, command, filterProcessingDetails)
     );
 
@@ -223,14 +217,14 @@ export class MessageMatcher {
   ): Promise<boolean> {
     const { webhookFilters, otherFilters } = this.splitFilters(filter);
 
-    const foundFilter = await findAsync(otherFilters, (i) =>
+    const foundFilter = await this.findAsync(otherFilters, (i) =>
       this.processFilter(variables, i, command, filterProcessingDetails)
     );
     if (foundFilter) {
       return true;
     }
 
-    return !!(await findAsync(webhookFilters, (i) =>
+    return !!(await this.findAsync(webhookFilters, (i) =>
       this.processFilter(variables, i, command, filterProcessingDetails)
     ));
   }
@@ -373,56 +367,6 @@ export class MessageMatcher {
     return result;
   }
 
-  private processFilterEquality(
-    variables: IFilterVariables,
-    fieldFilter: IBaseFieldFilterPart,
-    filterProcessingDetails: FilterProcessingDetails
-  ): boolean {
-    const actualValue = _.get(variables, `${fieldFilter.on}.${fieldFilter.field}`);
-    const filterValue = this.parseValue(actualValue, fieldFilter.value);
-    let result = false;
-
-    if (fieldFilter.operator === 'EQUAL') {
-      result = actualValue === filterValue;
-    }
-    if (fieldFilter.operator === 'NOT_EQUAL') {
-      result = actualValue !== filterValue;
-    }
-    if (fieldFilter.operator === 'LARGER') {
-      result = actualValue > filterValue;
-    }
-    if (fieldFilter.operator === 'SMALLER') {
-      result = actualValue < filterValue;
-    }
-    if (fieldFilter.operator === 'LARGER_EQUAL') {
-      result = actualValue >= filterValue;
-    }
-    if (fieldFilter.operator === 'SMALLER_EQUAL') {
-      result = actualValue <= filterValue;
-    }
-    if (fieldFilter.operator === 'NOT_IN') {
-      result = !actualValue.includes(filterValue);
-    }
-    if (fieldFilter.operator === 'IN') {
-      result = actualValue.includes(filterValue);
-    }
-    if (fieldFilter.operator === 'IS_DEFINED') {
-      result = actualValue !== undefined;
-    }
-    const actualValueString: string = Array.isArray(actualValue) ? JSON.stringify(actualValue) : `${actualValue ?? ''}`;
-
-    filterProcessingDetails.addCondition({
-      filter: FILTER_TO_LABEL[fieldFilter.on],
-      field: fieldFilter.field,
-      expected: `${filterValue}`,
-      actual: `${actualValueString}`,
-      operator: `${fieldFilter.operator}`,
-      passed: result,
-    });
-
-    return result;
-  }
-
   private async getWebhookResponse(
     child: IWebhookFilterPart,
     variables: IFilterVariables,
@@ -529,37 +473,4 @@ export class MessageMatcher {
 
     return passed;
   }
-
-  private parseValue(originValue, parsingValue) {
-    switch (typeof originValue) {
-      case 'number':
-        return Number(parsingValue);
-      case 'string':
-        return String(parsingValue);
-      case 'boolean':
-        return parsingValue === 'true';
-      case 'bigint':
-        return Number(parsingValue);
-      default:
-        return parsingValue;
-    }
-  }
-}
-
-async function findAsync<T>(array: T[], predicate: (t: T) => Promise<boolean>): Promise<T | undefined> {
-  for (const t of array) {
-    if (await predicate(t)) {
-      return t;
-    }
-  }
-
-  return undefined;
-}
-
-async function filterAsync<T>(arr: T[], callback: (item: T) => Promise<boolean>): Promise<T[]> {
-  const fail = Symbol('Filter Async failure');
-
-  return (await Promise.all(arr.map(async (item) => ((await callback(item)) ? item : fail)))).filter(
-    (i) => i !== fail
-  ) as T[];
 }

--- a/apps/worker/src/app/workflow/usecases/message-matcher/types.ts
+++ b/apps/worker/src/app/workflow/usecases/message-matcher/types.ts
@@ -1,8 +1,0 @@
-import type { ITriggerPayload } from '@novu/shared';
-import type { SubscriberEntity } from '@novu/dal';
-
-export interface IFilterVariables {
-  payload?: ITriggerPayload;
-  subscriber?: SubscriberEntity;
-  webhook?: Record<string, unknown>;
-}

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -67,7 +67,7 @@ export class SendMessage {
 
     if (!command.payload?.$on_boarding_trigger) {
       const usedFilters = shouldRun.conditions.reduce(MessageMatcher.sumFilters, {
-        stepFilters: [],
+        filters: [],
         failedFilters: [],
         passedFilters: [],
       });

--- a/packages/application-generic/src/index.ts
+++ b/packages/application-generic/src/index.ts
@@ -7,4 +7,6 @@ export * from './logging/index';
 export * from './usecases';
 export * from './instrumentation/index';
 export * from './utils/subscriber';
+export * from './utils/filter';
+export * from './utils/filter-processing-details';
 export * from './resilience';

--- a/packages/application-generic/src/utils/filter-processing-details.ts
+++ b/packages/application-generic/src/utils/filter-processing-details.ts
@@ -1,7 +1,11 @@
-import { StepFilter } from '@novu/dal';
-import { ICondition } from '@novu/shared';
+import { StepFilter, SubscriberEntity } from '@novu/dal';
+import { ICondition, ITriggerPayload } from '@novu/shared';
 
-import { IFilterVariables } from './types';
+export interface IFilterVariables {
+  payload?: ITriggerPayload;
+  subscriber?: SubscriberEntity;
+  webhook?: Record<string, unknown>;
+}
 
 export class FilterProcessingDetails {
   private conditions: ICondition[] = [];

--- a/packages/application-generic/src/utils/filter.ts
+++ b/packages/application-generic/src/utils/filter.ts
@@ -1,0 +1,139 @@
+import * as _ from 'lodash';
+import {
+  IBaseFieldFilterPart,
+  FILTER_TO_LABEL,
+  ICondition,
+} from '@novu/shared';
+
+import {
+  FilterProcessingDetails,
+  IFilterVariables,
+} from './filter-processing-details';
+
+export abstract class Filter {
+  protected processFilterEquality(
+    variables: IFilterVariables,
+    fieldFilter: IBaseFieldFilterPart,
+    filterProcessingDetails: FilterProcessingDetails
+  ): boolean {
+    const actualValue = _.get(
+      variables,
+      `${fieldFilter.on}.${fieldFilter.field}`
+    );
+    const filterValue = this.parseValue(actualValue, fieldFilter.value);
+    let result = false;
+
+    if (fieldFilter.operator === 'EQUAL') {
+      result = actualValue === filterValue;
+    }
+    if (fieldFilter.operator === 'NOT_EQUAL') {
+      result = actualValue !== filterValue;
+    }
+    if (fieldFilter.operator === 'LARGER') {
+      result = actualValue > filterValue;
+    }
+    if (fieldFilter.operator === 'SMALLER') {
+      result = actualValue < filterValue;
+    }
+    if (fieldFilter.operator === 'LARGER_EQUAL') {
+      result = actualValue >= filterValue;
+    }
+    if (fieldFilter.operator === 'SMALLER_EQUAL') {
+      result = actualValue <= filterValue;
+    }
+    if (fieldFilter.operator === 'NOT_IN') {
+      result = !actualValue.includes(filterValue);
+    }
+    if (fieldFilter.operator === 'IN') {
+      result = actualValue.includes(filterValue);
+    }
+    if (fieldFilter.operator === 'IS_DEFINED') {
+      result = actualValue !== undefined;
+    }
+    const actualValueString: string = Array.isArray(actualValue)
+      ? JSON.stringify(actualValue)
+      : `${actualValue ?? ''}`;
+
+    filterProcessingDetails.addCondition({
+      filter: FILTER_TO_LABEL[fieldFilter.on],
+      field: fieldFilter.field,
+      expected: `${filterValue}`,
+      actual: `${actualValueString}`,
+      operator: `${fieldFilter.operator}`,
+      passed: result,
+    });
+
+    return result;
+  }
+
+  public static sumFilters(
+    summary: {
+      filters: string[];
+      failedFilters: string[];
+      passedFilters: string[];
+    },
+    condition: ICondition,
+    type?: string
+  ) {
+    if (!type) {
+      type = condition.filter;
+    }
+
+    type = type?.toLowerCase();
+
+    if (condition.passed && !summary.passedFilters.includes(type)) {
+      summary.passedFilters.push(type);
+    }
+
+    if (!condition.passed && !summary.failedFilters.includes(type)) {
+      summary.failedFilters.push(type);
+    }
+
+    if (!summary.filters.includes(type)) {
+      summary.filters.push(type);
+    }
+
+    return summary;
+  }
+
+  private parseValue(originValue, parsingValue) {
+    switch (typeof originValue) {
+      case 'number':
+        return Number(parsingValue);
+      case 'string':
+        return String(parsingValue);
+      case 'boolean':
+        return parsingValue === 'true';
+      case 'bigint':
+        return Number(parsingValue);
+      default:
+        return parsingValue;
+    }
+  }
+
+  protected async findAsync<T>(
+    array: T[],
+    predicate: (t: T) => Promise<boolean>
+  ): Promise<T | undefined> {
+    for (const t of array) {
+      if (await predicate(t)) {
+        return t;
+      }
+    }
+
+    return undefined;
+  }
+
+  protected async filterAsync<T>(
+    arr: T[],
+    callback: (item: T) => Promise<boolean>
+  ): Promise<T[]> {
+    const fail = Symbol('Filter Async failure');
+
+    return (
+      await Promise.all(
+        arr.map(async (item) => ((await callback(item)) ? item : fail))
+      )
+    ).filter((i) => i !== fail) as T[];
+  }
+}


### PR DESCRIPTION
### What change does this PR introduce?
I move some of the methods that will be used for conditions as well from message matcher so we can reuse it. I was not able to move as much as I would like to lets see if we can move some more when we are doing the conditions equal usecase.
