### PR TITLE
Allow fetching of no level preferences

### DIFF
--- a/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
@@ -120,7 +120,6 @@ export class UpdateSubscriberPreference {
         _organizationId: command.organizationId,
         _subscriberId: subscriber._id,
         _templateId: command.templateId,
-        level: PreferenceLevelEnum.TEMPLATE,
       },
       {
         $set: updatePayload,

--- a/packages/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/packages/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -5,7 +5,6 @@ import {
   SubscriberRepository,
   SubscriberEntity,
   MessageTemplateRepository,
-  PreferenceLevelEnum,
 } from '@novu/dal';
 import {
   ChannelTypeEnum,
@@ -54,7 +53,6 @@ export class GetSubscriberTemplatePreference {
         _environmentId: command.environmentId,
         _subscriberId: subscriber._id,
         _templateId: command.template._id,
-        level: PreferenceLevelEnum.TEMPLATE,
       });
 
     const subscriberChannelPreference = subscriberPreference?.channels;


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- updates the get preferences to allow preferences with missing level property to be fetched as Template level
### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
