### PR TITLE
add "name" property in nodemailer smtpTransportOptions to support hos…

### DIFF
--- a/providers/nodemailer/src/lib/nodemailer.provider.ts
+++ b/providers/nodemailer/src/lib/nodemailer.provider.ts
@@ -44,6 +44,7 @@ export class NodemailerProvider implements IEmailProvider {
     const tls: ConnectionOptions = this.getTlsOptions();
 
     const smtpTransportOptions: SMTPTransport.Options = {
+      name: this.config.host,
       host: this.config.host,
       port: this.config.port,
       secure: this.config.secure,


### PR DESCRIPTION
### What change does this PR introduce?

This change is to add a "name" property to nodemailer's SMTPTransport options. The added "name" property reuses the "config.host" value.

### Why was this change needed?
Few email hosting providers like "HostGator" requires name field with nodemailer transporter method

 Fixes #4314 
