### PR TITLE
feat: fix so conditions are emptied when integration are set as primary

### DIFF
--- a/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.usecase.ts
@@ -46,6 +46,7 @@ export class SetIntegrationAsPrimary {
         $set: {
           active: true,
           primary: true,
+          conditions: [],
         },
       }
     );


### PR DESCRIPTION
### What change does this PR introduce?
Not sure it's supposed to be this easy but. it should empty conditions when an integration is set as primary.
