### PR TITLE
NV-2697 - senderName field is missing in resend api and nodejs sdk

### DIFF
--- a/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
@@ -7,9 +7,10 @@ export class ResendHandler extends BaseHandler {
     super('resend', ChannelTypeEnum.EMAIL);
   }
   buildProvider(credentials: ICredentials, from?: string) {
-    const config: { apiKey: string; from: string } = {
+    const config: { apiKey: string; from: string; senderName: string } = {
       from: from as string,
       apiKey: credentials.apiKey as string,
+      senderName: credentials.senderName as string,
     };
 
     this.provider = new ResendEmailProvider(config);

--- a/providers/resend/src/lib/resend.provider.spec.ts
+++ b/providers/resend/src/lib/resend.provider.spec.ts
@@ -3,10 +3,11 @@ import { ResendEmailProvider } from './resend.provider';
 const mockConfig = {
   apiKey: 'this-api-key-from-resend',
   from: 'test@test.com',
+  senderName: 'Test Sender',
 };
 
 const mockNovuMessage = {
-  from: 'test@test.com',
+  from: 'Test Sender <test@test.com>',
   to: ['test@test.com'],
   html: '<div> Mail Content </div>',
   subject: 'Test subject',

--- a/providers/resend/src/lib/resend.provider.ts
+++ b/providers/resend/src/lib/resend.provider.ts
@@ -17,6 +17,7 @@ export class ResendEmailProvider implements IEmailProvider {
     private config: {
       apiKey: string;
       from: string;
+      senderName: string;
     }
   ) {
     this.resendClient = new Resend(this.config.apiKey);
@@ -26,7 +27,7 @@ export class ResendEmailProvider implements IEmailProvider {
     options: IEmailOptions
   ): Promise<ISendMessageSuccessResponse> {
     const response: any = await this.resendClient.sendEmail({
-      from: options.from || this.config.from,
+      from: `${this.config.senderName} <${options.from || this.config.from}>`,
       to: options.to,
       subject: options.subject,
       text: options.text,


### PR DESCRIPTION
 ### What change does this PR introduce?
This fix ensures field senderName is part of the payload for the resendEmail API

### Description

Novu allows the use of the sender name field in the email editor and via overrides. If the sender name is Pawan Jain and the sender from email is [pawan@novu.co](mailto:pawan@novu.co), in email clients shows like this `Pawan Jain <pawan@novu.co>`

Resend API Doc: https://resend.com/docs/api-reference/emails/send-email


 ### Why was this change needed?
closes https://github.com/novuhq/novu/issues/3957

### Other information



---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
