### PR TITLE
Added words for Kannada language translation and also changed the language code

### DIFF
--- a/packages/notification-center/src/i18n/lang.ts
+++ b/packages/notification-center/src/i18n/lang.ts
@@ -31,7 +31,7 @@ import { ID } from './languages/id';
 import { IG } from './languages/ig';
 import { IT } from './languages/it';
 import { JA } from './languages/ja';
-import { KA } from './languages/kn';
+import { KN } from './languages/kn';
 import { KK } from './languages/kk';
 import { KM } from './languages/km';
 import { KO } from './languages/ko';
@@ -120,9 +120,9 @@ export const TRANSLATIONS: Record<I18NLanguage, ITranslationEntry> = {
   ig: IG,
   it: IT,
   ja: JA,
-  ka: KA,
   kk: KK,
   km: KM,
+  kn: KN,
   ko: KO,
   ku: KU,
   lo: LO,
@@ -206,9 +206,9 @@ export type I18NLanguage =
   | 'ig'
   | 'it'
   | 'ja'
-  | 'ka'
   | 'kk'
   | 'km'
+  | 'kn'
   | 'ko'
   | 'ku'
   | 'lo'

--- a/packages/notification-center/src/i18n/lang.ts
+++ b/packages/notification-center/src/i18n/lang.ts
@@ -31,7 +31,7 @@ import { ID } from './languages/id';
 import { IG } from './languages/ig';
 import { IT } from './languages/it';
 import { JA } from './languages/ja';
-import { KA } from './languages/ka';
+import { KA } from './languages/kn';
 import { KK } from './languages/kk';
 import { KM } from './languages/km';
 import { KO } from './languages/ko';

--- a/packages/notification-center/src/i18n/languages/kn.ts
+++ b/packages/notification-center/src/i18n/languages/kn.ts
@@ -5,8 +5,8 @@ export const KA: ITranslationEntry = {
     notifications: 'ಅಧಿಸೂಚನೆಗಳು',
     markAllAsRead: 'ಎಲ್ಲವನ್ನು ಓದಲಾಗಿದೆ ಎಂದು ಗುರುತಿಸಿ',
     poweredBy: 'ಮೂಲಕ ನಡೆಸಲ್ಪಡುತ್ತಿದೆ',
-    settings: '',
-    noNewNotification: '',
+    settings: 'ಸೆಟ್ಟಿಂಗ್ಸ್',
+    noNewNotification: 'ಹೊಸ ಅಧಿಸೂಚನೆ ಇಲ್ಲ',
   },
   lang: 'kn',
 };

--- a/packages/notification-center/src/i18n/languages/kn.ts
+++ b/packages/notification-center/src/i18n/languages/kn.ts
@@ -1,6 +1,6 @@
 import { ITranslationEntry } from '../lang';
 
-export const KA: ITranslationEntry = {
+export const KN: ITranslationEntry = {
   translations: {
     notifications: 'ಅಧಿಸೂಚನೆಗಳು',
     markAllAsRead: 'ಎಲ್ಲವನ್ನು ಓದಲಾಗಿದೆ ಎಂದು ಗುರುತಿಸಿ',

--- a/packages/notification-center/src/i18n/languages/kn.ts
+++ b/packages/notification-center/src/i18n/languages/kn.ts
@@ -5,8 +5,8 @@ export const KA: ITranslationEntry = {
     notifications: 'ಅಧಿಸೂಚನೆಗಳು',
     markAllAsRead: 'ಎಲ್ಲವನ್ನು ಓದಲಾಗಿದೆ ಎಂದು ಗುರುತಿಸಿ',
     poweredBy: 'ಮೂಲಕ ನಡೆಸಲ್ಪಡುತ್ತಿದೆ',
-    settings: 'ಸಂಯೋಜನೆಗಳು',
-    noNewNotification: 'აქ ახალი სანახავი ჯერ არაფერია',
+    settings: '',
+    noNewNotification: '',
   },
-  lang: 'ka',
+  lang: 'kn',
 };


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
It adds two more words for the translation to kannada and changes the actual language code for Kannada

Why was this change needed?
Because settings and no new notification words were not translated into Kannada
And the actual code for kannada language is kn not ka