### PR TITLE
Add Pushpad provider to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Novu provides a single API to manage providers across multiple channels with a s
 - [x] [Expo](https://github.com/novuhq/novu/tree/main/providers/expo)
 - [x] [APNS](https://github.com/novuhq/novu/tree/main/providers/apns)
 - [x] [OneSignal](https://github.com/novuhq/novu/tree/main/providers/one-signal)
+- [x] [Pushpad](https://github.com/novuhq/novu/tree/main/providers/pushpad)
 - [ ] Pushwoosh
 
 #### 👇 Chat


### PR DESCRIPTION
### What change does this PR introduce?

Include Pushpad provider in README.

### Why was this change needed?

Pushpad push provider has been merged (https://github.com/novuhq/novu/pull/4235) but it is not listed in README. 

@LetItRock Can you please merge this missing piece?
