### PR TITLE
feat: allow variables in sender name field of email editor

### DIFF
--- a/apps/api/e2e/compile-email-template.e2e.ts
+++ b/apps/api/e2e/compile-email-template.e2e.ts
@@ -140,6 +140,35 @@ describe('Compile E-mail Template', function () {
     expect(subject).to.equal(subjectText);
   });
 
+  it('should apply sender name variable if provided', async function () {
+    const senderNameTest = 'Novu Test';
+    const { html, senderName } = await useCase.execute(
+      CompileEmailTemplateCommand.create({
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        layoutId: null,
+        preheader: null,
+        content: [
+          {
+            content: '<p>{{senderName}}</p>',
+            type: EmailBlockTypeEnum.TEXT,
+          },
+        ],
+        payload: { senderName: senderNameTest },
+        userId: session.user._id,
+        contentType: 'editor',
+        subject: 'sub',
+        senderName: '{{senderName}}',
+      })
+    );
+
+    expect(html).to.contain('<!DOCTYPE html');
+    expect(html).not.to.contain('{{senderName}}');
+    expect(html).to.contain(`<p>${senderNameTest}</p>`);
+
+    expect(senderName).to.equal(senderNameTest);
+  });
+
   describe('Backwards compatability', function () {
     it('should compile e-mail template for custom html without layouts attached for backwards compatability', async function () {
       const { html, subject } = await useCase.execute(

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -150,8 +150,10 @@ export class SendMessageEmail extends SendMessageBase {
     let html;
     let subject = '';
     let content;
+    let senderName = overrides?.senderName || emailChannel.template.senderName;
 
     const payload = {
+      senderName: emailChannel.template.senderName || '',
       subject: emailChannel.template.subject || '',
       preheader: emailChannel.template.preheader,
       content: emailChannel.template.content,
@@ -204,7 +206,7 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     try {
-      ({ html, content, subject } = await this.compileEmailTemplateUsecase.execute(
+      ({ html, content, subject, senderName } = await this.compileEmailTemplateUsecase.execute(
         CompileEmailTemplateCommand.create({
           environmentId: command.environmentId,
           organizationId: command.organizationId,
@@ -289,13 +291,7 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     if (email && integration) {
-      await this.sendMessage(
-        integration,
-        mailData,
-        message,
-        command,
-        overrides?.senderName || emailChannel.template.senderName
-      );
+      await this.sendMessage(integration, mailData, message, command, senderName);
 
       return;
     }

--- a/packages/application-generic/src/usecases/compile-email-template/compile-email-template.command.ts
+++ b/packages/application-generic/src/usecases/compile-email-template/compile-email-template.command.ts
@@ -24,4 +24,8 @@ export class CompileEmailTemplateCommand extends EnvironmentWithUserCommand {
   @IsString()
   @IsOptional()
   preheader?: string | null;
+
+  @IsString()
+  @IsOptional()
+  senderName?: string | null;
 }

--- a/packages/application-generic/src/usecases/compile-email-template/compile-email-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-email-template/compile-email-template.usecase.ts
@@ -62,6 +62,7 @@ export class CompileEmailTemplate {
     }
 
     let subject = '';
+    let senderName = '';
     const content: string | IEmailBlock[] = command.content;
     let preheader = command.preheader;
 
@@ -82,6 +83,9 @@ export class CompileEmailTemplate {
 
       if (preheader) {
         preheader = await this.renderContent(preheader, payload);
+      }
+      if (command.senderName) {
+        senderName = await this.renderContent(command.senderName, payload);
       }
     } catch (e: any) {
       throw new ApiException(
@@ -128,7 +132,7 @@ export class CompileEmailTemplate {
         )
       : body;
 
-    return { html, content, subject };
+    return { html, content, subject, senderName };
   }
 
   private async renderContent(


### PR DESCRIPTION
### What change does this PR introduce?

- pass senderName variable to compile template to parse the variable
- use parsed sender name as sender name to email provider

### Why was this change needed?

closes #3958 

### Other information (Screenshots)
<img width="839" alt="Screenshot 2023-09-20 at 10 44 44 PM" src="https://github.com/novuhq/novu/assets/22556323/6155bb53-ee57-4121-a595-7c744518b56e">

<img width="942" alt="Screenshot 2023-09-20 at 10 50 14 PM" src="https://github.com/novuhq/novu/assets/22556323/479a9fcf-206a-4cd1-87d9-2ca95799b9d4">
<img width="737" alt="Screenshot 2023-09-20 at 10 51 05 PM" src="https://github.com/novuhq/novu/assets/22556323/cd98e6bb-e45d-4a8a-ae28-6f87e6e0e2da">


