### PR TITLE
fix: Fixed send the sender name in email when using resend email provider

### DIFF
--- a/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
@@ -6,10 +6,11 @@ export class ResendHandler extends BaseHandler {
   constructor() {
     super('resend', ChannelTypeEnum.EMAIL);
   }
-  buildProvider(credentials: ICredentials, from?: string) {
-    const config: { apiKey: string; from: string } = {
+  buildProvider(credentials: ICredentials, from?: string, senderName?: string) {
+    const config: { apiKey: string; from: string; senderName: string } = {
       from: from as string,
       apiKey: credentials.apiKey as string,
+      senderName,
     };
 
     this.provider = new ResendEmailProvider(config);

--- a/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
+++ b/packages/application-generic/src/factories/mail/handlers/resend.handler.ts
@@ -7,7 +7,7 @@ export class ResendHandler extends BaseHandler {
     super('resend', ChannelTypeEnum.EMAIL);
   }
   buildProvider(credentials: ICredentials, from?: string, senderName?: string) {
-    const config: { apiKey: string; from: string; senderName: string } = {
+    const config: { apiKey: string; from: string; senderName?: string } = {
       from: from as string,
       apiKey: credentials.apiKey as string,
       senderName,

--- a/providers/resend/src/lib/resend.provider.ts
+++ b/providers/resend/src/lib/resend.provider.ts
@@ -17,6 +17,7 @@ export class ResendEmailProvider implements IEmailProvider {
     private config: {
       apiKey: string;
       from: string;
+      senderName?: string;
     }
   ) {
     this.resendClient = new Resend(this.config.apiKey);
@@ -26,7 +27,9 @@ export class ResendEmailProvider implements IEmailProvider {
     options: IEmailOptions
   ): Promise<ISendMessageSuccessResponse> {
     const response: any = await this.resendClient.sendEmail({
-      from: options.from || this.config.from,
+      from: this.config?.senderName
+        ? `${this.config?.senderName} <${options.from || this.config.from}>`
+        : options.from || this.config.from,
       to: options.to,
       subject: options.subject,
       text: options.text,


### PR DESCRIPTION
…ider

### What change does this PR introduce?
This PR fixes the sender name being not sent in email when using Resend as an email provider.


### Why was this change needed?
The change was to add senderName before the from email address. Example: `Naman Mujawdiya <nm76130292gmail.com>` .

Fixes #3957 