### PR TITLE
Nv 2795 allow to create integration for novu sms and email providers

### DIFF
--- a/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
@@ -505,6 +505,50 @@ describe('Create Integration - /integration (POST)', function () {
     expect(second.active).to.equal(false);
     expect(second.priority).to.equal(0);
   });
+
+  it('should not allow creating the same novu provider on same environment twice', async function () {
+    const inAppPayload = {
+      name: InAppProviderIdEnum.Novu,
+      providerId: InAppProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.IN_APP,
+      credentials: {},
+      active: true,
+      check: false,
+    };
+
+    const inAppResult = await session.testAgent.post('/v1/integrations').send(inAppPayload);
+
+    expect(inAppResult.body.statusCode).to.equal(400);
+    expect(inAppResult.body.message).to.equal('One environment can only have one In app provider');
+
+    const emailPayload = {
+      name: EmailProviderIdEnum.Novu,
+      providerId: EmailProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.EMAIL,
+      credentials: {},
+      active: true,
+      check: false,
+    };
+
+    const emailResult = await session.testAgent.post('/v1/integrations').send(emailPayload);
+
+    expect(emailResult.body.statusCode).to.equal(409);
+    expect(emailResult.body.message).to.equal('Integration with novu provider for email channel already exists');
+
+    const smsPayload = {
+      name: SmsProviderIdEnum.Novu,
+      providerId: SmsProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.SMS,
+      credentials: {},
+      active: true,
+      check: false,
+    };
+
+    const smsResult = await session.testAgent.post('/v1/integrations').send(smsPayload);
+
+    expect(smsResult.body.statusCode).to.equal(409);
+    expect(smsResult.body.message).to.equal('Integration with novu provider for sms channel already exists');
+  });
 });
 
 async function insertIntegrationTwice(

--- a/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
@@ -114,7 +114,7 @@ export class CreateIntegration {
     if (command.providerId === SmsProviderIdEnum.Novu || command.providerId === EmailProviderIdEnum.Novu) {
       const count = await this.integrationRepository.count({
         _environmentId: command.environmentId,
-        providerId: EmailProviderIdEnum.Novu,
+        providerId: command.providerId,
         channel: command.channel,
       });
 

--- a/apps/web/src/pages/integrations/components/multi-provider/CreateProviderInstanceSidebar.tsx
+++ b/apps/web/src/pages/integrations/components/multi-provider/CreateProviderInstanceSidebar.tsx
@@ -1,32 +1,24 @@
-import { ActionIcon, Group, Radio, Text } from '@mantine/core';
-import { useEffect, useMemo } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Controller, useForm } from 'react-hook-form';
 import styled from '@emotion/styled';
-import {
-  ChannelTypeEnum,
-  EmailProviderIdEnum,
-  ICreateIntegrationBodyDto,
-  InAppProviderIdEnum,
-  providers,
-  ProvidersIdEnum,
-  SmsProviderIdEnum,
-} from '@novu/shared';
+import { ActionIcon, Group, Radio, Text } from '@mantine/core';
+import { ChannelTypeEnum, ICreateIntegrationBodyDto, NOVU_PROVIDERS, providers } from '@novu/shared';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 
-import { Button, colors, NameInput, Sidebar } from '../../../../design-system';
-import { ArrowLeft } from '../../../../design-system/icons';
-import { inputStyles } from '../../../../design-system/config/inputs.styles';
-import { useFetchEnvironments } from '../../../../hooks/useFetchEnvironments';
-import { useSegment } from '../../../../components/providers/SegmentProvider';
 import { createIntegration } from '../../../../api/integration';
-import { IntegrationsStoreModalAnalytics } from '../../constants';
-import { errorMessage, successMessage } from '../../../../utils/notifications';
 import { QueryKeys } from '../../../../api/query.keys';
-import { ProviderImage } from './SelectProviderSidebar';
+import { useSegment } from '../../../../components/providers/SegmentProvider';
+import { When } from '../../../../components/utils/When';
+import { Button, colors, NameInput, Sidebar } from '../../../../design-system';
+import { inputStyles } from '../../../../design-system/config/inputs.styles';
+import { ArrowLeft } from '../../../../design-system/icons';
+import { useFetchEnvironments } from '../../../../hooks/useFetchEnvironments';
 import { CHANNEL_TYPE_TO_STRING } from '../../../../utils/channels';
+import { errorMessage, successMessage } from '../../../../utils/notifications';
+import { IntegrationsStoreModalAnalytics } from '../../constants';
 import type { IntegrationEntity } from '../../types';
 import { useProviders } from '../../useProviders';
-import { When } from '../../../../components/utils/When';
+import { ProviderImage } from './SelectProviderSidebar';
 
 interface ICreateProviderInstanceForm {
   name: string;
@@ -76,12 +68,7 @@ export function CreateProviderInstanceSidebar({
   const selectedEnvironmentId = watch('environmentId');
 
   const showNovuProvidersErrorMessage = useMemo(() => {
-    const novuProviders: ProvidersIdEnum[] = [
-      InAppProviderIdEnum.Novu,
-      SmsProviderIdEnum.Novu,
-      EmailProviderIdEnum.Novu,
-    ];
-    if (!provider || integrations.length === 0 || !novuProviders.includes(provider.id)) {
+    if (!provider || integrations.length === 0 || !NOVU_PROVIDERS.includes(provider.id)) {
       return false;
     }
 

--- a/apps/web/src/pages/integrations/components/multi-provider/CreateProviderInstanceSidebar.tsx
+++ b/apps/web/src/pages/integrations/components/multi-provider/CreateProviderInstanceSidebar.tsx
@@ -3,7 +3,15 @@ import { useEffect, useMemo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Controller, useForm } from 'react-hook-form';
 import styled from '@emotion/styled';
-import { ChannelTypeEnum, ICreateIntegrationBodyDto, InAppProviderIdEnum, providers } from '@novu/shared';
+import {
+  ChannelTypeEnum,
+  EmailProviderIdEnum,
+  ICreateIntegrationBodyDto,
+  InAppProviderIdEnum,
+  providers,
+  ProvidersIdEnum,
+  SmsProviderIdEnum,
+} from '@novu/shared';
 
 import { Button, colors, NameInput, Sidebar } from '../../../../design-system';
 import { ArrowLeft } from '../../../../design-system/icons';
@@ -67,8 +75,13 @@ export function CreateProviderInstanceSidebar({
 
   const selectedEnvironmentId = watch('environmentId');
 
-  const showInAppErrorMessage = useMemo(() => {
-    if (!provider || integrations.length === 0 || provider.id !== InAppProviderIdEnum.Novu) {
+  const showNovuProvidersErrorMessage = useMemo(() => {
+    const novuProviders: ProvidersIdEnum[] = [
+      InAppProviderIdEnum.Novu,
+      SmsProviderIdEnum.Novu,
+      EmailProviderIdEnum.Novu,
+    ];
+    if (!provider || integrations.length === 0 || !novuProviders.includes(provider.id)) {
       return false;
     }
 
@@ -170,7 +183,7 @@ export function CreateProviderInstanceSidebar({
             Cancel
           </Button>
           <Button
-            disabled={isLoading || isLoadingCreate || showInAppErrorMessage}
+            disabled={isLoading || isLoadingCreate || showNovuProvidersErrorMessage}
             loading={isLoadingCreate}
             submit
             data-test-id="create-provider-instance-sidebar-create"
@@ -231,9 +244,11 @@ export function CreateProviderInstanceSidebar({
           );
         }}
       />
-      <When truthy={showInAppErrorMessage}>
+      <When truthy={showNovuProvidersErrorMessage}>
         <WarningMessage>
-          <Text>You can only create one {provider.displayName} per environment.</Text>
+          <Text data-test-id="novu-provider-error">
+            You can only create one {provider.displayName} per environment.
+          </Text>
         </WarningMessage>
       </When>
     </Sidebar>

--- a/apps/web/src/pages/integrations/components/multi-provider/SelectProviderSidebar.tsx
+++ b/apps/web/src/pages/integrations/components/multi-provider/SelectProviderSidebar.tsx
@@ -9,7 +9,6 @@ import {
   inAppProviders,
   chatProviders,
   InAppProviderIdEnum,
-  NOVU_SMS_EMAIL_PROVIDERS,
 } from '@novu/shared';
 
 import { colors, Sidebar } from '../../../../design-system';
@@ -32,14 +31,12 @@ const filterSearch = (list, search: string) =>
   list.filter((prov) => prov.displayName.toLowerCase().includes(search.toLowerCase()));
 
 const mapStructure = (listProv): IIntegratedProvider[] =>
-  listProv
-    .filter((providerItem) => !NOVU_SMS_EMAIL_PROVIDERS.includes(providerItem.id))
-    .map((providerItem) => ({
-      providerId: providerItem.id,
-      displayName: providerItem.displayName,
-      channel: providerItem.channel,
-      docReference: providerItem.docReference,
-    }));
+  listProv.map((providerItem) => ({
+    providerId: providerItem.id,
+    displayName: providerItem.displayName,
+    channel: providerItem.channel,
+    docReference: providerItem.docReference,
+  }));
 
 const initialProvidersList = {
   [ChannelTypeEnum.EMAIL]: mapStructure(emailProviders),


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- allows the user to create Novu email and SMS integrations
- each provider is limited to 1 for each environment
### Why was this change needed?
- After deleting a Novu provider there was no option to re-add them.
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
