### PR TITLE
NV-2696 - allow variables in Sender Name field in email editor

### DIFF
--- a/apps/api/src/app/events/dtos/test-email-request.dto.ts
+++ b/apps/api/src/app/events/dtos/test-email-request.dto.ts
@@ -17,6 +17,10 @@ export class TestSendEmailRequestDto {
   @IsString()
   preheader?: string;
 
+  @IsOptional()
+  @IsString()
+  senderName?: string;
+
   @IsDefined()
   content: string | IEmailBlock[];
 

--- a/apps/api/src/app/events/events.controller.ts
+++ b/apps/api/src/app/events/events.controller.ts
@@ -148,6 +148,7 @@ export class EventsController {
         contentType: body.contentType,
         content: body.content,
         preheader: body.preheader,
+        senderName: body.senderName,
         layoutId: body.layoutId,
         to: body.to,
         userId: user._id,

--- a/apps/api/src/app/shared/helpers/content.service.ts
+++ b/apps/api/src/app/shared/helpers/content.service.ts
@@ -149,6 +149,8 @@ export class ContentService {
         yield message.template.title as string;
       } else if (Array.isArray(message.template?.content)) {
         yield message.template.subject || '';
+        yield message.template.senderName || '';
+        yield message.template.preheader || '';
 
         for (const block of message.template.content) {
           yield block.url || '';

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -150,11 +150,13 @@ export class SendMessageEmail extends SendMessageBase {
     let html;
     let subject = '';
     let content;
+    let senderName = overrides?.senderName || emailChannel.template.senderName;
 
     const payload = {
       subject: emailChannel.template.subject || '',
       preheader: emailChannel.template.preheader,
       content: emailChannel.template.content,
+      senderName: senderName,
       layoutId: overrideLayoutId ?? emailChannel.template._layoutId,
       contentType: emailChannel.template.contentType ? emailChannel.template.contentType : 'editor',
       payload: {
@@ -204,7 +206,7 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     try {
-      ({ html, content, subject } = await this.compileEmailTemplateUsecase.execute(
+      ({ html, content, subject, senderName } = await this.compileEmailTemplateUsecase.execute(
         CompileEmailTemplateCommand.create({
           environmentId: command.environmentId,
           organizationId: command.organizationId,
@@ -289,13 +291,7 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     if (email && integration) {
-      await this.sendMessage(
-        integration,
-        mailData,
-        message,
-        command,
-        overrides?.senderName || emailChannel.template.senderName
-      );
+      await this.sendMessage(integration, mailData, message, command, senderName);
 
       return;
     }

--- a/packages/application-generic/src/usecases/compile-email-template/compile-email-template.command.ts
+++ b/packages/application-generic/src/usecases/compile-email-template/compile-email-template.command.ts
@@ -24,4 +24,8 @@ export class CompileEmailTemplateCommand extends EnvironmentWithUserCommand {
   @IsString()
   @IsOptional()
   preheader?: string | null;
+
+  @IsString()
+  @IsOptional()
+  senderName?: string | null;
 }

--- a/packages/application-generic/src/usecases/compile-email-template/compile-email-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-email-template/compile-email-template.usecase.ts
@@ -64,6 +64,7 @@ export class CompileEmailTemplate {
     let subject = '';
     const content: string | IEmailBlock[] = command.content;
     let preheader = command.preheader;
+    let senderName = command.senderName ?? '';
 
     command.payload = merge({}, defaultPayload, command.payload);
 
@@ -83,6 +84,10 @@ export class CompileEmailTemplate {
       if (preheader) {
         preheader = await this.renderContent(preheader, payload);
       }
+
+      if (senderName) {
+        senderName = await this.renderContent(senderName, payload);
+      }
     } catch (e: any) {
       throw new ApiException(
         e?.message || `Message content could not be generated`
@@ -97,6 +102,7 @@ export class CompileEmailTemplate {
       ...payload,
       subject,
       preheader,
+      senderName,
       body: '',
       blocks: isEditorMode ? content : [],
     };
@@ -128,7 +134,7 @@ export class CompileEmailTemplate {
         )
       : body;
 
-    return { html, content, subject };
+    return { html, content, subject, senderName };
   }
 
   private async renderContent(

--- a/packages/application-generic/src/usecases/send-test-email/send-test-email.usecase.ts
+++ b/packages/application-generic/src/usecases/send-test-email/send-test-email.usecase.ts
@@ -67,21 +67,22 @@ export class SendTestEmail {
       });
     }
 
-    const { html, subject } = await this.compileEmailTemplateUsecase.execute(
-      CompileEmailTemplateCommand.create({
-        ...command,
-        payload: {
-          ...command.payload,
-          step: {
-            digest: true,
-            events: [],
-            total_count: 1,
-            ...this.getSystemVariables('step', command),
+    const { html, subject, senderName } =
+      await this.compileEmailTemplateUsecase.execute(
+        CompileEmailTemplateCommand.create({
+          ...command,
+          payload: {
+            ...command.payload,
+            step: {
+              digest: true,
+              events: [],
+              total_count: 1,
+              ...this.getSystemVariables('step', command),
+            },
+            subscriber: this.getSystemVariables('subscriber', command),
           },
-          subscriber: this.getSystemVariables('subscriber', command),
-        },
-      })
-    );
+        })
+      );
 
     if (email && integration) {
       const mailData: IEmailOptions = {
@@ -89,6 +90,7 @@ export class SendTestEmail {
         subject,
         html: html as string,
         from:
+          senderName ||
           command.payload.$sender_email ||
           integration?.credentials.from ||
           'no-reply@novu.co',


### PR DESCRIPTION
### What change does this PR introduce?
Fix Variable Not working on sender name field in email template while triggering workflow.

### Why was this change needed?
 Closes : https://github.com/novuhq/novu/issues/3958
 
### Other Information
#### Reference video
https://www.loom.com/share/e7d9a28310934b72a1c6485cfa410ced?sid=61ad4a4a-b910-4d3a-b529-30bef37e05dd
![image](https://github.com/GitStartHQ/client-novu/assets/58044533/8da34e64-4110-40bc-933c-470f8bf642cd)

#### After Changes 
![image](https://github.com/GitStartHQ/client-novu/assets/58044533/3badf3d7-47f1-4000-96cd-fd0a01676e35)
![image](https://github.com/GitStartHQ/client-novu/assets/58044533/43a5f30e-ed84-4bdf-9773-f22d70cd538d)
![image](https://github.com/GitStartHQ/client-novu/assets/58044533/5f1b2558-8abe-4644-ba0f-f08979bbc15f)


![image](https://github.com/GitStartHQ/client-novu/assets/58044533/1063152d-5c9f-4bb5-8b85-2438771e99ac)

![image](https://github.com/GitStartHQ/client-novu/assets/58044533/8a66c2da-3fb6-46b3-af85-0f19593c8252)
![Screenshot from 2023-09-25 21-01-30](https://github.com/GitStartHQ/client-novu/assets/58044533/4bb69b91-808a-4d6d-94ec-2b0959d82718)
![image](https://github.com/GitStartHQ/client-novu/assets/58044533/bd269c9f-6b44-4ec2-a804-89d5da14a91e)



---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
