### PR TITLE
docs: Updated node version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ You can open a new issue with this [issue form](https://github.com/novuhq/novu/i
 
 ### Requirements
 
-- Node.js version v14.19.3
+- Node.js version v16.15.1
 - MongoDB
 - Redis. To install Redis on your O.S, please follow the below guides
   - [To install Redis on Windows](https://redis.io/docs/getting-started/installation/install-redis-on-windows/)


### PR DESCRIPTION
### What change does this PR introduce?
This PR updates the node version specified in CONTRIBUTING.md file.

* The current Docs of CONTRIBUTING.md is:
<img width="602" alt="Screenshot 2023-10-02 at 3 24 53 PM" src="https://github.com/novuhq/novu/assets/73417521/5054c734-87c9-44fd-bdf1-ad8199798875">

* Actually, Docs should be like:
<img width="553" alt="Screenshot 2023-10-02 at 3 27 51 PM" src="https://github.com/novuhq/novu/assets/73417521/fcfc38e7-a20c-4934-992c-8063bd98acf4">

### Why was this change needed?
It causes a number of issues with the specified node version in the CONTRIBUTING.md file.
