### PR TITLE
fix: Z index of profile card to increase visibility

### DIFF
--- a/apps/web/src/components/layout/components/HeaderNav.tsx
+++ b/apps/web/src/components/layout/components/HeaderNav.tsx
@@ -158,6 +158,8 @@ export function HeaderNav({ isIntercomOpened }: Props) {
     </Dropdown.Item>,
   ];
 
+  const profileMenuMantineZ = <div style={{ zIndex: 999 }}>{profileMenuMantine}</div>;
+
   return (
     <Header
       height={`${HEADER_HEIGHT}px`}
@@ -206,7 +208,7 @@ export function HeaderNav({ isIntercomOpened }: Props) {
               </ActionIcon>
             }
           >
-            {profileMenuMantine}
+            {profileMenuMantineZ}
           </Dropdown>
         </Group>
       </Container>


### PR DESCRIPTION
### What change does this PR introduce?

increased Z index of the profile card, to place it over other contents of a page.
fixes #4268 

### Other information (Screenshots)
Added code : 
  const profileMenuMantineZ = <div style={{ zIndex: 999 }}>{profileMenuMantine}</div>;
