### PR TITLE
chore(api): Add generic migration helper script

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -36,3 +36,29 @@ $ npm run test
 
 ### E2E tests
 See the docs for [Running on Local Machine - API Tests](https://docs.novu.co/community/run-in-local-machine#api).
+
+## Migrations
+Database migrations are included for features that have a hard dependency on specific data being available on database entities. These migrations are run by both Novu Cloud and Novu Self-Hosted users to support new feature releases.
+
+### How to Run
+
+The `npm run migration` script is present in the `package.json` to ensure script changes are DRY, consistent, and repeatable. This script is included in user-facing communications such as our documentation and release notes, and the script naming therefore MUST remain stable.
+
+The path to the migration to run is passed as a positional argument to the script. For example, to run the Add Integration Identifier script, we would enter the following:
+
+```bash
+npm run migration -- ./migrations/integration-scheme-update/add-integration-identifier-migration.ts
+```
+
+### Conventions
+
+These migrations live in the `./migrations` directory, and follow the naming convention of:
+`./migrations/<CHANGE_DESCRIPTION>/<CHANGE_ACTION>.ts`. Each `<CHANGE_DESCRIPTION>` may have 1 or more `<CHANGE_ACTION>.ts` scripts. For example:
+
+```
+.
+└── migrations/
+    └── integration-scheme-update/
+        ├── add-integration-identifier-migration.ts
+        └── add-primary-priority-migration.ts
+```

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -42,7 +42,7 @@ Database migrations are included for features that have a hard dependency on spe
 
 ### How to Run
 
-The `npm run migration` script is present in the `package.json` to ensure script changes are DRY, consistent, and repeatable. This script is included in user-facing communications such as our documentation and release notes, and the script naming therefore MUST remain stable.
+The `npm run migration` script is available in the `package.json` to ensure script changes are DRY and consistent. This script is included in user-facing communications such as our documentation and release notes, and the script naming therefore MUST remain stable.
 
 The path to the migration to run is passed as a positional argument to the script. For example, to run the Add Integration Identifier script, we would enter the following:
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,9 +23,7 @@
     "test": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file e2e/setup.ts src/**/**/*.spec.ts",
     "test:e2e": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file e2e/setup.ts src/**/*.e2e.ts",
     "test:e2e:ee": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file e2e/setup.ts src/**/*.e2e-ee.ts",
-    "migration": "cross-env NODE_ENV=local MIGRATION=true ts-node --transpileOnly ./migrations/expire-at/expire-at.migration.ts",
-    "migration:in-app": "cross-env NODE_ENV=local MIGRATION=true ts-node --transpileOnly ./migrations/integration-scheme-update/add-primary-priority-migration.ts",
-    "migration:primary-provider": "cross-env NODE_ENV=local MIGRATION=true ts-node --transpileOnly ./migrations/integration-scheme-update/add-primary-priority-migration.ts",
+    "migration": "cross-env NODE_ENV=local MIGRATION=true ts-node --transpileOnly",
     "link:submodules": "pnpm link ../../enterprise/packages/auth"
   },
   "dependencies": {


### PR DESCRIPTION
### What change does this PR introduce?

* Modifies the existing and now defunct `migration` script to allow the migration script path to be provided as a positional npm script argument
* Removes feature specific migration scripts in favour of the new pattern. These are unreleased migrations, so no customer impact is expected.
* Adds documentation for API database migrations

### Why was this change needed?

Every time a new migration script is added, we are currently adding a new NPM script. This is not DRY and can result in migrations being run differently. Furthermore, abstracting this pattern will enable us to write consistent documentation for our users to migrate their self-hosted Novu databases.

### Other information (Screenshots)
_Migrations section in `apps/api/README.md`_
<img width="830" alt="image" src="https://github.com/novuhq/novu/assets/32132657/e6444ef1-80a8-4d30-8da9-aa827e1894e5">

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
