### PR TITLE
feat(shared): tidy up filters operators to reuse in events broadcast

### DIFF
--- a/apps/api/src/app/blueprint/e2e/get-grouped-blueprints.e2e.ts
+++ b/apps/api/src/app/blueprint/e2e/get-grouped-blueprints.e2e.ts
@@ -3,7 +3,14 @@ import * as sinon from 'sinon';
 
 import { UserSession } from '@novu/testing';
 import { NotificationTemplateRepository, EnvironmentRepository } from '@novu/dal';
-import { EmailBlockTypeEnum, FilterPartTypeEnum, INotificationTemplate, StepTypeEnum } from '@novu/shared';
+import {
+  EmailBlockTypeEnum,
+  FieldLogicalOperatorEnum,
+  FieldOperatorEnum,
+  FilterPartTypeEnum,
+  INotificationTemplate,
+  StepTypeEnum,
+} from '@novu/shared';
 import {
   buildGroupedBlueprintsKey,
   CacheService,
@@ -177,13 +184,13 @@ export async function createTemplateFromBlueprint({
           {
             isNegated: false,
             type: 'GROUP',
-            value: 'AND',
+            value: FieldLogicalOperatorEnum.AND,
             children: [
               {
                 on: FilterPartTypeEnum.SUBSCRIBER,
                 field: 'firstName',
                 value: 'test value',
-                operator: 'EQUAL',
+                operator: FieldOperatorEnum.EQUAL,
               },
             ],
           },

--- a/apps/api/src/app/change/e2e/get-changes.e2e.ts
+++ b/apps/api/src/app/change/e2e/get-changes.e2e.ts
@@ -1,6 +1,12 @@
 import { expect } from 'chai';
 import { ChangeRepository } from '@novu/dal';
-import { EmailBlockTypeEnum, StepTypeEnum, FilterPartTypeEnum } from '@novu/shared';
+import {
+  EmailBlockTypeEnum,
+  StepTypeEnum,
+  FilterPartTypeEnum,
+  FieldLogicalOperatorEnum,
+  FieldOperatorEnum,
+} from '@novu/shared';
 import { UserSession } from '@novu/testing';
 
 import { CreateWorkflowRequestDto, UpdateWorkflowRequestDto } from '../../workflows/dto';
@@ -32,13 +38,13 @@ describe('Get changes', () => {
             {
               isNegated: false,
               type: 'GROUP',
-              value: 'AND',
+              value: FieldLogicalOperatorEnum.AND,
               children: [
                 {
                   on: FilterPartTypeEnum.SUBSCRIBER,
                   field: 'firstName',
                   value: 'test value',
-                  operator: 'EQUAL',
+                  operator: FieldOperatorEnum.EQUAL,
                 },
               ],
             },

--- a/apps/api/src/app/change/e2e/promote-changes.e2e.ts
+++ b/apps/api/src/app/change/e2e/promote-changes.e2e.ts
@@ -13,6 +13,8 @@ import {
   ChangeEntityTypeEnum,
   ChannelCTATypeEnum,
   EmailBlockTypeEnum,
+  FieldLogicalOperatorEnum,
+  FieldOperatorEnum,
   StepTypeEnum,
   FilterPartTypeEnum,
   TemplateVariableTypeEnum,
@@ -69,13 +71,13 @@ describe('Promote changes', () => {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.SUBSCRIBER,
                     field: 'firstName',
                     value: 'test value',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                   },
                 ],
               },
@@ -96,7 +98,7 @@ describe('Promote changes', () => {
         _parentId: notificationTemplateId,
       });
 
-      expect(prodVersion._notificationGroupId).to.eq(prodGroup._id);
+      expect(prodVersion?._notificationGroupId).to.eq(prodGroup._id);
     });
 
     it('should promote step variables default values', async () => {
@@ -204,13 +206,13 @@ describe('Promote changes', () => {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.SUBSCRIBER,
                     field: 'firstName',
                     value: 'test value',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                   },
                 ],
               },
@@ -242,7 +244,7 @@ describe('Promote changes', () => {
         _parentId: notificationTemplateId,
       } as any);
 
-      expect(prodVersion.steps.length).to.eq(0);
+      expect(prodVersion?.steps.length).to.eq(0);
     });
 
     it('update active flag on notification template', async () => {
@@ -274,7 +276,7 @@ describe('Promote changes', () => {
         _parentId: notificationTemplateId,
       });
 
-      expect(prodVersion.active).to.eq(true);
+      expect(prodVersion?.active).to.eq(true);
     });
 
     it('update existing message', async () => {
@@ -295,13 +297,13 @@ describe('Promote changes', () => {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.SUBSCRIBER,
                     field: 'firstName',
                     value: 'test value',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                   },
                 ],
               },
@@ -352,7 +354,7 @@ describe('Promote changes', () => {
         _parentId: step._templateId,
       });
 
-      expect(prodVersion.name).to.eq('test');
+      expect(prodVersion?.name).to.eq('test');
     });
 
     it('add one more message', async () => {
@@ -373,13 +375,13 @@ describe('Promote changes', () => {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.SUBSCRIBER,
                     field: 'firstName',
                     value: 'test value',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                   },
                 ],
               },
@@ -431,13 +433,13 @@ describe('Promote changes', () => {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.SUBSCRIBER,
                     field: 'secondName',
                     value: 'test value',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                   },
                 ],
               },
@@ -479,13 +481,13 @@ describe('Promote changes', () => {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.SUBSCRIBER,
                     field: 'firstName',
                     value: 'test value',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                   },
                 ],
               },
@@ -521,13 +523,13 @@ describe('Promote changes', () => {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.SUBSCRIBER,
                     field: 'firstName',
                     value: 'test value',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                   },
                 ],
               },
@@ -632,13 +634,13 @@ describe('Promote changes', () => {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.SUBSCRIBER,
                     field: 'firstName',
                     value: 'test value',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                   },
                 ],
               },
@@ -659,7 +661,7 @@ describe('Promote changes', () => {
         _parentId: notificationTemplateId,
       });
 
-      expect(prodVersion.isBlueprint).to.equal(true);
+      expect(prodVersion?.isBlueprint).to.equal(true);
     });
 
     it('should merge creation, and status changes to one change', async () => {
@@ -724,9 +726,15 @@ describe('Promote changes', () => {
     });
   });
 
-  async function getProductionEnvironment() {
-    return await environmentRepository.findOne({
+  async function getProductionEnvironment(): Promise<EnvironmentEntity> {
+    const production = await environmentRepository.findOne({
       _parentId: session.environment._id,
     });
+
+    if (!production) {
+      throw new Error('No production environment');
+    }
+
+    return production;
   }
 });

--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -19,13 +19,15 @@ import { UserSession, SubscribersService } from '@novu/testing';
 import {
   ChannelTypeEnum,
   EmailBlockTypeEnum,
+  FieldLogicalOperatorEnum,
+  FieldOperatorEnum,
+  FilterPartTypeEnum,
   StepTypeEnum,
   IEmailBlock,
   ISubscribersDefine,
   TemplateVariableTypeEnum,
   EmailProviderIdEnum,
   SmsProviderIdEnum,
-  FilterPartTypeEnum,
   DigestUnitEnum,
   DelayTypeEnum,
   PreviousStepTypeEnum,
@@ -90,11 +92,11 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.PAYLOAD,
-                    operator: 'IS_DEFINED',
+                    operator: FieldOperatorEnum.IS_DEFINED,
                     field: 'exclude',
                     value: '',
                   },
@@ -170,11 +172,11 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.PAYLOAD,
-                    operator: 'IS_DEFINED',
+                    operator: FieldOperatorEnum.IS_DEFINED,
                     field: 'exclude',
                     value: '',
                   },
@@ -250,11 +252,11 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.PAYLOAD,
-                    operator: 'IS_DEFINED',
+                    operator: FieldOperatorEnum.IS_DEFINED,
                     field: 'exclude',
                     value: '',
                   },
@@ -331,11 +333,11 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     on: FilterPartTypeEnum.PAYLOAD,
-                    operator: 'IS_DEFINED',
+                    operator: FieldOperatorEnum.IS_DEFINED,
                     field: 'exclude',
                     value: '',
                   },
@@ -397,7 +399,7 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
         _environmentId: session.environment._id,
         conditions: [
           {
-            children: [{ field: 'identifier', value: 'test', operator: 'EQUAL', on: 'tenant' }],
+            children: [{ field: 'identifier', value: 'test', operator: FieldOperatorEnum.EQUAL, on: 'tenant' }],
           },
         ],
         active: true,
@@ -436,10 +438,10 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
         _environmentId: session.environment._id,
         conditions: [
           {
-            value: 'OR',
+            value: FieldLogicalOperatorEnum.OR,
             children: [
-              { field: 'identifier', value: 'test3', operator: 'EQUAL', on: 'tenant' },
-              { field: 'identifier', value: 'test2', operator: 'EQUAL', on: 'tenant' },
+              { field: 'identifier', value: 'test3', operator: FieldOperatorEnum.EQUAL, on: 'tenant' },
+              { field: 'identifier', value: 'test2', operator: FieldOperatorEnum.EQUAL, on: 'tenant' },
             ],
           },
         ],
@@ -496,7 +498,7 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
         _environmentId: session.environment._id,
         conditions: [
           {
-            children: [{ field: 'identifier', value: 'test1', operator: 'EQUAL', on: 'tenant' }],
+            children: [{ field: 'identifier', value: 'test1', operator: FieldOperatorEnum.EQUAL, on: 'tenant' }],
           },
         ],
         active: true,
@@ -1701,13 +1703,13 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
 
                 type: 'GROUP',
 
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
 
                 children: [
                   {
                     field: 'run',
                     value: 'true',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                     on: FilterPartTypeEnum.PAYLOAD,
                   },
                 ],
@@ -1734,13 +1736,13 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
 
                 type: 'GROUP',
 
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
 
                 children: [
                   {
                     field: 'subscriberId',
                     value: subscriber.subscriberId,
-                    operator: 'NOT_EQUAL',
+                    operator: FieldOperatorEnum.NOT_EQUAL,
                     on: FilterPartTypeEnum.SUBSCRIBER,
                   },
                 ],
@@ -1799,12 +1801,12 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     field: 'isOnline',
                     value: 'true',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                     on: FilterPartTypeEnum.WEBHOOK,
                     webhookUrl: 'www.user.com/webhook',
                   },
@@ -1901,12 +1903,12 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     field: 'isOnline',
                     value: 'true',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                     on: FilterPartTypeEnum.WEBHOOK,
                     webhookUrl: 'www.user.com/webhook',
                   },
@@ -1966,12 +1968,12 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
               {
                 isNegated: false,
                 type: 'GROUP',
-                value: 'AND',
+                value: FieldLogicalOperatorEnum.AND,
                 children: [
                   {
                     field: 'isOnline',
                     value: 'true',
-                    operator: 'EQUAL',
+                    operator: FieldOperatorEnum.EQUAL,
                     on: FilterPartTypeEnum.WEBHOOK,
                     webhookUrl: 'www.user.com/webhook',
                   },
@@ -2228,7 +2230,7 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
                 {
                   isNegated: false,
                   type: 'GROUP',
-                  value: 'AND',
+                  value: FieldLogicalOperatorEnum.AND,
                   children: [
                     {
                       on: FilterPartTypeEnum.PREVIOUS_STEP,
@@ -2320,7 +2322,7 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
                 {
                   isNegated: false,
                   type: 'GROUP',
-                  value: 'AND',
+                  value: FieldLogicalOperatorEnum.AND,
                   children: [
                     {
                       on: FilterPartTypeEnum.PREVIOUS_STEP,

--- a/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
@@ -4,6 +4,7 @@ import {
   ChannelTypeEnum,
   ChatProviderIdEnum,
   EmailProviderIdEnum,
+  FieldOperatorEnum,
   InAppProviderIdEnum,
   PushProviderIdEnum,
   SmsProviderIdEnum,
@@ -106,7 +107,7 @@ describe('Create Integration - /integration (POST)', function () {
       check: false,
       conditions: [
         {
-          children: [{ field: 'identifier', value: 'test', operator: 'EQUAL', on: 'tenant' }],
+          children: [{ field: 'identifier', value: 'test', operator: FieldOperatorEnum.EQUAL, on: 'tenant' }],
         },
       ],
     };

--- a/apps/api/src/app/shared/helpers/content.service.spec.ts
+++ b/apps/api/src/app/shared/helpers/content.service.spec.ts
@@ -3,6 +3,8 @@ import {
   DelayTypeEnum,
   DigestTypeEnum,
   DigestUnitEnum,
+  FieldLogicalOperatorEnum,
+  FieldOperatorEnum,
   FilterPartTypeEnum,
   StepTypeEnum,
   TriggerContextTypeEnum,
@@ -292,13 +294,13 @@ describe('ContentService', function () {
             {
               isNegated: false,
               type: 'GROUP',
-              value: 'AND',
+              value: FieldLogicalOperatorEnum.AND,
               children: [
                 {
                   on: FilterPartTypeEnum.PAYLOAD,
                   field: 'counter',
                   value: 'test value',
-                  operator: 'EQUAL',
+                  operator: FieldOperatorEnum.EQUAL,
                 },
               ],
             },

--- a/apps/api/src/app/workflows/e2e/create-notification-templates.e2e.ts
+++ b/apps/api/src/app/workflows/e2e/create-notification-templates.e2e.ts
@@ -4,6 +4,8 @@ import {
   ChannelCTATypeEnum,
   ChannelTypeEnum,
   EmailBlockTypeEnum,
+  FieldLogicalOperatorEnum,
+  FieldOperatorEnum,
   StepTypeEnum,
   INotificationTemplate,
   TriggerTypeEnum,
@@ -80,13 +82,13 @@ describe('Create Workflow - /workflows (POST)', async () => {
             {
               isNegated: false,
               type: 'GROUP',
-              value: 'AND',
+              value: FieldLogicalOperatorEnum.AND,
               children: [
                 {
                   on: FilterPartTypeEnum.SUBSCRIBER,
                   field: 'firstName',
                   value: 'test value',
-                  operator: 'EQUAL',
+                  operator: FieldOperatorEnum.EQUAL,
                 },
               ],
             },
@@ -504,13 +506,13 @@ export async function createTemplateFromBlueprint({
           {
             isNegated: false,
             type: 'GROUP',
-            value: 'AND',
+            value: FieldLogicalOperatorEnum.AND,
             children: [
               {
                 on: FilterPartTypeEnum.SUBSCRIBER,
                 field: 'firstName',
                 value: 'test value',
-                operator: 'EQUAL',
+                operator: FieldOperatorEnum.EQUAL,
               },
             ],
           },

--- a/apps/web/src/components/conditions/Conditions.tsx
+++ b/apps/web/src/components/conditions/Conditions.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { useMemo } from 'react';
 import { Control, Controller, useFieldArray, useForm, useWatch } from 'react-hook-form';
 
-import { FILTER_TO_LABEL, FilterPartTypeEnum } from '@novu/shared';
+import { FILTER_TO_LABEL, FilterPartTypeEnum, FieldLogicalOperatorEnum, FieldOperatorEnum } from '@novu/shared';
 
 import {
   Button,
@@ -135,13 +135,13 @@ export function Conditions({
                     <Controller
                       control={control}
                       name={`conditions.0.value`}
-                      defaultValue="AND"
+                      defaultValue={FieldLogicalOperatorEnum.AND}
                       render={({ field }) => {
                         return (
                           <Select
                             data={[
-                              { value: 'AND', label: 'And' },
-                              { value: 'OR', label: 'Or' },
+                              { value: FieldLogicalOperatorEnum.AND, label: 'And' },
+                              { value: FieldLogicalOperatorEnum.OR, label: 'Or' },
                             ]}
                             {...field}
                             data-test-id="conditions-form-value-dropdown"
@@ -207,7 +207,7 @@ export function Conditions({
           variant="outline"
           onClick={() => {
             append({
-              operator: 'EQUAL',
+              operator: FieldOperatorEnum.EQUAL,
               on: FilterPartTypeEnum.TENANT,
               field: 'identifier',
               value: '',
@@ -255,17 +255,17 @@ function EqualityForm({ control, index }: { control: Control<IConditionsForm>; i
         <Controller
           control={control}
           name={`conditions.0.children.${index}.operator`}
-          defaultValue="EQUAL"
+          defaultValue={FieldOperatorEnum.EQUAL}
           render={({ field }) => {
             return (
               <Select
                 placeholder="Operator"
                 data={[
-                  { value: 'EQUAL', label: 'Equal' },
-                  { value: 'NOT_EQUAL', label: 'Does not equal' },
-                  { value: 'IN', label: 'Contains' },
-                  { value: 'NOT_IN', label: 'Does not contain' },
-                  { value: 'IS_DEFINED', label: 'Is defined' },
+                  { value: FieldOperatorEnum.EQUAL, label: 'Equal' },
+                  { value: FieldOperatorEnum.NOT_EQUAL, label: 'Does not equal' },
+                  { value: FieldOperatorEnum.IN, label: 'Contains' },
+                  { value: FieldOperatorEnum.NOT_IN, label: 'Does not contain' },
+                  { value: FieldOperatorEnum.IS_DEFINED, label: 'Is defined' },
                 ]}
                 {...field}
                 data-test-id="conditions-form-operator"
@@ -276,7 +276,7 @@ function EqualityForm({ control, index }: { control: Control<IConditionsForm>; i
       </Grid.Col>
 
       <Grid.Col span={6}>
-        {operator !== 'IS_DEFINED' && (
+        {operator !== FieldOperatorEnum.IS_DEFINED && (
           <Controller
             control={control}
             name={`conditions.0.children.${index}.value`}

--- a/apps/web/src/components/execution-detail/ExecutionDetailsConditionItem.cy.tsx
+++ b/apps/web/src/components/execution-detail/ExecutionDetailsConditionItem.cy.tsx
@@ -1,4 +1,4 @@
-import { ICondition } from '@novu/shared';
+import { FieldOperatorEnum, ICondition } from '@novu/shared';
 import { TestWrapper } from '../../testing';
 import { ExecutionDetailsConditionItem } from './ExecutionDetailsConditionItem';
 
@@ -7,7 +7,7 @@ const condition: ICondition = {
   field: 'test',
   expected: '1000',
   actual: '100000000',
-  operator: 'LARGER',
+  operator: FieldOperatorEnum.LARGER,
   passed: true,
 };
 

--- a/apps/web/src/components/execution-detail/ExecutionDetailsConditions.cy.tsx
+++ b/apps/web/src/components/execution-detail/ExecutionDetailsConditions.cy.tsx
@@ -1,4 +1,4 @@
-import { ICondition, TimeOperatorEnum } from '@novu/shared';
+import { FieldOperatorEnum, ICondition, TimeOperatorEnum } from '@novu/shared';
 
 import { TestWrapper } from '../../testing';
 import { ExecutionDetailsConditions } from './ExecutionDetailsConditions';
@@ -9,7 +9,7 @@ const conditions: ICondition[] = [
     field: 'test',
     expected: '1000',
     actual: '100000000',
-    operator: 'LARGER',
+    operator: FieldOperatorEnum.LARGER,
     passed: true,
   },
   {
@@ -17,7 +17,7 @@ const conditions: ICondition[] = [
     field: 'isOnline',
     expected: 'true',
     actual: 'true',
-    operator: 'EQUAL',
+    operator: FieldOperatorEnum.EQUAL,
     passed: true,
   },
   {
@@ -33,7 +33,7 @@ const conditions: ICondition[] = [
     field: 'test-key',
     expected: 'test-value',
     actual: 'wrong-value',
-    operator: 'EQUAL',
+    operator: FieldOperatorEnum.EQUAL,
     passed: false,
   },
 ];

--- a/apps/web/src/pages/templates/filter/FilterModal.tsx
+++ b/apps/web/src/pages/templates/filter/FilterModal.tsx
@@ -1,6 +1,6 @@
 import { Divider, Grid, Group, Modal, useMantineTheme } from '@mantine/core';
 import { Controller, useFieldArray, useWatch } from 'react-hook-form';
-import { FILTER_TO_LABEL, FilterPartTypeEnum, ChannelTypeEnum } from '@novu/shared';
+import { FILTER_TO_LABEL, FilterPartTypeEnum, ChannelTypeEnum, FieldOperatorEnum } from '@novu/shared';
 
 import { When } from '../../../components/utils/When';
 import { Button, colors, Input, Select, shadows, Title, Trash } from '@novu/design-system';
@@ -136,7 +136,7 @@ export function FilterModal({
             mt={30}
             onClick={() => {
               append({
-                operator: 'EQUAL',
+                operator: FieldOperatorEnum.EQUAL,
                 on: 'payload',
               });
             }}
@@ -332,28 +332,28 @@ function EqualityForm({
         <Controller
           control={control}
           name={`steps.${stepIndex}.filters.0.children.${index}.operator`}
-          defaultValue="EQUAL"
+          defaultValue={FieldOperatorEnum.EQUAL}
           render={({ field }) => {
             return (
               <Select
                 placeholder="Operator"
                 data={[
-                  { value: 'EQUAL', label: 'Equal' },
-                  { value: 'NOT_EQUAL', label: 'Not equal' },
-                  { value: 'LARGER', label: 'Larger' },
-                  { value: 'SMALLER', label: 'Smaller' },
-                  { value: 'LARGER_EQUAL', label: 'Larger or equal' },
-                  { value: 'SMALLER_EQUAL', label: 'Smaller or equal' },
-                  { value: 'IN', label: 'Contains' },
-                  { value: 'NOT_IN', label: 'Not contains' },
-                  { value: 'IS_DEFINED', label: 'Is Defined' },
+                  { value: FieldOperatorEnum.EQUAL, label: 'Equal' },
+                  { value: FieldOperatorEnum.NOT_EQUAL, label: 'Not equal' },
+                  { value: FieldOperatorEnum.LARGER, label: 'Larger' },
+                  { value: FieldOperatorEnum.SMALLER, label: 'Smaller' },
+                  { value: FieldOperatorEnum.LARGER_EQUAL, label: 'Larger or equal' },
+                  { value: FieldOperatorEnum.SMALLER_EQUAL, label: 'Smaller or equal' },
+                  { value: FieldOperatorEnum.IN, label: 'Contains' },
+                  { value: FieldOperatorEnum.NOT_IN, label: 'Not contains' },
+                  { value: FieldOperatorEnum.IS_DEFINED, label: 'Is Defined' },
                 ]}
                 {...field}
                 data-test-id="filter-operator-dropdown"
                 disabled={readonly}
                 onChange={(value) => {
                   field.onChange(value);
-                  if (value === 'IS_DEFINED') {
+                  if (value === FieldOperatorEnum.IS_DEFINED) {
                     setValue(`steps.${stepIndex}.filters.0.children.${index}.value`, '');
                   }
                 }}
@@ -364,7 +364,7 @@ function EqualityForm({
       </Grid.Col>
 
       <Grid.Col span={spaSize}>
-        {operator !== 'IS_DEFINED' && (
+        {operator !== FieldOperatorEnum.IS_DEFINED && (
           <Controller
             control={control}
             name={`steps.${stepIndex}.filters.0.children.${index}.value`}

--- a/apps/web/src/pages/templates/filter/Filters.cy.tsx
+++ b/apps/web/src/pages/templates/filter/Filters.cy.tsx
@@ -4,6 +4,7 @@ import {
   IOnlineInLastFilterPart,
   IWebhookFilterPart,
   IFieldFilterPart,
+  FieldOperatorEnum,
   FilterPartTypeEnum,
   TimeOperatorEnum,
 } from '@novu/shared';
@@ -105,7 +106,7 @@ describe('Filters Component', function () {
                       on: FilterPartTypeEnum.PAYLOAD,
                       field: 'name',
                       value: 'Novu',
-                      operator: 'EQUAL',
+                      operator: FieldOperatorEnum.EQUAL,
                     },
                   ],
                 },
@@ -121,14 +122,14 @@ describe('Filters Component', function () {
   });
 
   it('should print correct translation of operator', () => {
-    expect(translateOperator('EQUAL')).to.equal('equal');
-    expect(translateOperator('NOT_EQUAL')).to.equal('not equal');
-    expect(translateOperator('LARGER')).to.equal('larger');
-    expect(translateOperator('SMALLER')).to.equal('smaller');
-    expect(translateOperator('LARGER_EQUAL')).to.equal('larger or equal');
-    expect(translateOperator('SMALLER_EQUAL')).to.equal('smaller or equal');
-    expect(translateOperator('NOT_IN')).to.equal('do not include');
-    expect(translateOperator('IN')).to.equal('includes');
+    expect(translateOperator(FieldOperatorEnum.EQUAL)).to.equal('equal');
+    expect(translateOperator(FieldOperatorEnum.NOT_EQUAL)).to.equal('not equal');
+    expect(translateOperator(FieldOperatorEnum.LARGER)).to.equal('larger');
+    expect(translateOperator(FieldOperatorEnum.SMALLER)).to.equal('smaller');
+    expect(translateOperator(FieldOperatorEnum.LARGER_EQUAL)).to.equal('larger or equal');
+    expect(translateOperator(FieldOperatorEnum.SMALLER_EQUAL)).to.equal('smaller or equal');
+    expect(translateOperator(FieldOperatorEnum.NOT_IN)).to.equal('do not include');
+    expect(translateOperator(FieldOperatorEnum.IN)).to.equal('includes');
   });
 
   it('should print correct filter description value according to the filter type', () => {
@@ -141,14 +142,14 @@ describe('Filters Component', function () {
     const webhookFilter: IWebhookFilterPart = {
       field: 'test-field',
       on: FilterPartTypeEnum.WEBHOOK,
-      operator: 'EQUAL',
+      operator: FieldOperatorEnum.EQUAL,
       value: 'test',
       webhookUrl: 'test-url',
     };
     const fieldFilters: IFieldFilterPart = {
       field: 'test-field',
       on: FilterPartTypeEnum.PAYLOAD,
-      operator: 'IN',
+      operator: FieldOperatorEnum.IN,
       value: 'test-value',
     };
 

--- a/apps/web/src/pages/templates/filter/Filters.tsx
+++ b/apps/web/src/pages/templates/filter/Filters.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useMantineColorScheme } from '@mantine/core';
-import { BuilderFieldOperator, FilterParts, FilterPartTypeEnum } from '@novu/shared';
+import { BuilderFieldOperator, FieldOperatorEnum, FilterParts, FilterPartTypeEnum } from '@novu/shared';
 
 import type { IFormStep } from '../components/formTypes';
 import { colors } from '@novu/design-system';
@@ -46,25 +46,25 @@ export const Filter = ({ filter }: { filter: FilterParts }) => {
 };
 
 export const translateOperator = (operator?: BuilderFieldOperator) => {
-  if (operator === 'NOT_EQUAL') {
+  if (operator === FieldOperatorEnum.NOT_EQUAL) {
     return 'not equal';
   }
-  if (operator === 'LARGER') {
+  if (operator === FieldOperatorEnum.LARGER) {
     return 'larger';
   }
-  if (operator === 'SMALLER') {
+  if (operator === FieldOperatorEnum.SMALLER) {
     return 'smaller';
   }
-  if (operator === 'LARGER_EQUAL') {
+  if (operator === FieldOperatorEnum.LARGER_EQUAL) {
     return 'larger or equal';
   }
-  if (operator === 'SMALLER_EQUAL') {
+  if (operator === FieldOperatorEnum.SMALLER_EQUAL) {
     return 'smaller or equal';
   }
-  if (operator === 'NOT_IN') {
+  if (operator === FieldOperatorEnum.NOT_IN) {
     return 'do not include';
   }
-  if (operator === 'IN') {
+  if (operator === FieldOperatorEnum.IN) {
     return 'includes';
   }
 
@@ -73,7 +73,7 @@ export const translateOperator = (operator?: BuilderFieldOperator) => {
 
 export const getFilterLabel = (filter: FilterParts, steps: IFormStep[]): string => {
   if (filter.on === FilterPartTypeEnum.IS_ONLINE) {
-    return `is online right now ${translateOperator('EQUAL')}`;
+    return `is online right now ${translateOperator(FieldOperatorEnum.EQUAL)}`;
   }
   if (filter.on === FilterPartTypeEnum.IS_ONLINE_IN_LAST) {
     return `online in the last "X" ${filter.timeOperator}`;

--- a/apps/web/src/pages/templates/filter/OnlineFiltersForms.tsx
+++ b/apps/web/src/pages/templates/filter/OnlineFiltersForms.tsx
@@ -1,5 +1,5 @@
 import { Grid } from '@mantine/core';
-import { TimeOperatorEnum } from '@novu/shared';
+import { FieldOperatorEnum, TimeOperatorEnum } from '@novu/shared';
 import { Controller } from 'react-hook-form';
 
 import { DeleteStepButton } from './FilterModal.styles';
@@ -61,7 +61,12 @@ function OnlineRightNowForm({
   return (
     <>
       <Grid.Col span={spanSize}>
-        <Select placeholder="Operator" data={[{ value: 'EQUAL', label: 'Equal' }]} value={'EQUAL'} disabled />
+        <Select
+          placeholder="Operator"
+          data={[{ value: FieldOperatorEnum.EQUAL, label: 'Equal' }]}
+          value={FieldOperatorEnum.EQUAL}
+          disabled
+        />
       </Grid.Col>
       <Grid.Col span={spanSize}>
         <Controller

--- a/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.spec.ts
@@ -2,7 +2,16 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import axios from 'axios';
 import { Duration, sub } from 'date-fns';
-import { FilterParts, FilterPartTypeEnum, FILTER_TO_LABEL, StepTypeEnum, TimeOperatorEnum } from '@novu/shared';
+import {
+  BuilderGroupValues,
+  FieldLogicalOperatorEnum,
+  FieldOperatorEnum,
+  FilterParts,
+  FilterPartTypeEnum,
+  FILTER_TO_LABEL,
+  StepTypeEnum,
+  TimeOperatorEnum,
+} from '@novu/shared';
 import { JobEntity, MessageTemplateEntity, NotificationStepEntity } from '@novu/dal';
 
 import { MessageMatcher } from './message-matcher.usecase';
@@ -24,9 +33,9 @@ describe('Message filter matcher', function () {
   it('should filter correct message by the filter value', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'OR', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.OR, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'firstVar',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -46,15 +55,15 @@ describe('Message filter matcher', function () {
   it('should match a message for AND filter group', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'firstVar',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
           },
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'secondVar',
             field: 'secondField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -75,15 +84,15 @@ describe('Message filter matcher', function () {
   it('should not match AND group for single bad item', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Title', 'AND', [
+        step: makeStep('Title', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'firstVar',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
           },
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'secondVar',
             field: 'secondField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -104,15 +113,15 @@ describe('Message filter matcher', function () {
   it('should match a NOT_EQUAL for EQUAL var', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'firstVar',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
           },
           {
-            operator: 'NOT_EQUAL',
+            operator: FieldOperatorEnum.NOT_EQUAL,
             value: 'secondVar',
             field: 'secondField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -133,9 +142,9 @@ describe('Message filter matcher', function () {
   it('should match a EQUAL for a boolean var', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -154,7 +163,7 @@ describe('Message filter matcher', function () {
 
   it('should fall thru for no filters item', async function () {
     const matchedMessage = await messageMatcher.filter(
-      sendMessageCommand({ step: makeStep('Correct Match 2', 'OR', []) }),
+      sendMessageCommand({ step: makeStep('Correct Match 2', FieldLogicalOperatorEnum.OR, []) }),
       {
         payload: {
           varField: 'firstVar',
@@ -169,9 +178,9 @@ describe('Message filter matcher', function () {
   it('should get larger payload var then filter value', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'LARGER',
+            operator: FieldOperatorEnum.LARGER,
             value: '0',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -191,9 +200,9 @@ describe('Message filter matcher', function () {
   it('should get smaller payload var then filter value', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'SMALLER',
+            operator: FieldOperatorEnum.SMALLER,
             value: '3',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -213,9 +222,9 @@ describe('Message filter matcher', function () {
   it('should get larger or equal payload var then filter value', async function () {
     let matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'LARGER_EQUAL',
+            operator: FieldOperatorEnum.LARGER_EQUAL,
             value: '0',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -233,9 +242,9 @@ describe('Message filter matcher', function () {
 
     matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'LARGER_EQUAL',
+            operator: FieldOperatorEnum.LARGER_EQUAL,
             value: '3',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -254,9 +263,9 @@ describe('Message filter matcher', function () {
   it('should check if value is defined in payload', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'IS_DEFINED',
+            operator: FieldOperatorEnum.IS_DEFINED,
             value: '',
             field: 'emailMessage',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -276,9 +285,9 @@ describe('Message filter matcher', function () {
   it('should check if key is defined or not in subscriber data', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'IS_DEFINED',
+            operator: FieldOperatorEnum.IS_DEFINED,
             value: '',
             field: 'data.nestedKey',
             on: FilterPartTypeEnum.SUBSCRIBER,
@@ -310,9 +319,9 @@ describe('Message filter matcher', function () {
   it('should get nested custom subscriber data', async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'OR', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.OR, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'nestedValue',
             field: 'data.nestedKey',
             on: FilterPartTypeEnum.SUBSCRIBER,
@@ -344,9 +353,9 @@ describe('Message filter matcher', function () {
   it("should return false with nested data that doesn't exist", async function () {
     const matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'OR', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.OR, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'nestedValue',
             field: 'data.nestedKey.doesNotExist',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -370,9 +379,9 @@ describe('Message filter matcher', function () {
   it('should get smaller or equal payload var then filter value', async function () {
     let matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'SMALLER_EQUAL',
+            operator: FieldOperatorEnum.SMALLER_EQUAL,
             value: '3',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -390,9 +399,9 @@ describe('Message filter matcher', function () {
 
     matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'SMALLER_EQUAL',
+            operator: FieldOperatorEnum.SMALLER_EQUAL,
             value: '3',
             field: 'varField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -474,7 +483,7 @@ describe('Message filter matcher', function () {
             {
               isNegated: false,
               type: 'GROUP',
-              value: 'AND',
+              value: FieldLogicalOperatorEnum.AND,
               children: [],
             },
           ],
@@ -504,7 +513,7 @@ describe('Message filter matcher', function () {
             {
               isNegated: false,
               type: 'GROUP',
-              value: 'AND',
+              value: FieldLogicalOperatorEnum.AND,
               children: [],
             },
           ],
@@ -530,7 +539,7 @@ describe('Message filter matcher', function () {
       sendMessageCommand({
         step: makeStep('Correct Match', undefined, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
@@ -557,15 +566,15 @@ describe('Message filter matcher', function () {
 
     let matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'OR', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.OR, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'payloadVarField',
             on: FilterPartTypeEnum.PAYLOAD,
           },
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
@@ -587,16 +596,16 @@ describe('Message filter matcher', function () {
 
     matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'OR', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.OR, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
             webhookUrl: 'www.user.com/webhook',
           },
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'payloadVarField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -625,15 +634,15 @@ describe('Message filter matcher', function () {
 
     let matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'payloadVarField',
             on: FilterPartTypeEnum.PAYLOAD,
           },
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
@@ -655,16 +664,16 @@ describe('Message filter matcher', function () {
 
     matchedMessage = await messageMatcher.filter(
       sendMessageCommand({
-        step: makeStep('Correct Match', 'AND', [
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
             webhookUrl: 'www.user.com/webhook',
           },
           {
-            operator: 'EQUAL',
+            operator: FieldOperatorEnum.EQUAL,
             value: 'true',
             field: 'payloadVarField',
             on: FilterPartTypeEnum.PAYLOAD,
@@ -707,13 +716,13 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE,
                 value: true,
               },
               {
-                operator: 'EQUAL',
+                operator: FieldOperatorEnum.EQUAL,
                 value: 'true',
                 field: 'payloadVarField',
                 on: FilterPartTypeEnum.PAYLOAD,
@@ -744,7 +753,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE,
                 value: true,
@@ -775,7 +784,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE,
                 value: false,
@@ -800,7 +809,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE,
                 value: true,
@@ -825,7 +834,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE,
                 value: true,
@@ -854,14 +863,14 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE_IN_LAST,
                 value: 5,
                 timeOperator: TimeOperatorEnum.MINUTES,
               },
               {
-                operator: 'EQUAL',
+                operator: FieldOperatorEnum.EQUAL,
                 value: 'true',
                 field: 'payloadVarField',
                 on: FilterPartTypeEnum.PAYLOAD,
@@ -892,7 +901,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE_IN_LAST,
                 value: 5,
@@ -920,7 +929,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE_IN_LAST,
                 value: 5,
@@ -948,7 +957,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE_IN_LAST,
                 value: 5,
@@ -976,7 +985,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE_IN_LAST,
                 value: 5,
@@ -1004,7 +1013,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE_IN_LAST,
                 value: 1,
@@ -1032,7 +1041,7 @@ describe('Message filter matcher', function () {
         );
         const matchedMessage = await matcher.filter(
           sendMessageCommand({
-            step: makeStep('Correct Match', 'AND', [
+            step: makeStep('Correct Match', FieldLogicalOperatorEnum.AND, [
               {
                 on: FilterPartTypeEnum.IS_ONLINE_IN_LAST,
                 value: 1,
@@ -1062,7 +1071,7 @@ describe('Message filter matcher', function () {
           field: '',
           expected: '',
           actual: '',
-          operator: 'LARGER',
+          operator: FieldOperatorEnum.LARGER,
           passed: true,
         }
       );
@@ -1085,7 +1094,7 @@ describe('Message filter matcher', function () {
           field: '',
           expected: '',
           actual: '',
-          operator: 'LARGER',
+          operator: FieldOperatorEnum.LARGER,
           passed: false,
         }
       );
@@ -1108,7 +1117,7 @@ describe('Message filter matcher', function () {
           field: '',
           expected: '',
           actual: '',
-          operator: 'LARGER',
+          operator: FieldOperatorEnum.LARGER,
           passed: true,
         }
       );
@@ -1129,7 +1138,7 @@ describe('Message filter matcher', function () {
           field: '',
           expected: '',
           actual: '',
-          operator: 'LARGER',
+          operator: FieldOperatorEnum.LARGER,
           passed: true,
         }
       );
@@ -1144,7 +1153,7 @@ describe('Message filter matcher', function () {
 
 function makeStep(
   name: string,
-  groupOperator: 'AND' | 'OR' = 'AND',
+  groupOperator: BuilderGroupValues = FieldLogicalOperatorEnum.AND,
   filters: FilterParts[],
   channel = StepTypeEnum.EMAIL
 ): NotificationStepEntity {

--- a/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.ts
@@ -7,6 +7,7 @@ import {
   IWebhookFilterPart,
   IRealtimeOnlineFilterPart,
   IOnlineInLastFilterPart,
+  FieldLogicalOperatorEnum,
   FILTER_TO_LABEL,
   FilterPartTypeEnum,
   ICondition,
@@ -16,6 +17,7 @@ import {
   PreviousStepTypeEnum,
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
+  FieldOperatorEnum,
 } from '@novu/shared';
 import {
   SubscriberEntity,
@@ -176,7 +178,7 @@ export class MessageMatcher extends Filter {
     command: MessageMatcherCommand,
     filterProcessingDetails: FilterProcessingDetails
   ): Promise<boolean> {
-    if (filter.value === 'OR') {
+    if (filter.value === FieldLogicalOperatorEnum.OR) {
       return await this.handleOrFilters(filter, variables, command, filterProcessingDetails);
     }
 
@@ -270,7 +272,7 @@ export class MessageMatcher extends Filter {
     const label = FILTER_TO_LABEL[filter.on];
     const field = filter.stepType;
     const expected = 'true';
-    const operator = 'EQUAL';
+    const operator = FieldOperatorEnum.EQUAL;
 
     if (message?.channel === ChannelTypeEnum.EMAIL) {
       const count = await this.executionDetailsRepository.count({
@@ -337,7 +339,7 @@ export class MessageMatcher extends Filter {
         field: 'isOnline',
         expected: `${filter.value}`,
         actual: `${filter.on === FilterPartTypeEnum.IS_ONLINE ? isOnlineString : lastOnlineAtString}`,
-        operator: filter.on === FilterPartTypeEnum.IS_ONLINE ? 'EQUAL' : filter.timeOperator,
+        operator: filter.on === FilterPartTypeEnum.IS_ONLINE ? FieldOperatorEnum.EQUAL : filter.timeOperator,
         passed: false,
       });
 
@@ -351,7 +353,7 @@ export class MessageMatcher extends Filter {
         field: 'isOnline',
         expected: `${filter.value}`,
         actual: isOnlineString,
-        operator: 'EQUAL',
+        operator: FieldOperatorEnum.EQUAL,
         passed: isOnlineMatch,
       });
 

--- a/libs/shared/src/types/builder/builder.types.ts
+++ b/libs/shared/src/types/builder/builder.types.ts
@@ -1,20 +1,43 @@
-export type BuilderGroupValues = 'AND' | 'OR';
+export enum FieldOperatorEnum {
+  ALL_IN = 'ALL_IN',
+  ANY_IN = 'ANY_IN',
+  BETWEEN = 'BETWEEN',
+  EQUAL = 'EQUAL',
+  IN = 'IN',
+  IS_DEFINED = 'IS_DEFINED',
+  LARGER = 'LARGER',
+  LARGER_EQUAL = 'LARGER_EQUAL',
+  LIKE = 'LIKE',
+  NOT_BETWEEN = 'NOT_BETWEEN',
+  NOT_EQUAL = 'NOT_EQUAL',
+  NOT_IN = 'NOT_IN',
+  NOT_LIKE = 'NOT_LIKE',
+  SMALLER = 'SMALLER',
+  SMALLER_EQUAL = 'SMALLER_EQUAL',
+}
+
+export enum FieldLogicalOperatorEnum {
+  AND = 'AND',
+  OR = 'OR',
+}
+
+export type BuilderGroupValues = FieldLogicalOperatorEnum.AND | FieldLogicalOperatorEnum.OR;
 
 export type BuilderFieldType = 'BOOLEAN' | 'TEXT' | 'DATE' | 'NUMBER' | 'STATEMENT' | 'LIST' | 'MULTI_LIST' | 'GROUP';
 
 export type BuilderFieldOperator =
-  | 'LARGER'
-  | 'SMALLER'
-  | 'LARGER_EQUAL'
-  | 'SMALLER_EQUAL'
-  | 'EQUAL'
-  | 'NOT_EQUAL'
-  | 'ALL_IN'
-  | 'ANY_IN'
-  | 'NOT_IN'
-  | 'BETWEEN'
-  | 'NOT_BETWEEN'
-  | 'LIKE'
-  | 'NOT_LIKE'
-  | 'IN'
-  | 'IS_DEFINED';
+  | FieldOperatorEnum.LARGER
+  | FieldOperatorEnum.SMALLER
+  | FieldOperatorEnum.LARGER_EQUAL
+  | FieldOperatorEnum.SMALLER_EQUAL
+  | FieldOperatorEnum.EQUAL
+  | FieldOperatorEnum.NOT_EQUAL
+  | FieldOperatorEnum.ALL_IN
+  | FieldOperatorEnum.ANY_IN
+  | FieldOperatorEnum.NOT_IN
+  | FieldOperatorEnum.BETWEEN
+  | FieldOperatorEnum.NOT_BETWEEN
+  | FieldOperatorEnum.LIKE
+  | FieldOperatorEnum.NOT_LIKE
+  | FieldOperatorEnum.IN
+  | FieldOperatorEnum.IS_DEFINED;

--- a/packages/application-generic/src/utils/filter.ts
+++ b/packages/application-generic/src/utils/filter.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import {
   IBaseFieldFilterPart,
+  FieldOperatorEnum,
   FILTER_TO_LABEL,
   ICondition,
 } from '@novu/shared';
@@ -23,31 +24,31 @@ export abstract class Filter {
     const filterValue = this.parseValue(actualValue, fieldFilter.value);
     let result = false;
 
-    if (fieldFilter.operator === 'EQUAL') {
+    if (fieldFilter.operator === FieldOperatorEnum.EQUAL) {
       result = actualValue === filterValue;
     }
-    if (fieldFilter.operator === 'NOT_EQUAL') {
+    if (fieldFilter.operator === FieldOperatorEnum.NOT_EQUAL) {
       result = actualValue !== filterValue;
     }
-    if (fieldFilter.operator === 'LARGER') {
+    if (fieldFilter.operator === FieldOperatorEnum.LARGER) {
       result = actualValue > filterValue;
     }
-    if (fieldFilter.operator === 'SMALLER') {
+    if (fieldFilter.operator === FieldOperatorEnum.SMALLER) {
       result = actualValue < filterValue;
     }
-    if (fieldFilter.operator === 'LARGER_EQUAL') {
+    if (fieldFilter.operator === FieldOperatorEnum.LARGER_EQUAL) {
       result = actualValue >= filterValue;
     }
-    if (fieldFilter.operator === 'SMALLER_EQUAL') {
+    if (fieldFilter.operator === FieldOperatorEnum.SMALLER_EQUAL) {
       result = actualValue <= filterValue;
     }
-    if (fieldFilter.operator === 'NOT_IN') {
+    if (fieldFilter.operator === FieldOperatorEnum.NOT_IN) {
       result = !actualValue.includes(filterValue);
     }
-    if (fieldFilter.operator === 'IN') {
+    if (fieldFilter.operator === FieldOperatorEnum.IN) {
       result = actualValue.includes(filterValue);
     }
-    if (fieldFilter.operator === 'IS_DEFINED') {
+    if (fieldFilter.operator === FieldOperatorEnum.IS_DEFINED) {
       result = actualValue !== undefined;
     }
     const actualValueString: string = Array.isArray(actualValue)
@@ -59,7 +60,7 @@ export abstract class Filter {
       field: fieldFilter.field,
       expected: `${filterValue}`,
       actual: `${actualValueString}`,
-      operator: `${fieldFilter.operator}`,
+      operator: fieldFilter.operator,
       passed: result,
     });
 

--- a/packages/node/src/lib/integrations/integrations.spec.ts
+++ b/packages/node/src/lib/integrations/integrations.spec.ts
@@ -1,6 +1,6 @@
 import { Novu } from '../novu';
 import axios from 'axios';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, FieldLogicalOperatorEnum } from '@novu/shared';
 
 const mockConfig = {
   apiKey: '1234',
@@ -38,7 +38,12 @@ describe('test use of novus node package - Integrations class', () => {
       channel: ChannelTypeEnum.EMAIL,
       check: true,
       conditions: [
-        { isNegated: false, type: 'GROUP', value: 'AND', children: [] },
+        {
+          isNegated: false,
+          type: 'GROUP',
+          value: FieldLogicalOperatorEnum.AND,
+          children: [],
+        },
       ],
     });
 
@@ -53,7 +58,12 @@ describe('test use of novus node package - Integrations class', () => {
       channel: ChannelTypeEnum.EMAIL,
       check: true,
       conditions: [
-        { isNegated: false, type: 'GROUP', value: 'AND', children: [] },
+        {
+          isNegated: false,
+          type: 'GROUP',
+          value: FieldLogicalOperatorEnum.AND,
+          children: [],
+        },
       ],
     });
   });
@@ -89,7 +99,12 @@ describe('test use of novus node package - Integrations class', () => {
         secretKey: 'newApiSecret',
       },
       conditions: [
-        { isNegated: false, type: 'GROUP', value: 'AND', children: [] },
+        {
+          isNegated: false,
+          type: 'GROUP',
+          value: FieldLogicalOperatorEnum.AND,
+          children: [],
+        },
       ],
     });
 
@@ -104,7 +119,12 @@ describe('test use of novus node package - Integrations class', () => {
           secretKey: 'newApiSecret',
         },
         conditions: [
-          { isNegated: false, type: 'GROUP', value: 'AND', children: [] },
+          {
+            isNegated: false,
+            type: 'GROUP',
+            value: FieldLogicalOperatorEnum.AND,
+            children: [],
+          },
         ],
       }
     );


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Creates an enum with existing filter operators that were hardcoded in the codebase.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
In order to implement events broadcast filtering in the payload I found useful to reuse a similar implementation for filtering in a similar way we did for the Workflow steps filtering.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
