### PR TITLE
fix(api): clear the primary and priority fields when novu integration is disabled

### DIFF
--- a/apps/api/migrations/integration-scheme-update/update-primary-for-disabled-novu-integrations.ts
+++ b/apps/api/migrations/integration-scheme-update/update-primary-for-disabled-novu-integrations.ts
@@ -1,0 +1,79 @@
+// Aug 29th, 2023
+
+/* eslint-disable no-console */
+import '../../src/config';
+
+import { NestFactory } from '@nestjs/core';
+import { IntegrationRepository, EnvironmentRepository, OrganizationRepository } from '@novu/dal';
+import { EmailProviderIdEnum, SmsProviderIdEnum } from '@novu/shared';
+
+import { AppModule } from '../../src/app.module';
+
+export async function run() {
+  console.log('Update the primary and priority fields for inactive Novu integrations\n');
+
+  const app = await NestFactory.create(AppModule, {
+    logger: false,
+  });
+  const organizationRepository = app.get(OrganizationRepository);
+  const environmentRepository = app.get(EnvironmentRepository);
+  const integrationRepository = app.get(IntegrationRepository);
+
+  const environments = await environmentRepository.find({});
+
+  for (const environment of environments) {
+    const organization = await organizationRepository.findById(environment._organizationId);
+    if (!organization) {
+      console.log(
+        `Organization ${environment._organizationId} is not found for environment ${environment.name}, id: ${environment._id}`
+      );
+      continue;
+    }
+
+    console.log('\n------------------------------------------');
+    console.log(
+      `Updating integrations for the "${organization.name}" organization in the ${environment.name} environment`
+    );
+
+    const integrations = await integrationRepository.find(
+      {
+        _organizationId: organization._id,
+        _environmentId: environment._id,
+        active: false,
+        primary: true,
+        providerId: {
+          $in: [EmailProviderIdEnum.Novu, SmsProviderIdEnum.Novu],
+        },
+      },
+      undefined,
+      { sort: { createdAt: -1 } }
+    );
+
+    console.log(
+      `Found ${integrations.length} inactive and primary Novu integrations ` +
+        `for the "${organization.name}" organization in the ${environment.name} environment`
+    );
+
+    const ids = integrations.map((integration) => integration._id);
+    if (ids.length > 0) {
+      console.log(`Updating Novu integrations with: `, { primary: false, priority: 0 });
+
+      await integrationRepository._model.updateMany(
+        {
+          _id: { $in: ids },
+        },
+        { $set: { primary: false, priority: 0 } }
+      );
+    }
+
+    console.log(
+      `Finished updating integrations for the "${organization.name}" organization in the ${environment.name} environment`
+    );
+    console.log('------------------------------------------\n');
+  }
+
+  app.close();
+  process.exit(0);
+}
+
+run();

--- a/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
@@ -180,6 +180,14 @@ export class CreateIntegration {
 
       const isActiveAndChannelSupportsPrimary = command.active && CHANNELS_WITH_PRIMARY.includes(command.channel);
       if (isMultiProviderConfigurationEnabled && isActiveAndChannelSupportsPrimary) {
+        await this.disableNovuIntegration.execute({
+          channel: command.channel,
+          providerId: command.providerId,
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          userId: command.userId,
+        });
+
         const { primary, priority } = await this.calculatePriorityAndPrimary(command);
 
         query.primary = primary;
@@ -198,16 +206,6 @@ export class CreateIntegration {
           organizationId: command.organizationId,
           integrationId: integrationEntity._id,
           channel: command.channel,
-          userId: command.userId,
-        });
-      }
-
-      if (integrationEntity.active) {
-        await this.disableNovuIntegration.execute({
-          channel: command.channel,
-          providerId: command.providerId,
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
           userId: command.userId,
         });
       }

--- a/apps/api/src/app/integrations/usecases/disable-novu-integration/disable-novu-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/disable-novu-integration/disable-novu-integration.usecase.ts
@@ -26,7 +26,7 @@ export class DisableNovuIntegration {
 
     await this.integrationRepository.update(
       { _environmentId: command.environmentId, providerId: novuProviderId, channel: command.channel },
-      { $set: { active: false } }
+      { $set: { active: false, primary: false, priority: 0 } }
     );
   }
 }

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
@@ -196,6 +196,16 @@ export class UpdateIntegration {
 
     const isChannelSupportsPrimary = CHANNELS_WITH_PRIMARY.includes(existingIntegration.channel);
     if (isMultiProviderConfigurationEnabled && isActiveChanged && isChannelSupportsPrimary) {
+      if (command.active) {
+        await this.disableNovuIntegration.execute({
+          channel: existingIntegration.channel,
+          providerId: existingIntegration.providerId,
+          environmentId: existingIntegration._environmentId,
+          organizationId: existingIntegration._organizationId,
+          userId: command.userId,
+        });
+      }
+
       const { primary, priority } = await this.calculatePriorityAndPrimary({
         existingIntegration,
         active: !!command.active,
@@ -235,16 +245,6 @@ export class UpdateIntegration {
     });
     if (!updatedIntegration) {
       throw new NotFoundException(`Integration with id ${command.integrationId} is not found`);
-    }
-
-    if (updatedIntegration.active) {
-      await this.disableNovuIntegration.execute({
-        channel: updatedIntegration.channel,
-        providerId: updatedIntegration.providerId,
-        environmentId: updatedIntegration._environmentId,
-        organizationId: updatedIntegration._organizationId,
-        userId: command.userId,
-      });
     }
 
     return updatedIntegration;


### PR DESCRIPTION
### What change does this PR introduce?

When we migrated the Novu integrations to the database we forgot to update the code that is executed when integration is created/updated. The code disables the Novu integration when we create/update any new active integration, but the missing thing is that we need also to clear the `primary` and `priority` fields for the disabled Novu integration in that case.
This issue causes confusion in the UI, displaying to the user two primary integrations for the same channel.
More context: https://discord.com/channels/895029566685462578/1045289346598703164/1145987920881262675

Note:
**We have to run the migration script that fixes that issue.**

### Why was this change needed?


### Other information (Screenshots)


