### PR TITLE
[NV-3037] Fixed closing off the wrong socket in useUnreadCount.ts

### DIFF
--- a/packages/notification-center/src/components/novu-provider/NovuProvider.tsx
+++ b/packages/notification-center/src/components/novu-provider/NovuProvider.tsx
@@ -27,6 +27,7 @@ export const queryClient = new QueryClient({
 const DEFAULT_FETCHING_STRATEGY: IFetchingStrategy = {
   fetchUnseenCount: true,
   fetchOrganization: true,
+  fetchUnreadCount: false,
   fetchNotifications: false,
   fetchUserPreferences: false,
   fetchUserGlobalPreferences: false,

--- a/packages/notification-center/src/components/novu-provider/NovuProvider.tsx
+++ b/packages/notification-center/src/components/novu-provider/NovuProvider.tsx
@@ -27,7 +27,7 @@ export const queryClient = new QueryClient({
 const DEFAULT_FETCHING_STRATEGY: IFetchingStrategy = {
   fetchUnseenCount: true,
   fetchOrganization: true,
-  fetchUnreadCount: false,
+  fetchUnreadCount: true,
   fetchNotifications: false,
   fetchUserPreferences: false,
   fetchUserGlobalPreferences: false,

--- a/packages/notification-center/src/hooks/useUnreadCount.ts
+++ b/packages/notification-center/src/hooks/useUnreadCount.ts
@@ -75,7 +75,7 @@ export const useUnreadCount = ({ onSuccess, ...restOptions }: UseQueryOptions<IC
     () => apiService.getUnreadCount({ limit: 100 }),
     {
       ...restOptions,
-      enabled: isSessionInitialized && fetchingStrategy.fetchUnseenCount,
+      enabled: isSessionInitialized && fetchingStrategy.fetchUnreadCount,
       onSuccess: (data) => {
         dispatchUnreadCountEvent(data.count);
         onSuccess?.(data);

--- a/packages/notification-center/src/hooks/useUnreadCount.ts
+++ b/packages/notification-center/src/hooks/useUnreadCount.ts
@@ -66,7 +66,7 @@ export const useUnreadCount = ({ onSuccess, ...restOptions }: UseQueryOptions<IC
     );
 
     return () => {
-      socket.off(WebSocketEventEnum.UNSEEN);
+      socket.off(WebSocketEventEnum.UNREAD);
     };
   }, [socket, queryClient, setQueryKey]);
 

--- a/packages/notification-center/src/shared/interfaces/index.ts
+++ b/packages/notification-center/src/shared/interfaces/index.ts
@@ -75,6 +75,7 @@ export interface IStore {
 
 export interface IFetchingStrategy {
   fetchUnseenCount: boolean;
+  fetchUnreadCount: boolean;
   fetchOrganization: boolean;
   fetchNotifications: boolean;
   fetchUserPreferences: boolean;


### PR DESCRIPTION
### What change does this PR introduce?

This fixes an issue where the useUnreadCount hook closes the wrong websocket channel.

### Why was this change needed?

https://github.com/novuhq/novu/issues/4582

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
