### PR TITLE
Updated the es typescript file , Fixed few broken words translation  

### DIFF
--- a/packages/notification-center/src/i18n/languages/es.ts
+++ b/packages/notification-center/src/i18n/languages/es.ts
@@ -4,12 +4,12 @@ export const ES: ITranslationEntry = {
   translations: {
     notifications: 'Notificaciones',
     markAllAsRead: 'Marcar todo como leído',
-    poweredBy: 'Con tecnología de',
-    settings: 'Configuración',
+    poweredBy: 'Energizado por',
+    settings: 'Ajustes',
     removeMessage: 'Eliminar mensaje',
     markAsRead: 'Marcar como leído',
     markAsUnRead: 'Marcar como no leído',
-    noNewNotification: 'Nada nuevo por aquí',
+    noNewNotification: 'noNuevaNotificación',
   },
   lang: 'es',
 };


### PR DESCRIPTION
Resolves #4659
### What change does this PR introduce?
I was looking for a proper Spanish translation and it appears that some of the words are not properly translated :So I translated the below words :
Con tecnología de - Energizado por
Configuración - Ajustes
Nada nuevo por aquí - noNuevaNotificación

### Why was this change needed?

I was looking for a proper Spanish translation and it appears that some of the words are not properly translated :

poweredBy: 'Con tecnología de' - The correct translation should be 'Energizado por'
settings: 'Configuración' - The correct translation should be 'Ajustes'
noNewNotification: 'Nada nuevo por aquí' - The correct translation should be 'noNuevaNotificación'

### Other information (Screenshots)

![image](https://github.com/novuhq/novu/assets/87201444/575fe021-b5d5-4bf5-926b-e7b918fce999)

