### PR TITLE
fix: fixed the link in Readme.md which was redirecting to undesired page

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ We are more than happy to help you. If you are getting any errors or facing prob
 
 - [Home page](https://novu.co/)
 - [Contribution Guidelines](https://github.com/novuhq/novu/blob/main/CONTRIBUTING.md)
-- [Run Novu Locally](https://docs.novu.co/community/run-locally)
+- [Run Novu Locally](https://docs.novu.co/community/run-in-local-machine)
 
 ## 🛡️ License
 


### PR DESCRIPTION
In the README.md file located, at the bottom of the page, there is a link "Run Novu Locally" under Links section. Clicking on the link actually takes us to "Introduction" page instead of "Run Novu in local machine" page. The issue has been fixed in this commit.

### What change does this PR introduce?

In the README.md file located, at the bottom of the page, there is a link "Run Novu Locally" under Links section. Clicking on the link actually takes us to "Introduction" page instead of "Run Novu in local machine" page. The PR changes replaces wrong link with the desired one.

### Why was this change needed?

Closes #4354