### PR TITLE
Revert "Fix icon overlapping"

### DIFF
--- a/libs/design-system/src/sidebar/Sidebar.tsx
+++ b/libs/design-system/src/sidebar/Sidebar.tsx
@@ -10,7 +10,7 @@ import { ArrowLeft, Close } from '../icons';
 const HeaderHolder = styled.div`
   display: flex;
   flex-wrap: nowrap;
-  gap: 36px;
+  gap: 12px;
   margin: 24px;
   margin-bottom: 0;
 `;


### PR DESCRIPTION
Reverts novuhq/novu#4574 as it doesn't fix the problem.

![Screenshot 2023-10-25 at 17 55 23](https://github.com/novuhq/novu/assets/2607232/752136a6-45f0-4b66-9b8f-0dc72f01406c)
