### PR TITLE
Remove duplicate mention of SNS in SMS providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ Novu provides a single API to manage providers across multiple channels with a s
 - [x] [Burst SMS](https://github.com/novuhq/novu/tree/main/providers/burst-sms)
 - [x] [Firetext](https://github.com/novuhq/novu/tree/main/providers/firetext)
 - [x] [Infobip](https://github.com/novuhq/novu/tree/main/providers/infobip)
-- [x] [SNS](https://github.com/novuhq/novu/tree/main/providers/sns)
 - [ ] Bandwidth
 - [ ] RingCentral
+
 
 #### 📱 Push
 


### PR DESCRIPTION
### What change does this PR introduce?

This PR removes the duplicate mention of SNS in the SMS providers section of the Readme file.
### Why was this change needed?

This change was needed to ensure that the information in the Readme file is accurate and concise. The duplicate mention of SNS in the SMS providers section can lead to confusion and redundancy.

Closes #4196






