### PR TITLE
feat(api): create trigger event status enum

### DIFF
--- a/apps/api/src/app/events/dtos/trigger-event-response.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-response.dto.ts
@@ -1,4 +1,5 @@
 import { IsBoolean, IsDefined, IsString } from 'class-validator';
+import { TriggerEventStatusEnum } from '@novu/shared';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class TriggerEventResponseDto {
@@ -11,11 +12,10 @@ export class TriggerEventResponseDto {
 
   @ApiProperty({
     description: 'Status for trigger',
-    enum: ['processed', 'trigger_not_active', 'subscriber_id_missing', 'error'],
+    enum: TriggerEventStatusEnum,
   })
-  @IsString()
   @IsDefined()
-  status: string;
+  status: TriggerEventStatusEnum;
 
   @ApiProperty({
     description: 'In case of an error, this field will contain the error message',

--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -17,6 +17,7 @@ import {
   ITenantDefine,
   ReservedVariablesMap,
   TriggerContextTypeEnum,
+  TriggerEventStatusEnum,
   TriggerTenantContext,
 } from '@novu/shared';
 
@@ -73,21 +74,21 @@ export class ParseEventRequest {
     if (!template.active) {
       return {
         acknowledged: true,
-        status: 'trigger_not_active',
+        status: TriggerEventStatusEnum.NOT_ACTIVE,
       };
     }
 
     if (!template.steps?.length) {
       return {
         acknowledged: true,
-        status: 'no_workflow_steps_defined',
+        status: TriggerEventStatusEnum.NO_WORKFLOW_STEPS,
       };
     }
 
     if (!template.steps?.some((step) => step.active)) {
       return {
         acknowledged: true,
-        status: 'no_workflow_active_steps_defined',
+        status: TriggerEventStatusEnum.NO_WORKFLOW_ACTIVE_STEPS,
       };
     }
 
@@ -97,7 +98,7 @@ export class ParseEventRequest {
       } catch (e) {
         return {
           acknowledged: true,
-          status: 'no_tenant_found',
+          status: TriggerEventStatusEnum.TENANT_MISSING,
         };
       }
     }
@@ -135,8 +136,8 @@ export class ParseEventRequest {
 
     return {
       acknowledged: true,
-      status: 'processed',
-      transactionId: transactionId,
+      status: TriggerEventStatusEnum.PROCESSED,
+      transactionId,
     };
   }
 

--- a/apps/api/src/app/events/usecases/process-bulk-trigger/process-bulk-trigger.usecase.ts
+++ b/apps/api/src/app/events/usecases/process-bulk-trigger/process-bulk-trigger.usecase.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
+import { TriggerEventStatusEnum } from '@novu/shared';
+
 import { ProcessBulkTriggerCommand } from './process-bulk-trigger.command';
+
 import { TriggerEventResponseDto } from '../../dtos';
 import { MapTriggerRecipients } from '../map-trigger-recipients';
 import { ParseEventRequestCommand } from '../parse-event-request/parse-event-request.command';
@@ -40,9 +43,9 @@ export class ProcessBulkTrigger {
         }
 
         result = {
-          status: 'error',
-          error: error,
           acknowledged: true,
+          status: TriggerEventStatusEnum.ERROR,
+          error,
         };
       }
 

--- a/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.usecase.ts
+++ b/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.usecase.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import * as _ from 'lodash';
 import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
 import { TriggerEvent, TriggerEventCommand } from '@novu/application-generic';
+import { TriggerEventStatusEnum } from '@novu/shared';
 
 import { TriggerEventToAllCommand } from './trigger-event-to-all.command';
 
@@ -35,7 +36,7 @@ export class TriggerEventToAll {
 
     return {
       acknowledged: true,
-      status: 'processed',
+      status: TriggerEventStatusEnum.PROCESSED,
       transactionId: command.transactionId,
     };
   }

--- a/libs/shared/src/types/events/index.ts
+++ b/libs/shared/src/types/events/index.ts
@@ -1,6 +1,17 @@
 import { ChannelTypeEnum } from '../channel';
 import { TopicKey } from '../topic';
 
+export enum TriggerEventStatusEnum {
+  ERROR = 'error',
+  NOT_ACTIVE = 'trigger_not_active',
+  NO_WORKFLOW_ACTIVE_STEPS = 'no_workflow_active_steps_defined',
+  NO_WORKFLOW_STEPS = 'no_workflow_steps_defined',
+  PROCESSED = 'processed',
+  // TODO: Seems not used. Remove.
+  SUBSCRIBER_MISSING = 'subscriber_id_missing',
+  TENANT_MISSING = 'no_tenant_found',
+}
+
 export interface IAttachmentOptions {
   mime: string;
   file: Buffer;


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Creates an enum to gather all the potential status of the result of executing the trigger event endpoints.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
