### PR TITLE
fix: solved issue of senders name before email in resend provider

### DIFF
--- a/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
@@ -6,10 +6,11 @@ export class ResendHandler extends BaseHandler {
   constructor() {
     super('resend', ChannelTypeEnum.EMAIL);
   }
-  buildProvider(credentials: ICredentials, from?: string) {
-    const config: { apiKey: string; from: string } = {
+  buildProvider(credentials: ICredentials, from?: string, senderName?: string) {
+    const config: { apiKey: string; from: string; senderName: string } = {
       from: from as string,
       apiKey: credentials.apiKey as string,
+      senderName,
     };
 
     this.provider = new ResendEmailProvider(config);

--- a/packages/application-generic/tsconfig.json
+++ b/packages/application-generic/tsconfig.json
@@ -9,7 +9,8 @@
     "rootDir": "src",
     "strict": true,
     "types": ["node", "jest"],
-    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
+    "ignoreDeprecations": "5.0"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules/**"]

--- a/providers/resend/src/lib/resend.provider.ts
+++ b/providers/resend/src/lib/resend.provider.ts
@@ -17,6 +17,7 @@ export class ResendEmailProvider implements IEmailProvider {
     private config: {
       apiKey: string;
       from: string;
+      senderName?: string;
     }
   ) {
     this.resendClient = new Resend(this.config.apiKey);
@@ -26,7 +27,9 @@ export class ResendEmailProvider implements IEmailProvider {
     options: IEmailOptions
   ): Promise<ISendMessageSuccessResponse> {
     const response: any = await this.resendClient.sendEmail({
-      from: options.from || this.config.from,
+      from: this.config.senderName
+        ? `${this.config.senderName}  <${options.from || this.config.from}>`
+        : options.from || this.config.from,
       to: options.to,
       subject: options.subject,
       text: options.text,

--- a/providers/resend/tsconfig.json
+++ b/providers/resend/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "build/main",
     "rootDir": "src",
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "ignoreDeprecations": "5.0"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules/**"]


### PR DESCRIPTION
### What change does this PR introduce?

it fixes the issue of sender name  before email in resend email provider 
e.g.  before change : "raghav@gmail.com"  -->  after change: "Raghav Chaddha <raghav@gmail.com>"

### Why was this change needed?

this change was needed for the concatenation of name before email 

fixing issue #4409


