### PR TITLE
fix(worker): self hosted metrics services were not shutdown properly

### DIFF
--- a/apps/worker/src/app/workflow/services/active-jobs-metric.service.ts
+++ b/apps/worker/src/app/workflow/services/active-jobs-metric.service.ts
@@ -120,8 +120,12 @@ export class ActiveJobsMetricService {
   public async gracefulShutdown(): Promise<void> {
     Logger.log('Shutting the Active Jobs Metric service down', LOG_CONTEXT);
 
-    await this.activeJobsMetricQueueService.gracefulShutdown();
-    await this.activeJobsMetricWorkerService.gracefulShutdown();
+    if (this.activeJobsMetricQueueService) {
+      await this.activeJobsMetricQueueService.gracefulShutdown();
+    }
+    if (this.activeJobsMetricWorkerService) {
+      await this.activeJobsMetricWorkerService.gracefulShutdown();
+    }
 
     Logger.log('Shutting down the Active Jobs Metric service has finished', LOG_CONTEXT);
   }

--- a/apps/worker/src/app/workflow/services/completed-jobs-metric.service.ts
+++ b/apps/worker/src/app/workflow/services/completed-jobs-metric.service.ts
@@ -121,8 +121,12 @@ export class CompletedJobsMetricService {
   public async gracefulShutdown(): Promise<void> {
     Logger.log('Shutting the Completed Jobs Metric service down', LOG_CONTEXT);
 
-    await this.completedJobsMetricQueueService.gracefulShutdown();
-    await this.completedJobsMetricWorkerService.gracefulShutdown();
+    if (this.completedJobsMetricQueueService) {
+      await this.completedJobsMetricQueueService.gracefulShutdown();
+    }
+    if (this.completedJobsMetricWorkerService) {
+      await this.completedJobsMetricWorkerService.gracefulShutdown();
+    }
 
     Logger.log('Shutting down the Completed Jobs Metric service has finished', LOG_CONTEXT);
   }


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Fixes the graceful shutdown for the Metrics services for the self hosted users.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
Because self hosted users didn't have the Metrics services initialised the graceful shutdown would fail throwing an error and potentially blocking the shutdown.

### Other information (Screenshots)
<img width="669" alt="Screenshot 2023-10-13 at 11 48 39" src="https://github.com/novuhq/novu/assets/18152036/33c2b81e-9685-43a6-97af-7a4b65e830c2">

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
