### PR TITLE
Add ES i18n translations

### DIFF
--- a/packages/notification-center/src/i18n/languages/es.ts
+++ b/packages/notification-center/src/i18n/languages/es.ts
@@ -3,10 +3,13 @@ import { ITranslationEntry } from '../lang';
 export const ES: ITranslationEntry = {
   translations: {
     notifications: 'Notificaciones',
-    markAllAsRead: 'marcar todo como leído',
+    markAllAsRead: 'Marcar todo como leído',
     poweredBy: 'Con tecnología de',
     settings: 'Configuración',
-    noNewNotification: 'Nada nuevo que ver aquí todavía',
+    removeMessage: 'Eliminar mensaje',
+    markAsRead: 'Marcar como leído',
+    markAsUnRead: 'Marcar como no leído',
+    noNewNotification: 'Nada nuevo por aquí',
   },
   lang: 'es',
 };


### PR DESCRIPTION
### What change does this PR introduce?

Add ES i18n messages

### Why was this change needed?

There is no traduction for some ES messages
