### PR TITLE
chore: add Elixir SDK to hacktoberfest list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ In addition to this repository, here are the other Novu repositories you can con
 - [Novu Go SDK](https://github.com/novuhq/go-novu/issues)
 - [Novu Java SDK](https://github.com/novuhq/novu-java/issues)
 - [Novu Kotlin SDK](https://github.com/novuhq/novu-kotlin/issues)
+- [Novu Elixir SDK](https://github.com/novuhq/novu-elixir/issues)
 
 Your contribution, no matter its size, holds immense value. We eagerly await to see the impact you'll make in our community! 🚀
 


### PR DESCRIPTION
### What change does this PR introduce?

Adds the Elixir SDK to the hacktoberfest repo list

### Why was this change needed?

We have added a [CONTRIBUTING.md](https://github.com/novuhq/novu-elixir/blob/main/CONTRIBUTING.md) file, ensured CI is passing, and [labeled recent issues for hacktoberfest](https://github.com/novuhq/novu-elixir/issues).

### Other information (Screenshots)

cc @Cliftonz 
