### PR TITLE
fix(notification-center): when the ws unread event comes in refetch the unseen messages count

### DIFF
--- a/apps/widget/cypress/e2e/shell-embed.spec.ts
+++ b/apps/widget/cypress/e2e/shell-embed.spec.ts
@@ -61,6 +61,89 @@ describe('Shell Embed', function () {
     });
     cy.get('#notification-bell .ntf-counter').should('be.visible');
   });
+
+  it('should display unseen count label in header', function () {
+    cy.task('createNotifications', {
+      identifier: this.session.templates[0].triggers[0].identifier,
+      token: this.session.token,
+      subscriberId: this.session.subscriber.subscriberId,
+      count: 5,
+    });
+
+    cy.get('#notification-bell').click();
+    cy.get('#novu-iframe-element')
+      .its('0.contentDocument.body')
+      .should('not.be.empty')
+      .then((body) => {
+        cy.wrap(body).find('[data-test-id="unseen-count-label"]').should('be.visible').contains('5');
+        cy.wrap(body).find('.nc-notifications-list-item-unread').should('have.length', 5);
+      });
+  });
+
+  it('should change unseen count label in header when message is read', function () {
+    cy.intercept('*/widgets/notifications/unseen*').as('fetchUnseenCount');
+
+    cy.task('createNotifications', {
+      identifier: this.session.templates[0].triggers[0].identifier,
+      token: this.session.token,
+      subscriberId: this.session.subscriber.subscriberId,
+      count: 5,
+    });
+
+    cy.get('#notification-bell').click();
+    cy.get('#novu-iframe-element')
+      .its('0.contentDocument.body')
+      .should('not.be.empty')
+      .then((body) => {
+        cy.wrap(body).find('[data-test-id="notification-list-item"]').first().trigger('mouseover');
+        cy.wrap(body)
+          .find('[data-test-id="notification-list-item"]')
+          .first()
+          .find('[data-test-id="notification-dots-button"]')
+          .click();
+        cy.wrap(body)
+          .find('[data-test-id="notification-list-item"]')
+          .first()
+          .find('[data-test-id="notification-mark-as-read"]')
+          .click();
+        cy.wait('@fetchUnseenCount');
+      });
+
+    cy.get('#novu-iframe-element')
+      .its('0.contentDocument.body')
+      .should('not.be.empty')
+      .then((body) => {
+        cy.wrap(body).find('[data-test-id="unseen-count-label"]').should('be.visible').contains('4');
+        cy.wrap(body).find('.nc-notifications-list-item-unread').should('have.length', 4);
+      });
+  });
+
+  it('should change unseen count label in header when all messages are read', function () {
+    cy.intercept('*/widgets/notifications/unseen*').as('fetchUnseenCount');
+
+    cy.task('createNotifications', {
+      identifier: this.session.templates[0].triggers[0].identifier,
+      token: this.session.token,
+      subscriberId: this.session.subscriber.subscriberId,
+      count: 5,
+    });
+
+    cy.get('#notification-bell').click();
+    cy.get('#novu-iframe-element')
+      .its('0.contentDocument.body')
+      .should('not.be.empty')
+      .then((body) => {
+        cy.wrap(body).find('[data-test-id="notifications-header-mark-all-as-read"]').click();
+        cy.wait('@fetchUnseenCount');
+      });
+
+    cy.get('#novu-iframe-element')
+      .its('0.contentDocument.body')
+      .should('not.be.empty')
+      .then((body) => {
+        cy.wrap(body).find('[data-test-id="unseen-count-label"]').eq(0);
+      });
+  });
 });
 
 describe('Shell Embed - Seen Read', function () {

--- a/packages/notification-center/src/hooks/index.ts
+++ b/packages/notification-center/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useSocket';
 export * from './useUnseenCount';
+export * from './useUnreadCount';
 export * from './useNotifications';
 export * from './useNovuContext';
 export * from './useNovuTheme';

--- a/packages/notification-center/src/hooks/queryKeys.ts
+++ b/packages/notification-center/src/hooks/queryKeys.ts
@@ -3,4 +3,5 @@ export const ORGANIZATION_QUERY_KEY = ['organization'];
 export const INFINITE_NOTIFICATIONS_QUERY_KEY = ['infinite_notifications'];
 export const USER_PREFERENCES_QUERY_KEY = ['user_preferences'];
 export const UNSEEN_COUNT_QUERY_KEY = ['unseen_count'];
+export const UNREAD_COUNT_QUERY_KEY = ['unread_count'];
 export const FEED_UNSEEN_COUNT_QUERY_KEY = ['feed_unseen_count'];

--- a/packages/notification-center/src/hooks/useUnreadCountQueryKey.ts
+++ b/packages/notification-center/src/hooks/useUnreadCountQueryKey.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+
+import { UNREAD_COUNT_QUERY_KEY } from './queryKeys';
+import { useSetQueryKey } from './useSetQueryKey';
+import { useStore } from './useStore';
+
+export const useUnreadCountQueryKey = () => {
+  const { storeQuery } = useStore();
+  const setQueryKey = useSetQueryKey();
+  const queryKey = useMemo(() => setQueryKey([...UNREAD_COUNT_QUERY_KEY, storeQuery]), [setQueryKey, storeQuery]);
+
+  return queryKey;
+};

--- a/packages/notification-center/src/shared/interfaces/index.ts
+++ b/packages/notification-center/src/shared/interfaces/index.ts
@@ -104,6 +104,7 @@ export interface IStoreContext {
 
 export interface INotificationsContext extends IStoreContext {
   unseenCount: number;
+  unreadCount: number;
   notifications: IMessage[];
   hasNextPage: boolean;
   isLoading: boolean;

--- a/packages/notification-center/src/store/notifications-provider.context.tsx
+++ b/packages/notification-center/src/store/notifications-provider.context.tsx
@@ -3,7 +3,13 @@ import type { IMessage } from '@novu/shared';
 
 import { NotificationsContext } from './notifications.context';
 import type { IStore } from '../shared/interfaces';
-import { useFetchNotifications, useRemoveNotification, useRemoveAllNotifications, useUnseenCount } from '../hooks';
+import {
+  useFetchNotifications,
+  useRemoveNotification,
+  useRemoveAllNotifications,
+  useUnseenCount,
+  useUnreadCount,
+} from '../hooks';
 import { useMarkNotificationsAs } from '../hooks';
 import { useMarkNotificationsAsRead } from '../hooks/useMarkNotificationAsRead';
 import { useMarkNotificationsAsSeen } from '../hooks/useMarkNotificationAsSeen';
@@ -38,6 +44,7 @@ function NotificationsProviderInternal({ children }: { children: React.ReactNode
     refetch,
   } = useFetchNotifications({ query: storeQuery });
   const { data: unseenCountData } = useUnseenCount();
+  const { data: unreadCountData } = useUnreadCount();
   const { markNotificationsAs } = useMarkNotificationsAs();
   const { removeNotification } = useRemoveNotification();
   const { removeAllNotifications } = useRemoveAllNotifications();
@@ -116,6 +123,7 @@ function NotificationsProviderInternal({ children }: { children: React.ReactNode
       storeId,
       stores,
       unseenCount: unseenCountData?.count ?? 0,
+      unreadCount: unreadCountData?.count ?? 0,
       notifications,
       hasNextPage,
       isLoading,
@@ -139,6 +147,7 @@ function NotificationsProviderInternal({ children }: { children: React.ReactNode
       storeId,
       stores,
       unseenCountData?.count,
+      unreadCountData?.count,
       notifications,
       hasNextPage,
       isLoading,


### PR DESCRIPTION
### What change does this PR introduce?

Issue: when all messages are marked as a read we do send the `unread_count_changed` WS event but the NC doesn't react to it.

Now: I've added the hook `useUnreadCount` that is listening on the `unread_count_changed` WS event and refreshes the notifications, unseen count, and feeds unseen count.

Covered also with tests.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)


https://github.com/novuhq/novu/assets/2607232/115f4654-b840-4043-9948-0addcde95ede


