### PR TITLE
NV-3934 - 🚀 Feature: Custom backendUrl in invite-member.usecase and resend-invite.usecase

### DIFF
--- a/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.usecase.ts
+++ b/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.usecase.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 import { differenceInHours, differenceInSeconds, parseISO } from 'date-fns';
 import { Novu } from '@novu/node';
-import { UserRepository, UserEntity, IUserResetTokenCount } from '@novu/dal';
+import { UserRepository, UserEntity, IUserResetTokenCount, MemberRepository } from '@novu/dal';
 import { buildUserKey, InvalidateCacheService } from '@novu/application-generic';
 
 import { normalizeEmail } from '../../../shared/helpers/email-normalization.service';
@@ -14,13 +14,21 @@ export class PasswordResetRequest {
   private MAX_ATTEMPTS_IN_A_DAY = 15;
   private RATE_LIMIT_IN_SECONDS = 60;
   private RATE_LIMIT_IN_HOURS = 24;
-  constructor(private invalidateCache: InvalidateCacheService, private userRepository: UserRepository) {}
+  constructor(
+    private invalidateCache: InvalidateCacheService,
+    private userRepository: UserRepository,
+    private memberRepository: MemberRepository
+  ) {}
 
   async execute(command: PasswordResetRequestCommand): Promise<{ success: boolean }> {
     const email = normalizeEmail(command.email);
     const foundUser = await this.userRepository.findByEmail(email);
+
     if (foundUser && foundUser.email) {
       const { error, isBlocked } = this.isRequestBlocked(foundUser);
+
+      const member = await this.memberRepository.findById(foundUser._id);
+
       if (isBlocked) {
         throw new UnauthorizedException(error);
       }
@@ -36,7 +44,7 @@ export class PasswordResetRequest {
       await this.userRepository.updatePasswordResetToken(foundUser._id, token, resetTokenCount);
 
       if ((process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'production') && process.env.NOVU_API_KEY) {
-        const novu = new Novu(process.env.NOVU_API_KEY);
+        const novu = new Novu(process.env.NOVU_API_KEY, member?.config);
 
         novu.trigger(process.env.NOVU_TEMPLATEID_PASSWORD_RESET || 'password-reset-llS-wzWMq', {
           to: {

--- a/apps/api/src/app/invites/dtos/invite-member.dto.ts
+++ b/apps/api/src/app/invites/dtos/invite-member.dto.ts
@@ -1,5 +1,5 @@
-import { IsEmail, IsEnum, IsNotEmpty } from 'class-validator';
-import { MemberRoleEnum } from '@novu/shared';
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
+import { CustomDataType, MemberRoleEnum } from '@novu/shared';
 
 export class InviteMemberDto {
   @IsEmail()
@@ -8,4 +8,7 @@ export class InviteMemberDto {
 
   @IsEnum(MemberRoleEnum)
   role: MemberRoleEnum;
+
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/dtos/resend-invite.dto.ts
+++ b/apps/api/src/app/invites/dtos/resend-invite.dto.ts
@@ -1,7 +1,11 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { CustomDataType } from '@novu/shared';
 
 export class ResendInviteDto {
   @IsNotEmpty()
   @IsString()
   memberId: string;
+
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/e2e/get-invite.e2e.ts
+++ b/apps/api/src/app/invites/e2e/get-invite.e2e.ts
@@ -66,4 +66,30 @@ describe('Get invite object - /invites/:inviteToken (GET)', async () => {
       expect(body.message).to.contain('expired');
     });
   });
+
+  describe('add config parameters', async () => {
+    before(async () => {
+      session = new UserSession();
+      await session.initialize();
+
+      await session.testAgent
+        .post('/v1/invites')
+        .send({
+          invitees: [
+            {
+              email: 'asdas@dasdas.com',
+            },
+          ],
+          config: { test: 'test' },
+        })
+        .expect(201);
+    });
+
+    it('check the value for config is not empty', async () => {
+      const members = await memberRepository.getOrganizationMembers(session.organization._id);
+      const member = members.find((i) => i.memberStatus === MemberStatusEnum.INVITED);
+
+      expect(member.config).to.deep.equal({ test: 'test' });
+    });
+  });
 });

--- a/apps/api/src/app/invites/e2e/resend-invite.e2e.ts
+++ b/apps/api/src/app/invites/e2e/resend-invite.e2e.ts
@@ -27,6 +27,26 @@ describe('Resend invite - /invites/resend (POST)', async () => {
     invitee = members.find((i) => i.memberStatus === MemberStatusEnum.INVITED);
   }
 
+  async function setupSingleInvite() {
+    session = new UserSession();
+    await session.initialize();
+
+    await session.testAgent
+      .post('/v1/invites')
+      .send({
+        invitees: [
+          {
+            email: 'asdas@dasdas.com',
+          },
+        ],
+        config: { test: 'test' },
+      })
+      .expect(201);
+
+    const members = await memberRepository.getOrganizationMembers(session.organization._id);
+    invitee = members.find((i) => i.memberStatus === MemberStatusEnum.INVITED);
+  }
+
   describe('Valid resend invite flow', async () => {
     before(async () => {
       await setup();
@@ -78,6 +98,27 @@ describe('Resend invite - /invites/resend (POST)', async () => {
       expect(body.message.length).to.exist;
       expect(body.message).to.equal('Member not found');
       expect(body.error).to.equal('Bad Request');
+    });
+  });
+
+  describe('Valid resend invite flow - single invite', async () => {
+    before(async () => {
+      await setupSingleInvite();
+
+      const members = await memberRepository.getOrganizationMembers(session.organization._id);
+
+      const invitedMember = members.find((i) => i.memberStatus === MemberStatusEnum.INVITED);
+
+      await session.testAgent
+        .post('/v1/invites/resend')
+        .send({ memberId: invitedMember._id, config: { test1: 'test2' } })
+        .expect(201);
+    });
+
+    it('should change config value', async () => {
+      const member = await memberRepository.findMemberById(session.organization._id, invitee._id);
+
+      expect(member?.config).to.equal({ test1: 'test2' });
     });
   });
 });

--- a/apps/api/src/app/invites/invites.controller.ts
+++ b/apps/api/src/app/invites/invites.controller.ts
@@ -72,6 +72,7 @@ export class InvitesController {
       organizationId: user.organizationId,
       email: body.email,
       role: body.role,
+      config: body.config,
     });
 
     await this.inviteMemberUsecase.execute(command);
@@ -92,6 +93,7 @@ export class InvitesController {
       userId: user._id,
       organizationId: user.organizationId,
       memberId: body.memberId,
+      config: body.config,
     });
 
     await this.resendInviteUsecase.execute(command);
@@ -112,6 +114,7 @@ export class InvitesController {
       userId: user._id,
       organizationId: user.organizationId,
       invitees: body.invitees,
+      config: body.config,
     });
 
     const response = await this.bulkInviteUsecase.execute(command);

--- a/apps/api/src/app/invites/usecases/accept-invite/accept-invite.command.ts
+++ b/apps/api/src/app/invites/usecases/accept-invite/accept-invite.command.ts
@@ -1,7 +1,11 @@
-import { IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
+import { CustomDataType } from '@novu/shared';
 
 export class AcceptInviteCommand extends AuthenticatedCommand {
   @IsString()
   readonly token: string;
+
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/usecases/accept-invite/accept-invite.usecase.ts
+++ b/apps/api/src/app/invites/usecases/accept-invite/accept-invite.usecase.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, NotFoundException, Scope } from '@nestjs/common';
 
 import { MemberEntity, OrganizationRepository, UserEntity, MemberRepository, UserRepository } from '@novu/dal';
-import { MemberStatusEnum } from '@novu/shared';
+import { CustomDataType, MemberStatusEnum } from '@novu/shared';
 import { Novu } from '@novu/node';
 import { AuthService } from '@novu/application-generic';
 
@@ -46,17 +46,17 @@ export class AcceptInvite {
       answerDate: new Date(),
     });
 
-    this.sendInviterAcceptedEmail(inviter, member);
+    this.sendInviterAcceptedEmail(inviter, member, member.config);
 
     return this.authService.generateUserToken(user);
   }
 
-  async sendInviterAcceptedEmail(inviter: UserEntity, member: MemberEntity) {
+  async sendInviterAcceptedEmail(inviter: UserEntity, member: MemberEntity, config?: CustomDataType) {
     if (!member.invite) return;
 
     try {
       if ((process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'production') && process.env.NOVU_API_KEY) {
-        const novu = new Novu(process.env.NOVU_API_KEY);
+        const novu = new Novu(process.env.NOVU_API_KEY, config);
 
         await novu.trigger(process.env.NOVU_TEMPLATEID_INVITE_ACCEPTED || 'invite-accepted-dEQAsKD1E', {
           to: {

--- a/apps/api/src/app/invites/usecases/invite-member/invite-member.command.ts
+++ b/apps/api/src/app/invites/usecases/invite-member/invite-member.command.ts
@@ -1,5 +1,5 @@
-import { IsDefined, IsEmail, IsEnum } from 'class-validator';
-import { MemberRoleEnum } from '@novu/shared';
+import { IsDefined, IsEmail, IsEnum, IsOptional } from 'class-validator';
+import { CustomDataType, MemberRoleEnum } from '@novu/shared';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
 
 export class InviteMemberCommand extends OrganizationCommand {
@@ -9,4 +9,7 @@ export class InviteMemberCommand extends OrganizationCommand {
   @IsDefined()
   @IsEnum(MemberRoleEnum)
   readonly role: MemberRoleEnum;
+
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/usecases/invite-member/invite-member.usecase.ts
+++ b/apps/api/src/app/invites/usecases/invite-member/invite-member.usecase.ts
@@ -35,7 +35,7 @@ export class InviteMember {
     const token = createGuid();
 
     if (process.env.NOVU_API_KEY && (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'production')) {
-      const novu = new Novu(process.env.NOVU_API_KEY);
+      const novu = new Novu(process.env.NOVU_API_KEY, command.config);
 
       // cspell:disable-next
       await novu.trigger(process.env.NOVU_TEMPLATEID_INVITE_TO_ORGANISATION || 'invite-to-organization-wBnO8NpDn', {
@@ -62,6 +62,7 @@ export class InviteMember {
         email: command.email,
         invitationDate: new Date(),
       },
+      config: command.config,
     };
 
     this.analyticsService.track('Invite Organization Member', command.userId, {

--- a/apps/api/src/app/invites/usecases/resend-invite/resend-invite.command.ts
+++ b/apps/api/src/app/invites/usecases/resend-invite/resend-invite.command.ts
@@ -1,7 +1,11 @@
-import { IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
+import { CustomDataType } from '@novu/shared';
 
 export class ResendInviteCommand extends OrganizationCommand {
   @IsString()
   readonly memberId: string;
+
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/usecases/resend-invite/resend-invite.usecase.ts
+++ b/apps/api/src/app/invites/usecases/resend-invite/resend-invite.usecase.ts
@@ -34,7 +34,7 @@ export class ResendInvite {
     const token = createGuid();
 
     if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'production') {
-      const novu = new Novu(process.env.NOVU_API_KEY ?? '');
+      const novu = new Novu(process.env.NOVU_API_KEY ?? '', command.config);
 
       // cspell:disable-next
       await novu.trigger(process.env.NOVU_TEMPLATEID_INVITE_TO_ORGANISATION || 'invite-to-organization-wBnO8NpDn', {
@@ -59,6 +59,7 @@ export class ResendInvite {
         _inviterId: command.userId,
         invitationDate: new Date(),
       },
+      config: command.config,
     });
   }
 }

--- a/libs/dal/src/repositories/member/member.entity.ts
+++ b/libs/dal/src/repositories/member/member.entity.ts
@@ -1,5 +1,5 @@
 import { Types } from 'mongoose';
-import { IMemberInvite, MemberRoleEnum, MemberStatusEnum } from '@novu/shared';
+import { CustomDataType, IMemberInvite, MemberRoleEnum, MemberStatusEnum } from '@novu/shared';
 
 import { UserEntity } from '../user';
 import type { OrganizationId } from '../organization';
@@ -19,6 +19,8 @@ export class MemberEntity {
   memberStatus: MemberStatusEnum;
 
   _organizationId: OrganizationId;
+
+  config?: CustomDataType;
 }
 
 export type MemberDBModel = ChangePropsValueType<Omit<MemberEntity, 'invite'>, '_userId' | '_organizationId'> & {

--- a/libs/dal/src/repositories/member/member.repository.ts
+++ b/libs/dal/src/repositories/member/member.repository.ts
@@ -1,5 +1,5 @@
 import { FilterQuery } from 'mongoose';
-import { IMemberInvite, MemberRoleEnum, MemberStatusEnum } from '@novu/shared';
+import { CustomDataType, IMemberInvite, MemberRoleEnum, MemberStatusEnum } from '@novu/shared';
 
 import { MemberEntity, MemberDBModel } from './member.entity';
 import { BaseRepository } from '../base-repository';
@@ -11,6 +11,7 @@ export interface IAddMemberData {
   roles: MemberRoleEnum[];
   invite?: IMemberInvite;
   memberStatus: MemberStatusEnum;
+  config?: CustomDataType;
 }
 
 type MemberQuery = FilterQuery<MemberDBModel> & EnforceOrgId;
@@ -165,6 +166,7 @@ export class MemberRepository extends BaseRepository<MemberDBModel, MemberEntity
       invite: member.invite,
       memberStatus: member.memberStatus,
       _organizationId: organizationId,
+      config: member.config,
     });
   }
 

--- a/libs/dal/src/repositories/member/member.schema.ts
+++ b/libs/dal/src/repositories/member/member.schema.ts
@@ -31,6 +31,7 @@ const memberSchema = new Schema<MemberDBModel>(
       ref: 'Organization',
       index: true,
     },
+    config: Schema.Types.Mixed,
   },
   schemaOptions
 );

--- a/packages/node/src/lib/novu.spec.ts
+++ b/packages/node/src/lib/novu.spec.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 
 const mockConfig = {
   apiKey: '1234',
+  baseUrl: 'https://test.com',
 };
 
 jest.mock('axios');
@@ -13,7 +14,7 @@ describe('test use of novu node package', () => {
 
   beforeEach(() => {
     mockedAxios.create.mockReturnThis();
-    novu = new Novu(mockConfig.apiKey);
+    novu = new Novu(mockConfig.apiKey, { backendUrl: mockConfig.baseUrl });
   });
 
   test('should trigger correctly', async () => {


### PR DESCRIPTION
 ### What change does this PR introduce?
This fix makes it possible Custom backendUrl in invite-member.usecase and resend-invite.usecase is added

#### Description
It would be great if when instantiating the Novu instance in [invite-member.usecase.ts](https://github.com/novuhq/novu/blob/v0.13.x/apps/api/src/app/invites/usecases/invite-member/invite-member.usecase.ts#L38), [resend-invite.usecase.ts](https://github.com/novuhq/novu/blob/v0.13.x/apps/api/src/app/invites/usecases/resend-invite/resend-invite.usecase.ts#L37), [accept-invite.usecase.ts](https://github.com/novuhq/novu/blob/v0.13.x/apps/api/src/app/invites/usecases/accept-invite/accept-invite.usecase.ts#L57) and [password-reset-request.usecase.ts](https://github.com/novuhq/novu/blob/v0.13.x/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.usecase.ts#L39) we could also pass a custom config object in case we want to inject our own backendUrl for example.



 ### Why was this change needed?
closes https://github.com/novuhq/novu/issues/3934

### Other information


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.