### PR TITLE
chore: update LICENSE section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,19 @@ We are more than happy to help you. If you are getting any errors or facing prob
 
 ## 🛡️ License
 
-Novu is licensed under the MIT License - see the [LICENSE](https://github.com/novuhq/novu/blob/main/LICENSE) file for details.
+<table>
+  <tr>
+     <td>
+       <p align="center"> <img src="https://user-images.githubusercontent.com/66154908/175827109-a9f2f54a-f63e-4e07-bd83-a1f760246b56.png" width="80%"></img>
+    </td>
+    <td> 
+      <img src="https://img.shields.io/badge/License-MIT-yellow.svg"/> <br> 
+Novu is licensed under the MIT License - see the  <a href="https://github.com/novuhq/novu/blob/main/LICENSE">LICENSE</a> file for details. <img width=2300/>
+    </td>
+  </tr>
+</table>
+
+
 
 ## 💪 Thanks To All Contributors
 


### PR DESCRIPTION
### What change does this PR introduce?

Updated the LICENSE section in the README file to enhance the presentation. Added a MIT logo, license badge and replaced the previous text with a cleaner format, including a hyperlink to the LICENSE file.

### Why was this change needed?

To enhance readability and presentation of LICENSE section

### Other information (Screenshots)

- Current:
> ![image](https://github.com/novuhq/novu/assets/66154908/56c5aeb1-7ae3-4025-97ed-3c4813c07735)
- Updated:
> ![image](https://github.com/novuhq/novu/assets/66154908/82669201-ef25-4d4a-b600-a98c9b0f94de)

Link to LICENSE section in updated repo [malivinayak/novu](https://github.com/malivinayak/novu#%EF%B8%8F-license)
