### PR TITLE
feat: add tags for workflow settings

### DIFF
--- a/apps/web/src/pages/templates/components/notification-setting-form/NotificationSettingsForm.tsx
+++ b/apps/web/src/pages/templates/components/notification-setting-form/NotificationSettingsForm.tsx
@@ -109,6 +109,7 @@ export const NotificationSettingsForm = ({ trigger }: { trigger?: INotificationT
           />
         </Grid.Col>
       </Grid>
+
       <Controller
         control={control}
         name="name"
@@ -137,6 +138,7 @@ export const NotificationSettingsForm = ({ trigger }: { trigger?: INotificationT
               value={field.value || ''}
               error={fieldState.error?.message}
               label="Trigger identifier"
+              description={'Used to identify your workflow when triggering it via the API'}
               disabled={readonly}
               rightSection={
                 <Tooltip data-test-id={'Tooltip'} label={idClipboard.copied ? 'Copied!' : 'Copy Key'}>
@@ -164,6 +166,33 @@ export const NotificationSettingsForm = ({ trigger }: { trigger?: INotificationT
             placeholder="Describe your workflow..."
           />
         )}
+      />
+
+      <Controller
+        name="tags"
+        control={control}
+        render={({ field }) => {
+          return (
+            <>
+              <Select
+                {...field}
+                data-test-id="tagsSelector"
+                disabled={readonly}
+                creatable
+                label={'Tags'}
+                description={
+                  'Use tags to organize your workflows, e.g. to filter them when displaying user preferences in the notification center'
+                }
+                searchable
+                type={'multiselect'}
+                error={errors.tags?.message}
+                getCreateLabel={(tag) => <div data-test-id="submit-tags-btn">+ Create Tag {tag}</div>}
+                placeholder="Attach a tag to identify workflow"
+                data={(field.value || [])?.map((item) => ({ label: item, value: item })) || []}
+              />
+            </>
+          );
+        }}
       />
     </>
   );

--- a/docs/docs/notification-center/react/api-reference.md
+++ b/docs/docs/notification-center/react/api-reference.md
@@ -627,7 +627,7 @@ interface IPreferenceChannels {
 }
 
 interface IUserPreferenceSettings {
-  template: { _id: string; name: string; critical: boolean };
+  template: { _id: string; name: string; critical: boolean; tags: string[] };
   preference: { enabled: boolean; channels: IPreferenceChannels };
 }
 

--- a/libs/shared/src/entities/subscriber-preference/subscriber-preference.interface.ts
+++ b/libs/shared/src/entities/subscriber-preference/subscriber-preference.interface.ts
@@ -26,4 +26,5 @@ export interface ITemplateConfiguration {
   _id: string;
   name: string;
   critical: boolean;
+  tags?: string[];
 }

--- a/packages/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/packages/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -251,6 +251,7 @@ function mapTemplateConfiguration(
   return {
     _id: template._id,
     name: template.name,
+    tags: template?.tags || [],
     critical: template.critical != null ? template.critical : true,
     ...(template.data ? { data: template.data } : {}),
   };

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -35,6 +35,7 @@ export interface IUserPreferenceSettings {
     _id: string;
     name: string;
     critical: boolean;
+    tags?: string[];
     data?: NotificationTemplateCustomData;
   };
   preference: { enabled: boolean; channels: IPreferenceChannels };


### PR DESCRIPTION
### What change does this PR introduce?

Adds the ability to use tags in the workflow settings screen.

### Why was this change needed?

This change allows usecases to group multiple workflows under the same tag, and then use it to filter subscriber preferences for example.



### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
