### PR TITLE
chore(web): variants cypress e2e tests

### DIFF
--- a/apps/web/cypress/tests/notification-editor/index.ts
+++ b/apps/web/cypress/tests/notification-editor/index.ts
@@ -1,4 +1,4 @@
-type Channel = 'inApp' | 'email' | 'sms' | 'digest' | 'delay';
+export type Channel = 'inApp' | 'email' | 'sms' | 'chat' | 'push' | 'digest' | 'delay';
 
 export function addAndEditChannel(channel: Channel) {
   cy.waitForNetworkIdle(500);

--- a/apps/web/cypress/tests/notification-editor/variants.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/variants.spec.ts
@@ -1,0 +1,544 @@
+import { Channel, dragAndDrop, editChannel, fillBasicNotificationDetails, goBack } from '.';
+
+const EDITOR_TEXT = 'Hello, world!';
+const VARIANT_EDITOR_TEXT = 'Hello, world from Variant!';
+const SUBJECT_LINE = 'Novu test';
+const PUSH_TITLE = 'Push test';
+
+describe('Workflow Editor - Variants', function () {
+  beforeEach(function () {
+    cy.initializeSession().as('session');
+  });
+
+  const createWorkflow = (title: string) => {
+    cy.intercept('GET', '**/notification-templates/**').as('getWorkflow');
+    cy.intercept('PUT', '**/notification-templates/**').as('updateWorkflow');
+    cy.waitLoadTemplatePage(() => {
+      cy.visit('/workflows/create');
+    });
+    cy.wait('@getWorkflow');
+    cy.getByTestId('title').first().clear().type(title).blur();
+  };
+
+  const fillInAppEditorContentWith = (text: string) => {
+    cy.get('.ace_text-input').first().clear({ force: true }).type(text, {
+      parseSpecialCharSequences: false,
+      force: true,
+    });
+  };
+
+  const fillEmailEditorContentWith = (subjectLine: string, content: string) => {
+    cy.getByTestId('emailSubject').clear().type(subjectLine, {
+      parseSpecialCharSequences: false,
+      force: true,
+    });
+    cy.getByTestId('editable-text-content').clear().type(content, {
+      parseSpecialCharSequences: false,
+    });
+  };
+
+  const fillSmsEditorContentWith = (content: string) => {
+    cy.getByTestId('smsNotificationContent').clear().type(content, {
+      parseSpecialCharSequences: false,
+      force: true,
+    });
+  };
+
+  const fillChatEditorContentWith = (content: string) => {
+    cy.getByTestId('chatNotificationContent').clear().type(content, {
+      parseSpecialCharSequences: false,
+      force: true,
+    });
+  };
+
+  const fillPushEditorContentWith = (title: string, content: string) => {
+    cy.getByTestId('pushNotificationTitle').clear().type(title, {
+      parseSpecialCharSequences: false,
+      force: true,
+    });
+    cy.getByTestId('pushNotificationContent').clear().type(content, {
+      parseSpecialCharSequences: false,
+      force: true,
+    });
+  };
+
+  const showStepActions = (channel: Channel) => {
+    cy.getByTestId(`node-${channel}Selector`).parent().trigger('mouseover');
+  };
+
+  const addVariantActionClick = (channel: Channel) => {
+    cy.getByTestId(`node-${channel}Selector`)
+      .getByTestId('step-actions-menu')
+      .click()
+      .getByTestId('add-variant-action')
+      .click();
+  };
+
+  const addConditions = () => {
+    cy.getByTestId('add-new-condition').click();
+    cy.getByTestId('conditions-form-key').last().type('test');
+    cy.getByTestId('conditions-form-value').last().type('test');
+    cy.getByTestId('apply-conditions-btn').click();
+  };
+
+  const checkTheVariantsList = (title: string, content: string) => {
+    cy.getByTestId('variants-list-sidebar').should('be.visible');
+    cy.getByTestId(`variant-item-card-0`).contains(title);
+    cy.getByTestId(`variant-item-card-0`).contains(content);
+    cy.getByTestId(`variant-item-card-0`).getByTestId('conditions-action').contains('1');
+    cy.getByTestId(`variant-root-card`).should('be.visible');
+  };
+
+  const fillEditorContent = (channel: Channel, isVariant = false) => {
+    switch (channel) {
+      case 'inApp':
+        fillInAppEditorContentWith(isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+      case 'email':
+        fillEmailEditorContentWith(SUBJECT_LINE, isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+      case 'sms':
+        fillSmsEditorContentWith(isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+      case 'chat':
+        fillChatEditorContentWith(isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+      case 'push':
+        fillPushEditorContentWith(PUSH_TITLE, isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+    }
+  };
+
+  const checkEditorContent = (channel: Channel, isVariant = false) => {
+    switch (channel) {
+      case 'inApp':
+        cy.get('#codeEditor')
+          .first()
+          .contains(isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+      case 'email':
+        cy.getByTestId('emailSubject').should('have.value', SUBJECT_LINE);
+        cy.getByTestId('email-editor').contains(isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+      case 'sms':
+        cy.getByTestId('smsNotificationContent').should('have.value', isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+      case 'chat':
+        cy.getByTestId('chatNotificationContent').should('have.value', isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+      case 'push':
+        cy.getByTestId('pushNotificationTitle').should('have.value', PUSH_TITLE);
+        cy.getByTestId('pushNotificationContent').should('have.value', isVariant ? VARIANT_EDITOR_TEXT : EDITOR_TEXT);
+        break;
+    }
+  };
+
+  const addVariantForChannel = (channel: Channel, variantName: string) => {
+    createWorkflow(`Test Add Variant Flow for ${channel}`);
+
+    // drag and edit the channel
+    dragAndDrop(channel);
+    editChannel(channel);
+
+    // fill the editor content
+    fillEditorContent(channel);
+    goBack();
+
+    // add the variant
+    showStepActions(channel);
+    addVariantActionClick(channel);
+
+    // add conditions for the variant
+    addConditions();
+
+    // should land in the editor and has the root step content shown
+    checkEditorContent(channel);
+    fillEditorContent(channel, true);
+    cy.getByTestId('notification-template-submit-btn').click();
+    cy.wait('@updateWorkflow');
+    goBack();
+
+    // should have the variant shown in the list
+    checkTheVariantsList(variantName, VARIANT_EDITOR_TEXT);
+
+    cy.reload();
+
+    // should successfully save the variants
+    checkTheVariantsList(variantName, VARIANT_EDITOR_TEXT);
+    goBack();
+
+    cy.getByTestId(`node-${channel}Selector`).getByTestId('variants-count').contains('1 variant');
+  };
+
+  const checkStepActions = (channel: Channel) => {
+    showStepActions(channel);
+    cy.getByTestId('step-actions').should('be.visible');
+    cy.getByTestId('add-conditions-action').should('be.visible');
+    cy.getByTestId('edit-action').should('be.visible');
+    cy.getByTestId('step-actions-menu').should('be.visible').click();
+    cy.getByTestId('step-actions-menu').getByTestId('add-variant-action').should('be.visible');
+    cy.getByTestId('step-actions-menu').getByTestId('delete-step-action').should('be.visible');
+  };
+
+  const checkEditorActions = (isVariant = false) => {
+    if (!isVariant) {
+      cy.getByTestId('editor-sidebar-add-variant').should('be.visible');
+      cy.getByTestId('editor-sidebar-add-conditions').should('be.visible');
+    } else {
+      cy.getByTestId('editor-sidebar-edit-conditions').should('be.visible');
+    }
+    cy.getByTestId('editor-sidebar-delete').should('be.visible');
+  };
+
+  describe('Add variant flow', function () {
+    it('should allow creating the variants for the in-app channel', function () {
+      addVariantForChannel('inApp', 'V1 In-App');
+    });
+
+    it('should allow creating the variants for the email channel', function () {
+      addVariantForChannel('email', 'V1 Email');
+    });
+
+    it('should allow creating the variants for the sms channel', function () {
+      addVariantForChannel('sms', 'V1 SMS');
+    });
+
+    it('should allow creating the variants for the chat channel', function () {
+      addVariantForChannel('chat', 'V1 Chat');
+    });
+
+    it('should allow creating the variants for the push channel', function () {
+      addVariantForChannel('push', 'V1 Push');
+    });
+
+    it('should allow creating variant from the step editor', function () {
+      createWorkflow('Add variant flow from variant editor');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+
+      cy.getByTestId('editor-sidebar-add-variant').should('be.visible').click();
+      addConditions();
+      fillEditorContent('inApp', true);
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      cy.reload();
+      cy.wait('@getWorkflow');
+
+      checkEditorContent('inApp', true);
+    });
+  });
+
+  describe('Step actions', function () {
+    it('should show the step actions', function () {
+      createWorkflow(`Test Step Actions`);
+
+      dragAndDrop('inApp');
+
+      checkStepActions('inApp');
+    });
+
+    it('should show the root step actions', function () {
+      createWorkflow(`Test Root Step Actions`);
+
+      // create in-app channel and add variant
+      dragAndDrop('inApp');
+      showStepActions('inApp');
+      addVariantActionClick('inApp');
+      addConditions();
+      goBack();
+      goBack();
+
+      // show the root step actions and check available actions
+      checkStepActions('inApp');
+    });
+  });
+
+  describe('Editor actions', function () {
+    it('check the step editor actions', function () {
+      createWorkflow('Test Editor Actions');
+
+      dragAndDrop('email');
+      editChannel('email');
+
+      checkEditorActions();
+    });
+
+    it('check the variant editor actions', function () {
+      createWorkflow('Test Editor Actions');
+
+      dragAndDrop('email');
+      showStepActions('email');
+      addVariantActionClick('email');
+      addConditions();
+
+      checkEditorActions(true);
+    });
+  });
+
+  describe('Add conditions action', function () {
+    it('should allow adding the conditions on the step', function () {
+      createWorkflow('Test Conditions Action');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+      goBack();
+
+      showStepActions('inApp');
+      cy.getByTestId('add-conditions-action').should('be.visible').click();
+      addConditions();
+
+      cy.getByTestId(`node-inAppSelector`).getByTestId('conditions-action').should('be.visible').contains('1');
+      showStepActions('inApp');
+      cy.getByTestId(`node-inAppSelector`).getByTestId('add-conditions-action').should('be.visible').contains('1');
+    });
+
+    it('should allow adding the conditions from the variants list sidebar header', function () {
+      createWorkflow('Test Conditions Action');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+      goBack();
+
+      showStepActions('inApp');
+      addVariantActionClick('inApp');
+      addConditions();
+      goBack();
+
+      cy.getByTestId('variants-list-sidebar').getByTestId('editor-sidebar-add-conditions').should('be.visible').click();
+      addConditions();
+
+      cy.getByTestId('variants-list-sidebar')
+        .getByTestId('editor-sidebar-edit-conditions')
+        .should('be.visible')
+        .contains('1');
+    });
+
+    it('should allow adding the conditions on the variant in the variants list', function () {
+      createWorkflow('Test Conditions Action');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+      goBack();
+
+      showStepActions('inApp');
+      addVariantActionClick('inApp');
+      addConditions();
+      goBack();
+
+      cy.getByTestId('variant-item-card-0').getByTestId('conditions-action').should('be.visible').contains('1');
+      cy.getByTestId('variant-item-card-0').should('be.visible').trigger('mouseover');
+      cy.getByTestId('variant-item-card-0').getByTestId('add-conditions-action').should('be.visible').click();
+      addConditions();
+
+      cy.getByTestId('variant-item-card-0').getByTestId('conditions-action').should('be.visible').contains('2');
+    });
+
+    it('should allow adding the conditions in the step editor', function () {
+      createWorkflow('Test Conditions Action');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+      cy.getByTestId('editor-sidebar-add-conditions').click();
+      addConditions();
+      cy.getByTestId('editor-sidebar-edit-conditions').contains('1');
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      cy.reload();
+      cy.wait('@getWorkflow');
+
+      checkEditorContent('inApp');
+      cy.getByTestId('editor-sidebar-edit-conditions').contains('1');
+    });
+
+    it('should allow adding the conditions in the variant editor', function () {
+      createWorkflow('Test Conditions Action');
+
+      dragAndDrop('email');
+      editChannel('email');
+      fillEditorContent('email');
+      goBack();
+
+      showStepActions('email');
+      addVariantActionClick('email');
+      addConditions();
+
+      cy.getByTestId('editor-sidebar-edit-conditions').contains('1');
+      cy.getByTestId('editor-sidebar-edit-conditions').click();
+      addConditions();
+
+      cy.getByTestId('editor-sidebar-edit-conditions').contains('2');
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      cy.reload();
+      cy.wait('@getWorkflow');
+      cy.getByTestId('editor-sidebar-edit-conditions').contains('2');
+    });
+  });
+
+  describe('Edit action', function () {
+    it('should allow editing step', function () {
+      createWorkflow('Test Edit Action');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+      goBack();
+
+      showStepActions('inApp');
+      cy.getByTestId('edit-action').should('be.visible').click();
+
+      checkEditorContent('inApp');
+    });
+
+    it('should allow editing root step from the variants list', function () {
+      createWorkflow('Test Edit Action');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+      goBack();
+
+      showStepActions('inApp');
+      addVariantActionClick('inApp');
+      addConditions();
+      checkEditorContent('inApp');
+      goBack();
+
+      cy.getByTestId('variant-root-card').getByTestId('conditions-action').should('be.visible').contains('No');
+      cy.getByTestId('variant-root-card').should('be.visible').trigger('mouseover');
+      cy.getByTestId('variant-root-card').getByTestId('edit-step-action').should('be.visible').click();
+
+      checkEditorContent('inApp');
+    });
+
+    it('should allow editing variant from the variants list', function () {
+      createWorkflow('Test Edit Action');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+      goBack();
+
+      showStepActions('inApp');
+      addVariantActionClick('inApp');
+      addConditions();
+      checkEditorContent('inApp');
+      goBack();
+
+      cy.getByTestId('variant-item-card-0').getByTestId('conditions-action').should('be.visible').contains('1');
+      cy.getByTestId('variant-item-card-0').should('be.visible').trigger('mouseover');
+      cy.getByTestId('variant-item-card-0').getByTestId('edit-action').should('be.visible').click();
+
+      checkEditorContent('inApp');
+    });
+  });
+
+  describe('Delete action', function () {
+    it('should allow deleting step', function () {
+      createWorkflow('Test Delete Action');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      cy.reload();
+      cy.wait('@getWorkflow');
+
+      goBack();
+
+      showStepActions('inApp');
+      cy.getByTestId('step-actions-menu').should('be.visible').click();
+      cy.getByTestId('step-actions-menu').getByTestId('delete-step-action').should('be.visible').click();
+
+      cy.get('.mantine-Modal-modal').contains('Delete step?');
+      cy.get('.mantine-Modal-modal button').contains('Delete step').click();
+      cy.getByTestId(`node-inAppSelector`).should('not.exist');
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      cy.reload();
+      cy.wait('@getWorkflow');
+
+      cy.getByTestId(`node-inAppSelector`).should('not.exist');
+    });
+
+    it('should allow deleting step from the variants list', function () {
+      createWorkflow('Test Delete Action');
+
+      dragAndDrop('email');
+      editChannel('email');
+      fillEditorContent('email');
+      goBack();
+
+      showStepActions('email');
+      addVariantActionClick('email');
+      addConditions();
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+      goBack();
+
+      cy.reload();
+      cy.wait('@getWorkflow');
+
+      cy.getByTestId('editor-sidebar-delete').click();
+
+      cy.get('.mantine-Modal-modal').contains('Delete step?');
+      cy.get('.mantine-Modal-modal button').contains('Delete step').click();
+      cy.getByTestId(`node-emailSelector`).should('not.exist');
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      cy.reload();
+      cy.wait('@getWorkflow');
+
+      cy.getByTestId(`node-emailSelector`).should('not.exist');
+    });
+
+    it('should allow deleting variant', function () {
+      createWorkflow('Test Delete Action');
+
+      dragAndDrop('email');
+      editChannel('email');
+      fillEditorContent('email');
+      goBack();
+
+      showStepActions('email');
+      addVariantActionClick('email');
+      addConditions();
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+      goBack();
+
+      cy.getByTestId('variant-item-card-0').should('be.visible').trigger('mouseover');
+      cy.getByTestId('variant-item-card-0').getByTestId('step-actions-menu').should('be.visible').click();
+      cy.getByTestId('variant-item-card-0').getByTestId('delete-step-action').click();
+
+      cy.get('.mantine-Modal-modal').contains('Delete variant?');
+      cy.get('.mantine-Modal-modal button').contains('Delete variant').click();
+      cy.getByTestId('variant-item-card-0').should('not.exist');
+      goBack();
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      cy.reload();
+      cy.wait('@getWorkflow');
+      cy.getByTestId('variants-count').should('not.exist');
+    });
+  });
+});

--- a/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
+++ b/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
@@ -116,7 +116,12 @@ export const EditorSidebarHeaderActions = () => {
     <>
       <Group noWrap spacing={12} ml={'auto'} sx={{ alignItems: 'flex-start' }}>
         <When truthy={isUnderTheStepPath || isUnderVariantsListPath}>
-          <ActionButton tooltip="Add variant" onClick={onAddVariant} Icon={VariantPlus} />
+          <ActionButton
+            tooltip="Add variant"
+            onClick={onAddVariant}
+            Icon={VariantPlus}
+            data-test-id="editor-sidebar-add-variant"
+          />
         </When>
         <When truthy={hasNoFilters}>
           <ActionButton

--- a/apps/web/src/pages/templates/components/VariantItemCard.tsx
+++ b/apps/web/src/pages/templates/components/VariantItemCard.tsx
@@ -118,6 +118,7 @@ export const VariantItemCard = ({
   isFirst = false,
   nodeType,
   variant,
+  'data-test-id': dataTestId,
 }: {
   isReadonly?: boolean;
   stepIndex?: number;
@@ -125,6 +126,7 @@ export const VariantItemCard = ({
   isFirst?: boolean;
   variant: IFormStep | IVariantStep;
   nodeType: NodeType;
+  'data-test-id'?: string;
 }) => {
   const { setValue } = useFormContext<IForm>();
   const { channel, stepUuid = '' } = useParams<{
@@ -189,7 +191,7 @@ export const VariantItemCard = ({
   };
 
   return (
-    <VariantItemCardHolder>
+    <VariantItemCardHolder data-test-id={dataTestId}>
       {!isFirst ? (
         <NoSpan>No</NoSpan>
       ) : (

--- a/apps/web/src/pages/templates/components/VariantsListSidebar.tsx
+++ b/apps/web/src/pages/templates/components/VariantsListSidebar.tsx
@@ -50,6 +50,7 @@ export const VariantsListSidebar = ({ isLoading = false, children }: { isLoading
           },
         },
       }}
+      data-test-id="variants-list-sidebar"
     >
       {children}
     </Sidebar>

--- a/apps/web/src/pages/templates/components/VariantsPage.tsx
+++ b/apps/web/src/pages/templates/components/VariantsPage.tsx
@@ -74,11 +74,18 @@ export function VariantsPage() {
               stepIndex={stepIndex}
               variantIndex={variantIndex}
               nodeType="variant"
+              data-test-id={`variant-item-card-${variantIndex}`}
             />
           );
         })}
         {step && variants.length > 0 && (
-          <VariantItemCard isReadonly={isReadonly} key={stepUuid} variant={step} nodeType="variantRoot" />
+          <VariantItemCard
+            isReadonly={isReadonly}
+            key={stepUuid}
+            variant={step}
+            nodeType="variantRoot"
+            data-test-id="variant-root-card"
+          />
         )}
         {isScrollable && <FloatingButton isUp={scrollPosition.y > 0} onClick={scrollTo} />}
       </ScrollArea>

--- a/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNode.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNode.tsx
@@ -178,6 +178,7 @@ export function WorkflowNode({
                     {variantsCount} <span style={{ fontSize: '12px' }}>variants</span>
                   </>
                 }
+                data-test-id="variants-count"
               />
               <WorkflowNodeActions
                 nodeType={nodeType}
@@ -332,9 +333,19 @@ export function WorkflowNode({
   );
 }
 
-const IconText = ({ color, label, Icon }: { color?: string; label: any; Icon: React.FC<any> }) => {
+const IconText = ({
+  color,
+  label,
+  Icon,
+  ['data-test-id']: dataTestId,
+}: {
+  color?: string;
+  label: any;
+  Icon: React.FC<any>;
+  'data-test-id'?: string;
+}) => {
   return (
-    <IconTextWrapper>
+    <IconTextWrapper data-test-id={dataTestId}>
       <Icon color={color} width="20px" height="20px" />
       <Text color={color} weight={'bold'} size={14}>
         {label}

--- a/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
@@ -17,7 +17,7 @@ import {
 import { NodeType } from './WorkflowNode';
 import { When } from '../../../../../components/utils/When';
 
-const ContainerButton = styled(Container)`
+const ButtonsContainer = styled(Container)`
   padding: 0;
   margin-left: auto;
   margin-right: 0;
@@ -78,7 +78,7 @@ export const WorkflowNodeActions = ({
 
   if (nodeType === 'variantRoot') {
     return (
-      <ContainerButton>
+      <ButtonsContainer data-test-id="variant-root-actions">
         <When truthy={!showMenu}>
           <ActionButton
             onClick={onAddConditions}
@@ -87,19 +87,27 @@ export const WorkflowNodeActions = ({
             }
             text="No"
             Icon={NoConditions}
+            data-test-id="conditions-action"
           />
         </When>
         <When truthy={showMenu}>
           <Group noWrap spacing={5}>
-            {onEdit && <ActionButton onClick={onEdit} tooltip={VARIANT_TYPE_TO_EDIT[nodeType]} Icon={PencilOutlined} />}
+            {onEdit && (
+              <ActionButton
+                onClick={onEdit}
+                tooltip={VARIANT_TYPE_TO_EDIT[nodeType]}
+                Icon={PencilOutlined}
+                data-test-id="edit-step-action"
+              />
+            )}
           </Group>
         </When>
-      </ContainerButton>
+      </ButtonsContainer>
     );
   }
 
   return (
-    <ContainerButton>
+    <ButtonsContainer data-test-id="step-actions">
       <When truthy={!showMenu && conditionsCount > 0}>
         <ActionButton
           onClick={onAddConditions}
@@ -108,11 +116,19 @@ export const WorkflowNodeActions = ({
           }
           text={`${conditionsCount > 0 ? conditionsCount : ''}`}
           Icon={conditionsCount > 0 ? ConditionsFile : ConditionPlus}
+          data-test-id="conditions-action"
         />
       </When>
       <When truthy={showMenu}>
         <Group noWrap spacing={5}>
-          {onEdit && <ActionButton onClick={onEdit} tooltip={VARIANT_TYPE_TO_EDIT[nodeType]} Icon={PencilOutlined} />}
+          {onEdit && (
+            <ActionButton
+              onClick={onEdit}
+              tooltip={VARIANT_TYPE_TO_EDIT[nodeType]}
+              Icon={PencilOutlined}
+              data-test-id="edit-action"
+            />
+          )}
           {onAddConditions && (
             <ActionButton
               onClick={onAddConditions}
@@ -123,6 +139,7 @@ export const WorkflowNodeActions = ({
               }
               text={`${conditionsCount > 0 ? conditionsCount : ''}`}
               Icon={conditionsCount > 0 ? ConditionsFile : ConditionPlus}
+              data-test-id="add-conditions-action"
             />
           )}
           <Dropdown
@@ -166,6 +183,6 @@ export const WorkflowNodeActions = ({
           </Dropdown>
         </Group>
       </When>
-    </ContainerButton>
+    </ButtonsContainer>
   );
 };


### PR DESCRIPTION
### What change does this PR introduce?

The E2E tests for the Variants project, covering:
- add variant flow
- add conditions for step/variant
- edit step/variant
- delete step/variant
- check available actions on step, step with variants, inside the editor, and variants list

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)
![Screenshot 2023-11-03 at 12 58 45](https://github.com/novuhq/novu/assets/2607232/8aa5afa2-7893-454c-9bb9-afdfee90c260)


