### PR TITLE
Delete workflow override use-case

### DIFF
--- a/apps/api/src/app/workflows/e2e/delete-workflow-override.e2e.ts
+++ b/apps/api/src/app/workflows/e2e/delete-workflow-override.e2e.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import { UserSession } from '@novu/testing';
+import { TenantRepository, WorkflowOverrideRepository } from '@novu/dal';
+import { WorkflowOverrideService } from '@novu/testing';
+
+describe('Delete workflow override - /overrides/:overrideId (Delete)', async () => {
+  let session: UserSession;
+  const tenantRepository = new TenantRepository();
+  const workflowOverrideRepository = new WorkflowOverrideRepository();
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  it('should delete the workflow override', async function () {
+    const workflowOverrideService = new WorkflowOverrideService({
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+    });
+
+    const createdWorkflowOverride = await workflowOverrideService.createWorkflowOverride();
+
+    const tenant = await tenantRepository.findOne({
+      _environmentId: session.environment._id,
+      _id: createdWorkflowOverride._tenantId,
+    });
+
+    if (!tenant) throw new Error('Tenant not found');
+
+    const validatedCreationWorkflowOverride = await workflowOverrideRepository.findOne({
+      _environmentId: session.environment._id,
+      _id: createdWorkflowOverride._id,
+    });
+
+    if (!validatedCreationWorkflowOverride) throw new Error('WorkflowOverride not found');
+
+    expect(validatedCreationWorkflowOverride._id).to.be.ok;
+
+    const deleteRes = await session.testAgent.delete(
+      `/v1/workflows/overrides/${validatedCreationWorkflowOverride._id}`
+    );
+
+    const foundWorkflowOverride: boolean = deleteRes.body.data;
+
+    expect(foundWorkflowOverride).to.equal(true);
+
+    const findDeleted = await workflowOverrideRepository.findOne({
+      _environmentId: session.environment._id,
+      _id: createdWorkflowOverride._id,
+    });
+
+    expect(findDeleted).to.be.null;
+  });
+
+  it('should fail to delete non-existing workflow override', async function () {
+    const fakeWorkflowOverrideId = session.user._id;
+    const deleteRes = await session.testAgent.delete(`/v1/workflows/overrides/${fakeWorkflowOverrideId}`);
+
+    const foundWorkflowOverride = deleteRes.body;
+
+    expect(foundWorkflowOverride.statusCode).to.equal(404);
+    expect(foundWorkflowOverride.message).to.equal(`Workflow Override with id ${fakeWorkflowOverrideId} not found`);
+  });
+});

--- a/apps/api/src/app/workflows/usecases/delete-workflow-override/delete-workflow-override.command.ts
+++ b/apps/api/src/app/workflows/usecases/delete-workflow-override/delete-workflow-override.command.ts
@@ -1,0 +1,9 @@
+import { IsDefined, IsMongoId } from 'class-validator';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class DeleteWorkflowOverrideCommand extends EnvironmentWithUserCommand {
+  @IsMongoId()
+  @IsDefined()
+  _id: string;
+}

--- a/apps/api/src/app/workflows/usecases/delete-workflow-override/delete-workflow-override.usecase.ts
+++ b/apps/api/src/app/workflows/usecases/delete-workflow-override/delete-workflow-override.usecase.ts
@@ -1,0 +1,30 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { WorkflowOverrideRepository } from '@novu/dal';
+import { DeleteWorkflowOverrideCommand } from './delete-workflow-override.command';
+
+@Injectable()
+export class DeleteWorkflowOverride {
+  constructor(private workflowOverrideRepository: WorkflowOverrideRepository) {}
+
+  async execute(command: DeleteWorkflowOverrideCommand): Promise<boolean> {
+    const workflowOverride = await this.workflowOverrideRepository.findOne({
+      _environmentId: command.environmentId,
+      _id: command._id,
+    });
+
+    if (!workflowOverride) {
+      throw new NotFoundException(`Workflow Override with id ${command._id} not found`);
+    }
+
+    const deletedWorkflowOverride = await this.workflowOverrideRepository.delete({
+      _environmentId: command.environmentId,
+      _id: command._id,
+    });
+
+    if (!deletedWorkflowOverride?.acknowledged) {
+      throw new Error(`Unexpected error: failed to delete workflow override with id ${command._id}`);
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/app/workflows/usecases/index.ts
+++ b/apps/api/src/app/workflows/usecases/index.ts
@@ -8,6 +8,7 @@ import { DeleteNotificationTemplate } from './delete-notification-template/delet
 import { CreateWorkflowOverride } from './create-workflow-override/create-workflow-override.usecase';
 import { UpdateWorkflowOverride } from './update-workflow-override/update-workflow-override.usecase';
 import { GetWorkflowOverride } from './get-workflow-override/get-workflow-override.usecase';
+import { DeleteWorkflowOverride } from './delete-workflow-override/delete-workflow-override.usecase';
 
 export const USE_CASES = [
   GetActiveIntegrationsStatus,
@@ -20,4 +21,5 @@ export const USE_CASES = [
   CreateWorkflowOverride,
   UpdateWorkflowOverride,
   GetWorkflowOverride,
+  DeleteWorkflowOverride,
 ];

--- a/apps/api/src/app/workflows/workflow.controller.ts
+++ b/apps/api/src/app/workflows/workflow.controller.ts
@@ -46,6 +46,8 @@ import { UpdateWorkflowOverride } from './usecases/update-workflow-override/upda
 import { GetWorkflowOverrideResponseDto } from './dto/get-workflow-override-response.dto';
 import { GetWorkflowOverride } from './usecases/get-workflow-override/get-workflow-override.usecase';
 import { GetWorkflowOverrideCommand } from './usecases/get-workflow-override/get-workflow-override.command';
+import { DeleteWorkflowOverride } from './usecases/delete-workflow-override/delete-workflow-override.usecase';
+import { DeleteWorkflowOverrideCommand } from './usecases/delete-workflow-override/delete-workflow-override.command';
 
 @Controller('/workflows')
 @UseInterceptors(ClassSerializerInterceptor)
@@ -61,7 +63,8 @@ export class WorkflowController {
     private changeWorkflowActiveStatusUsecase: ChangeTemplateActiveStatus,
     private createWorkflowOverrideUsecase: CreateWorkflowOverride,
     private updateWorkflowOverrideUsecase: UpdateWorkflowOverride,
-    private getWorkflowOverrideUsecase: GetWorkflowOverride
+    private getWorkflowOverrideUsecase: GetWorkflowOverride,
+    private deleteWorkflowOverrideUsecase: DeleteWorkflowOverride
   ) {}
 
   @Get('')
@@ -289,6 +292,30 @@ export class WorkflowController {
         userId: user._id,
         tenantIdentifier: tenantIdentifier,
         _workflowId: workflowId,
+      })
+    );
+  }
+
+  @Delete('/overrides/:workflowOverrideId')
+  @UseGuards(RootEnvironmentGuard)
+  @Roles(MemberRoleEnum.ADMIN)
+  @ApiOkResponse({
+    type: DataBooleanDto,
+  })
+  @ApiOperation({
+    summary: 'Delete workflow override',
+  })
+  @ExternalApiAccessible()
+  deleteWorkflowOverride(
+    @UserSession() user: IJwtPayload,
+    @Param('workflowOverrideId') workflowOverrideId: string
+  ): Promise<boolean> {
+    return this.deleteWorkflowOverrideUsecase.execute(
+      DeleteWorkflowOverrideCommand.create({
+        organizationId: user.organizationId,
+        environmentId: user.environmentId,
+        userId: user._id,
+        _id: workflowOverrideId,
       })
     );
   }


### PR DESCRIPTION
### What change does this PR introduce?
* Workflow configurations (enabled, disabled)
* Channel Preferences

 
### Why was this change needed?
In some cases particular workflows should be managed in coordination with a given tenant, meaning that for a workflow:
* Tenants can have different preference defaults
* The tenant can have the whole workflow as disabled altogether


 
### Definition of Done
* add delete workflow override usecase.
* e2e

