### PR TITLE
feat(ws): add old instance worker for web sockets jobs

### DIFF
--- a/apps/ws/src/socket/services/index.ts
+++ b/apps/ws/src/socket/services/index.ts
@@ -1,1 +1,3 @@
+export { OldInstanceWebSocketsWorker } from './old-instance-web-sockets.worker';
+export { OldInstanceWebSocketsWorkerService } from './old-instance-web-sockets-worker.service';
 export { WebSocketWorker } from './web-socket.worker';

--- a/apps/ws/src/socket/services/old-instance-web-sockets-worker.service.ts
+++ b/apps/ws/src/socket/services/old-instance-web-sockets-worker.service.ts
@@ -1,0 +1,91 @@
+import { IJobData, JobTopicNameEnum } from '@novu/shared';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { JobsOptions, OldInstanceBullMqService, Processor, Worker, WorkerOptions } from '@novu/application-generic';
+
+const LOG_CONTEXT = 'OldInstanceWebSocketsWorkerService';
+
+type WorkerProcessor = string | Processor<any, unknown, string> | undefined;
+
+/**
+ * TODO: Temporary for migration to MemoryDB
+ */
+export class OldInstanceWebSocketsWorkerService {
+  private instance: OldInstanceBullMqService;
+
+  public readonly DEFAULT_ATTEMPTS = 3;
+  public readonly topic: JobTopicNameEnum;
+
+  constructor() {
+    this.topic = JobTopicNameEnum.WEB_SOCKETS;
+    this.instance = new OldInstanceBullMqService();
+    if (this.instance.enabled) {
+      Logger.log(`Old instance Worker ${this.topic} instantiated`, LOG_CONTEXT);
+    } else {
+      Logger.warn(
+        `Old instance web sockets worker not instantiated as it is only needed for MemoryDB migration`,
+        LOG_CONTEXT
+      );
+    }
+  }
+
+  public get bullMqService(): OldInstanceBullMqService {
+    return this.instance;
+  }
+
+  public get worker(): Worker {
+    return this.instance.worker;
+  }
+
+  public initWorker(processor: WorkerProcessor, options?: WorkerOptions): void {
+    if (this.instance.enabled) {
+      this.createWorker(processor, options);
+    }
+  }
+
+  public createWorker(processor: WorkerProcessor, options?: WorkerOptions): void {
+    if (this.instance.enabled) {
+      this.instance.createWorker(this.topic, processor, options);
+    } else {
+      Logger.log(
+        { enabled: this.instance.enabled },
+        'We are not running OldInstanceWorkflowWorkerService as it is not needed in this environment',
+        LOG_CONTEXT
+      );
+    }
+  }
+
+  public async isRunning(): Promise<boolean> {
+    return await this.instance.isWorkerRunning();
+  }
+
+  public async isPaused(): Promise<boolean> {
+    return await this.instance.isWorkerPaused();
+  }
+
+  public async pause(): Promise<void> {
+    if (this.instance.enabled && this.worker) {
+      await this.instance.pauseWorker();
+    }
+  }
+
+  public async resume(): Promise<void> {
+    if (this.instance.enabled && this.worker) {
+      await this.instance.resumeWorker();
+    }
+  }
+
+  public async gracefulShutdown(): Promise<void> {
+    if (this.instance.enabled) {
+      Logger.log('Shutting the old web sockets Worker service down', LOG_CONTEXT);
+
+      await this.instance.gracefulShutdown();
+
+      Logger.log('Shutting down the old web sockets Worker service has finished', LOG_CONTEXT);
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.gracefulShutdown();
+  }
+}

--- a/apps/ws/src/socket/services/old-instance-web-sockets.worker.ts
+++ b/apps/ws/src/socket/services/old-instance-web-sockets.worker.ts
@@ -5,11 +5,12 @@ import { INovuWorker, WebSocketsWorkerService } from '@novu/application-generic'
 
 import { ExternalServicesRoute, ExternalServicesRouteCommand } from '../usecases/external-services-route';
 import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
+import { OldInstanceWebSocketsWorkerService } from './old-instance-web-sockets-worker.service';
 
-const LOG_CONTEXT = 'WebSocketWorker';
+const LOG_CONTEXT = 'OldInstanceWebSocketsWorker';
 
 @Injectable()
-export class WebSocketWorker extends WebSocketsWorkerService implements INovuWorker {
+export class OldInstanceWebSocketsWorker extends OldInstanceWebSocketsWorkerService implements INovuWorker {
   constructor(private externalServicesRoute: ExternalServicesRoute) {
     super();
 
@@ -23,7 +24,7 @@ export class WebSocketWorker extends WebSocketsWorkerService implements INovuWor
         const _this = this;
 
         Logger.verbose(
-          `Job ${job.id} / ${job.data.event} is being processed in the MemoryDB instance WebSocketWorker`,
+          `Job ${job.id} / ${job.data.event} is being processed in the old instance web sockets worker`,
           LOG_CONTEXT
         );
 

--- a/apps/ws/src/socket/socket.module.ts
+++ b/apps/ws/src/socket/socket.module.ts
@@ -6,11 +6,17 @@ import { WSGateway } from './ws.gateway';
 import { SharedModule } from '../shared/shared.module';
 import { ExternalServicesRoute } from './usecases/external-services-route';
 
-import { WebSocketWorker } from './services';
+import { OldInstanceWebSocketsWorker, OldInstanceWebSocketsWorkerService, WebSocketWorker } from './services';
 
 const USE_CASES: Provider[] = [ExternalServicesRoute];
 
-const PROVIDERS: Provider[] = [WSGateway, WebSocketsWorkerService, WebSocketWorker];
+const PROVIDERS: Provider[] = [
+  WSGateway,
+  OldInstanceWebSocketsWorker,
+  OldInstanceWebSocketsWorkerService,
+  WebSocketsWorkerService,
+  WebSocketWorker,
+];
 
 @Module({
   imports: [SharedModule],

--- a/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.ts
+++ b/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.ts
@@ -252,13 +252,6 @@ export class InMemoryProviderService {
 
     const { getClient, getConfig, isClientReady } = getClientAndConfig();
 
-    console.log(
-      getClient(),
-      getConfig(),
-      isClientReady(this.provider),
-      LOG_CONTEXT
-    );
-
     this.isProviderClientReady = isClientReady;
     this.inMemoryProviderConfig = getConfig();
     const { host, port, ttl } = getConfig();

--- a/packages/application-generic/src/services/index.ts
+++ b/packages/application-generic/src/services/index.ts
@@ -16,6 +16,7 @@ export {
   BullMqService,
   Job,
   JobsOptions,
+  Processor,
   Queue,
   QueueBaseOptions,
   QueueOptions,


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Adds Worker for pulling jobs from old instance during transition to MemoryDB to not have old jobs unprocessed.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
