### PR TITLE
docs(notification-center-vue): Fix repository url

### DIFF
--- a/packages/notification-center-vue/package.json
+++ b/packages/notification-center-vue/package.json
@@ -5,7 +5,7 @@
   "description": "Vue specific wrapper for notification-center",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ionic-team/ionic.git"
+    "url": "https://github.com/novuhq/novu.git"
   },
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
### What change does this PR introduce?
* Fixes the repository `url` in the Vue Notification center

### Why was this change needed?
* An incocrect repository URL was present for the Vue Notification Center

### Other information (Screenshots)
N/A
<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
