### PR TITLE
feat(worker): handle different push flows with better exec details

### DIFF
--- a/apps/api/src/app/events/e2e/send-message-push.e2e.ts
+++ b/apps/api/src/app/events/e2e/send-message-push.e2e.ts
@@ -1,0 +1,208 @@
+import axios from 'axios';
+import { expect } from 'chai';
+import {
+  ExecutionDetailsRepository,
+  IntegrationRepository,
+  MessageRepository,
+  NotificationTemplateEntity,
+} from '@novu/dal';
+import { DetailEnum } from '@novu/application-generic';
+import { ChannelTypeEnum, PushProviderIdEnum, StepTypeEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+
+const axiosInstance = axios.create();
+
+describe('Trigger event - Send Push Notification - /v1/events/trigger (POST)', () => {
+  let session: UserSession;
+  let template: NotificationTemplateEntity;
+
+  const executionDetailsRepository = new ExecutionDetailsRepository();
+  const integrationRepository = new IntegrationRepository();
+  const messageRepository = new MessageRepository();
+
+  before(async () => {
+    process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = 'true';
+
+    session = new UserSession();
+    await session.initialize();
+
+    template = await session.createTemplate({
+      steps: [
+        {
+          active: true,
+          type: StepTypeEnum.PUSH,
+          title: 'Title',
+          content: 'Welcome to {{organizationName}}' as string,
+        },
+      ],
+    });
+  });
+
+  after(() => {
+    process.env.IS_MULTI_PROVIDER_CONFIGURATION_ENABLED = 'false';
+  });
+
+  describe('Multiple providers active', () => {
+    before(async () => {
+      const payload = {
+        providerId: PushProviderIdEnum.EXPO,
+        channel: ChannelTypeEnum.PUSH,
+        credentials: { apiKey: '123' },
+        _environmentId: session.environment._id,
+        active: true,
+        check: false,
+      };
+
+      await session.testAgent.post('/v1/integrations').send(payload);
+
+      const integrations = await integrationRepository.find({
+        _environmentId: session.environment._id,
+        channel: ChannelTypeEnum.PUSH,
+        active: true,
+      });
+
+      expect(integrations.length).to.equal(2);
+    });
+
+    afterEach(async () => {
+      await executionDetailsRepository.delete({ _environmentId: session.environment._id });
+    });
+
+    it('should not create any message if subscriber has no configured channel', async () => {
+      await triggerEvent(session, template);
+
+      await session.awaitRunningJobs(template._id);
+
+      const messages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        _subscriberId: session.subscriberId,
+      });
+
+      expect(messages.length).to.equal(0);
+
+      const executionDetails = await executionDetailsRepository.find({
+        _environmentId: session.environment._id,
+      });
+
+      expect(executionDetails.length).to.equal(5);
+      const noActiveChannel = executionDetails.find((ex) => ex.detail === DetailEnum.SUBSCRIBER_NO_ACTIVE_CHANNEL);
+      expect(noActiveChannel).to.be.ok;
+      expect(noActiveChannel?.providerId).to.equal('fcm');
+      const genericError = executionDetails.find((ex) => ex.detail === DetailEnum.NOTIFICATION_ERROR);
+      expect(genericError).to.be.ok;
+    });
+
+    it('should not create any message if subscriber has configured two providers without device tokens', async () => {
+      await updateCredentials(session, session.subscriberId, PushProviderIdEnum.FCM, []);
+      await updateCredentials(session, session.subscriberId, PushProviderIdEnum.EXPO, []);
+
+      await triggerEvent(session, template);
+
+      await session.awaitRunningJobs(template._id);
+
+      const messages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        _subscriberId: session.subscriberId,
+      });
+
+      expect(messages.length).to.equal(0);
+
+      const executionDetails = await executionDetailsRepository.find({
+        _environmentId: session.environment._id,
+      });
+
+      expect(executionDetails.length).to.equal(6);
+      const fcm = executionDetails.find(
+        (ex) => ex.detail === DetailEnum.PUSH_MISSING_DEVICE_TOKENS && ex.providerId === PushProviderIdEnum.FCM
+      );
+      expect(fcm).to.be.ok;
+      const expo = executionDetails.find(
+        (ex) => ex.detail === DetailEnum.PUSH_MISSING_DEVICE_TOKENS && ex.providerId === PushProviderIdEnum.EXPO
+      );
+      expect(expo).to.be.ok;
+      const genericError = executionDetails.find((ex) => ex.detail === DetailEnum.NOTIFICATION_ERROR);
+      expect(genericError).to.be.ok;
+    });
+
+    it('should not create any message if subscriber has configured one provider without device tokens and the other has invalid device token', async () => {
+      await updateCredentials(session, session.subscriberId, PushProviderIdEnum.FCM, ['invalidDeviceToken']);
+      await updateCredentials(session, session.subscriberId, PushProviderIdEnum.EXPO, []);
+
+      await triggerEvent(session, template);
+
+      await session.awaitRunningJobs(template._id);
+
+      const messages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        _subscriberId: session.subscriberId,
+      });
+
+      expect(messages.length).to.equal(0);
+
+      const executionDetails = await executionDetailsRepository.find({
+        _environmentId: session.environment._id,
+      });
+
+      expect(executionDetails.length).to.equal(8);
+      const fcmMessageCreated = executionDetails.find(
+        (ex) =>
+          ex.detail === `${DetailEnum.MESSAGE_CREATED}: ${PushProviderIdEnum.FCM}` &&
+          ex.providerId === PushProviderIdEnum.FCM
+      );
+      expect(fcmMessageCreated).to.be.ok;
+      const fcmProviderError = executionDetails.find(
+        (ex) => ex.detail === DetailEnum.PROVIDER_ERROR && ex.providerId === PushProviderIdEnum.FCM
+      );
+      expect(fcmProviderError).to.be.ok;
+
+      const expo = executionDetails.find(
+        (ex) => ex.detail === DetailEnum.PUSH_MISSING_DEVICE_TOKENS && ex.providerId === PushProviderIdEnum.EXPO
+      );
+      expect(expo).to.be.ok;
+      const genericError = executionDetails.find((ex) => ex.detail === DetailEnum.NOTIFICATION_ERROR);
+      expect(genericError).to.be.ok;
+    });
+  });
+});
+
+async function triggerEvent(session: UserSession, template: NotificationTemplateEntity) {
+  await axiosInstance.post(
+    `${session.serverUrl}/v1/events/trigger`,
+    {
+      name: template.triggers[0].identifier,
+      to: [{ subscriberId: session.subscriberId }],
+      payload: {},
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+}
+
+async function updateCredentials(
+  session: UserSession,
+  subscriberId: string,
+  providerId: PushProviderIdEnum,
+  deviceTokens: string[]
+) {
+  await axiosInstance.put(
+    `${session.serverUrl}/v1/subscribers/${subscriberId}/credentials`,
+    {
+      subscriberId,
+      providerId,
+      credentials: {
+        deviceTokens,
+      },
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+}

--- a/packages/application-generic/src/usecases/create-execution-details/types/index.ts
+++ b/packages/application-generic/src/usecases/create-execution-details/types/index.ts
@@ -35,4 +35,5 @@ export enum DetailEnum {
   DIGEST_MERGED = 'Digest was merged with other digest',
   DELAY_FINISHED = 'Delay is finished',
   PUSH_MISSING_DEVICE_TOKENS = 'Subscriber credentials is missing the tokens for sending a push notification message',
+  NOTIFICATION_ERROR = 'There was one or more errors when trying to execute the notification',
 }


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Improves the handling of different push notifications messages sending:
- Doesn't throw anymore breaking the loop so cases of multiple push providers are handled properly.
- Increases the details in the activity feed for the cases of missing configuration, missing device tokens, when there is an error in one or many of multiple providers active.
- Creates a new notification error detail for the summary card of the execution details.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Code wasn't handling properly cases where multiple Push providers were active at the very same time.
Also there was no test suite for sending push notifications so it was added.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
<img width="1615" alt="Screenshot 2023-10-11 at 16 03 10" src="https://github.com/novuhq/novu/assets/18152036/a72c96cb-8841-4b0f-b680-035f7022608e">
<img width="1599" alt="Screenshot 2023-10-11 at 16 04 15" src="https://github.com/novuhq/novu/assets/18152036/22b05c85-9813-492f-b356-abe41d546e1b">
