### PR TITLE
fix: make integration identifier optional

### DIFF
--- a/packages/node/src/lib/events/events.interface.ts
+++ b/packages/node/src/lib/events/events.interface.ts
@@ -25,7 +25,7 @@ export interface ITriggerPayloadOptions extends IBroadcastPayloadOptions {
   transactionId?: string;
 }
 export interface IIntegrationOverride {
-  integrationIdentifier: string;
+  integrationIdentifier?: string;
 }
 export interface IEmailOverrides extends IIntegrationOverride {
   to?: string[];


### PR DESCRIPTION
### What change does this PR introduce?
Made `integrationIdentifier` as optional
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
To fix this error
<img width="847" alt="Screenshot 2023-08-31 at 10 49 21 AM" src="https://github.com/novuhq/novu/assets/39362422/51f67ac1-59fb-4736-9412-6e472bf45743">


<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
