### PR TITLE
feat: add missing endpoints

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -867,6 +867,9 @@ await novu.integrations.delete("integrationId")
 
 // get novu in-app status
 await novu.integrations.getInAppStatus()
+
+// set an integration as primary
+await novu.integrations.setIntegrationAsPrimary("integrationId")
 ```
 
 ### Feeds

--- a/packages/node/src/lib/integrations/integrations.interface.ts
+++ b/packages/node/src/lib/integrations/integrations.interface.ts
@@ -8,6 +8,7 @@ export interface IIntegrations {
   update(integrationId: string, data: IIntegrationsUpdatePayload);
   delete(integrationId: string);
   getInAppStatus();
+  setIntegrationAsPrimary(integrationId: string);
 }
 
 export interface IIntegrationsPayload extends IIntegrationsUpdatePayload {

--- a/packages/node/src/lib/integrations/integrations.spec.ts
+++ b/packages/node/src/lib/integrations/integrations.spec.ts
@@ -108,4 +108,24 @@ describe('test use of novus node package - Integrations class', () => {
       '/integrations/INTEGRATION_ID'
     );
   });
+
+  test('should set the integration as primary', async () => {
+    mockedAxios.post.mockResolvedValue({});
+
+    await novu.integrations.setIntegrationAsPrimary('INTEGRATION_ID');
+
+    expect(mockedAxios.post).toHaveBeenCalled();
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      '/integrations/INTEGRATION_ID/set-primary'
+    );
+  });
+
+  test('should get the in-app status of the integration', async () => {
+    mockedAxios.post.mockResolvedValue({});
+
+    await novu.integrations.getInAppStatus();
+
+    expect(mockedAxios.get).toHaveBeenCalled();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/integrations/in-app/status');
+  });
 });

--- a/packages/node/src/lib/integrations/integrations.spec.ts
+++ b/packages/node/src/lib/integrations/integrations.spec.ts
@@ -116,7 +116,8 @@ describe('test use of novus node package - Integrations class', () => {
 
     expect(mockedAxios.post).toHaveBeenCalled();
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      '/integrations/INTEGRATION_ID/set-primary'
+      '/integrations/INTEGRATION_ID/set-primary',
+      {}
     );
   });
 

--- a/packages/node/src/lib/integrations/integrations.ts
+++ b/packages/node/src/lib/integrations/integrations.ts
@@ -1,9 +1,10 @@
+import { ChannelTypeEnum } from '@novu/shared';
+import { WithHttp } from '../novu.interface';
 import {
   IIntegrations,
   IIntegrationsPayload,
   IIntegrationsUpdatePayload,
 } from './integrations.interface';
-import { WithHttp } from '../novu.interface';
 
 export class Integrations extends WithHttp implements IIntegrations {
   async getAll() {
@@ -12,6 +13,10 @@ export class Integrations extends WithHttp implements IIntegrations {
 
   async getActive() {
     return await this.http.get('/integrations/active');
+  }
+
+  async getInAppStatus() {
+    return await this.http.get('/integrations/in-app/status');
   }
 
   /**
@@ -45,13 +50,19 @@ export class Integrations extends WithHttp implements IIntegrations {
   }
 
   /**
+   * @param {string} integrationId - integrationId of the integration to set it as primary
+   */
+  async setIntegrationAsPrimary(integrationId: string) {
+    return await this.http.post(
+      `/integrations/${integrationId}/set-primary`,
+      {}
+    );
+  }
+
+  /**
    * @param {string} integrationId - integrationId of the integration to delete
    */
   async delete(integrationId: string) {
     return await this.http.delete(`/integrations/${integrationId}`);
-  }
-
-  async getInAppStatus() {
-    return await this.http.get('/integrations/in-app/status');
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- adds the missing setIntegration primary API endpoint to the node package
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
