### PR TITLE
Feature/implement hidden button

### DIFF
--- a/apps/web/src/design-system/input/Input.tsx
+++ b/apps/web/src/design-system/input/Input.tsx
@@ -14,6 +14,7 @@ interface IInputProps extends SpacingProps {
   description?: string;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   rightSection?: React.ReactNode;
+  rightSectionWidth?: React.CSSProperties['width'];
   type?: 'text' | 'password' | 'email' | 'search' | 'tel' | 'url' | 'number' | 'time';
   min?: string | number;
   max?: string | number;
@@ -26,13 +27,25 @@ interface IInputProps extends SpacingProps {
  *
  */
 export const Input = React.forwardRef<HTMLInputElement, IInputProps>(
-  ({ value, rightSection, onChange, readOnly = false, disabled = false, type, ...props }: IInputProps, ref) => {
+  (
+    {
+      value,
+      rightSection,
+      rightSectionWidth,
+      onChange,
+      readOnly = false,
+      disabled = false,
+      type,
+      ...props
+    }: IInputProps,
+    ref
+  ) => {
     const defaultDesign = { radius: 'md', size: 'md', styles: inputStyles, type: 'text' } as TextInputProps;
 
     return (
       <MantineTextInput
         ref={ref}
-        {...(rightSection ? { rightSection, rightSectionWidth: 50 } : {})}
+        {...(rightSection ? { rightSection, rightSectionWidth: rightSectionWidth ?? 50 } : {})}
         {...defaultDesign}
         onChange={onChange}
         autoComplete="off"

--- a/apps/web/src/pages/settings/tabs/ApiKeysCard.tsx
+++ b/apps/web/src/pages/settings/tabs/ApiKeysCard.tsx
@@ -9,7 +9,6 @@ import { getApiKeys } from '../../../api/environment';
 import { inputStyles } from '../../../design-system/config/inputs.styles';
 import { useEnvController } from '../../../hooks';
 import { Regenerate } from './components/Regenerate';
-import { useMantineTheme } from '@mantine/core';
 import { When } from '../../../components/utils/When';
 import { EyeInvisibleOutlined, EyeOutlined } from '@ant-design/icons';
 import { useState } from 'react';
@@ -26,7 +25,6 @@ export const ApiKeysCard = () => {
   const environmentIdentifier = environment?.identifier ? environment.identifier : '';
   const environmentId = environment?._id ? environment._id : '';
 
-  const { colorScheme } = useMantineTheme();
   const [hidden, setHidden] = useState(true);
 
   return (

--- a/apps/web/src/pages/settings/tabs/ApiKeysCard.tsx
+++ b/apps/web/src/pages/settings/tabs/ApiKeysCard.tsx
@@ -40,7 +40,7 @@ export const ApiKeysCard = () => {
           <Input
             readOnly
             type={hidden ? 'password' : 'text'}
-            rightSectionWidth={70}
+            rightSectionWidth={78}
             rightSection={
               <>
                 <ActionIcon variant="transparent" onClick={() => setHidden(!hidden)}>

--- a/apps/web/src/pages/settings/tabs/ApiKeysCard.tsx
+++ b/apps/web/src/pages/settings/tabs/ApiKeysCard.tsx
@@ -3,12 +3,16 @@ import { useClipboard } from '@mantine/hooks';
 import { useQuery } from '@tanstack/react-query';
 import styled from '@emotion/styled';
 
-import { Input, Tooltip } from '../../../design-system';
+import { Input, Tooltip, colors } from '../../../design-system';
 import { Check, Copy } from '../../../design-system/icons';
 import { getApiKeys } from '../../../api/environment';
 import { inputStyles } from '../../../design-system/config/inputs.styles';
 import { useEnvController } from '../../../hooks';
 import { Regenerate } from './components/Regenerate';
+import { useMantineTheme } from '@mantine/core';
+import { When } from '../../../components/utils/When';
+import { EyeInvisibleOutlined, EyeOutlined } from '@ant-design/icons';
+import { useState } from 'react';
 
 export const ApiKeysCard = () => {
   const clipboardApiKey = useClipboard({ timeout: 1000 });
@@ -22,6 +26,9 @@ export const ApiKeysCard = () => {
   const environmentIdentifier = environment?.identifier ? environment.identifier : '';
   const environmentId = environment?._id ? environment._id : '';
 
+  const { colorScheme } = useMantineTheme();
+  const [hidden, setHidden] = useState(true);
+
   return (
     <>
       <ParamContainer>
@@ -32,17 +39,46 @@ export const ApiKeysCard = () => {
         >
           <Input
             readOnly
-            type={'password'}
+            type={hidden ? 'password' : 'text'}
+            rightSectionWidth={70}
             rightSection={
-              <Tooltip label={clipboardApiKey.copied ? 'Copied!' : 'Copy Key'}>
-                <ActionIcon
-                  data-test-id={'api-key-copy'}
-                  variant="transparent"
-                  onClick={() => clipboardApiKey.copy(apiKey)}
-                >
-                  {clipboardApiKey.copied ? <Check /> : <Copy />}
+              <>
+                <ActionIcon variant="transparent" onClick={() => setHidden(!hidden)}>
+                  <When truthy={hidden}>
+                    <EyeOutlined
+                      style={{
+                        color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                        fontSize: '16px',
+                      }}
+                    />
+                  </When>
+                  <When truthy={!hidden}>
+                    <EyeInvisibleOutlined
+                      style={{
+                        color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                        fontSize: '16px',
+                      }}
+                    />
+                  </When>
                 </ActionIcon>
-              </Tooltip>
+                <Tooltip label={clipboardApiKey.copied ? 'Copied!' : 'Copy Key'}>
+                  <ActionIcon
+                    data-test-id={'api-key-copy'}
+                    variant="transparent"
+                    onClick={() => clipboardApiKey.copy(apiKey)}
+                  >
+                    {clipboardApiKey.copied ? (
+                      <Check />
+                    ) : (
+                      <Copy
+                        style={{
+                          color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                        }}
+                      />
+                    )}
+                  </ActionIcon>
+                </Tooltip>
+              </>
             }
             value={apiKey}
             data-test-id="api-key-container"
@@ -65,7 +101,15 @@ export const ApiKeysCard = () => {
                   data-test-id={'application-identifier-copy'}
                   onClick={() => clipboardEnvironmentIdentifier.copy(environmentIdentifier)}
                 >
-                  {clipboardEnvironmentIdentifier.copied ? <Check /> : <Copy />}
+                  {clipboardEnvironmentIdentifier.copied ? (
+                    <Check />
+                  ) : (
+                    <Copy
+                      style={{
+                        color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                      }}
+                    />
+                  )}
                 </ActionIcon>
               </Tooltip>
             }
@@ -85,7 +129,15 @@ export const ApiKeysCard = () => {
                   data-test-id={'environment-id-copy'}
                   onClick={() => clipboardEnvironmentId.copy(environmentId)}
                 >
-                  {clipboardEnvironmentId.copied ? <Check /> : <Copy />}
+                  {clipboardEnvironmentId.copied ? (
+                    <Check />
+                  ) : (
+                    <Copy
+                      style={{
+                        color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                      }}
+                    />
+                  )}
                 </ActionIcon>
               </Tooltip>
             }

--- a/apps/web/src/pages/settings/tabs/ApiKeysCard.tsx
+++ b/apps/web/src/pages/settings/tabs/ApiKeysCard.tsx
@@ -47,7 +47,7 @@ export const ApiKeysCard = () => {
                   <When truthy={hidden}>
                     <EyeOutlined
                       style={{
-                        color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                        color: colors.B60,
                         fontSize: '16px',
                       }}
                     />
@@ -55,7 +55,7 @@ export const ApiKeysCard = () => {
                   <When truthy={!hidden}>
                     <EyeInvisibleOutlined
                       style={{
-                        color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                        color: colors.B60,
                         fontSize: '16px',
                       }}
                     />
@@ -68,11 +68,15 @@ export const ApiKeysCard = () => {
                     onClick={() => clipboardApiKey.copy(apiKey)}
                   >
                     {clipboardApiKey.copied ? (
-                      <Check />
+                      <Check
+                        style={{
+                          color: colors.B60,
+                        }}
+                      />
                     ) : (
                       <Copy
                         style={{
-                          color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                          color: colors.B60,
                         }}
                       />
                     )}
@@ -102,11 +106,15 @@ export const ApiKeysCard = () => {
                   onClick={() => clipboardEnvironmentIdentifier.copy(environmentIdentifier)}
                 >
                   {clipboardEnvironmentIdentifier.copied ? (
-                    <Check />
+                    <Check
+                      style={{
+                        color: colors.B60,
+                      }}
+                    />
                   ) : (
                     <Copy
                       style={{
-                        color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                        color: colors.B60,
                       }}
                     />
                   )}
@@ -130,11 +138,15 @@ export const ApiKeysCard = () => {
                   onClick={() => clipboardEnvironmentId.copy(environmentId)}
                 >
                   {clipboardEnvironmentId.copied ? (
-                    <Check />
+                    <Check
+                      style={{
+                        color: colors.B60,
+                      }}
+                    />
                   ) : (
                     <Copy
                       style={{
-                        color: colorScheme === 'dark' ? colors.B60 : colors.B80,
+                        color: colors.B60,
                       }}
                     />
                   )}

--- a/apps/web/src/pages/settings/tabs/EmailSettings.tsx
+++ b/apps/web/src/pages/settings/tabs/EmailSettings.tsx
@@ -87,7 +87,19 @@ export const EmailSettings = () => {
                     data-test-id={'mail-server-domiain-copy'}
                     onClick={() => clipboardEnvironmentIdentifier.copy(mailServerDomain)}
                   >
-                    {clipboardEnvironmentIdentifier.copied ? <Check /> : <Copy />}
+                    {clipboardEnvironmentIdentifier.copied ? (
+                      <Check
+                        style={{
+                          color: colors.B60,
+                        }}
+                      />
+                    ) : (
+                      <Copy
+                        style={{
+                          color: colors.B60,
+                        }}
+                      />
+                    )}
                   </ActionIcon>
                 </Tooltip>
               }


### PR DESCRIPTION
### What change does this PR introduce?

- Implement an unmask button for the API key field.
- Change colors of copied buttons to B60 to follow [figma design](https://www.figma.com/file/mxViLXxtC0PnB0ehXDcafw/Crafting-updates?type=design&node-id=874%3A29001&mode=design&t=fSsejrVYpULIzMlH-1)

### Why was this change needed?

The user has the option to copy the API key and application identifier. Sometimes in the case of self-hosting, the browser blocks the copy action on http.

Closes #4231 

### Other information (Screenshots)

Hidden:
![image](https://github.com/novuhq/novu/assets/96212888/a9a9c7f9-ac15-488a-aa84-b578e251efb2)

Not hidden
![image](https://github.com/novuhq/novu/assets/96212888/91f3e4dd-cf91-45bd-ab10-a19d8efcf879)

