### PR TITLE
feat(worker): refactor get digest events flow

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/digest/digest-events.command.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/digest-events.command.ts
@@ -1,0 +1,11 @@
+import { IsDefined } from 'class-validator';
+import { JobEntity } from '@novu/dal';
+import { BaseCommand } from '@novu/application-generic';
+
+export class DigestEventsCommand extends BaseCommand {
+  @IsDefined()
+  _subscriberId: string;
+
+  @IsDefined()
+  currentJob: JobEntity;
+}

--- a/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events-backoff.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events-backoff.usecase.ts
@@ -1,22 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { JobStatusEnum } from '@novu/dal';
-import { IDigestRegularMetadata, StepTypeEnum } from '@novu/shared';
-import { DigestFilterSteps, InstrumentUsecase } from '@novu/application-generic';
+import { StepTypeEnum } from '@novu/shared';
+import { InstrumentUsecase } from '@novu/application-generic';
 
-import { SendMessageCommand } from '../send-message.command';
+import { DigestEventsCommand } from './digest-events.command';
 import { GetDigestEvents } from './get-digest-events.usecase';
-import { PlatformException } from '../../../../shared/utils';
 
 @Injectable()
 export class GetDigestEventsBackoff extends GetDigestEvents {
   @InstrumentUsecase()
-  public async execute(command: SendMessageCommand) {
-    const currentJob = await this.jobRepository.findOne({ _environmentId: command.environmentId, _id: command.jobId });
-    if (!currentJob) throw new PlatformException('Digest job is not found');
+  public async execute(command: DigestEventsCommand) {
+    const currentJob = command.currentJob;
 
-    const digestMeta = currentJob.digest as IDigestRegularMetadata | undefined;
-    const digestKey = digestMeta?.digestKey;
-    const digestValue = DigestFilterSteps.getNestedValue(currentJob.payload, digestKey);
+    const { digestKey, digestMeta, digestValue } = this.getJobDigest(currentJob);
 
     const jobs = await this.jobRepository.find({
       createdAt: {
@@ -25,12 +21,11 @@ export class GetDigestEventsBackoff extends GetDigestEvents {
       _templateId: currentJob._templateId,
       status: JobStatusEnum.COMPLETED,
       type: StepTypeEnum.TRIGGER,
-      _environmentId: command.environmentId,
+      _environmentId: currentJob._environmentId,
       ...(digestKey && { [`payload.${digestKey}`]: digestValue }),
-      // backward compatibility - ternary needed to be removed once the queue renewed
-      _subscriberId: command._subscriberId ? command._subscriberId : command.subscriberId,
+      _subscriberId: command._subscriberId,
     });
 
-    return this.filterJobs(currentJob, command.transactionId, jobs);
+    return this.filterJobs(currentJob, currentJob.transactionId, jobs);
   }
 }

--- a/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events-regular.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events-regular.usecase.ts
@@ -1,47 +1,42 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Injectable } from '@nestjs/common';
 import { sub } from 'date-fns';
-import { IDigestRegularMetadata } from '@novu/shared';
-import { DigestFilterSteps, InstrumentUsecase } from '@novu/application-generic';
+import { InstrumentUsecase } from '@novu/application-generic';
 
-import { PlatformException } from '../../../../shared/utils';
-import { SendMessageCommand } from '../send-message.command';
+import { DigestEventsCommand } from './digest-events.command';
 import { GetDigestEvents } from './get-digest-events.usecase';
 
 @Injectable()
 export class GetDigestEventsRegular extends GetDigestEvents {
   @InstrumentUsecase()
-  public async execute(command: SendMessageCommand) {
-    const currentJob = await this.jobRepository.findOne({
-      _environmentId: command.environmentId,
-      _id: command.jobId,
-    });
-    if (!currentJob) throw new PlatformException('Digest job is not found');
+  public async execute(command: DigestEventsCommand) {
+    const currentJob = command.currentJob;
 
-    const digestMeta = currentJob.digest as IDigestRegularMetadata | undefined;
-    const amount =
-      typeof digestMeta?.amount === 'number'
+    const { digestKey, digestMeta, digestValue } = this.getJobDigest(currentJob);
+
+    const amount = digestMeta
+      ? typeof digestMeta.amount === 'number'
         ? digestMeta.amount
-        : // @ts-ignore
-          parseInt(digestMeta?.amount, 10);
-    const earliest = sub(new Date(currentJob.createdAt), {
-      // @ts-ignore
-      [digestMeta?.unit]: amount,
-    });
+        : parseInt(digestMeta.amount, 10)
+      : undefined;
 
-    const digestKey = digestMeta?.digestKey;
-    const digestValue = DigestFilterSteps.getNestedValue(currentJob.payload, digestKey);
+    const createdDate = new Date(currentJob.createdAt);
+    const subtractedTime = digestMeta
+      ? {
+          [digestMeta.unit]: amount,
+        }
+      : {};
+    const earliest = sub(new Date(currentJob.createdAt), subtractedTime);
 
     const jobs = await this.jobRepository.findJobsToDigest(
       earliest,
       currentJob._templateId,
-      command.environmentId,
-      // backward compatibility - ternary needed to be removed once the queue renewed
-      command._subscriberId ? command._subscriberId : command.subscriberId,
+      currentJob._environmentId,
+      command._subscriberId,
       digestKey,
       digestValue
     );
 
-    return this.filterJobs(currentJob, command.transactionId, jobs);
+    return this.filterJobs(currentJob, currentJob.transactionId, jobs);
   }
 }

--- a/packages/application-generic/src/usecases/digest-filter-steps/digest-filter-steps.usecase.ts
+++ b/packages/application-generic/src/usecases/digest-filter-steps/digest-filter-steps.usecase.ts
@@ -59,7 +59,10 @@ export class DigestFilterSteps {
     };
   }
 
-  public static getNestedValue<ObjectType>(payload: ObjectType, path?: string) {
+  public static getNestedValue<ObjectType>(
+    payload: ObjectType,
+    path?: string
+  ): ObjectType | undefined {
     if (!path || !payload) {
       return undefined;
     }


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Refactors the logic flow in getting the digest events for message of type digest.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
During the works to provide stability to the Digest feature performed by @scopsy and @davidsoderberg it was noticed that we needed improvements in the send message codebase.
I noticed in the Digest Events flow that unneeded calls to the database were made and we could avoid that with a simple refactor, besides reusing functionality for regular and backoff digest cases.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
This PR shouldn't conflict with https://github.com/novuhq/novu/pull/4158 but let's keep an eye in both and prioritise the linked one as it is more crucial for our needs.
