### PR TITLE
feat: export types/interfaces from headless servive

### DIFF
--- a/packages/headless/src/lib/types.ts
+++ b/packages/headless/src/lib/types.ts
@@ -1,12 +1,35 @@
 import {
-  QueryObserverResult,
-  MutationObserverResult,
-} from '@tanstack/query-core';
-import {
   ButtonTypeEnum,
   ChannelTypeEnum,
+  IMessage,
+  IOrganizationEntity,
+  IPaginatedResponse,
   MessageActionStatusEnum,
+  WebSocketEventEnum,
 } from '@novu/shared';
+import {
+  MutationObserverResult,
+  QueryObserverResult,
+} from '@tanstack/query-core';
+
+import {
+  IStoreQuery,
+  IUserGlobalPreferenceSettings,
+  IUserPreferenceSettings,
+} from '@novu/client';
+
+export {
+  ButtonTypeEnum,
+  ChannelTypeEnum,
+  IMessage,
+  IOrganizationEntity,
+  IPaginatedResponse,
+  IStoreQuery,
+  IUserGlobalPreferenceSettings,
+  IUserPreferenceSettings,
+  MessageActionStatusEnum,
+  WebSocketEventEnum,
+};
 
 export interface IHeadlessServiceOptions {
   backendUrl?: string;


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
- Few interfaces and types were not being exported from @novu/headless.
This PR  exports those missing interfaces types to be able to imported from @novu/headless
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
