### PR TITLE
feat(infra): create dedicated services for in-memory for wf and cache

### DIFF
--- a/apps/api/src/app/blueprint/e2e/get-grouped-blueprints.e2e.ts
+++ b/apps/api/src/app/blueprint/e2e/get-grouped-blueprints.e2e.ts
@@ -13,9 +13,8 @@ import {
 } from '@novu/shared';
 import {
   buildGroupedBlueprintsKey,
+  CacheInMemoryProviderService,
   CacheService,
-  InMemoryProviderEnum,
-  InMemoryProviderService,
   InvalidateCacheService,
 } from '@novu/application-generic';
 
@@ -34,8 +33,8 @@ describe('Get grouped notification template blueprints - /blueprints/group-by-ca
   let indexModuleStub: sinon.SinonStub;
 
   before(async () => {
-    const inMemoryProviderService = new InMemoryProviderService(InMemoryProviderEnum.REDIS);
-    const cacheService = new CacheService(inMemoryProviderService);
+    const cacheInMemoryProviderService = new CacheInMemoryProviderService();
+    const cacheService = new CacheService(cacheInMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);
 

--- a/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
+++ b/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
@@ -12,9 +12,8 @@ import { ChannelTypeEnum, ISubscribersDefine, IUpdateNotificationTemplateDto, St
 import {
   buildNotificationTemplateIdentifierKey,
   buildNotificationTemplateKey,
+  CacheInMemoryProviderService,
   CacheService,
-  InMemoryProviderEnum,
-  InMemoryProviderService,
   InvalidateCacheService,
 } from '@novu/application-generic';
 
@@ -29,15 +28,15 @@ describe('Trigger event - process subscriber /v1/events/trigger (POST)', functio
   let subscriberService: SubscribersService;
   let cacheService: CacheService;
   let invalidateCache: InvalidateCacheService;
-  let inMemoryProviderService: InMemoryProviderService;
+  let cacheInMemoryProviderService: CacheInMemoryProviderService;
 
   const subscriberRepository = new SubscriberRepository();
   const messageRepository = new MessageRepository();
   const notificationTemplateRepository = new NotificationTemplateRepository();
 
   before(async () => {
-    inMemoryProviderService = new InMemoryProviderService(InMemoryProviderEnum.REDIS);
-    cacheService = new CacheService(inMemoryProviderService);
+    cacheInMemoryProviderService = new CacheInMemoryProviderService();
+    cacheService = new CacheService(cacheInMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);
   });

--- a/apps/api/src/app/health/e2e/health-check.e2e.ts
+++ b/apps/api/src/app/health/e2e/health-check.e2e.ts
@@ -1,13 +1,10 @@
 import { UserSession } from '@novu/testing';
-import { InMemoryProviderEnum, InMemoryProviderService } from '@novu/application-generic';
 import { expect } from 'chai';
 
 describe('Health-check', () => {
   const session = new UserSession();
 
   before(async () => {
-    const inMemoryProviderService = new InMemoryProviderService(InMemoryProviderEnum.REDIS);
-
     await session.initialize();
   });
 

--- a/apps/api/src/app/widgets/e2e/get-count.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/get-count.e2e.ts
@@ -6,9 +6,8 @@ import { ChannelTypeEnum, InAppProviderIdEnum } from '@novu/shared';
 import {
   buildFeedKey,
   buildMessageCountKey,
+  CacheInMemoryProviderService,
   CacheService,
-  InMemoryProviderEnum,
-  InMemoryProviderService,
   InvalidateCacheService,
 } from '@novu/application-generic';
 
@@ -23,11 +22,11 @@ describe('Count - GET /widget/notifications/count', function () {
   } | null = null;
 
   let invalidateCache: InvalidateCacheService;
-  let inMemoryProviderService: InMemoryProviderService;
+  let cacheInMemoryProviderService: CacheInMemoryProviderService;
 
   before(async () => {
-    inMemoryProviderService = new InMemoryProviderService(InMemoryProviderEnum.REDIS);
-    const cacheService = new CacheService(inMemoryProviderService);
+    cacheInMemoryProviderService = new CacheInMemoryProviderService();
+    const cacheService = new CacheService(cacheInMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);
   });
@@ -256,7 +255,7 @@ describe('Count - GET /widget/notifications/count', function () {
 
     const messages = await messageRepository.findBySubscriberChannel(
       session.environment._id,
-      subscriberProfile!._id,
+      String(subscriberProfile?._id),
       ChannelTypeEnum.IN_APP
     );
     const messageId = messages[0]._id;
@@ -319,7 +318,7 @@ describe('Count - GET /widget/notifications/count', function () {
 
     const messages = await messageRepository.findBySubscriberChannel(
       session.environment._id,
-      subscriberProfile!._id,
+      String(subscriberProfile?._id),
       ChannelTypeEnum.IN_APP
     );
     const messageId = messages[0]._id;

--- a/apps/api/src/app/widgets/e2e/get-unseen-count.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/get-unseen-count.e2e.ts
@@ -6,9 +6,8 @@ import { ChannelTypeEnum } from '@novu/shared';
 import {
   buildFeedKey,
   buildMessageCountKey,
+  CacheInMemoryProviderService,
   CacheService,
-  InMemoryProviderEnum,
-  InMemoryProviderService,
   InvalidateCacheService,
 } from '@novu/application-generic';
 
@@ -22,12 +21,12 @@ describe('Unseen Count - GET /widget/notifications/unseen', function () {
     _id: string;
   } | null = null;
 
-  let inMemoryProviderService: InMemoryProviderService;
+  let cacheInMemoryProviderService: CacheInMemoryProviderService;
   let invalidateCache: InvalidateCacheService;
 
   before(async () => {
-    inMemoryProviderService = new InMemoryProviderService(InMemoryProviderEnum.REDIS);
-    const cacheService = new CacheService(inMemoryProviderService);
+    cacheInMemoryProviderService = new CacheInMemoryProviderService();
+    const cacheService = new CacheService(cacheInMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);
   });
@@ -68,7 +67,7 @@ describe('Unseen Count - GET /widget/notifications/unseen', function () {
 
     const messages = await messageRepository.findBySubscriberChannel(
       session.environment._id,
-      subscriberProfile!._id,
+      String(subscriberProfile?._id),
       ChannelTypeEnum.IN_APP
     );
     const messageId = messages[0]._id;
@@ -97,7 +96,7 @@ describe('Unseen Count - GET /widget/notifications/unseen', function () {
 
     const messages = await messageRepository.findBySubscriberChannel(
       session.environment._id,
-      subscriberProfile!._id,
+      String(subscriberProfile?._id),
       ChannelTypeEnum.IN_APP
     );
     const messageId = messages[0]._id;
@@ -126,7 +125,7 @@ describe('Unseen Count - GET /widget/notifications/unseen', function () {
 
     const messages = await messageRepository.findBySubscriberChannel(
       session.environment._id,
-      subscriberProfile!._id,
+      String(subscriberProfile?._id),
       ChannelTypeEnum.IN_APP
     );
     const messageId = messages[0]._id;
@@ -155,7 +154,7 @@ describe('Unseen Count - GET /widget/notifications/unseen', function () {
 
     const messages = await messageRepository.findBySubscriberChannel(
       session.environment._id,
-      subscriberProfile!._id,
+      String(subscriberProfile?._id),
       ChannelTypeEnum.IN_APP
     );
     const messageId = messages[0]._id;

--- a/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
@@ -5,10 +5,9 @@ import { expect } from 'chai';
 import { createHash } from '../../shared/helpers/hmac.service';
 import {
   buildIntegrationKey,
+  CacheInMemoryProviderService,
   CacheService,
-  InMemoryProviderService,
   InvalidateCacheService,
-  InMemoryProviderEnum,
 } from '@novu/application-generic';
 
 const integrationRepository = new IntegrationRepository();
@@ -19,8 +18,8 @@ describe('Initialize Session - /widgets/session/initialize (POST)', async () => 
   let invalidateCache: InvalidateCacheService;
 
   before(async () => {
-    const inMemoryProviderService = new InMemoryProviderService(InMemoryProviderEnum.REDIS);
-    const cacheService = new CacheService(inMemoryProviderService);
+    const cacheInMemoryProviderService = new CacheInMemoryProviderService();
+    const cacheService = new CacheService(cacheInMemoryProviderService);
     await cacheService.initialize();
     invalidateCache = new InvalidateCacheService(cacheService);
   });

--- a/apps/worker/src/app/health/e2e/health-check.e2e.ts
+++ b/apps/worker/src/app/health/e2e/health-check.e2e.ts
@@ -1,4 +1,3 @@
-import { InMemoryProviderEnum, InMemoryProviderService } from '@novu/application-generic';
 import { expect } from 'chai';
 import * as request from 'supertest';
 import * as defaults from 'superagent-defaults';
@@ -7,9 +6,6 @@ describe('Health-check', () => {
   let testAgent;
 
   before(async () => {
-    const inMemoryProviderService = new InMemoryProviderService(InMemoryProviderEnum.REDIS);
-    await inMemoryProviderService.delayUntilReadiness();
-
     testAgent = defaults(request(`http://localhost:${process.env.PORT}`));
   });
 

--- a/packages/application-generic/src/health/active-jobs-metric-queue.health-indicator.ts
+++ b/packages/application-generic/src/health/active-jobs-metric-queue.health-indicator.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { ActiveJobsMetricQueueService } from '../services';
+import { ActiveJobsMetricQueueService } from '../services/queues';
 import { QueueHealthIndicator } from './queue-health-indicator.service';
 
 const LOG_CONTEXT = 'ActiveJobsMetricQueueServiceHealthIndicator';

--- a/packages/application-generic/src/health/cache.health-indicator.ts
+++ b/packages/application-generic/src/health/cache.health-indicator.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/terminus';
 import { Injectable, Logger } from '@nestjs/common';
 
-import { CacheService } from '../services';
+import { CacheService } from '../services/cache';
 
 const LOG_CONTEXT = 'CacheServiceHealthIndicator';
 

--- a/packages/application-generic/src/health/completed-jobs-metric-queue.health-indicator.ts
+++ b/packages/application-generic/src/health/completed-jobs-metric-queue.health-indicator.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { CompletedJobsMetricQueueService } from '../services';
+import { CompletedJobsMetricQueueService } from '../services/queues';
 import { QueueHealthIndicator } from './queue-health-indicator.service';
 
 const LOG_CONTEXT = 'CompletedJobsMetricQueueServiceHealthIndicator';

--- a/packages/application-generic/src/health/inbound-parse-queue.health-indicator.ts
+++ b/packages/application-generic/src/health/inbound-parse-queue.health-indicator.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { InboundParseQueue } from '../services';
+import { InboundParseQueue } from '../services/queues';
 import { QueueHealthIndicator } from './queue-health-indicator.service';
 
 const LOG_CONTEXT = 'InboundParseQueueServiceHealthIndicator';

--- a/packages/application-generic/src/health/queue-health-indicator.service.ts
+++ b/packages/application-generic/src/health/queue-health-indicator.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/terminus';
 import { Injectable, Logger } from '@nestjs/common';
 
-import { QueueBaseService } from '../services';
+import { QueueBaseService } from '../services/queues/queue-base.service';
 import { IHealthIndicator } from './health-indicator.interface';
 
 @Injectable()

--- a/packages/application-generic/src/health/standard-queue.health-indicator.ts
+++ b/packages/application-generic/src/health/standard-queue.health-indicator.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { StandardQueueService } from '../services';
+import { StandardQueueService } from '../services/queues';
 import { QueueHealthIndicator } from './queue-health-indicator.service';
 
 const LOG_CONTEXT = 'StandardQueueServiceHealthIndicator';

--- a/packages/application-generic/src/health/subscriber-process-queue.health-indicator.ts
+++ b/packages/application-generic/src/health/subscriber-process-queue.health-indicator.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { SubscriberProcessQueueService } from '../services';
+import { SubscriberProcessQueueService } from '../services/queues';
 import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
 import { QueueHealthIndicator } from './queue-health-indicator.service';
 

--- a/packages/application-generic/src/health/web-sockets-queue.health-indicator.ts
+++ b/packages/application-generic/src/health/web-sockets-queue.health-indicator.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { WebSocketsQueueService } from '../services';
+import { WebSocketsQueueService } from '../services/queues';
 import { QueueHealthIndicator } from './queue-health-indicator.service';
 
 const LOG_CONTEXT = 'WebSocketsQueueServiceHealthIndicator';

--- a/packages/application-generic/src/health/workflow-queue.health-indicator.ts
+++ b/packages/application-generic/src/health/workflow-queue.health-indicator.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { WorkflowQueueService } from '../services';
+import { WorkflowQueueService } from '../services/queues';
 import { QueueHealthIndicator } from './queue-health-indicator.service';
 
 const LOG_CONTEXT = 'WorkflowQueueServiceHealthIndicator';

--- a/packages/application-generic/src/modules/queues.module.ts
+++ b/packages/application-generic/src/modules/queues.module.ts
@@ -6,6 +6,7 @@ import {
   CompletedJobsMetricQueueServiceHealthIndicator,
   InboundParseQueueServiceHealthIndicator,
   StandardQueueServiceHealthIndicator,
+  SubscriberProcessQueueHealthIndicator,
   WebSocketsQueueServiceHealthIndicator,
   WorkflowQueueServiceHealthIndicator,
 } from '../health';
@@ -15,6 +16,7 @@ import {
   CompletedJobsMetricQueueService,
   InboundParseQueue,
   StandardQueueService,
+  SubscriberProcessQueueService,
   WebSocketsQueueService,
   WorkflowQueueService,
 } from '../services/queues';
@@ -23,15 +25,12 @@ import {
   CompletedJobsMetricWorkerService,
   InboundParseWorker,
   StandardWorkerService,
+  SubscriberProcessWorkerService,
   WebSocketsWorkerService,
   WorkflowWorkerService,
   OldInstanceStandardWorkerService,
   OldInstanceWorkflowWorkerService,
 } from '../services/workers';
-
-import { SubscriberProcessQueueService } from '../services/queues/subscriber-process-queue.service';
-import { SubscriberProcessWorkerService } from '../services/workers/subscriber-process-worker.service';
-import { SubscriberProcessQueueHealthIndicator } from '../health/subscriber-process-queue.health-indicator';
 
 const PROVIDERS: Provider[] = [
   ActiveJobsMetricQueueService,

--- a/packages/application-generic/src/services/bull-mq/old-instance-bull-mq.service.ts
+++ b/packages/application-generic/src/services/bull-mq/old-instance-bull-mq.service.ts
@@ -49,7 +49,8 @@ export class OldInstanceBullMqService {
   constructor() {
     if (this.shouldInstantiate()) {
       this.inMemoryProviderService = new InMemoryProviderService(
-        InMemoryProviderEnum.OLD_INSTANCE_REDIS
+        InMemoryProviderEnum.OLD_INSTANCE_REDIS,
+        true
       );
       this.enabled = true;
     } else {

--- a/packages/application-generic/src/services/cache/cache-service.spec.ts
+++ b/packages/application-generic/src/services/cache/cache-service.spec.ts
@@ -5,13 +5,7 @@ import {
   splitKey,
 } from './cache.service';
 
-import {
-  InMemoryProviderEnum,
-  InMemoryProviderService,
-} from '../in-memory-provider';
-
-const enableAutoPipelining =
-  process.env.REDIS_CACHE_ENABLE_AUTOPIPELINING === 'true';
+import { CacheInMemoryProviderService } from '../in-memory-provider';
 
 /**
  * TODO: Maybe create a Test single Redis instance to be able to run it in the
@@ -19,24 +13,20 @@ const enableAutoPipelining =
  */
 describe.skip('Cache Service - Redis Instance - Non Cluster Mode', () => {
   let cacheService: CacheService;
-  let inMemoryProviderService: InMemoryProviderService;
+  let cacheInMemoryProviderService: CacheInMemoryProviderService;
 
   beforeAll(async () => {
     process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED = 'false';
 
-    inMemoryProviderService = new InMemoryProviderService(
-      InMemoryProviderEnum.REDIS,
-      enableAutoPipelining
-    );
-    await inMemoryProviderService.delayUntilReadiness();
-    expect(inMemoryProviderService.isClusterMode()).toBe(false);
+    cacheInMemoryProviderService = new CacheInMemoryProviderService();
+    expect(cacheInMemoryProviderService.isCluster).toBe(false);
 
-    cacheService = new CacheService(inMemoryProviderService);
+    cacheService = new CacheService(cacheInMemoryProviderService);
     await cacheService.initialize();
   });
 
   afterAll(async () => {
-    await inMemoryProviderService.shutdown();
+    await cacheInMemoryProviderService.shutdown();
   });
 
   it('should be instantiated properly', async () => {
@@ -80,24 +70,20 @@ describe.skip('Cache Service - Redis Instance - Non Cluster Mode', () => {
 
 describe('Cache Service - Cluster Mode', () => {
   let cacheService: CacheService;
-  let inMemoryProviderService: InMemoryProviderService;
+  let cacheInMemoryProviderService: CacheInMemoryProviderService;
 
   beforeAll(async () => {
     process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED = 'true';
 
-    inMemoryProviderService = new InMemoryProviderService(
-      InMemoryProviderEnum.REDIS,
-      enableAutoPipelining
-    );
-    await inMemoryProviderService.delayUntilReadiness();
-    expect(inMemoryProviderService.isClusterMode()).toBe(true);
+    cacheInMemoryProviderService = new CacheInMemoryProviderService();
+    expect(cacheInMemoryProviderService.isCluster).toBe(true);
 
-    cacheService = new CacheService(inMemoryProviderService);
+    cacheService = new CacheService(cacheInMemoryProviderService);
     await cacheService.initialize();
   });
 
   afterAll(async () => {
-    await inMemoryProviderService.shutdown();
+    await cacheInMemoryProviderService.shutdown();
   });
 
   it('should be instantiated properly', async () => {

--- a/packages/application-generic/src/services/distributed-lock/distributed-lock.service.ts
+++ b/packages/application-generic/src/services/distributed-lock/distributed-lock.service.ts
@@ -4,8 +4,7 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import {
   InMemoryProviderClient,
-  InMemoryProviderEnum,
-  InMemoryProviderService,
+  CacheInMemoryProviderService,
 } from '../in-memory-provider';
 
 const LOG_CONTEXT = 'DistributedLock';
@@ -22,11 +21,13 @@ export class DistributedLockService {
   public lockCounter = {};
   public shuttingDown = false;
 
-  constructor(private inMemoryProviderService: InMemoryProviderService) {}
+  constructor(
+    private cacheInMemoryProviderService: CacheInMemoryProviderService
+  ) {}
 
   async initialize(): Promise<void> {
-    await this.inMemoryProviderService.delayUntilReadiness();
-    this.startup(this.inMemoryProviderService.inMemoryProviderClient);
+    await this.cacheInMemoryProviderService.initialize();
+    this.startup(this.cacheInMemoryProviderService.getClient());
   }
 
   public startup(
@@ -103,7 +104,7 @@ export class DistributedLockService {
         } finally {
           this.shuttingDown = false;
           this.distributedLock = undefined;
-          await this.inMemoryProviderService.shutdown();
+          await this.cacheInMemoryProviderService.shutdown();
           Logger.verbose('Redlock shutdown', LOG_CONTEXT);
         }
       }

--- a/packages/application-generic/src/services/in-memory-provider/cache-in-memory-provider.service.ts
+++ b/packages/application-generic/src/services/in-memory-provider/cache-in-memory-provider.service.ts
@@ -59,7 +59,7 @@ export class CacheInMemoryProviderService {
     Logger.log(
       this.descriptiveLogMessage(
         `Cluster mode ${
-          isClusterModeEnabled ? 'is' : 'is not'
+          isClusterModeEnabled ? 'IS' : 'IS NOT'
         } enabled for ${LOG_CONTEXT}`
       ),
       LOG_CONTEXT

--- a/packages/application-generic/src/services/in-memory-provider/cache-in-memory-provider.service.ts
+++ b/packages/application-generic/src/services/in-memory-provider/cache-in-memory-provider.service.ts
@@ -1,0 +1,105 @@
+import { Logger } from '@nestjs/common';
+
+import { InMemoryProviderService } from './in-memory-provider.service';
+import {
+  InMemoryProviderEnum,
+  InMemoryProviderClient,
+  ScanStream,
+} from './types';
+
+import { GetIsInMemoryClusterModeEnabled } from '../../usecases';
+
+const LOG_CONTEXT = 'CacheInMemoryProviderService';
+
+export class CacheInMemoryProviderService {
+  public inMemoryProviderService: InMemoryProviderService;
+  public isCluster: boolean;
+  private getIsInMemoryClusterModeEnabled: GetIsInMemoryClusterModeEnabled;
+
+  constructor() {
+    this.getIsInMemoryClusterModeEnabled =
+      new GetIsInMemoryClusterModeEnabled();
+
+    const provider = this.selectProvider();
+    this.isCluster = this.isClusterMode();
+
+    const enableAutoPipelining =
+      process.env.REDIS_CACHE_ENABLE_AUTOPIPELINING === 'true';
+
+    this.inMemoryProviderService = new InMemoryProviderService(
+      provider,
+      this.isCluster,
+      enableAutoPipelining
+    );
+  }
+
+  /**
+   * Rules for the provider selection:
+   * - For our self hosted users we assume all of them have a single node Redis
+   * instance.
+   * - For Novu we will use Elasticache. We fallback to a Redis Cluster configuration
+   * if Elasticache not configured properly. That's happening in the provider
+   * mapping in the /in-memory-provider/providers/index.ts
+   */
+  private selectProvider(): InMemoryProviderEnum {
+    if (process.env.IS_DOCKER_HOSTED) {
+      return InMemoryProviderEnum.REDIS;
+    }
+
+    return InMemoryProviderEnum.ELASTICACHE;
+  }
+
+  private descriptiveLogMessage(message) {
+    return `[Provider: ${this.selectProvider()}] ${message}`;
+  }
+
+  private isClusterMode(): boolean {
+    const isClusterModeEnabled = this.getIsInMemoryClusterModeEnabled.execute();
+
+    Logger.log(
+      this.descriptiveLogMessage(
+        `Cluster mode ${
+          isClusterModeEnabled ? 'is' : 'is not'
+        } enabled for ${LOG_CONTEXT}`
+      ),
+      LOG_CONTEXT
+    );
+
+    return isClusterModeEnabled;
+  }
+
+  public async initialize(): Promise<void> {
+    await this.inMemoryProviderService.delayUntilReadiness();
+  }
+
+  public getClient(): InMemoryProviderClient {
+    return this.inMemoryProviderService.inMemoryProviderClient;
+  }
+
+  public getClientStatus(): string {
+    return this.getClient().status;
+  }
+
+  public getTtl(): number {
+    return this.inMemoryProviderService.inMemoryProviderConfig.ttl;
+  }
+
+  public inMemoryScan(pattern: string): ScanStream {
+    return this.inMemoryProviderService.inMemoryScan(pattern);
+  }
+
+  public isReady(): boolean {
+    return this.inMemoryProviderService.isClientReady();
+  }
+
+  public providerInUseIsInClusterMode(): boolean {
+    const providerConfigured =
+      this.inMemoryProviderService.getProvider.configured;
+
+    return this.isCluster || providerConfigured !== InMemoryProviderEnum.REDIS;
+  }
+
+  public async shutdown(): Promise<void> {
+    await this.inMemoryProviderService.shutdown();
+  }
+}

--- a/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.spec.ts
+++ b/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.spec.ts
@@ -6,10 +6,9 @@ let inMemoryProviderService: InMemoryProviderService;
 describe('In-memory Provider Service', () => {
   describe('Non cluster mode', () => {
     beforeEach(async () => {
-      process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED = 'false';
-
       inMemoryProviderService = new InMemoryProviderService(
-        InMemoryProviderEnum.REDIS
+        InMemoryProviderEnum.REDIS,
+        false
       );
 
       await inMemoryProviderService.delayUntilReadiness();
@@ -45,8 +44,6 @@ describe('In-memory Provider Service', () => {
       });
 
       it('should instantiate the provider properly', async () => {
-        expect(inMemoryProviderService.isClusterMode()).toEqual(false);
-
         const { inMemoryProviderClient } = inMemoryProviderService;
 
         expect(inMemoryProviderClient.status).toEqual('ready');
@@ -84,10 +81,9 @@ describe('In-memory Provider Service', () => {
 
   describe('Cluster mode', () => {
     beforeEach(async () => {
-      process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED = 'true';
-
       inMemoryProviderService = new InMemoryProviderService(
-        InMemoryProviderEnum.REDIS
+        InMemoryProviderEnum.REDIS,
+        true
       );
       await inMemoryProviderService.delayUntilReadiness();
 
@@ -102,6 +98,7 @@ describe('In-memory Provider Service', () => {
       it('enableAutoPipelining is enabled', async () => {
         const clusterWithPipelining = new InMemoryProviderService(
           InMemoryProviderEnum.REDIS,
+          true,
           true
         );
         await clusterWithPipelining.delayUntilReadiness();
@@ -147,8 +144,6 @@ describe('In-memory Provider Service', () => {
       });
 
       it('should instantiate the provider properly', async () => {
-        expect(inMemoryProviderService.isClusterMode()).toEqual(true);
-
         const { inMemoryProviderClient } = inMemoryProviderService;
 
         expect(inMemoryProviderClient.status).toEqual('ready');

--- a/packages/application-generic/src/services/in-memory-provider/index.ts
+++ b/packages/application-generic/src/services/in-memory-provider/index.ts
@@ -1,2 +1,4 @@
+export * from './cache-in-memory-provider.service';
 export * from './in-memory-provider.service';
+export * from './workflow-in-memory-provider.service';
 export * from './types';

--- a/packages/application-generic/src/services/in-memory-provider/workflow-in-memory-provider.service.ts
+++ b/packages/application-generic/src/services/in-memory-provider/workflow-in-memory-provider.service.ts
@@ -1,0 +1,86 @@
+import { Logger } from '@nestjs/common';
+
+import { InMemoryProviderService } from './in-memory-provider.service';
+import { InMemoryProviderEnum, InMemoryProviderClient } from './types';
+
+import { GetIsInMemoryClusterModeEnabled } from '../../usecases';
+
+const LOG_CONTEXT = 'WorkflowInMemoryProviderService';
+
+export class WorkflowInMemoryProviderService {
+  public inMemoryProviderService: InMemoryProviderService;
+  public isCluster: boolean;
+  private getIsInMemoryClusterModeEnabled: GetIsInMemoryClusterModeEnabled;
+
+  constructor() {
+    this.getIsInMemoryClusterModeEnabled =
+      new GetIsInMemoryClusterModeEnabled();
+
+    const provider = this.selectProvider();
+    this.isCluster = this.isClusterMode();
+
+    this.inMemoryProviderService = new InMemoryProviderService(
+      provider,
+      this.isCluster,
+      false
+    );
+  }
+
+  /**
+   * Rules for the provider selection:
+   * - For our self hosted users we assume all of them have a single node Redis
+   * instance.
+   * - For Novu we will use MemoryDB. We fallback to a Redis Cluster configuration
+   * if MemoryDB not configured properly. That's happening in the provider
+   * mapping in the /in-memory-provider/providers/index.ts
+   */
+  private selectProvider(): InMemoryProviderEnum {
+    if (process.env.IS_DOCKER_HOSTED) {
+      return InMemoryProviderEnum.REDIS;
+    }
+
+    return InMemoryProviderEnum.MEMORY_DB;
+  }
+
+  private descriptiveLogMessage(message) {
+    return `[Provider: ${this.selectProvider()}] ${message}`;
+  }
+
+  private isClusterMode(): boolean {
+    const isClusterModeEnabled = this.getIsInMemoryClusterModeEnabled.execute();
+
+    Logger.log(
+      this.descriptiveLogMessage(
+        `Cluster mode ${
+          isClusterModeEnabled ? 'is' : 'is not'
+        } enabled for ${LOG_CONTEXT}`
+      ),
+      LOG_CONTEXT
+    );
+
+    return isClusterModeEnabled;
+  }
+
+  public async initialize(): Promise<void> {
+    await this.inMemoryProviderService.delayUntilReadiness();
+  }
+
+  public getClient(): InMemoryProviderClient {
+    return this.inMemoryProviderService.inMemoryProviderClient;
+  }
+
+  public isReady(): boolean {
+    return this.inMemoryProviderService.isClientReady();
+  }
+
+  public providerInUseIsInClusterMode(): boolean {
+    const providerConfigured =
+      this.inMemoryProviderService.getProvider.configured;
+
+    return this.isCluster || providerConfigured !== InMemoryProviderEnum.REDIS;
+  }
+
+  public async shutdown(): Promise<void> {
+    await this.inMemoryProviderService.shutdown();
+  }
+}

--- a/packages/application-generic/src/services/queues/active-jobs-metric-queue.service.ts
+++ b/packages/application-generic/src/services/queues/active-jobs-metric-queue.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
 
-import { QueueBaseService } from './index';
+import { QueueBaseService } from './queue-base.service';
 
 const LOG_CONTEXT = 'ActiveJobsMetricQueueService';
 

--- a/packages/application-generic/src/services/queues/completed-jobs-metric-queue.service.ts
+++ b/packages/application-generic/src/services/queues/completed-jobs-metric-queue.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
 
-import { QueueBaseService } from './index';
+import { QueueBaseService } from './queue-base.service';
 
 const LOG_CONTEXT = 'CompletedJobsMetricQueueService';
 

--- a/packages/application-generic/src/services/queues/inbound-parse-queue.service.ts
+++ b/packages/application-generic/src/services/queues/inbound-parse-queue.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
 
-import { QueueBaseService } from './index';
+import { QueueBaseService } from './queue-base.service';
 
 import { QueueOptions } from '../bull-mq';
 

--- a/packages/application-generic/src/services/queues/standard-queue.service.ts
+++ b/packages/application-generic/src/services/queues/standard-queue.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
 
-import { QueueBaseService } from './index';
+import { QueueBaseService } from './queue-base.service';
 
 const LOG_CONTEXT = 'StandardQueueService';
 

--- a/packages/application-generic/src/services/queues/subscriber-process-queue.service.ts
+++ b/packages/application-generic/src/services/queues/subscriber-process-queue.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
+
 import { QueueBaseService } from './queue-base.service';
 
 @Injectable()

--- a/packages/application-generic/src/services/queues/web-sockets-queue.service.ts
+++ b/packages/application-generic/src/services/queues/web-sockets-queue.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
 
-import { QueueBaseService } from './index';
+import { QueueBaseService } from './queue-base.service';
 
 const LOG_CONTEXT = 'WebSocketsQueueService';
 

--- a/packages/application-generic/src/services/queues/workflow-queue.service.ts
+++ b/packages/application-generic/src/services/queues/workflow-queue.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
 
-import { QueueBaseService } from './index';
+import { QueueBaseService } from './queue-base.service';
 
 const LOG_CONTEXT = 'WorkflowQueueService';
 

--- a/packages/application-generic/src/usecases/create-subscriber/create-subscriber.spec.ts
+++ b/packages/application-generic/src/usecases/create-subscriber/create-subscriber.spec.ts
@@ -7,30 +7,29 @@ import { CreateSubscriberCommand } from './create-subscriber.command';
 
 import {
   CacheService,
+  CacheInMemoryProviderService,
   InMemoryProviderEnum,
   InMemoryProviderService,
   InvalidateCacheService,
 } from '../../services';
 import { UpdateSubscriber } from '../update-subscriber';
 
-const inMemoryProviderService = {
-  provide: InMemoryProviderService,
-  useFactory: async (): Promise<InMemoryProviderService> => {
-    const inMemoryProvider = new InMemoryProviderService(
-      InMemoryProviderEnum.REDIS
-    );
+const cacheInMemoryProviderService = {
+  provide: CacheInMemoryProviderService,
+  useFactory: async (): Promise<CacheInMemoryProviderService> => {
+    const cacheInMemoryProvider = new CacheInMemoryProviderService();
 
-    return inMemoryProvider;
+    return cacheInMemoryProvider;
   },
 };
 
 const cacheService = {
   provide: CacheService,
   useFactory: async () => {
-    const factoryInMemoryProviderService =
-      await inMemoryProviderService.useFactory();
+    const factoryCacheInMemoryProviderService =
+      await cacheInMemoryProviderService.useFactory();
 
-    const service = new CacheService(factoryInMemoryProviderService);
+    const service = new CacheService(factoryCacheInMemoryProviderService);
     await service.initialize();
 
     return service;
@@ -44,7 +43,7 @@ describe('Create Subscriber', function () {
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [SubscriberRepository, InvalidateCacheService],
-      providers: [UpdateSubscriber, inMemoryProviderService, cacheService],
+      providers: [UpdateSubscriber, cacheInMemoryProviderService, cacheService],
     }).compile();
 
     session = new UserSession();

--- a/packages/application-generic/src/usecases/get-feature-flag/get-is-in-memory-cluster-mode-enabled.use-case.ts
+++ b/packages/application-generic/src/usecases/get-feature-flag/get-is-in-memory-cluster-mode-enabled.use-case.ts
@@ -7,9 +7,9 @@ import { GetSystemCriticalFlag } from './get-system-critical-flag.use-case';
 @Injectable()
 export class GetIsInMemoryClusterModeEnabled extends GetSystemCriticalFlag {
   execute(): boolean {
-    const value =
-      process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED ??
-      process.env.IN_MEMORY_CLUSTER_MODE_ENABLED;
+    const value = process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED
+      ? process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED
+      : process.env.IN_MEMORY_CLUSTER_MODE_ENABLED;
     const fallbackValue = false;
     const defaultValue = this.prepareBooleanStringSystemCriticalFlag(
       value,

--- a/packages/application-generic/src/usecases/get-feature-flag/get-system-critical-flag.test.ts
+++ b/packages/application-generic/src/usecases/get-feature-flag/get-system-critical-flag.test.ts
@@ -40,6 +40,18 @@ describe('Get System Critical Flag', () => {
       const result = getIsInMemoryClusterModeEnabled.execute();
       expect(result).toEqual(true);
     });
+
+    it('should return new environment variable value when is set even if it is false', async () => {
+      // TODO: Temporary coexistence to replace env variable name
+      process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED = 'false';
+      process.env.IN_MEMORY_CLUSTER_MODE_ENABLED = 'true';
+
+      const getIsInMemoryClusterModeEnabled =
+        new GetIsInMemoryClusterModeEnabled();
+
+      const result = getIsInMemoryClusterModeEnabled.execute();
+      expect(result).toEqual(false);
+    });
   });
 
   describe('SystemCriticalFlagEnum.IS_REQUEST_RATE_LIMITING_ENABLED', () => {

--- a/packages/application-generic/src/usecases/update-subscriber/update-subscriber.spec.ts
+++ b/packages/application-generic/src/usecases/update-subscriber/update-subscriber.spec.ts
@@ -6,19 +6,17 @@ import { UpdateSubscriber } from './update-subscriber.usecase';
 import { UpdateSubscriberCommand } from './update-subscriber.command';
 import {
   CacheService,
+  CacheInMemoryProviderService,
   InvalidateCacheService,
-  InMemoryProviderService,
   InMemoryProviderEnum,
 } from '../../services';
 
-const inMemoryProviderService = {
-  provide: InMemoryProviderService,
-  useFactory: async (): Promise<InMemoryProviderService> => {
-    const inMemoryProvider = new InMemoryProviderService(
-      InMemoryProviderEnum.REDIS
-    );
+const cacheInMemoryProviderService = {
+  provide: CacheInMemoryProviderService,
+  useFactory: async (): Promise<CacheInMemoryProviderService> => {
+    const cacheInMemoryProvider = new CacheInMemoryProviderService();
 
-    return inMemoryProvider;
+    return cacheInMemoryProvider;
   },
 };
 
@@ -26,7 +24,7 @@ const cacheService = {
   provide: CacheService,
   useFactory: async () => {
     const factoryInMemoryProviderService =
-      await inMemoryProviderService.useFactory();
+      await cacheInMemoryProviderService.useFactory();
 
     return new CacheService(factoryInMemoryProviderService);
   },
@@ -39,7 +37,7 @@ describe('Update Subscriber', function () {
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [SubscriberRepository, InvalidateCacheService],
-      providers: [UpdateSubscriber, inMemoryProviderService, cacheService],
+      providers: [UpdateSubscriber, cacheInMemoryProviderService, cacheService],
     }).compile();
 
     session = new UserSession();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12668,7 +12668,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.2
       '@emotion/babel-plugin': 11.10.6
       '@emotion/cache': 11.10.7
       '@emotion/serialize': 1.1.1
@@ -25560,14 +25560,6 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.10.0
-    dev: true
-
-  /acorn-import-assertions@1.9.0(acorn@8.8.2):
-    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
-    peerDependencies:
-      acorn: ^8
-    dependencies:
-      acorn: 8.8.2
 
   /acorn-jsx@5.3.2(acorn@7.4.1):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -31408,7 +31400,7 @@ packages:
       eslint: 8.51.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.58.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-webpack@0.13.7)(eslint@8.51.0)
-      has: 1.0.3
+      has: 1.0.4
       is-core-module: 2.13.0
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -31486,7 +31478,7 @@ packages:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 8.51.0
-      has: 1.0.3
+      has: 1.0.4
       jsx-ast-utils: 3.3.3
       language-tags: 1.0.5
       minimatch: 3.1.2
@@ -50106,8 +50098,8 @@ packages:
       '@webassemblyjs/ast': 1.11.1
       '@webassemblyjs/wasm-edit': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
-      acorn: 8.8.2
-      acorn-import-assertions: 1.9.0(acorn@8.8.2)
+      acorn: 8.10.0
+      acorn-import-assertions: 1.9.0(acorn@8.10.0)
       browserslist: 4.21.10
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0
@@ -50146,8 +50138,8 @@ packages:
       '@webassemblyjs/ast': 1.11.1
       '@webassemblyjs/wasm-edit': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
-      acorn: 8.8.2
-      acorn-import-assertions: 1.9.0(acorn@8.8.2)
+      acorn: 8.10.0
+      acorn-import-assertions: 1.9.0(acorn@8.10.0)
       browserslist: 4.21.10
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Creates a parent class for both Workflow and Cache in-memory provider instances, to be used between the features and the InMemoryProviderService.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
This change will help us to implement the selection of the in-memory provider for each service in a more dynamic way and also to be able to independently set cluster mode.
Is a previous step to be able to implement properly Azure Redis DB provider and from there any in-memory provider.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
