### PR TITLE
feat(ws): simplify events for web sockets queue for performance

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
@@ -247,7 +247,7 @@ export class SendMessageInApp extends SendMessageBase {
     );
 
     await this.webSocketsQueueService.bullMqService.add(
-      `sendMessage-received-${message._id}`,
+      message._id,
       {
         event: WebSocketEventEnum.RECEIVED,
         userId: command._subscriberId,
@@ -255,28 +255,6 @@ export class SendMessageInApp extends SendMessageBase {
         payload: {
           messageId: message._id,
         },
-      },
-      {},
-      command.organizationId
-    );
-
-    await this.webSocketsQueueService.bullMqService.add(
-      `sendMessage-unseen-${message._id}`,
-      {
-        event: WebSocketEventEnum.UNSEEN,
-        userId: command._subscriberId,
-        _environmentId: command.environmentId,
-      },
-      {},
-      command.organizationId
-    );
-
-    await this.webSocketsQueueService.bullMqService.add(
-      `sendMessage-unread-${message._id}`,
-      {
-        event: WebSocketEventEnum.UNREAD,
-        userId: command._subscriberId,
-        _environmentId: command.environmentId,
       },
       {},
       command.organizationId

--- a/apps/ws/src/socket/usecases/external-services-route/external-services-route.spec.ts
+++ b/apps/ws/src/socket/usecases/external-services-route/external-services-route.spec.ts
@@ -1,5 +1,5 @@
 import * as sinon from 'sinon';
-import { EnvironmentRepository, MessageRepository, UserRepository } from '@novu/dal';
+import { EnvironmentRepository, MessageEntity, MessageRepository, UserRepository } from '@novu/dal';
 import { WebSocketEventEnum } from '@novu/shared';
 
 import { ExternalServicesRoute } from './external-services-route.usecase';
@@ -7,32 +7,45 @@ import { ExternalServicesRouteCommand } from './external-services-route.command'
 import { WSGateway } from '../../ws.gateway';
 
 const environmentId = EnvironmentRepository.createObjectId();
+const messageId = 'message-id-1';
 const userId = UserRepository.createObjectId();
+
+const commandReceivedMessage = ExternalServicesRouteCommand.create({
+  event: WebSocketEventEnum.RECEIVED,
+  userId,
+  _environmentId: environmentId,
+  payload: {
+    message: {
+      _id: messageId,
+      _environmentId: environmentId,
+      // etc...
+    } as MessageEntity,
+  },
+});
+
+const createWsGatewayStub = (result) => {
+  return {
+    sendMessage: sinon.stub(),
+    server: {
+      sockets: {
+        in: sinon.stub().returns({
+          fetchSockets: sinon.stub().resolves(result),
+        }),
+      },
+    },
+  } as WSGateway;
+};
 
 describe('ExternalServicesRoute', () => {
   let externalServicesRoute: ExternalServicesRoute;
   let wsGatewayStub;
-  let messageRepository: MessageRepository;
   let findByIdStub: sinon.Stub;
   let getCountStub: sinon.Stub;
+  const messageRepository = new MessageRepository();
 
   beforeEach(() => {
     findByIdStub = sinon.stub(MessageRepository.prototype, 'findById');
     getCountStub = sinon.stub(MessageRepository.prototype, 'getCount');
-
-    wsGatewayStub = {
-      sendMessage: sinon.stub(),
-      server: {
-        sockets: {
-          in: sinon.stub().returns({
-            fetchSockets: sinon.stub().resolves([{ id: 'socketId' }]),
-          }),
-        },
-      },
-    } as WSGateway;
-
-    messageRepository = new MessageRepository();
-    externalServicesRoute = new ExternalServicesRoute(wsGatewayStub, messageRepository);
   });
 
   afterEach(() => {
@@ -40,207 +53,196 @@ describe('ExternalServicesRoute', () => {
     getCountStub.restore();
   });
 
-  it('should send unseen count change when event is "unseen_count_changed"', async () => {
-    getCountStub.resolves(Promise.resolve(5));
+  describe('User is not online', () => {
+    beforeEach(() => {
+      wsGatewayStub = createWsGatewayStub([]);
+      externalServicesRoute = new ExternalServicesRoute(wsGatewayStub, messageRepository);
+    });
 
-    await externalServicesRoute.execute(
-      ExternalServicesRouteCommand.create({
+    it('should not send any message to the web socket if user is not online', async () => {
+      getCountStub.resolves(Promise.resolve(5));
+
+      await externalServicesRoute.execute(commandReceivedMessage);
+
+      sinon.assert.calledOnceWithExactly(wsGatewayStub.server.sockets.in, userId);
+      sinon.assert.calledOnceWithExactly(wsGatewayStub.server.sockets.in(userId).fetchSockets);
+      sinon.assert.notCalled(wsGatewayStub.sendMessage);
+    });
+  });
+
+  describe('User is online', () => {
+    beforeEach(() => {
+      wsGatewayStub = createWsGatewayStub([{ id: 'socket-id' }]);
+      externalServicesRoute = new ExternalServicesRoute(wsGatewayStub, messageRepository);
+      findByIdStub.resolves(Promise.resolve({ _id: messageId }));
+    });
+
+    it('should send message, unseen count and unread count change when event is received', async () => {
+      getCountStub.resolves(Promise.resolve(5));
+
+      await externalServicesRoute.execute(commandReceivedMessage);
+
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(0), userId, WebSocketEventEnum.RECEIVED, {
+        message: {
+          _id: messageId,
+        },
+      });
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(1), userId, WebSocketEventEnum.RECEIVED, {
+        unseenCount: 5,
+        hasMore: false,
+      });
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(2), userId, WebSocketEventEnum.RECEIVED, {
+        unreadCount: 5,
+        hasMore: false,
+      });
+    });
+
+    it('should skip getCount query if unseen count provided', async () => {
+      getCountStub.resolves(Promise.resolve(10));
+
+      let command: ExternalServicesRouteCommand = {
         event: WebSocketEventEnum.UNSEEN,
         userId,
         _environmentId: environmentId,
-        payload: {},
-      })
-    );
+        payload: { unseenCount: 5 },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledOnceWithExactly(wsGatewayStub.sendMessage, userId, WebSocketEventEnum.UNSEEN, {
+        unseenCount: 5,
+        hasMore: false,
+      });
 
-    sinon.assert.calledOnceWithExactly(wsGatewayStub.sendMessage, userId, WebSocketEventEnum.UNSEEN, {
-      unseenCount: 5,
-      hasMore: false,
+      command = {
+        event: WebSocketEventEnum.UNSEEN,
+        userId,
+        _environmentId: environmentId,
+        payload: { unseenCount: 4 },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(1), userId, WebSocketEventEnum.UNSEEN, {
+        unseenCount: 4,
+      });
+
+      getCountStub.resolves(Promise.resolve(20));
+      command = {
+        event: WebSocketEventEnum.UNSEEN,
+        userId,
+        _environmentId: environmentId,
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(2), userId, WebSocketEventEnum.UNSEEN, {
+        unseenCount: 20,
+      });
+
+      getCountStub.resolves(Promise.resolve(21));
+      command = {
+        event: WebSocketEventEnum.UNSEEN,
+        userId,
+        _environmentId: environmentId,
+        payload: { unseenCount: undefined },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(3), userId, WebSocketEventEnum.UNSEEN, {
+        unseenCount: 21,
+      });
+
+      getCountStub.resolves(Promise.resolve(22));
+      command = {
+        event: WebSocketEventEnum.UNSEEN,
+        userId,
+        _environmentId: environmentId,
+        payload: { unseenCount: undefined },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(4), userId, WebSocketEventEnum.UNSEEN, {
+        unseenCount: 22,
+      });
+
+      getCountStub.resolves(Promise.resolve(23));
+      command = {
+        event: WebSocketEventEnum.UNSEEN,
+        userId,
+        _environmentId: environmentId,
+        payload: { unseenCount: 0 },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(5), userId, WebSocketEventEnum.UNSEEN, {
+        unseenCount: 0,
+      });
     });
-  });
 
-  it('should send unread count change when event is "unread_count_changed"', async () => {
-    getCountStub.resolves(Promise.resolve(10));
+    it('should skip getCount query if unread count provided', async () => {
+      getCountStub.resolves(Promise.resolve(10));
 
-    await externalServicesRoute.execute(
-      ExternalServicesRouteCommand.create({
+      let command: ExternalServicesRouteCommand = {
         event: WebSocketEventEnum.UNREAD,
         userId,
         _environmentId: environmentId,
-        payload: {},
-      })
-    );
+        payload: { unreadCount: 5 },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledOnceWithExactly(wsGatewayStub.sendMessage, userId, WebSocketEventEnum.UNREAD, {
+        unreadCount: 5,
+        hasMore: false,
+      });
 
-    sinon.assert.calledOnceWithExactly(wsGatewayStub.sendMessage, userId, WebSocketEventEnum.UNREAD, {
-      unreadCount: 10,
-      hasMore: false,
-    });
-  });
+      command = {
+        event: WebSocketEventEnum.UNREAD,
+        userId,
+        _environmentId: environmentId,
+        payload: { unreadCount: 4 },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(1), userId, WebSocketEventEnum.UNREAD, {
+        unreadCount: 4,
+      });
 
-  it('should send general message when event is neither "unseen_count_changed" nor "unread_count_changed"', async () => {
-    const messageId = MessageRepository.createObjectId();
+      getCountStub.resolves(Promise.resolve(20));
+      command = {
+        event: WebSocketEventEnum.UNREAD,
+        userId,
+        _environmentId: environmentId,
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(2), userId, WebSocketEventEnum.UNREAD, {
+        unreadCount: 20,
+      });
 
-    findByIdStub.resolves(Promise.resolve({ _id: messageId }));
+      getCountStub.resolves(Promise.resolve(21));
+      command = {
+        event: WebSocketEventEnum.UNREAD,
+        userId,
+        _environmentId: environmentId,
+        payload: { unreadCount: undefined },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(3), userId, WebSocketEventEnum.UNREAD, {
+        unreadCount: 21,
+      });
 
-    const command: ExternalServicesRouteCommand = {
-      event: WebSocketEventEnum.RECEIVED,
-      userId,
-      payload: { messageId },
-    };
+      getCountStub.resolves(Promise.resolve(22));
+      command = {
+        event: WebSocketEventEnum.UNREAD,
+        userId,
+        _environmentId: environmentId,
+        payload: { unreadCount: undefined },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(4), userId, WebSocketEventEnum.UNREAD, {
+        unreadCount: 22,
+      });
 
-    await externalServicesRoute.execute(command);
-
-    sinon.assert.calledOnceWithExactly(wsGatewayStub.sendMessage, userId, WebSocketEventEnum.RECEIVED, {
-      message: {
-        _id: messageId,
-      },
-    });
-  });
-
-  it('should skip getCount query if unseen count provided', async () => {
-    getCountStub.resolves(Promise.resolve(10));
-
-    let command: ExternalServicesRouteCommand = {
-      event: WebSocketEventEnum.UNSEEN,
-      userId,
-      _environmentId: environmentId,
-      payload: { unseenCount: 5 },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledOnceWithExactly(wsGatewayStub.sendMessage, userId, WebSocketEventEnum.UNSEEN, {
-      unseenCount: 5,
-      hasMore: false,
-    });
-
-    command = {
-      event: WebSocketEventEnum.UNSEEN,
-      userId,
-      _environmentId: environmentId,
-      payload: { unseenCount: 4 },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(1), userId, WebSocketEventEnum.UNSEEN, {
-      unseenCount: 4,
-    });
-
-    getCountStub.resolves(Promise.resolve(20));
-    command = {
-      event: WebSocketEventEnum.UNSEEN,
-      userId,
-      _environmentId: environmentId,
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(2), userId, WebSocketEventEnum.UNSEEN, {
-      unseenCount: 20,
-    });
-
-    getCountStub.resolves(Promise.resolve(21));
-    command = {
-      event: WebSocketEventEnum.UNSEEN,
-      userId,
-      _environmentId: environmentId,
-      payload: { unseenCount: undefined },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(3), userId, WebSocketEventEnum.UNSEEN, {
-      unseenCount: 21,
-    });
-
-    getCountStub.resolves(Promise.resolve(22));
-    command = {
-      event: WebSocketEventEnum.UNSEEN,
-      userId,
-      _environmentId: environmentId,
-      payload: { unseenCount: undefined },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(4), userId, WebSocketEventEnum.UNSEEN, {
-      unseenCount: 22,
-    });
-
-    getCountStub.resolves(Promise.resolve(23));
-    command = {
-      event: WebSocketEventEnum.UNSEEN,
-      userId,
-      _environmentId: environmentId,
-      payload: { unseenCount: 0 },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(5), userId, WebSocketEventEnum.UNSEEN, {
-      unseenCount: 0,
-    });
-  });
-
-  it('should skip getCount query if unread count provided', async () => {
-    getCountStub.resolves(Promise.resolve(10));
-
-    let command: ExternalServicesRouteCommand = {
-      event: WebSocketEventEnum.UNREAD,
-      userId,
-      _environmentId: environmentId,
-      payload: { unreadCount: 5 },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledOnceWithExactly(wsGatewayStub.sendMessage, userId, WebSocketEventEnum.UNREAD, {
-      unreadCount: 5,
-      hasMore: false,
-    });
-
-    command = {
-      event: WebSocketEventEnum.UNREAD,
-      userId,
-      _environmentId: environmentId,
-      payload: { unreadCount: 4 },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(1), userId, WebSocketEventEnum.UNREAD, {
-      unreadCount: 4,
-    });
-
-    getCountStub.resolves(Promise.resolve(20));
-    command = {
-      event: WebSocketEventEnum.UNREAD,
-      userId,
-      _environmentId: environmentId,
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(2), userId, WebSocketEventEnum.UNREAD, {
-      unreadCount: 20,
-    });
-
-    getCountStub.resolves(Promise.resolve(21));
-    command = {
-      event: WebSocketEventEnum.UNREAD,
-      userId,
-      _environmentId: environmentId,
-      payload: { unreadCount: undefined },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(3), userId, WebSocketEventEnum.UNREAD, {
-      unreadCount: 21,
-    });
-
-    getCountStub.resolves(Promise.resolve(22));
-    command = {
-      event: WebSocketEventEnum.UNREAD,
-      userId,
-      _environmentId: environmentId,
-      payload: { unreadCount: undefined },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(4), userId, WebSocketEventEnum.UNREAD, {
-      unreadCount: 22,
-    });
-
-    getCountStub.resolves(Promise.resolve(23));
-    command = {
-      event: WebSocketEventEnum.UNREAD,
-      userId,
-      _environmentId: environmentId,
-      payload: { unreadCount: 0 },
-    };
-    await externalServicesRoute.execute(command);
-    sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(5), userId, WebSocketEventEnum.UNREAD, {
-      unreadCount: 0,
+      getCountStub.resolves(Promise.resolve(23));
+      command = {
+        event: WebSocketEventEnum.UNREAD,
+        userId,
+        _environmentId: environmentId,
+        payload: { unreadCount: 0 },
+      };
+      await externalServicesRoute.execute(command);
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(5), userId, WebSocketEventEnum.UNREAD, {
+        unreadCount: 0,
+      });
     });
   });
 });


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
From the Worker we will only send one event instead of 3 and we will process it executing the functions that before were triggered by 3 different events, as they are sent at the same time.
We also only process the event and trigger the messages to the WebSocket if the user is online as if not it is a waste of resources.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
It is a performance improvement identified during the MemoryDB migration.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
