### PR TITLE
fix/docs: Add missing provider links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Novu provides a single API to manage providers across multiple channels with a s
 - [x] [Slack](https://github.com/novuhq/novu/tree/main/providers/slack)
 - [x] [Discord](https://github.com/novuhq/novu/tree/main/providers/discord)
 - [x] [MS Teams](https://github.com/novuhq/novu/tree/main/providers/ms-teams)
-- [x] Mattermost
+- [x] [Mattermost](https://github.com/novuhq/novu/tree/main/providers/mattermost)
 
 #### 📱 In-App
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Novu provides a single API to manage providers across multiple channels with a s
 
 #### 👇 Chat
 
-- [x] Slack
+- [x] [Slack](https://github.com/novuhq/novu/tree/main/providers/slack)
 - [x] Discord
 - [x] MS Teams
 - [x] Mattermost

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Novu provides a single API to manage providers across multiple channels with a s
 #### 👇 Chat
 
 - [x] [Slack](https://github.com/novuhq/novu/tree/main/providers/slack)
-- [x] Discord
+- [x] [Discord](https://github.com/novuhq/novu/tree/main/providers/discord)
 - [x] MS Teams
 - [x] Mattermost
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Novu provides a single API to manage providers across multiple channels with a s
 
 - [x] [Slack](https://github.com/novuhq/novu/tree/main/providers/slack)
 - [x] [Discord](https://github.com/novuhq/novu/tree/main/providers/discord)
-- [x] MS Teams
+- [x] [MS Teams](https://github.com/novuhq/novu/tree/main/providers/ms-teams)
 - [x] Mattermost
 
 #### 📱 In-App


### PR DESCRIPTION
### What change does this PR introduce?
Brings the list of Chat providers in line and consistent with the others with quick links to the usage documentation file.

### Why was this change needed?
Consistency reasons along with providing a quick way for users to access the provider documentation they are looking for.

### Other information (Screenshots)
N/A
