### PR TITLE
feat: add support for variables in filter values

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -303,14 +303,14 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
 
       expect(messagesAfter.length).to.equal(2);
 
-      const executionDetails = await executionDetailsRepository.findOne({
+      const executionDetails = await executionDetailsRepository.find({
         _environmentId: session.environment._id,
         _notificationTemplateId: template?._id,
         channel: StepTypeEnum.DIGEST,
         detail: DetailEnum.FILTER_STEPS,
       });
 
-      expect(executionDetails?.detail).to.be.equal('Step was filtered based on steps filters');
+      expect(executionDetails.length).to.equal(0);
     });
 
     it('should not filter delay step', async function () {
@@ -384,14 +384,14 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
 
       expect(messagesAfter.length).to.equal(2);
 
-      const executionDetails = await executionDetailsRepository.findOne({
+      const executionDetails = await executionDetailsRepository.find({
         _environmentId: session.environment._id,
         _notificationTemplateId: template?._id,
         channel: StepTypeEnum.DELAY,
         detail: DetailEnum.FILTER_STEPS,
       });
 
-      expect(executionDetails?.detail).to.be.equal('Step was filtered based on steps filters');
+      expect(executionDetails.length).to.equal(0);
     });
 
     it('should use conditions to select integration', async function () {
@@ -2161,6 +2161,248 @@ describe(`Trigger event - ${eventTriggerPath} (POST)`, function () {
 
       expect(messages.length).to.equal(1);
       expect(messages[0].subject).to.equal('Better Variant subject');
+    });
+
+    describe('filters logic', () => {
+      it('should filter a message with variables', async function () {
+        template = await session.createTemplate({
+          steps: [
+            {
+              type: StepTypeEnum.EMAIL,
+              subject: 'Password reset',
+              content: [
+                {
+                  type: EmailBlockTypeEnum.TEXT,
+                  content: 'This are the text contents of the template for {{firstName}}',
+                },
+                {
+                  type: EmailBlockTypeEnum.BUTTON,
+                  content: 'SIGN UP',
+                  url: 'https://url-of-app.com/{{urlVariable}}',
+                },
+              ],
+              filters: [
+                {
+                  isNegated: false,
+                  type: 'GROUP',
+                  value: FieldLogicalOperatorEnum.AND,
+                  children: [
+                    {
+                      field: 'run',
+                      value: '{{payload.var}}',
+                      operator: FieldOperatorEnum.EQUAL,
+                      on: FilterPartTypeEnum.PAYLOAD,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: StepTypeEnum.EMAIL,
+              subject: 'Password reset',
+              content: [
+                {
+                  type: EmailBlockTypeEnum.TEXT,
+                  content: 'This are the text contents of the template for {{firstName}}',
+                },
+              ],
+              filters: [
+                {
+                  isNegated: false,
+                  type: 'GROUP',
+                  value: FieldLogicalOperatorEnum.AND,
+                  children: [
+                    {
+                      field: 'subscriberId',
+                      value: subscriber.subscriberId,
+                      operator: FieldOperatorEnum.NOT_EQUAL,
+                      on: FilterPartTypeEnum.SUBSCRIBER,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+
+        await axiosInstance.post(
+          `${session.serverUrl}${eventTriggerPath}`,
+          {
+            name: template.triggers[0].identifier,
+            to: subscriber.subscriberId,
+            payload: {
+              firstName: 'Testing of User Name',
+              urlVariable: '/test/url/path',
+              run: true,
+              var: true,
+            },
+          },
+          {
+            headers: {
+              authorization: `ApiKey ${session.apiKey}`,
+            },
+          }
+        );
+
+        await session.awaitRunningJobs(template._id);
+
+        const messages = await messageRepository.count({
+          _environmentId: session.environment._id,
+          _templateId: template._id,
+        });
+
+        expect(messages).to.equal(1);
+      });
+
+      it('should filter a message with value that includes variables and strings', async function () {
+        const actorSubscriber = await subscriberService.createSubscriber({
+          firstName: 'Actor',
+        });
+
+        template = await session.createTemplate({
+          steps: [
+            {
+              type: StepTypeEnum.EMAIL,
+              subject: 'Password reset',
+              content: [
+                {
+                  type: EmailBlockTypeEnum.TEXT,
+                  content: 'This are the text contents of the template for {{firstName}}',
+                },
+              ],
+              filters: [
+                {
+                  isNegated: false,
+                  type: 'GROUP',
+                  value: FieldLogicalOperatorEnum.AND,
+                  children: [
+                    {
+                      field: 'name',
+                      value: 'Test {{actor.firstName}}',
+                      operator: FieldOperatorEnum.EQUAL,
+                      on: FilterPartTypeEnum.PAYLOAD,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+
+        await axiosInstance.post(
+          `${session.serverUrl}${eventTriggerPath}`,
+          {
+            name: template.triggers[0].identifier,
+            to: subscriber.subscriberId,
+            payload: {
+              firstName: 'Testing of User Name',
+              urlVariable: '/test/url/path',
+              name: 'Test Actor',
+            },
+            actor: actorSubscriber.subscriberId,
+          },
+          {
+            headers: {
+              authorization: `ApiKey ${session.apiKey}`,
+            },
+          }
+        );
+
+        await session.awaitRunningJobs(template._id);
+
+        const messages = await messageRepository.count({
+          _environmentId: session.environment._id,
+          _templateId: template._id,
+        });
+
+        expect(messages).to.equal(1);
+      });
+
+      it('should filter by tenant variables data', async function () {
+        const tenant = await tenantRepository.create({
+          _organizationId: session.organization._id,
+          _environmentId: session.environment._id,
+          identifier: 'one_123',
+          name: 'The one and only tenant',
+          data: { value1: 'Best fighter', value2: 'Ever', count: 4 },
+        });
+
+        const templateWithVariants = await session.createTemplate({
+          name: 'test email template',
+          description: 'This is a test description',
+          steps: [
+            {
+              name: 'Message Name',
+              subject: 'Test email subject',
+              preheader: 'Test email preheader',
+              content: [{ type: EmailBlockTypeEnum.TEXT, content: 'This is a sample text block' }],
+              type: StepTypeEnum.EMAIL,
+              filters: [
+                {
+                  isNegated: false,
+                  type: 'GROUP',
+                  value: FieldLogicalOperatorEnum.AND,
+                  children: [
+                    {
+                      on: FilterPartTypeEnum.TENANT,
+                      field: 'data.count',
+                      value: '{{payload.count}}',
+                      operator: FieldOperatorEnum.LARGER,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+
+        await axiosInstance.post(
+          `${session.serverUrl}${eventTriggerPath}`,
+          {
+            name: templateWithVariants.triggers[0].identifier,
+            to: subscriber.subscriberId,
+            payload: { count: 5 },
+            tenant: { identifier: tenant.identifier },
+          },
+          {
+            headers: {
+              authorization: `ApiKey ${session.apiKey}`,
+            },
+          }
+        );
+
+        await session.awaitRunningJobs(templateWithVariants._id);
+
+        let messages = await messageRepository.find({
+          _environmentId: session.environment._id,
+          _templateId: templateWithVariants._id,
+        });
+
+        expect(messages.length).to.equal(0);
+
+        await axiosInstance.post(
+          `${session.serverUrl}${eventTriggerPath}`,
+          {
+            name: templateWithVariants.triggers[0].identifier,
+            to: subscriber.subscriberId,
+            payload: { count: 1 },
+            tenant: { identifier: tenant.identifier },
+          },
+          {
+            headers: {
+              authorization: `ApiKey ${session.apiKey}`,
+            },
+          }
+        );
+        await session.awaitRunningJobs(templateWithVariants._id);
+
+        messages = await messageRepository.find({
+          _environmentId: session.environment._id,
+          _templateId: templateWithVariants._id,
+        });
+
+        expect(messages.length).to.equal(1);
+      });
     });
 
     describe('in-app avatar', () => {

--- a/apps/api/src/app/integrations/integrations.module.ts
+++ b/apps/api/src/app/integrations/integrations.module.ts
@@ -4,11 +4,12 @@ import { SharedModule } from '../shared/shared.module';
 import { USE_CASES } from './usecases';
 import { IntegrationsController } from './integrations.controller';
 import { AuthModule } from '../auth/auth.module';
+import { CompileTemplate, CreateExecutionDetails } from '@novu/application-generic';
 
 @Module({
   imports: [SharedModule, forwardRef(() => AuthModule)],
   controllers: [IntegrationsController],
-  providers: [...USE_CASES],
+  providers: [...USE_CASES, CompileTemplate, CreateExecutionDetails],
   exports: [...USE_CASES],
 })
 export class IntegrationModule {}

--- a/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
@@ -13,7 +13,7 @@ import {
   TimeOperatorEnum,
 } from '@novu/shared';
 import { JobEntity, MessageTemplateEntity, NotificationStepEntity } from '@novu/dal';
-import { ConditionsFilter, ConditionsFilterCommand } from '@novu/application-generic';
+import { CompileTemplate, ConditionsFilter, ConditionsFilterCommand } from '@novu/application-generic';
 
 describe('Message filter matcher', function () {
   const createExecutionDetails = {
@@ -21,11 +21,13 @@ describe('Message filter matcher', function () {
   };
   const conditionsFilter = new ConditionsFilter(
     undefined as any,
+    undefined as any,
+    undefined as any,
+    undefined as any,
+    undefined as any,
+    undefined as any,
     createExecutionDetails as any,
-    undefined as any,
-    undefined as any,
-    undefined as any,
-    undefined as any
+    new CompileTemplate()
   );
 
   it('should filter correct message by the filter value', async function () {
@@ -42,6 +44,29 @@ describe('Message filter matcher', function () {
         variables: {
           payload: {
             varField: 'firstVar',
+          },
+        },
+      })
+    );
+
+    expect(matchedMessage.passed).to.equal(true);
+  });
+
+  it('should filter correct message by the filter variable value', async function () {
+    const matchedMessage = await conditionsFilter.filter(
+      mapConditionsFilterCommand({
+        step: makeStep('Correct Match', FieldLogicalOperatorEnum.OR, [
+          {
+            operator: FieldOperatorEnum.EQUAL,
+            value: '{{payload.var}}',
+            field: 'varField',
+            on: FilterPartTypeEnum.PAYLOAD,
+          },
+        ]),
+        variables: {
+          payload: {
+            varField: 'firstVar',
+            var: 'firstVar',
           },
         },
       })
@@ -702,11 +727,13 @@ describe('Message filter matcher', function () {
       it('allows to process multiple filter parts', async () => {
         const filter = new ConditionsFilter(
           { findOne: () => Promise.resolve(getSubscriber()) } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -738,11 +765,13 @@ describe('Message filter matcher', function () {
                 lastName: 'Doe',
               }),
           } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -768,11 +797,13 @@ describe('Message filter matcher', function () {
                 lastName: 'Doe',
               }),
           } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -792,11 +823,13 @@ describe('Message filter matcher', function () {
       it('allows to process if the subscriber is online', async () => {
         const filter = new ConditionsFilter(
           { findOne: () => Promise.resolve(getSubscriber()) } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -816,11 +849,13 @@ describe('Message filter matcher', function () {
       it("doesn't allow to process if the subscriber is not online", async () => {
         const filter = new ConditionsFilter(
           { findOne: () => Promise.resolve(getSubscriber({ isOnline: false })) } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -844,11 +879,13 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: true }, { subDuration: { minutes: 3 } })),
           } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -881,11 +918,13 @@ describe('Message filter matcher', function () {
                 lastName: 'Doe',
               }),
           } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -908,11 +947,13 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: true }, { subDuration: { minutes: 10 } })),
           } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -935,11 +976,13 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: false }, { subDuration: { minutes: 4 } })),
           } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -962,11 +1005,13 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: false }, { subDuration: { minutes: 6 } })),
           } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -989,11 +1034,13 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: false }, { subDuration: { minutes: 30 } })),
           } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1016,11 +1063,13 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: false }, { subDuration: { hours: 23 } })),
           } as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
+          undefined as any,
           createExecutionDetails as any,
-          undefined as any,
-          undefined as any,
-          undefined as any,
-          undefined as any
+          new CompileTemplate()
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
@@ -10,6 +10,9 @@ export class SendMessageCommand extends EnvironmentWithUserCommand {
   @IsDefined()
   payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
+  @IsOptional()
+  compileContext?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
   @IsDefined()
   overrides: Record<string, Record<string, unknown>>;
 

--- a/packages/application-generic/src/usecases/create-execution-details/types/index.ts
+++ b/packages/application-generic/src/usecases/create-execution-details/types/index.ts
@@ -25,6 +25,7 @@ export enum DetailEnum {
   START_SENDING = 'Start sending message',
   START_DIGESTING = 'Start digesting',
   PROCESSING_STEP_FILTER = 'Processing step filter',
+  PROCESSING_STEP_FILTER_ERROR = 'Processing step filter failed',
   FILTER_STEPS = 'Step was filtered based on steps filters',
   DIGESTED_EVENTS_PROVIDED = 'Steps to get digest events found',
   DIGEST_TRIGGERED_EVENTS = 'Digest triggered events',

--- a/packages/application-generic/src/usecases/select-integration/select-integration.spec.ts
+++ b/packages/application-generic/src/usecases/select-integration/select-integration.spec.ts
@@ -15,6 +15,8 @@ import { SelectIntegration } from './select-integration.usecase';
 import { SelectIntegrationCommand } from './select-integration.command';
 import { GetDecryptedIntegrations } from '../get-decrypted-integrations';
 import { ConditionsFilter } from '../conditions-filter';
+import { CompileTemplate } from '../compile-template';
+import { CreateExecutionDetails } from '../create-execution-details';
 
 const testIntegration: IntegrationEntity = {
   _environmentId: 'env-test-123',
@@ -86,20 +88,25 @@ jest.mock('../get-decrypted-integrations', () => ({
 
 describe('select integration', function () {
   let useCase: SelectIntegration;
-  let integrationRepository: IntegrationRepository;
+  const integrationRepository: IntegrationRepository =
+    new IntegrationRepository();
+  const executionDetailsRepository: ExecutionDetailsRepository =
+    new ExecutionDetailsRepository();
 
   beforeEach(async function () {
+    // @ts-ignore
     useCase = new SelectIntegration(
-      new IntegrationRepository() as any,
-      // @ts-ignore
-      new GetDecryptedIntegrations(),
+      integrationRepository,
+      new GetDecryptedIntegrations(integrationRepository),
       new ConditionsFilter(
         new SubscriberRepository(),
         new MessageRepository(),
-        new ExecutionDetailsRepository(),
+        executionDetailsRepository,
         new JobRepository(),
         new TenantRepository(),
-        new EnvironmentRepository()
+        new EnvironmentRepository(),
+        new CreateExecutionDetails(executionDetailsRepository),
+        new CompileTemplate()
       ),
       new TenantRepository()
     );

--- a/packages/application-generic/src/utils/filter-processing-details.ts
+++ b/packages/application-generic/src/utils/filter-processing-details.ts
@@ -4,8 +4,14 @@ import { ICondition, IMessageFilter, ITriggerPayload } from '@novu/shared';
 export interface IFilterVariables {
   payload?: ITriggerPayload;
   subscriber?: SubscriberEntity;
+  actor?: SubscriberEntity;
   webhook?: Record<string, unknown>;
   tenant?: TenantEntity;
+  step?: {
+    digest: boolean;
+    events: any[] | undefined;
+    total_count: number | undefined;
+  };
 }
 
 export class FilterProcessingDetails {


### PR DESCRIPTION
### What change does this PR introduce?

When filtering a step, allow using payload/subscriber/actor.tenant values 
for example:

Payload :
  Key: data.customProp
  Value: {{subscriber.data.someOtherValue}}

Subscriber:
   Key: data.subscriberValue
   Value: {{someProp.from.payload}}


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
