### PR TITLE
feat(worker): add trigger-handler queue worker for old instance redis

### DIFF
--- a/apps/worker/src/app/workflow/services/cold-start.service.ts
+++ b/apps/worker/src/app/workflow/services/cold-start.service.ts
@@ -4,6 +4,7 @@ import { INovuWorker, ReadinessService } from '@novu/application-generic';
 import { StandardWorker } from './standard.worker';
 import { WorkflowWorker } from './workflow.worker';
 import { OldInstanceStandardWorker } from './old-instance-standard.worker';
+import { OldInstanceWorkflowWorker } from './old-instance-workflow.worker';
 
 /**
  * TODO: Temporary engage OldInstanceWorkflowWorker while migrating to MemoryDB
@@ -12,8 +13,9 @@ const getWorkers = (app: INestApplication): INovuWorker[] => {
   const standardWorker = app.get(StandardWorker, { strict: false });
   const workflowWorker = app.get(WorkflowWorker, { strict: false });
   const oldInstanceStandardWorker = app.get(OldInstanceStandardWorker, { strict: false });
+  const oldInstanceWorkflowWorker = app.get(OldInstanceWorkflowWorker, { strict: false });
 
-  const workers: INovuWorker[] = [standardWorker, workflowWorker, oldInstanceStandardWorker];
+  const workers: INovuWorker[] = [standardWorker, workflowWorker, oldInstanceStandardWorker, oldInstanceWorkflowWorker];
 
   return workers;
 };

--- a/apps/worker/src/app/workflow/services/index.ts
+++ b/apps/worker/src/app/workflow/services/index.ts
@@ -2,3 +2,4 @@ export * from './job-metric.service';
 export * from './standard.worker';
 export * from './workflow.worker';
 export * from './old-instance-standard.worker';
+export * from './old-instance-workflow.worker';

--- a/apps/worker/src/app/workflow/services/old-instance-standard.worker.ts
+++ b/apps/worker/src/app/workflow/services/old-instance-standard.worker.ts
@@ -24,7 +24,7 @@ import {
   HandleLastFailedJob,
 } from '../usecases';
 
-const LOG_CONTEXT = 'OldInstanceWorkflowWorker';
+const LOG_CONTEXT = 'OldInstanceStandardWorker';
 
 /**
  * TODO: Temporary for migration to MemoryDB
@@ -94,6 +94,8 @@ export class OldInstanceStandardWorker extends OldInstanceStandardWorkerService 
   private getWorkerProcessor() {
     return async ({ data }: { data: IJobData | any }) => {
       const minimalJobData = this.extractMinimalJobData(data);
+
+      Logger.verbose(`Job ${minimalJobData.jobId} is being processed in the old instance standard worker`, LOG_CONTEXT);
 
       return await new Promise(async (resolve, reject) => {
         // eslint-disable-next-line @typescript-eslint/no-this-alias

--- a/apps/worker/src/app/workflow/services/old-instance-workflow.worker.ts
+++ b/apps/worker/src/app/workflow/services/old-instance-workflow.worker.ts
@@ -1,0 +1,64 @@
+const nr = require('newrelic');
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import { IJobData, ObservabilityBackgroundTransactionEnum } from '@novu/shared';
+import {
+  INovuWorker,
+  Job,
+  OldInstanceBullMqService,
+  PinoLogger,
+  storage,
+  Store,
+  OldInstanceWorkflowWorkerService,
+  TriggerEvent,
+  WorkerOptions,
+} from '@novu/application-generic';
+
+const LOG_CONTEXT = 'OldInstanceWorkflowWorker';
+
+/**
+ * TODO: Temporary for migration to MemoryDB
+ */
+@Injectable()
+export class OldInstanceWorkflowWorker extends OldInstanceWorkflowWorkerService implements INovuWorker {
+  constructor(private triggerEventUsecase: TriggerEvent) {
+    super();
+
+    this.initWorker(this.getWorkerProcessor(), this.getWorkerOptions());
+  }
+
+  private getWorkerOptions(): WorkerOptions {
+    return {
+      lockDuration: 90000,
+      concurrency: 200,
+    };
+  }
+
+  private getWorkerProcessor() {
+    return async ({ data }: { data: IJobData | any }) => {
+      return await new Promise(async (resolve, reject) => {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const _this = this;
+
+        Logger.verbose(`Job ${data.id} is being processed in the old instance workflow worker`, LOG_CONTEXT);
+
+        nr.startBackgroundTransaction(
+          ObservabilityBackgroundTransactionEnum.TRIGGER_HANDLER_QUEUE,
+          'Trigger Engine',
+          function () {
+            const transaction = nr.getTransaction();
+
+            storage.run(new Store(PinoLogger.root), () => {
+              _this.triggerEventUsecase
+                .execute(data)
+                .then(resolve)
+                .catch(reject)
+                .finally(() => {
+                  transaction.end();
+                });
+            });
+          }
+        );
+      });
+    };
+  }
+}

--- a/apps/worker/src/app/workflow/workflow.module.ts
+++ b/apps/worker/src/app/workflow/workflow.module.ts
@@ -29,7 +29,13 @@ import {
 } from '@novu/application-generic';
 import { JobRepository, MessageRepository, OrganizationRepository, SubscriberRepository } from '@novu/dal';
 
-import { JobMetricService, StandardWorker, WorkflowWorker, OldInstanceStandardWorker } from './services';
+import {
+  JobMetricService,
+  StandardWorker,
+  WorkflowWorker,
+  OldInstanceStandardWorker,
+  OldInstanceWorkflowWorker,
+} from './services';
 import {
   MessageMatcher,
   SendMessage,
@@ -103,6 +109,7 @@ const PROVIDERS: Provider[] = [
   WorkflowWorker,
   OldInstanceBullMqService,
   OldInstanceStandardWorker,
+  OldInstanceWorkflowWorker,
 ];
 
 @Module({

--- a/packages/application-generic/src/modules/queues.module.ts
+++ b/packages/application-generic/src/modules/queues.module.ts
@@ -25,6 +25,7 @@ import {
   WebSocketsWorkerService,
   WorkflowWorkerService,
   OldInstanceStandardWorkerService,
+  OldInstanceWorkflowWorkerService,
 } from '../services/workers';
 
 const PROVIDERS: Provider[] = [
@@ -44,6 +45,7 @@ const PROVIDERS: Provider[] = [
   WorkflowQueueServiceHealthIndicator,
   WorkflowWorkerService,
   OldInstanceStandardWorkerService,
+  OldInstanceWorkflowWorkerService,
   OldInstanceBullMqService,
 ];
 

--- a/packages/application-generic/src/services/workers/index.ts
+++ b/packages/application-generic/src/services/workers/index.ts
@@ -10,6 +10,7 @@ import { StandardWorkerService } from './standard-worker.service';
 import { WebSocketsWorkerService } from './web-sockets-worker.service';
 import { WorkflowWorkerService } from './workflow-worker.service';
 import { OldInstanceStandardWorkerService } from './old-instance-standard-worker.service';
+import { OldInstanceWorkflowWorkerService } from './old-instance-workflow-worker.service';
 
 export {
   InboundParseWorkerService as InboundParseWorker,
@@ -21,4 +22,5 @@ export {
   WorkerProcessor,
   WorkflowWorkerService,
   OldInstanceStandardWorkerService,
+  OldInstanceWorkflowWorkerService,
 };

--- a/packages/application-generic/src/services/workers/old-instance-workflow-worker.service.ts
+++ b/packages/application-generic/src/services/workers/old-instance-workflow-worker.service.ts
@@ -1,0 +1,106 @@
+import { IJobData, JobTopicNameEnum } from '@novu/shared';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import {
+  JobsOptions,
+  OldInstanceBullMqService,
+  Processor,
+  Worker,
+  WorkerOptions,
+} from '../bull-mq';
+
+const LOG_CONTEXT = 'OldInstanceWorkflowWorkerService';
+
+type WorkerProcessor = string | Processor<any, unknown, string> | undefined;
+
+/**
+ * TODO: Temporary for migration to MemoryDB
+ */
+export class OldInstanceWorkflowWorkerService {
+  private instance: OldInstanceBullMqService;
+
+  public readonly DEFAULT_ATTEMPTS = 3;
+  public readonly topic: JobTopicNameEnum;
+
+  constructor() {
+    this.topic = JobTopicNameEnum.WORKFLOW;
+    this.instance = new OldInstanceBullMqService();
+    if (this.instance.enabled) {
+      Logger.log(`Worker ${this.topic} instantiated`, LOG_CONTEXT);
+    } else {
+      Logger.warn(
+        `Old instance workflow worker not instantiated as it is only needed for MemoryDB migration`,
+        LOG_CONTEXT
+      );
+    }
+  }
+
+  public get bullMqService(): OldInstanceBullMqService {
+    return this.instance;
+  }
+
+  public get worker(): Worker {
+    return this.instance.worker;
+  }
+
+  public initWorker(processor: WorkerProcessor, options?: WorkerOptions): void {
+    if (this.instance.enabled) {
+      this.createWorker(processor, options);
+    }
+  }
+
+  public createWorker(
+    processor: WorkerProcessor,
+    options: WorkerOptions
+  ): void {
+    if (this.instance.enabled) {
+      this.instance.createWorker(this.topic, processor, options);
+    } else {
+      Logger.log(
+        { enabled: this.instance.enabled },
+        'We are not running OldInstanceWorkflowWorkerService as it is not needed in this environment',
+        LOG_CONTEXT
+      );
+    }
+  }
+
+  public async isRunning(): Promise<boolean> {
+    return await this.instance.isWorkerRunning();
+  }
+
+  public async isPaused(): Promise<boolean> {
+    return await this.instance.isWorkerPaused();
+  }
+
+  public async pause(): Promise<void> {
+    if (this.instance.enabled && this.worker) {
+      await this.instance.pauseWorker();
+    }
+  }
+
+  public async resume(): Promise<void> {
+    if (this.instance.enabled && this.worker) {
+      await this.instance.resumeWorker();
+    }
+  }
+
+  public async gracefulShutdown(): Promise<void> {
+    if (this.instance.enabled) {
+      Logger.log(
+        'Shutting the old instance workflow worker service down',
+        LOG_CONTEXT
+      );
+
+      await this.instance.gracefulShutdown();
+
+      Logger.log(
+        'Shutting down the old instance workflow worker service has finished',
+        LOG_CONTEXT
+      );
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.gracefulShutdown();
+  }
+}


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Adds a worker connected to the old instance that will process the jobs in the Trigger handler queue so while we deploy the MemoryDB migration as not all the apps are deployed at the same time, if there are ongoing triggered notifications those can be processed by rerouting them to the new MemoryDB instance while the API app is not fully deployed with the new version that directly routes the triggered events to store the jobs and add them to the trigger handler queue located in MemoryDB.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
