### PR TITLE
feat(api): Add Access-Control-Max-Age response header

### DIFF
--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -137,6 +137,7 @@ const corsOptionsDelegate = function (req, callback) {
   const corsOptions = {
     origin: false as boolean | string | string[],
     preflightContinue: false,
+    maxAge: 86400,
     allowedHeaders: ['Content-Type', 'Authorization', 'sentry-trace'],
     methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
   };


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Adds an Access-Control-Max-Age response header to API responses, with cache duration of 86400 (maximum allowable on browsers, 1 day).

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
By specifying a Max-Age CORS header, we can provide a more responsive browser experience by eliminating a round-trip to the API in event of a preflight request cache-hit, and significantly reduce API server load.

### Other information (Screenshots)
After a successful preflight request against a URI, subsequent requests against the same URI do not require a new preflight request.
<img width="1840" alt="image" src="https://github.com/novuhq/novu/assets/32132657/90e5c849-eaa1-44f2-b610-35d2b4df51ad">
