### PR TITLE
chore(web): disable add variant flow for the digest and delay

### DIFF
--- a/apps/web/cypress/tests/notification-editor/variants.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/variants.spec.ts
@@ -1,4 +1,4 @@
-import { Channel, dragAndDrop, editChannel, fillBasicNotificationDetails, goBack } from '.';
+import { Channel, dragAndDrop, editChannel, goBack } from '.';
 
 const EDITOR_TEXT = 'Hello, world!';
 const VARIANT_EDITOR_TEXT = 'Hello, world from Variant!';
@@ -228,6 +228,40 @@ describe('Workflow Editor - Variants', function () {
       cy.wait('@getWorkflow');
 
       checkEditorContent('inApp', true);
+    });
+
+    it('should not allow creating variant for digest step', function () {
+      const channel = 'digest';
+      createWorkflow('Add variant not available');
+
+      dragAndDrop(channel);
+      showStepActions(channel);
+
+      cy.getByTestId(`node-${channel}Selector`)
+        .getByTestId('step-actions-menu')
+        .click()
+        .getByTestId('add-variant-action')
+        .should('not.exist');
+
+      editChannel(channel);
+      cy.getByTestId('editor-sidebar-add-variant').should('not.exist');
+    });
+
+    it('should not allow creating variant for delay step', function () {
+      const channel = 'delay';
+      createWorkflow('Add variant not available');
+
+      dragAndDrop(channel);
+      showStepActions(channel);
+
+      cy.getByTestId(`node-${channel}Selector`)
+        .getByTestId('step-actions-menu')
+        .click()
+        .getByTestId('add-variant-action')
+        .should('not.exist');
+
+      editChannel(channel);
+      cy.getByTestId('editor-sidebar-add-variant').should('not.exist');
     });
   });
 

--- a/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
+++ b/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
@@ -2,7 +2,7 @@ import { Group } from '@mantine/core';
 import { useEffect, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { FilterPartTypeEnum } from '@novu/shared';
+import { FilterPartTypeEnum, DELAYED_STEPS, StepTypeEnum } from '@novu/shared';
 import { ActionButton, Condition, ConditionPlus, ConditionsFile, Trash, VariantPlus } from '@novu/design-system';
 
 import { Conditions, IConditions } from '../../../components/conditions';
@@ -62,6 +62,8 @@ export const EditorSidebarHeaderActions = () => {
   const PlusIcon = isUnderVariantsListPath ? ConditionsFile : ConditionPlus;
   const ConditionsIcon = isUnderVariantsListPath ? ConditionsFile : Condition;
   const hasNoFilters = (filters && filters?.length === 0) || !filters || isNewVariantCreationUrl;
+  const isDelayedStep = DELAYED_STEPS.includes(channel as StepTypeEnum);
+  const isAddVariantActionAvailable = (isUnderTheStepPath || isUnderVariantsListPath) && !isDelayedStep;
 
   const onAddVariant = () => {
     const newPath = basePath + `/${channel}/${stepUuid}/variants/create`;
@@ -115,7 +117,7 @@ export const EditorSidebarHeaderActions = () => {
   return (
     <>
       <Group noWrap spacing={12} ml={'auto'} sx={{ alignItems: 'flex-start' }}>
-        <When truthy={isUnderTheStepPath || isUnderVariantsListPath}>
+        <When truthy={isAddVariantActionAvailable}>
           <ActionButton
             tooltip="Add variant"
             onClick={onAddVariant}

--- a/apps/web/src/pages/templates/components/VariantsPage.tsx
+++ b/apps/web/src/pages/templates/components/VariantsPage.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useRef, useState } from 'react';
 import { ScrollArea } from '@mantine/core';
 import { useFormContext } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
-import { StepTypeEnum } from '@novu/shared';
+import { useNavigate, useParams } from 'react-router-dom';
+import { DELAYED_STEPS, StepTypeEnum } from '@novu/shared';
 
 import { VariantItemCard } from './VariantItemCard';
 import { VariantsListSidebar } from './VariantsListSidebar';
@@ -10,8 +10,11 @@ import { IForm } from './formTypes';
 import { FloatingButton } from './FloatingButton';
 import { useEnvController } from '../../../hooks';
 import { useTemplateEditorForm } from './TemplateEditorFormProvider';
+import { useBasePath } from '../hooks/useBasePath';
 
 export function VariantsPage() {
+  const navigate = useNavigate();
+  const basePath = useBasePath();
   const { watch } = useFormContext<IForm>();
   const { channel, stepUuid = '' } = useParams<{
     channel: StepTypeEnum | undefined;
@@ -30,6 +33,7 @@ export function VariantsPage() {
     [channel, stepUuid, steps]
   );
   const step = watch(`steps.${stepIndex}`);
+  const isDelayedStep = DELAYED_STEPS.includes(channel as StepTypeEnum);
 
   const setViewportRef = (ref: HTMLDivElement | null) => {
     if (!ref) {
@@ -51,6 +55,10 @@ export function VariantsPage() {
 
   if (!channel) {
     return null;
+  }
+
+  if (isDelayedStep) {
+    navigate(`${basePath}/${channel}/${stepUuid}`);
   }
 
   const variants = step?.variants ?? [];

--- a/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNode.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNode.tsx
@@ -185,6 +185,7 @@ export function WorkflowNode({
                 showMenu={showMenu}
                 menuPosition={menuPosition}
                 conditionsCount={conditionsCount}
+                channelType={channelType}
                 onEdit={onEdit}
                 onAddConditions={onAddConditions}
                 onAddVariant={onAddVariant}
@@ -234,6 +235,7 @@ export function WorkflowNode({
                   showMenu={showMenu}
                   menuPosition={menuPosition}
                   conditionsCount={conditionsCount}
+                  channelType={channelType}
                   onEdit={onEdit}
                   onAddConditions={onAddConditions}
                   onAddVariant={onAddVariant}

--- a/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
@@ -13,6 +13,7 @@ import {
   Trash,
   VariantPlus,
 } from '@novu/design-system';
+import { DELAYED_STEPS, StepTypeEnum } from '@novu/shared';
 
 import { NodeType } from './WorkflowNode';
 import { When } from '../../../../../components/utils/When';
@@ -56,6 +57,7 @@ interface IWorkflowNodeActionsProps {
   menuPosition: IDropdownProps['position'];
   showMenu: boolean;
   conditionsCount: number;
+  channelType: StepTypeEnum;
   onDelete?: () => void;
   onAddVariant?: () => void;
   onEdit?: MouseEventHandler<HTMLButtonElement>;
@@ -67,6 +69,7 @@ export const WorkflowNodeActions = ({
   menuPosition,
   conditionsCount,
   nodeType = 'step',
+  channelType,
   onEdit,
   onAddConditions,
   onAddVariant,
@@ -105,6 +108,8 @@ export const WorkflowNodeActions = ({
       </ButtonsContainer>
     );
   }
+
+  const isDelayedStep = DELAYED_STEPS.includes(channelType);
 
   return (
     <ButtonsContainer data-test-id="step-actions">
@@ -156,7 +161,7 @@ export const WorkflowNodeActions = ({
             }
             middlewares={{ flip: false, shift: false }}
           >
-            {onAddVariant && (
+            {onAddVariant && !isDelayedStep && (
               <Dropdown.Item
                 icon={<VariantPlus />}
                 onClick={(e) => {

--- a/libs/shared/src/types/channel/index.ts
+++ b/libs/shared/src/types/channel/index.ts
@@ -52,3 +52,4 @@ export enum SystemAvatarIconEnum {
 }
 
 export const CHANNELS_WITH_PRIMARY = [ChannelTypeEnum.EMAIL, ChannelTypeEnum.SMS];
+export const DELAYED_STEPS = [StepTypeEnum.DELAY, StepTypeEnum.DIGEST];


### PR DESCRIPTION
### What change does this PR introduce?

Disable the add variant flow for the digest and delay steps (we don't support it currently on the backend).

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)


https://github.com/novuhq/novu/assets/2607232/9fe2aa57-8ac9-44d6-9f56-d3be6ac7e472


