### PR TITLE
NV-4163 - 🐛 Bug Report: Variable not Working in Subject with SMTP Email Provider

### DIFF
--- a/packages/application-generic/src/usecases/send-test-email/send-test-email.usecase.ts
+++ b/packages/application-generic/src/usecases/send-test-email/send-test-email.usecase.ts
@@ -77,8 +77,12 @@ export class SendTestEmail {
             events: [],
             total_count: 1,
             ...this.getSystemVariables('step', command),
+            ...command.payload.step,
           },
-          subscriber: this.getSystemVariables('subscriber', command),
+          subscriber: {
+            ...this.getSystemVariables('subscriber', command),
+            ...command.payload.subscriber,
+          },
         },
       })
     );


### PR DESCRIPTION
### What change does this PR introduce?
Fix the issue where the variable on the  mail subject and mail body is not been replaced by the actual value

### Why was this change needed?
 Closes: https://github.com/novuhq/novu/issues/4163

### Additional information
#### Before Changes
https://www.loom.com/share/9361a4a030134d8fbd689a0969fc5304?sid=dc369f8d-a379-445c-8a86-8b612ed20678

#### After Changes 
https://www.loom.com/share/5872e82fb8d84ea69412b4b916fe0f94?sid=8a4c935e-c488-4b76-a392-421ff36bea4d


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
