### PR TITLE
fix(api): malformed filters in messages throw errors

### DIFF
--- a/apps/api/src/app/shared/helpers/content.service.spec.ts
+++ b/apps/api/src/app/shared/helpers/content.service.spec.ts
@@ -335,4 +335,99 @@ describe('ContentService', function () {
       expect(extractVariables[0].name).to.include('lastName');
     });
   });
+
+  describe('extractStepVariables', () => {
+    it('should not fail if no filters available', () => {
+      const contentService = new ContentService();
+      const messages = [
+        {
+          template: {
+            type: StepTypeEnum.EMAIL,
+            subject: 'Test {{subscriber.firstName}}',
+            content: [
+              {
+                content: 'Test of {{subscriber.firstName}} {{lastName}}',
+                type: 'text',
+              },
+            ],
+          },
+        },
+      ] as INotificationTemplateStep[];
+      const variables = contentService.extractStepVariables(messages);
+
+      expect(variables.length).to.equal(0);
+    });
+
+    it('should not fail if filters are set as non array', () => {
+      const contentService = new ContentService();
+      const messages = [
+        {
+          template: {
+            type: StepTypeEnum.EMAIL,
+            subject: 'Test {{subscriber.firstName}}',
+            content: [
+              {
+                content: 'Test of {{subscriber.firstName}} {{lastName}}',
+                type: 'text',
+              },
+            ],
+          },
+          filters: {},
+        },
+      ] as INotificationTemplateStep[];
+      const variables = contentService.extractStepVariables(messages);
+
+      expect(variables.length).to.equal(0);
+    });
+
+    it('should not fail if filters are an empty array', () => {
+      const contentService = new ContentService();
+      const messages = [
+        {
+          template: {
+            type: StepTypeEnum.EMAIL,
+            subject: 'Test {{subscriber.firstName}}',
+            content: [
+              {
+                content: 'Test of {{subscriber.firstName}} {{lastName}}',
+                type: 'text',
+              },
+            ],
+          },
+          filters: [],
+        },
+      ] as INotificationTemplateStep[];
+      const variables = contentService.extractStepVariables(messages);
+
+      expect(variables.length).to.equal(0);
+    });
+
+    it('should not fail if filters have some wrong settings like missing children in filters', () => {
+      const contentService = new ContentService();
+      const messages = [
+        {
+          template: {
+            type: StepTypeEnum.EMAIL,
+            subject: 'Test {{subscriber.firstName}}',
+            content: [
+              {
+                content: 'Test of {{subscriber.firstName}} {{lastName}}',
+                type: 'text',
+              },
+            ],
+          },
+          filters: [
+            {
+              isNegated: false,
+              type: 'GROUP',
+              value: 'AND',
+            },
+          ],
+        },
+      ] as INotificationTemplateStep[];
+      const variables = contentService.extractStepVariables(messages);
+
+      expect(variables.length).to.equal(0);
+    });
+  });
 });

--- a/apps/api/src/app/shared/helpers/content.service.ts
+++ b/apps/api/src/app/shared/helpers/content.service.ts
@@ -73,17 +73,19 @@ export class ContentService {
 
     for (const message of messages) {
       if (message.filters) {
-        const filterVariables = message.filters.flatMap((filter) =>
-          filter.children
-            .filter((item) => item.on === FilterPartTypeEnum.PAYLOAD)
-            .map((item: IFieldFilterPart) => {
-              return {
-                name: item.field,
-                type: TemplateVariableTypeEnum.STRING,
-              };
-            })
-        );
-        variables.push(...filterVariables);
+        const filters = Array.isArray(message.filters) ? message.filters : [];
+        const filteredVariables = filters.flatMap((filter) => {
+          const filteredChildren = filter.children?.filter((item) => item.on === FilterPartTypeEnum.PAYLOAD) || [];
+          const mappedChildren = filteredChildren.map((item: IFieldFilterPart) => {
+            return {
+              name: item.field,
+              type: TemplateVariableTypeEnum.STRING,
+            };
+          });
+
+          return mappedChildren;
+        });
+        variables.push(...filteredVariables);
       }
 
       if (message.metadata?.type === DelayTypeEnum.SCHEDULED && message.metadata.delayPath) {


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Fixes errors thrown by malformed filters in messages.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
To fix this:
https://novu-r9.sentry.io/issues/4518246046/?alert_rule_id=10492815&alert_timestamp=1696232113867&alert_type=email&environment=production&notification_uuid=1f7176c6-ff05-4643-9a24-8b06a20c32e5&project=6248811&referrer=alert_email

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
