### PR TITLE
fix(web): variants project ui issues

### DIFF
--- a/apps/web/src/pages/templates/components/VariantItemCard.tsx
+++ b/apps/web/src/pages/templates/components/VariantItemCard.tsx
@@ -131,7 +131,11 @@ export const VariantItemCard = ({
     channel: StepTypeEnum;
     stepUuid: string;
   }>();
-  const subtitle = useStepSubtitle(variant, channel);
+  const subtitle = useStepSubtitle({
+    path: `steps.${stepIndex}.variants.${variantIndex}`,
+    step: variant,
+    channelType: channel,
+  });
   const navigate = useNavigate();
   const basePath = useBasePath();
   const [areConditionsOpened, setConditionsOpened] = useState(false);

--- a/apps/web/src/pages/templates/hooks/useStepSubtitle.tsx
+++ b/apps/web/src/pages/templates/hooks/useStepSubtitle.tsx
@@ -5,7 +5,15 @@ import { IFlowStep } from '../../../components/workflow/types';
 import { WillBeSentHeader } from '../workflow/digest/WillBeSentHeader';
 import { delaySubtitle } from '../workflow/workflow/node-types/utils';
 
-export const useStepSubtitle = (step?: IFlowStep, channelType?: StepTypeEnum) => {
+export const useStepSubtitle = ({
+  path,
+  step,
+  channelType,
+}: {
+  path: string;
+  step?: IFlowStep;
+  channelType?: StepTypeEnum;
+}) => {
   return useMemo(() => {
     if (!step) {
       return undefined;
@@ -16,7 +24,7 @@ export const useStepSubtitle = (step?: IFlowStep, channelType?: StepTypeEnum) =>
       return delaySubtitle(channelType, step);
     }
     if (StepTypeEnum.DIGEST === channelType) {
-      return <WillBeSentHeader isHighlight={false} />;
+      return <WillBeSentHeader isHighlight={false} path={path} />;
     }
 
     if (typeof content === 'string') {
@@ -33,5 +41,5 @@ export const useStepSubtitle = (step?: IFlowStep, channelType?: StepTypeEnum) =>
     }
 
     return undefined;
-  }, [channelType, step]);
+  }, [channelType, step, path]);
 };

--- a/apps/web/src/pages/templates/workflow/DigestMetadata.tsx
+++ b/apps/web/src/pages/templates/workflow/DigestMetadata.tsx
@@ -133,7 +133,7 @@ export const DigestMetadata = () => {
                   <b>Will be sent</b>
                 </div>
                 <div>
-                  <WillBeSentHeader />
+                  <WillBeSentHeader path={stepFormPath} />
                 </div>
               </div>
             </GroupStyled>

--- a/apps/web/src/pages/templates/workflow/digest/WillBeSentHeader.tsx
+++ b/apps/web/src/pages/templates/workflow/digest/WillBeSentHeader.tsx
@@ -1,11 +1,10 @@
 import { useFormContext } from 'react-hook-form';
 import { useMantineColorScheme } from '@mantine/core';
 import { DigestTypeEnum, DigestUnitEnum } from '@novu/shared';
-
 import { colors } from '@novu/design-system';
+
 import { pluralizeTime } from '../../../../utils';
 import { TimedDigestWillBeSentHeader } from './TimedDigestWillBeSentHeader';
-import { useStepFormPath } from '../../hooks/useStepFormPath';
 
 const DIGEST_UNIT_TYPE_TO_SINGULAR = {
   [DigestUnitEnum.SECONDS]: 'second',
@@ -33,19 +32,17 @@ const Highlight = ({ children, isHighlight }) => {
   );
 };
 
-export const WillBeSentHeader = ({ isHighlight = true }: { isHighlight?: boolean }) => {
+export const WillBeSentHeader = ({ path, isHighlight = true }: { path: string; isHighlight?: boolean }) => {
   const { watch } = useFormContext();
-  const stepFormPath = useStepFormPath();
-
-  const type = watch(`${stepFormPath}.digestMetadata.type`);
+  const type = watch(`${path}.digestMetadata.type`);
 
   if (type === DigestTypeEnum.TIMED) {
     return <TimedDigestWillBeSentHeader isHighlight={isHighlight} />;
   }
 
-  const unit = watch(`${stepFormPath}.digestMetadata.regular.unit`);
-  const amount = watch(`${stepFormPath}.digestMetadata.regular.amount`);
-  const backoff = watch(`${stepFormPath}.digestMetadata.regular.backoff`);
+  const unit = watch(`${path}.digestMetadata.regular.unit`);
+  const amount = watch(`${path}.digestMetadata.regular.amount`);
+  const backoff = watch(`${path}.digestMetadata.regular.backoff`);
 
   return (
     <>

--- a/apps/web/src/pages/templates/workflow/workflow/node-types/ChannelNode.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/node-types/ChannelNode.tsx
@@ -50,7 +50,7 @@ export default memo((node: INode) => {
     setCount(foundIndex + 1);
   }, [nodes, channelType, id]);
 
-  const subtitle = useStepSubtitle(step, channelType);
+  const subtitle = useStepSubtitle({ path: `steps.${index}`, step, channelType });
 
   if (!step) {
     return null;

--- a/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
@@ -126,6 +126,7 @@ export const WorkflowNodeActions = ({
             />
           )}
           <Dropdown
+            withinPortal
             position={menuPosition}
             withArrow={false}
             offset={0}


### PR DESCRIPTION
### What change does this PR introduce?

Fixed two small UI issues found for the Variants project:
- the workflow node dropdown menu was closing when hovered on the last item (which was rendered outside the node)
- the digest node was missing the content information about the time

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

https://github.com/novuhq/novu/assets/2607232/8463be05-f97a-4247-8e17-c534845ed64f


