### PR TITLE
added novu contributions url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,6 @@ Questions, suggestions, and thoughts are most welcome. Feel free to open a [GitH
 ## Missing a provider?
 
 If you are in need of a provider we do not yet have, you can request a new one by [submitting an issue](#submitting-an-issue). Or you can build a new one by following our [create a provider guide](https://docs.novu.co/community/add-a-new-provider).
+Contributor Novu: [Check your contributions](https://novu.co/contributors/)
+
+


### PR DESCRIPTION
### What change does this PR introduce?
There is a simple change in Contributions.md
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
I had added one line for the users to check their contributions in Novu project.
### Why was this change needed?
Novu provides the information of the commits done by the contributions and also the PR count so we can show it on our repo in Contribution.md

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
