### PR TITLE
fix(ws): send correct unseen, unread events when the notification is received

### DIFF
--- a/apps/ws/src/socket/usecases/external-services-route/external-services-route.spec.ts
+++ b/apps/ws/src/socket/usecases/external-services-route/external-services-route.spec.ts
@@ -87,11 +87,11 @@ describe('ExternalServicesRoute', () => {
           _id: messageId,
         },
       });
-      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(1), userId, WebSocketEventEnum.RECEIVED, {
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(1), userId, WebSocketEventEnum.UNSEEN, {
         unseenCount: 5,
         hasMore: false,
       });
-      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(2), userId, WebSocketEventEnum.RECEIVED, {
+      sinon.assert.calledWithMatch(wsGatewayStub.sendMessage.getCall(2), userId, WebSocketEventEnum.UNREAD, {
         unreadCount: 5,
         hasMore: false,
       });

--- a/apps/ws/src/socket/usecases/external-services-route/external-services-route.usecase.ts
+++ b/apps/ws/src/socket/usecases/external-services-route/external-services-route.usecase.ts
@@ -74,7 +74,7 @@ export class ExternalServicesRoute {
     const paginationIndication: IUnreadCountPaginationIndication =
       unreadCount > 100 ? { unreadCount: 100, hasMore: true } : { unreadCount: unreadCount, hasMore: false };
 
-    await this.wsGateway.sendMessage(command.userId, command.event, {
+    await this.wsGateway.sendMessage(command.userId, WebSocketEventEnum.UNREAD, {
       unreadCount: paginationIndication.unreadCount,
       hasMore: paginationIndication.hasMore,
     });
@@ -106,7 +106,7 @@ export class ExternalServicesRoute {
     const paginationIndication: IUnseenCountPaginationIndication =
       unseenCount > 100 ? { unseenCount: 100, hasMore: true } : { unseenCount: unseenCount, hasMore: false };
 
-    await this.wsGateway.sendMessage(command.userId, command.event, {
+    await this.wsGateway.sendMessage(command.userId, WebSocketEventEnum.UNSEEN, {
       unseenCount: paginationIndication.unseenCount,
       hasMore: paginationIndication.hasMore,
     });


### PR DESCRIPTION
### What change does this PR introduce?

Some time ago we did the refactoring on the WS queue, like instead of adding 3 separate jobs to the WS queue (for notification_received, unread_count_changed, unseen_count_changed) we decided to put just one notification_received which makes sense. And on the WS service side when we handle this event we will just send unseen/unread events to the socket directly. 

But the missing part is the event name, which we forgot to change for these unseen/unread events, like it is notification_received, which is not expected event for NC (and our clients). Ref:  https://github.com/novuhq/novu/blob/14269cd95f63314248cea2b646c615bf6296f2d2/apps/ws/src/socket/usecases/external-services-route/external-services-route.usecase.ts#L77

### Why was this change needed?


### Other information (Screenshots)

![Screenshot 2023-09-19 at 12 48 53](https://github.com/novuhq/novu/assets/2607232/5c6130f5-aa64-4050-9cb5-cba9fa6c2344)

