### PR TITLE
added API reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ We are excited to launch the complete Novu API and admin panel. Want to give it 
 npx novu init
 ```
 
-After setting up your account using the cloud or docker version you can trigger the API using the `@novu/node` package.
+After setting up your account using the cloud or docker version, you can trigger the API using the `@novu/node` package.
+
+For API documentation and reference, please visit [Novu API Reference](https://docs.novu.co/api-reference/events/trigger-event).
+
+To get started with the Node.js package, you can install it using npm:
 
 ```bash
 npm install @novu/node


### PR DESCRIPTION
### What change does this PR introduce?
The change is in the README.md, where I added the API reference link from the official Novu documentation.


### Why was this change needed?
I provided a direct link to the Novu API, even though the link to the official documentation is already mentioned. I added the direct API reference link so that users can conveniently access the APIs in other languages directly from the provided link. This makes it easier for users and can save them some time as well.

### Other information (Screenshots)

<img width="836" alt="image" src="https://github.com/novuhq/novu/assets/67964054/df6949aa-6675-4560-93b1-e6b26909ad56">
