### PR TITLE
add volume claim to mongodb deployment

### DIFF
--- a/docker/kubernetes/kustomize/kustomization.yaml
+++ b/docker/kubernetes/kustomize/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - mongodb-volume.yaml
   - mongodb-deployment.yaml
   - mongodb-service.yaml
   - api-deployment.yaml
@@ -18,6 +19,7 @@ resources:
   - ws-service.yaml
   - worker-deployment.yaml
   - worker-service.yaml
+ 
 
 # namespace
 # Adds namespace to all resources.

--- a/docker/kubernetes/kustomize/mongodb-deployment.yaml
+++ b/docker/kubernetes/kustomize/mongodb-deployment.yaml
@@ -28,3 +28,10 @@ spec:
           name: mongodb
           ports:
             - containerPort: 27017
+          volumeMounts: 
+              - name: "mongodb-persistent-storage"
+                mountPath: "/data/db"
+      volumes: 
+          - name: "mongodb-persistent-storage"
+            persistentVolumeClaim: 
+              claimName: "novu-mongodb-pvc"

--- a/docker/kubernetes/kustomize/mongodb-volume.yaml
+++ b/docker/kubernetes/kustomize/mongodb-volume.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: novu-mongodb-pvc
+spec:
+  resources:
+    requests:
+      storage: 5Gi
+  volumeMode: Filesystem
+  storageClassName: local-storage
+  accessModes:
+    - ReadWriteOnce


### PR DESCRIPTION
### What change does this PR introduce?

This PR introduces the addition of a volume claim to the MongoDB deployment in the Novu open-source project. It involves modifying the configuration of the MongoDB deployment to include a volume claim, which allows for persistent storage of data.

### Why was this change needed?

This change was needed to address the need for data persistence and reliability in the Novu project's MongoDB deployment. Without a volume claim, MongoDB data would be stored in ephemeral containers, which means that any data stored would be lost if the container were to be restarted or recreated. By adding a volume claim, we ensure that data is stored persistently and can survive container restarts and recreations.


