### PR TITLE
Fix/resend email sender

### DIFF
--- a/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
@@ -6,10 +6,11 @@ export class ResendHandler extends BaseHandler {
   constructor() {
     super('resend', ChannelTypeEnum.EMAIL);
   }
-  buildProvider(credentials: ICredentials, from?: string) {
-    const config: { apiKey: string; from: string } = {
+  buildProvider(credentials: ICredentials, from?: string, senderName?: string) {
+    const config: { apiKey: string; from: string; senderName: string } = {
       from: from as string,
       apiKey: credentials.apiKey as string,
+      senderName,
     };
 
     this.provider = new ResendEmailProvider(config);

--- a/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
@@ -7,7 +7,7 @@ export class ResendHandler extends BaseHandler {
     super('resend', ChannelTypeEnum.EMAIL);
   }
   buildProvider(credentials: ICredentials, from?: string, senderName?: string) {
-    const config: { apiKey: string; from: string; senderName: string } = {
+    const config: { apiKey: string; from: string; senderName?: string } = {
       from: from as string,
       apiKey: credentials.apiKey as string,
       senderName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,7 +390,7 @@ importers:
       nodemon: 2.0.22
       prettier: 2.8.7
       sinon: 9.2.4
-      ts-jest: 27.1.5_cnngzrja2umb46xxazlucyx2qu
+      ts-jest: 27.1.5_4aafjbpmnrfjtrzkyohogv4jce
       ts-loader: 9.4.2_rggdtlzfqxxwxudp3onsqdyocm
       ts-node: 10.9.1_wh2cnrlliuuxb2etxm2m3ttgna
       tsconfig-paths: 4.1.2
@@ -24721,7 +24721,7 @@ packages:
     resolution: {integrity: sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==}
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   /concat-stream/1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -41680,7 +41680,7 @@ packages:
       jest-worker: 26.6.2
       rollup: 2.79.1
       serialize-javascript: 4.0.0
-      terser: 5.19.3
+      terser: 5.16.9
 
   /rollup-plugin-terser/7.0.2_rollup@3.20.2:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
@@ -44086,7 +44086,6 @@ packages:
       acorn: 8.10.0
       commander: 2.20.3
       source-map-support: 0.5.21
-    dev: true
 
   /terser/5.19.3:
     resolution: {integrity: sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==}
@@ -44447,7 +44446,7 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest/27.1.5_cnngzrja2umb46xxazlucyx2qu:
+  /ts-jest/27.1.5_4aafjbpmnrfjtrzkyohogv4jce:
     resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -44468,6 +44467,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
+      '@babel/core': 7.22.11
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1_ts-node@10.9.1

--- a/providers/resend/src/lib/resend.provider.ts
+++ b/providers/resend/src/lib/resend.provider.ts
@@ -17,6 +17,7 @@ export class ResendEmailProvider implements IEmailProvider {
     private config: {
       apiKey: string;
       from: string;
+      senderName?: string;
     }
   ) {
     this.resendClient = new Resend(this.config.apiKey);
@@ -26,7 +27,9 @@ export class ResendEmailProvider implements IEmailProvider {
     options: IEmailOptions
   ): Promise<ISendMessageSuccessResponse> {
     const response: any = await this.resendClient.sendEmail({
-      from: options.from || this.config.from,
+      from: this.config?.senderName
+        ? `${this.config?.senderName} <${options.from || this.config.from}>`
+        : options.from || this.config.from,
       to: options.to,
       subject: options.subject,
       text: options.text,


### PR DESCRIPTION
### What change does this PR introduce?
This PR Fix : The sender name can't send a Email when we used Resend as email provider;

### Why was this change needed?
 The channge is add senderName Before a Email address 

Fixes : #3957

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
