### PR TITLE
Update Sendinblue to Brevo

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Novu provides a single API to manage providers across multiple channels with a s
 - [x] [Custom SMTP](https://github.com/novuhq/novu/tree/main/providers/nodemailer)
 - [x] [Mailjet](https://github.com/novuhq/novu/tree/main/providers/mailjet)
 - [x] [Mandrill](https://github.com/novuhq/novu/tree/main/providers/mandrill)
-- [x] [SendinBlue](https://github.com/novuhq/novu/tree/main/providers/sendinblue)
+- [x] [Brevo (formerly Sendinblue)](https://github.com/novuhq/novu/tree/main/providers/sendinblue)
 - [x] [MailerSend](https://github.com/novuhq/novu/tree/main/providers/mailersend)
 - [x] [Infobip](https://github.com/novuhq/novu/tree/main/providers/infobip)
 - [x] [Resend](https://github.com/novuhq/novu/tree/main/providers/resend)


### PR DESCRIPTION
### What change does this PR introduce?
Sendinblue is now Brevo but Readme still displays it as Sendinblue - Added Brevo keeping Sendinblue name intact

`Sendinblue` => `Brevo (formerly Sendinblue)`

References::
- https://www.brevo.com/blog/becoming-brevo/
- https://help.brevo.com/hc/en-us/articles/11279317272722-FAQs-Sendinblue-becomes-Brevo