### PR TITLE
An AsyncGenerator object cannot be iterated at 'yield*'

### DIFF
--- a/scripts/pnpm-context.mjs
+++ b/scripts/pnpm-context.mjs
@@ -216,11 +216,14 @@ async function withTmpdir(callable) {
  */
 async function getFiles(dir) {
   async function* yieldFiles(dirPath) {
-    const paths = await fs.readdir(dirPath, { withFileTypes: true });
+    const paths = await readdir(dirPath, { withFileTypes: true });
     for (const path of paths) {
       const res = resolve(dirPath, path.name);
       if (path.isDirectory()) {
-        yield* yieldFiles(res);
+        // Manually iterate over the nested async generator
+        for await (const file of yieldFiles(res)) {
+          yield file;
+        }
       } else {
         yield res;
       }


### PR DESCRIPTION
The error you're encountering, "An AsyncGenerator object cannot be iterated at 'yield*'," is because you are trying to yield from an async generator using the yield* syntax, and it's not allowed in JavaScript. The yield* syntax is used for delegating to another generator, but in the context of an async generator, you cannot directly delegate to an async generator using yield*.