### PR TITLE
feat(infra): temporary env var to decommission old cluster in azure

### DIFF
--- a/packages/application-generic/src/services/bull-mq/old-instance-bull-mq.service.ts
+++ b/packages/application-generic/src/services/bull-mq/old-instance-bull-mq.service.ts
@@ -59,9 +59,14 @@ export class OldInstanceBullMqService {
   }
 
   private shouldInstantiate(): boolean {
-    const shouldInstantiate =
-      !process.env.IS_DOCKER_HOSTED &&
+    const isDecommissioned =
+      process.env.IS_OLD_CLUSTER_DECOMMISSIONED === 'true';
+    const isNotDockerHosted = !process.env.IS_DOCKER_HOSTED;
+    const hasMemoryDbClusterServiceHost =
       !!process.env.MEMORY_DB_CLUSTER_SERVICE_HOST;
+
+    const shouldInstantiate =
+      !isDecommissioned && isNotDockerHosted && hasMemoryDbClusterServiceHost;
 
     Logger.warn(
       { shouldInstantiate },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31400,7 +31400,7 @@ packages:
       eslint: 8.51.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.58.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-webpack@0.13.7)(eslint@8.51.0)
-      has: 1.0.4
+      has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -35091,7 +35091,7 @@ packages:
   /is-core-module@2.13.0:
     resolution: {integrity: sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==}
     dependencies:
-      has: 1.0.3
+      has: 1.0.4
     dev: true
 
   /is-data-descriptor@0.1.4:


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Sets a temporary environment variable so the OldInstanceBullMqService is not instantiated.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
To unblock Azure deployment as it doesn't need to connect to the old Redis cluster instance.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
