### PR TITLE
fix: #4249-Highligh hints

### DIFF
--- a/apps/web/src/components/quick-start/digest-demo-flow/NodeStepWithPopover.tsx
+++ b/apps/web/src/components/quick-start/digest-demo-flow/NodeStepWithPopover.tsx
@@ -73,11 +73,11 @@ export function NodeStepWithPopover({
     setSequence(popoverData.sequence[counter.toString()] as IBeat);
   }, [counter, popoverData]);
 
-  const onDropdownMouseEnter = () => {
+  const onHoverEnter = () => {
     setHoveredHintId(id);
   };
 
-  const onDropdownMouseLeave = () => {
+  const onHoverLeave = () => {
     setHoveredHintId(undefined);
   };
 
@@ -90,7 +90,10 @@ export function NodeStepWithPopover({
       transitionDuration={600}
       opacity={getOpacity(id, hoveredHintId, sequence)}
       target={
-        <StyledDiv>
+        <StyledDiv
+          onMouseEnter={onHoverEnter} // Added hover event handlers to the target div
+          onMouseLeave={onHoverLeave}
+        >
           <NodeStep Handlers={Handlers} Icon={Icon} data={data} ActionItem={ActionItem} ContentItem={ContentItem} />
         </StyledDiv>
       }
@@ -99,11 +102,12 @@ export function NodeStepWithPopover({
       description={description}
       url={popoverData.docsUrl}
       onUrlClick={onUrlClickHandler}
-      onDropdownMouseEnter={onDropdownMouseEnter}
-      onDropdownMouseLeave={onDropdownMouseLeave}
+      onDropdownMouseEnter={onHoverEnter} // Added hover event handlers to the popover
+      onDropdownMouseLeave={onHoverLeave}
     />
   );
 }
+
 
 function useCounter() {
   const INTERVAL = 1500;


### PR DESCRIPTION
Closes #4249-Display hints on hover over card step

### What change does this PR introduce?
This PR introduces changes to the NodeStepWithPopover component in order to address the issue with highlighting hints. Specifically, it adds hover event handling logic to both the step and hint elements. When the user hovers over a step, the associated hints will be highlighted, providing a better user experience in the application.

### Why was this change needed?
This change was needed to improve the user experience in the application. The original behaviour did not highlight hints when the user hovered over a step. By adding the hover event handling logic, the hints are now highlighted both when the user hovers over a step and when they hover over a hint. This change ensures consistency and enhances usability in the application.
