### PR TITLE
feat: Custom backendUrl in invite-member.usecase and resend-invite.usecase #3934

### DIFF
--- a/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.command.ts
+++ b/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.command.ts
@@ -1,8 +1,10 @@
-import { IsDefined, IsEmail } from 'class-validator';
+import { IsDefined, IsEmail, IsOptional } from 'class-validator';
 import { BaseCommand } from '../../../shared/commands/base.command';
-
+import { CustomDataType } from '@novu/shared';
 export class PasswordResetRequestCommand extends BaseCommand {
   @IsEmail()
   @IsDefined()
   email: string;
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/dtos/bulk-invite-members.dto.ts
+++ b/apps/api/src/app/invites/dtos/bulk-invite-members.dto.ts
@@ -1,12 +1,14 @@
-import { IBulkInviteRequestDto } from '@novu/shared';
+import { IBulkInviteRequestDto, CustomDataType } from '@novu/shared';
 import { Type } from 'class-transformer';
-import { ArrayNotEmpty, IsArray, IsDefined, IsEmail, IsNotEmpty, ValidateNested } from 'class-validator';
+import { ArrayNotEmpty, IsArray, IsOptional, IsDefined, IsEmail, IsNotEmpty, ValidateNested } from 'class-validator';
 
 class EmailInvitee {
   @IsDefined()
   @IsNotEmpty()
   @IsEmail()
   email: string;
+  @IsOptional()
+  config?: CustomDataType;
 }
 
 export class BulkInviteMembersDto implements IBulkInviteRequestDto {
@@ -15,4 +17,6 @@ export class BulkInviteMembersDto implements IBulkInviteRequestDto {
   @ValidateNested()
   @Type(() => EmailInvitee)
   invitees: EmailInvitee[];
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/dtos/invite-member.dto.ts
+++ b/apps/api/src/app/invites/dtos/invite-member.dto.ts
@@ -1,6 +1,5 @@
-import { IsEmail, IsEnum, IsNotEmpty } from 'class-validator';
-import { MemberRoleEnum } from '@novu/shared';
-
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
+import { CustomDataType, MemberRoleEnum } from '@novu/shared';
 export class InviteMemberDto {
   @IsEmail()
   @IsNotEmpty()
@@ -8,4 +7,6 @@ export class InviteMemberDto {
 
   @IsEnum(MemberRoleEnum)
   role: MemberRoleEnum;
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/dtos/resend-invite.dto.ts
+++ b/apps/api/src/app/invites/dtos/resend-invite.dto.ts
@@ -1,7 +1,10 @@
-import { IsNotEmpty, IsString } from 'class-validator';
-
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { CustomDataType } from '@novu/shared';
 export class ResendInviteDto {
   @IsNotEmpty()
   @IsString()
   memberId: string;
+
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/e2e/get-invite.e2e.ts
+++ b/apps/api/src/app/invites/e2e/get-invite.e2e.ts
@@ -66,4 +66,30 @@ describe('Get invite object - /invites/:inviteToken (GET)', async () => {
       expect(body.message).to.contain('expired');
     });
   });
+
+  describe('add config parameters', async () => {
+    before(async () => {
+      session = new UserSession();
+      await session.initialize();
+
+      await session.testAgent
+        .post('/v1/invites')
+        .send({
+          invitees: [
+            {
+              email: 'asdas@dasdas.com',
+            },
+          ],
+          config: { test: 'test' },
+        })
+        .expect(201);
+    });
+
+    it('check the value for config is not empty', async () => {
+      const members = await memberRepository.getOrganizationMembers(session.organization._id);
+      const member = members.find((i) => i.memberStatus === MemberStatusEnum.INVITED);
+
+      expect(member.config).to.deep.equal({ test: 'test' });
+    });
+  });
 });

--- a/apps/api/src/app/invites/invites.controller.ts
+++ b/apps/api/src/app/invites/invites.controller.ts
@@ -72,6 +72,7 @@ export class InvitesController {
       organizationId: user.organizationId,
       email: body.email,
       role: body.role,
+      config: body.config,
     });
 
     await this.inviteMemberUsecase.execute(command);
@@ -92,6 +93,7 @@ export class InvitesController {
       userId: user._id,
       organizationId: user.organizationId,
       memberId: body.memberId,
+      config: body.config,
     });
 
     await this.resendInviteUsecase.execute(command);
@@ -112,6 +114,7 @@ export class InvitesController {
       userId: user._id,
       organizationId: user.organizationId,
       invitees: body.invitees,
+      config: body.config,
     });
 
     const response = await this.bulkInviteUsecase.execute(command);

--- a/apps/api/src/app/invites/usecases/accept-invite/accept-invite.command.ts
+++ b/apps/api/src/app/invites/usecases/accept-invite/accept-invite.command.ts
@@ -1,7 +1,10 @@
-import { IsString } from 'class-validator';
+import { IsString, IsOptional } from 'class-validator';
 import { AuthenticatedCommand } from '../../../shared/commands/authenticated.command';
+import { IBulkInviteRequestDto, CustomDataType } from '@novu/shared';
 
 export class AcceptInviteCommand extends AuthenticatedCommand {
   @IsString()
   readonly token: string;
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/usecases/accept-invite/accept-invite.usecase.ts
+++ b/apps/api/src/app/invites/usecases/accept-invite/accept-invite.usecase.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, NotFoundException, Scope } from '@nestjs/common';
 
 import { MemberEntity, OrganizationRepository, UserEntity, MemberRepository, UserRepository } from '@novu/dal';
-import { MemberStatusEnum } from '@novu/shared';
+import { MemberStatusEnum, CustomDataType } from '@novu/shared';
 import { Novu } from '@novu/node';
 import { AuthService } from '@novu/application-generic';
 
@@ -46,17 +46,17 @@ export class AcceptInvite {
       answerDate: new Date(),
     });
 
-    this.sendInviterAcceptedEmail(inviter, member);
+    this.sendInviterAcceptedEmail(inviter, member, member.config);
 
     return this.authService.generateUserToken(user);
   }
 
-  async sendInviterAcceptedEmail(inviter: UserEntity, member: MemberEntity) {
+  async sendInviterAcceptedEmail(inviter: UserEntity, member: MemberEntity, config?: CustomDataType) {
     if (!member.invite) return;
 
     try {
       if ((process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'production') && process.env.NOVU_API_KEY) {
-        const novu = new Novu(process.env.NOVU_API_KEY);
+        const novu = new Novu(process.env.NOVU_API_KEY, config);
 
         await novu.trigger(process.env.NOVU_TEMPLATEID_INVITE_ACCEPTED || 'invite-accepted-dEQAsKD1E', {
           to: {

--- a/apps/api/src/app/invites/usecases/bulk-invite/bulk-invite.command.ts
+++ b/apps/api/src/app/invites/usecases/bulk-invite/bulk-invite.command.ts
@@ -1,9 +1,11 @@
-import { MemberRoleEnum } from '@novu/shared';
+import { MemberRoleEnum, CustomDataType } from '@novu/shared';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
-
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 export class BulkInviteCommand extends OrganizationCommand {
   invitees: {
     email: string;
     role?: MemberRoleEnum;
   }[];
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/usecases/invite-member/invite-member.command.ts
+++ b/apps/api/src/app/invites/usecases/invite-member/invite-member.command.ts
@@ -1,7 +1,7 @@
-import { IsDefined, IsEmail, IsEnum } from 'class-validator';
+import { IsDefined, IsEmail, IsEnum, IsOptional } from 'class-validator';
 import { MemberRoleEnum } from '@novu/shared';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
-
+import { CustomDataType } from '@novu/shared';
 export class InviteMemberCommand extends OrganizationCommand {
   @IsEmail()
   readonly email: string;
@@ -9,4 +9,7 @@ export class InviteMemberCommand extends OrganizationCommand {
   @IsDefined()
   @IsEnum(MemberRoleEnum)
   readonly role: MemberRoleEnum;
+
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/usecases/invite-member/invite-member.usecase.ts
+++ b/apps/api/src/app/invites/usecases/invite-member/invite-member.usecase.ts
@@ -35,7 +35,7 @@ export class InviteMember {
     const token = createGuid();
 
     if (process.env.NOVU_API_KEY && (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'production')) {
-      const novu = new Novu(process.env.NOVU_API_KEY);
+      const novu = new Novu(process.env.NOVU_API_KEY, command.config);
 
       // cspell:disable-next
       await novu.trigger(process.env.NOVU_TEMPLATEID_INVITE_TO_ORGANISATION || 'invite-to-organization-wBnO8NpDn', {
@@ -62,6 +62,7 @@ export class InviteMember {
         email: command.email,
         invitationDate: new Date(),
       },
+      config: command.config,
     };
 
     this.analyticsService.track('Invite Organization Member', command.userId, {

--- a/apps/api/src/app/invites/usecases/resend-invite/resend-invite.command.ts
+++ b/apps/api/src/app/invites/usecases/resend-invite/resend-invite.command.ts
@@ -1,7 +1,9 @@
-import { IsString } from 'class-validator';
+import { IsString, IsOptional } from 'class-validator';
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
-
+import { CustomDataType } from '@novu/shared';
 export class ResendInviteCommand extends OrganizationCommand {
   @IsString()
   readonly memberId: string;
+  @IsOptional()
+  config?: CustomDataType;
 }

--- a/apps/api/src/app/invites/usecases/resend-invite/resend-invite.usecase.ts
+++ b/apps/api/src/app/invites/usecases/resend-invite/resend-invite.usecase.ts
@@ -34,7 +34,7 @@ export class ResendInvite {
     const token = createGuid();
 
     if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'production') {
-      const novu = new Novu(process.env.NOVU_API_KEY ?? '');
+      const novu = new Novu(process.env.NOVU_API_KEY ?? '', command.config);
 
       // cspell:disable-next
       await novu.trigger(process.env.NOVU_TEMPLATEID_INVITE_TO_ORGANISATION || 'invite-to-organization-wBnO8NpDn', {
@@ -59,6 +59,7 @@ export class ResendInvite {
         _inviterId: command.userId,
         invitationDate: new Date(),
       },
+      config: command.config,
     });
   }
 }

--- a/libs/dal/src/repositories/member/member.entity.ts
+++ b/libs/dal/src/repositories/member/member.entity.ts
@@ -1,5 +1,5 @@
 import { Types } from 'mongoose';
-import { IMemberInvite, MemberRoleEnum, MemberStatusEnum } from '@novu/shared';
+import { CustomDataType, IMemberInvite, MemberRoleEnum, MemberStatusEnum } from '@novu/shared';
 
 import { UserEntity } from '../user';
 import type { OrganizationId } from '../organization';
@@ -19,6 +19,8 @@ export class MemberEntity {
   memberStatus: MemberStatusEnum;
 
   _organizationId: OrganizationId;
+
+  config?: CustomDataType;
 }
 
 export type MemberDBModel = ChangePropsValueType<Omit<MemberEntity, 'invite'>, '_userId' | '_organizationId'> & {

--- a/libs/dal/src/repositories/member/member.repository.ts
+++ b/libs/dal/src/repositories/member/member.repository.ts
@@ -1,5 +1,5 @@
 import { FilterQuery } from 'mongoose';
-import { IMemberInvite, MemberRoleEnum, MemberStatusEnum } from '@novu/shared';
+import { CustomDataType, IMemberInvite, MemberRoleEnum, MemberStatusEnum } from '@novu/shared';
 
 import { MemberEntity, MemberDBModel } from './member.entity';
 import { BaseRepository } from '../base-repository';
@@ -11,6 +11,7 @@ export interface IAddMemberData {
   roles: MemberRoleEnum[];
   invite?: IMemberInvite;
   memberStatus: MemberStatusEnum;
+  config?: CustomDataType;
 }
 
 type MemberQuery = FilterQuery<MemberDBModel> & EnforceOrgId;
@@ -165,6 +166,7 @@ export class MemberRepository extends BaseRepository<MemberDBModel, MemberEntity
       invite: member.invite,
       memberStatus: member.memberStatus,
       _organizationId: organizationId,
+      config: member.config,
     });
   }
 

--- a/libs/dal/src/repositories/member/member.schema.ts
+++ b/libs/dal/src/repositories/member/member.schema.ts
@@ -31,6 +31,7 @@ const memberSchema = new Schema<MemberDBModel>(
       ref: 'Organization',
       index: true,
     },
+    config: Schema.Types.Mixed,
   },
   schemaOptions
 );

--- a/libs/dal/src/repositories/user/user.entity.ts
+++ b/libs/dal/src/repositories/user/user.entity.ts
@@ -1,4 +1,4 @@
-import { AuthProviderEnum } from '@novu/shared';
+import { AuthProviderEnum, CustomDataType } from '@novu/shared';
 import { Exclude } from 'class-transformer';
 
 import { UserId } from './types';
@@ -31,6 +31,8 @@ export class UserEntity {
   lastName?: string | null;
 
   email?: string | null;
+
+  config?: CustomDataType;
 
   profilePicture?: string | null;
 

--- a/packages/node/src/lib/novu.spec.ts
+++ b/packages/node/src/lib/novu.spec.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 
 const mockConfig = {
   apiKey: '1234',
+  configUrl: 'https://mock.com',
 };
 
 jest.mock('axios');
@@ -13,7 +14,7 @@ describe('test use of novu node package', () => {
 
   beforeEach(() => {
     mockedAxios.create.mockReturnThis();
-    novu = new Novu(mockConfig.apiKey);
+    novu = new Novu(mockConfig.apiKey, { backendUrl: mockConfig.configUrl });
   });
 
   test('should trigger correctly', async () => {


### PR DESCRIPTION
### What change does this PR introduce?

More flexibility for injecting a custom backendUrl for invite-member.usecase and resend-invite.usecase
I have added config in all the interfaces for invites, resend & bulk and passed it in. Password one is left but just wanted to get it reviewed first.

### Why was this change needed?

Closes [3934](https://github.com/novuhq/novu/issues/3934)

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
