### PR TITLE
chore: Replace deprecated command with environment file

### DIFF
--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -103,7 +103,7 @@ runs:
         docker run --network=host --name api -dit --env NODE_ENV=test ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
         docker run --network=host appropriate/curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:1337/v1/health-check | grep 'ok'
 
-        echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+        echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
     - name: Optionally tag docker image
       if: ${{ inputs.tag }}

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -106,7 +106,7 @@ runs:
         docker run --network=host --name worker -dit --env NODE_ENV=test ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
         docker run --network=host appropriate/curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:1342/v1/health-check | grep 'ok'
 
-        echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+        echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
     - name: Optionally tag docker image
       if: ${{ inputs.tag }}

--- a/.github/workflows/dev-deploy-embed.yml
+++ b/.github/workflows/dev-deploy-embed.yml
@@ -67,4 +67,4 @@ jobs:
           docker tag ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/dev-deploy-inbound-mail.yml
+++ b/.github/workflows/dev-deploy-inbound-mail.yml
@@ -79,7 +79,7 @@ jobs:
 
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout cloud infra
         uses: actions/checkout@master

--- a/.github/workflows/dev-deploy-web.yml
+++ b/.github/workflows/dev-deploy-web.yml
@@ -121,7 +121,7 @@ jobs:
             -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG \
             -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev \
             -f apps/web/Dockerfile .
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/dev-deploy-webhook.yml
+++ b/.github/workflows/dev-deploy-webhook.yml
@@ -55,7 +55,7 @@ jobs:
 
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout cloud infra
         uses: actions/checkout@master

--- a/.github/workflows/dev-deploy-widget.yml
+++ b/.github/workflows/dev-deploy-widget.yml
@@ -94,7 +94,7 @@ jobs:
           docker tag ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/dev-deploy-ws.yml
+++ b/.github/workflows/dev-deploy-ws.yml
@@ -103,7 +103,7 @@ jobs:
           docker tag ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Render Amazon ECS task definition
         id: render-container

--- a/.github/workflows/jarvis.yml
+++ b/.github/workflows/jarvis.yml
@@ -18,7 +18,7 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}" 
-          echo "::set-output name=body::$body"
+          echo "body=$body" >> $GITHUB_OUTPUT
       - name: Add comment
         uses: peter-evans/create-or-update-comment@v2
         with:

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -122,7 +122,7 @@ jobs:
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deploy_prod_api_eu:
     needs: build_prod_image

--- a/.github/workflows/prod-deploy-embed.yml
+++ b/.github/workflows/prod-deploy-embed.yml
@@ -118,4 +118,4 @@ jobs:
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -70,7 +70,7 @@ jobs:
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deploy_prod_inbound_mail_eu:
     needs:

--- a/.github/workflows/prod-deploy-web.yml
+++ b/.github/workflows/prod-deploy-web.yml
@@ -217,4 +217,4 @@ jobs:
             -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod \
             -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest \
             -f apps/web/Dockerfile .
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/prod-deploy-webhook.yml
+++ b/.github/workflows/prod-deploy-webhook.yml
@@ -48,7 +48,7 @@ jobs:
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deploy_prod_webhook_eu:
     needs:

--- a/.github/workflows/prod-deploy-widget.yml
+++ b/.github/workflows/prod-deploy-widget.yml
@@ -157,4 +157,4 @@ jobs:
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -81,7 +81,7 @@ jobs:
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deploy_prod_worker_eu:
     needs: build_prod_image

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -59,7 +59,7 @@ jobs:
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deploy_prod_ws_eu:
     needs:

--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -40,9 +40,9 @@ jobs:
       - id: setup
         run: |
           if ! [[ -z "${{ secrets.SUBMODULES_TOKEN }}" ]]; then
-            echo ::set-output has_token=true
+            echo "has_token=true" >> $GITHUB_OUTPUT
           else
-            echo ::set-output has_token=false
+            echo "has_token=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/checkout@v3
       # checkout with submodules if token is provided

--- a/.github/workflows/reusable-web-e2e.yml
+++ b/.github/workflows/reusable-web-e2e.yml
@@ -45,9 +45,9 @@ jobs:
       - id: setup
         run: |
           if ! [[ -z "${{ secrets.SUBMODULES_TOKEN }}" ]]; then
-            echo ::set-output has_token=true
+            echo "has_token=true" >> $GITHUB_OUTPUT
           else
-            echo ::set-output has_token=false
+            echo "has_token=false" >> $GITHUB_OUTPUT
           fi
 
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable-widget-e2e.yml
+++ b/.github/workflows/reusable-widget-e2e.yml
@@ -45,9 +45,9 @@ jobs:
       - id: setup
         run: |
           if ! [[ -z "${{ secrets.SUBMODULES_TOKEN }}" ]]; then
-            echo ::set-output has_token=true
+            echo "has_token=true" >> $GITHUB_OUTPUT
           else
-            echo ::set-output has_token=false
+            echo "has_token=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/checkout@v3
       # checkout with submodules if token is provided

--- a/.github/workflows/reusable-worker-e2e.yml
+++ b/.github/workflows/reusable-worker-e2e.yml
@@ -40,9 +40,9 @@ jobs:
     - id: setup
       run: |
         if ! [[ -z "${{ secrets.SUBMODULES_TOKEN }}" ]]; then
-           echo ::set-output has_token=true
+           echo "has_token=true" >> $GITHUB_OUTPUT
         else
-           echo ::set-output has_token=false
+           echo "has_token=false" >> $GITHUB_OUTPUT
         fi
     - uses: actions/checkout@v3
     # checkout with submodules if token is provided

--- a/.github/workflows/reusable-ws-e2e.yml
+++ b/.github/workflows/reusable-ws-e2e.yml
@@ -39,9 +39,9 @@ jobs:
       - id: setup
         run: |
           if ! [[ -z "${{ secrets.SUBMODULES_TOKEN }}" ]]; then
-             echo ::set-output has_token=true
+             echo "has_token=true" >> $GITHUB_OUTPUT
           else
-             echo ::set-output has_token=false
+             echo "has_token=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/checkout@v3
       # checkout with submodules if token is provided

--- a/.github/workflows/staging-deploy-web.yml
+++ b/.github/workflows/staging-deploy-web.yml
@@ -120,7 +120,7 @@ jobs:
             -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG \
             -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev \
             -f apps/web/Dockerfile .
-          echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
+          echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,9 @@ jobs:
         id: get-base-branch-name
         run: |
           if [[ "${{github.event.pull_request.base.ref}}" != "" ]]; then
-            echo "::set-output name=branch::${{github.event.pull_request.base.ref}}"
+            echo "branch=${{github.event.pull_request.base.ref}}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=branch::main"
+            echo "branch=main" >> $GITHUB_OUTPUT
           fi
       - uses: actions/checkout@v3
         with:
@@ -72,22 +72,22 @@ jobs:
         run: |
           if [[ "${{github.event.pull_request.base.ref}}" == "" && "${{steps.branch-name.outputs.current_branch}}" == "main" ]]; then
             echo "Running ALL"
-            echo "::set-output name=test-unit::$(pnpm run get-affected test:unit --all | tail -n +5)"
-            echo "::set-output name=test-e2e::$(pnpm run get-affected test:e2e --all | tail -n +5)"
-            echo "::set-output name=test-e2e-ee::$(pnpm run get-affected test:e2e:ee --all | tail -n +5)"
-            echo "::set-output name=test-cypress::$(pnpm run get-affected cypress:run --all | tail -n +5)"
-            echo "::set-output name=test-providers::$(pnpm run get-affected test --all providers | tail -n +5)"
-            echo "::set-output name=test-packages::$(pnpm run get-affected test --all packages | tail -n +5)"
-            echo "::set-output name=test-libs::$(pnpm run get-affected test --all libs | tail -n +5)"
+            echo "test-unit=$(pnpm run get-affected test:unit --all | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-e2e=$(pnpm run get-affected test:e2e --all | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-e2e-ee=$(pnpm run get-affected test:e2e:ee --all | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-cypress=$(pnpm run get-affected cypress:run --all | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-providers=$(pnpm run get-affected test --all providers | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-packages=$(pnpm run get-affected test --all packages | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-libs=$(pnpm run get-affected test --all libs | tail -n +5)" >> $GITHUB_OUTPUT
           else
             echo "Running PR origin/${{steps.get-base-branch-name.outputs.branch}}"
-            echo "::set-output name=test-unit::$(pnpm run get-affected test origin/${{steps.get-base-branch-name.outputs.branch}} | tail -n +5)"
-            echo "::set-output name=test-e2e::$(pnpm run get-affected test:e2e origin/${{steps.get-base-branch-name.outputs.branch}} | tail -n +5)"
-            echo "::set-output name=test-e2e-ee::$(pnpm run get-affected test:e2e:ee origin/${{steps.get-base-branch-name.outputs.branch}} | tail -n +5)"
-            echo "::set-output name=test-cypress::$(pnpm run get-affected cypress:run origin/${{steps.get-base-branch-name.outputs.branch}} | tail -n +5)"
-            echo "::set-output name=test-providers::$(pnpm run get-affected test origin/${{steps.get-base-branch-name.outputs.branch}} providers | tail -n +5)"
-            echo "::set-output name=test-packages::$(pnpm run get-affected test origin/${{steps.get-base-branch-name.outputs.branch}} packages | tail -n +5)"
-            echo "::set-output name=test-libs::$(pnpm run get-affected test origin/${{steps.get-base-branch-name.outputs.branch}} libs | tail -n +5)"
+            echo "test-unit=$(pnpm run get-affected test origin/${{steps.get-base-branch-name.outputs.branch}} | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-e2e=$(pnpm run get-affected test:e2e origin/${{steps.get-base-branch-name.outputs.branch}} | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-e2e-ee=$(pnpm run get-affected test:e2e:ee origin/${{steps.get-base-branch-name.outputs.branch}} | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-cypress=$(pnpm run get-affected cypress:run origin/${{steps.get-base-branch-name.outputs.branch}} | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-providers=$(pnpm run get-affected test origin/${{steps.get-base-branch-name.outputs.branch}} providers | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-packages=$(pnpm run get-affected test origin/${{steps.get-base-branch-name.outputs.branch}} packages | tail -n +5)" >> $GITHUB_OUTPUT
+            echo "test-libs=$(pnpm run get-affected test origin/${{steps.get-base-branch-name.outputs.branch}} libs | tail -n +5)" >> $GITHUB_OUTPUT
           fi
 
   test_web:


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=IMAGE::ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG"
```

**TO-BE**

```yaml
echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
```

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

Closes #4207 

### Other information (Screenshots)

None
<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
