### PR TITLE
fix : Fixed adding Trigger Identifier to the Subscriber Preferences

### DIFF
--- a/packages/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/packages/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -58,7 +58,7 @@ export class GetSubscriberTemplatePreference {
     const subscriberChannelPreference = subscriberPreference?.channels;
     const templateChannelPreference = command.template.preferenceSettings;
 
-    const { channels, overrides } = overridePreferences(
+    const { channels, overrides, triggers } = overridePreferences(
       {
         template: templateChannelPreference,
         subscriber: subscriberChannelPreference,
@@ -72,6 +72,7 @@ export class GetSubscriberTemplatePreference {
         enabled: subscriberPreference?.enabled ?? true,
         channels,
         overrides,
+        triggers, // Add the triggers field here
       },
     };
   }
@@ -254,5 +255,6 @@ function mapTemplateConfiguration(
     tags: template?.tags || [],
     critical: template.critical != null ? template.critical : true,
     ...(template.data ? { data: template.data } : {}),
+    triggers: template.triggers || [], // Add the triggers field here
   };
 }


### PR DESCRIPTION
### What change does this PR introduce?
This PR fixes the addition of Trigger Identifier to the Subscriber Preferences

### Why was this change needed?
In the code provided, the following changes were made to add the triggers field to the response of the GetSubscriberTemplatePreference query :-
1. Defined the triggers field in the ITemplateConfiguration interface
2. Modified the mapTemplateConfiguration function to include the triggers field
3. Included the triggers field in the ISubscriberPreferenceResponse returned by the execute method

Fixes #4417
