### PR TITLE
Update: template store to include blank workflow

### DIFF
--- a/apps/web/src/pages/templates/components/templates-store/TemplatesStoreModal.tsx
+++ b/apps/web/src/pages/templates/components/templates-store/TemplatesStoreModal.tsx
@@ -33,6 +33,8 @@ import { ROUTES } from '../../../../constants/routes.enum';
 import { TemplateCreationSourceEnum } from '../../shared';
 import { useSegment } from '../../../../components/providers/SegmentProvider';
 import { IBlueprintTemplate } from '../../../../api/types';
+import { faFile } from '@fortawesome/free-regular-svg-icons';
+import { TemplateAnalyticsEnum } from '../../constants';
 
 const nodeTypes = {
   triggerNode: TriggerNode,
@@ -70,6 +72,11 @@ export const TemplatesStoreModal = ({ general, popular, isOpened, onClose }: ITe
     });
 
     setTemplate(template);
+  };
+
+  const handleRedirectToCreateTemplate = (isFromHeader: boolean) => {
+    segment.track(TemplateAnalyticsEnum.CREATE_TEMPLATE_CLICK, { isFromHeader });
+    navigate(ROUTES.WORKFLOWS_CREATE);
   };
 
   const handleCreateTemplateClick = (blueprint: IBlueprintTemplate) => {
@@ -133,6 +140,22 @@ export const TemplatesStoreModal = ({ general, popular, isOpened, onClose }: ITe
               })}
             </TemplatesGroup>
           ))}
+          <TemplatesGroup key="blank-workflow">
+            <GroupName>Blank Workflow</GroupName>
+            <TemplateItem
+              key="temp-blank-workflow"
+              onClick={() => {
+                segment.track('[Template Store] Click Create Notification Template', {
+                  templateIdentifier: 'Blank Workflow',
+                  location: TemplateCreationSourceEnum.DROPDOWN,
+                });
+                handleRedirectToCreateTemplate(false);
+              }}
+            >
+              <FontAwesomeIcon icon={faFile} />
+              <span>Blank Workflow</span>
+            </TemplateItem>
+          </TemplatesGroup>
         </TemplatesSidebarHolder>
         <TemplatesDetailsHolder>
           <TemplateHeader>


### PR DESCRIPTION
### What change does this PR introduce?

Templates Store now have Blank Workflow when all templates is clicked in the dropdown 
### Why was this change needed?
So users don't have to pop out all templates dialog to reselect Blank Workflow.
Fixes #4258

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
![Screenshot 2023-10-02 133741](https://github.com/novuhq/novu/assets/78524377/53c223fc-2c31-4b73-a1b5-24f5d0387223)
