### PR TITLE
chore(web): step and variant actions in the production environment

### DIFF
--- a/apps/web/cypress/tests/notification-editor/variants.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/variants.spec.ts
@@ -190,6 +190,24 @@ describe('Workflow Editor - Variants', function () {
     cy.getByTestId('editor-sidebar-delete').should('be.visible');
   };
 
+  const navigateAndPromoteAllChanges = () => {
+    cy.getByTestId('side-nav-changes-link').click();
+    cy.waitForNetworkIdle(500);
+    cy.awaitAttachedGetByTestId('promote-all-btn').click();
+  };
+
+  const navigateAndOpenFirstWorkflow = () => {
+    cy.getByTestId('side-nav-templates-link').click();
+    cy.waitForNetworkIdle(500);
+    cy.getByTestId('notifications-template').find('tbody tr').first().click();
+    cy.wait('@getWorkflow');
+  };
+
+  const switchEnvironment = (environment: 'Production' | 'Development') => {
+    cy.getByTestId('environment-switch').find(`input[value="${environment}"]`).click({ force: true });
+    cy.waitForNetworkIdle(500);
+  };
+
   describe('Add variant flow', function () {
     it('should allow creating the variants for the in-app channel', function () {
       addVariantForChannel('inApp', 'V1 In-App');
@@ -288,6 +306,58 @@ describe('Workflow Editor - Variants', function () {
       // show the root step actions and check available actions
       checkStepActions('inApp');
     });
+
+    it('in production should show only the edit step action', function () {
+      const channel = 'sms';
+      createWorkflow(`Production Test Step Actions`);
+
+      dragAndDrop(channel);
+      editChannel(channel);
+      fillEditorContent(channel);
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      navigateAndPromoteAllChanges();
+
+      switchEnvironment('Production');
+
+      navigateAndOpenFirstWorkflow();
+
+      cy.getByTestId(`node-${channel}Selector`).getByTestId('conditions-action').should('not.exist');
+      showStepActions(channel);
+      cy.getByTestId(`node-${channel}Selector`).getByTestId('edit-action').should('be.visible');
+      cy.getByTestId(`node-${channel}Selector`).getByTestId('add-conditions-action').should('not.exist');
+      cy.getByTestId(`node-${channel}Selector`).getByTestId('step-actions-menu').should('not.exist');
+    });
+
+    it('in production should show the step actions: edit and conditions', function () {
+      const channel = 'sms';
+      createWorkflow(`Production Test Step Actions`);
+
+      dragAndDrop(channel);
+      editChannel(channel);
+      fillEditorContent(channel);
+      goBack();
+
+      showStepActions(channel);
+      cy.getByTestId('add-conditions-action').should('be.visible').click();
+      addConditions();
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      navigateAndPromoteAllChanges();
+
+      switchEnvironment('Production');
+
+      navigateAndOpenFirstWorkflow();
+
+      cy.getByTestId(`node-${channel}Selector`).getByTestId('conditions-action').should('be.visible').contains('1');
+      showStepActions(channel);
+      cy.getByTestId(`node-${channel}Selector`).getByTestId('edit-action').should('be.visible');
+      cy.getByTestId(`node-${channel}Selector`).getByTestId('add-conditions-action').should('be.visible');
+      cy.getByTestId(`node-${channel}Selector`).getByTestId('step-actions-menu').should('not.exist');
+    });
   });
 
   describe('Editor actions', function () {
@@ -309,6 +379,58 @@ describe('Workflow Editor - Variants', function () {
       addConditions();
 
       checkEditorActions(true);
+    });
+
+    it('in production should show only the close action', function () {
+      const channel = 'sms';
+      createWorkflow(`Production Test Editor Actions`);
+
+      dragAndDrop(channel);
+      editChannel(channel);
+      fillEditorContent(channel);
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      navigateAndPromoteAllChanges();
+
+      switchEnvironment('Production');
+
+      navigateAndOpenFirstWorkflow();
+
+      editChannel(channel);
+      cy.getByTestId('editor-sidebar-add-variant').should('not.exist');
+      cy.getByTestId('editor-sidebar-add-conditions').should('not.exist');
+      cy.getByTestId('editor-sidebar-edit-conditions').should('not.exist');
+      cy.getByTestId('editor-sidebar-delete').should('not.exist');
+    });
+
+    it('in production should only show the view conditions action', function () {
+      const channel = 'sms';
+      createWorkflow(`Production Test Editor Actions`);
+
+      dragAndDrop(channel);
+      editChannel(channel);
+      fillEditorContent(channel);
+      goBack();
+
+      showStepActions(channel);
+      cy.getByTestId('add-conditions-action').should('be.visible').click();
+      addConditions();
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      navigateAndPromoteAllChanges();
+
+      switchEnvironment('Production');
+
+      navigateAndOpenFirstWorkflow();
+
+      editChannel(channel);
+      cy.getByTestId('editor-sidebar-add-variant').should('not.exist');
+      cy.getByTestId('editor-sidebar-add-conditions').should('not.exist');
+      cy.getByTestId('editor-sidebar-edit-conditions').should('be.visible');
+      cy.getByTestId('editor-sidebar-delete').should('not.exist');
     });
   });
 
@@ -415,6 +537,68 @@ describe('Workflow Editor - Variants', function () {
       cy.reload();
       cy.wait('@getWorkflow');
       cy.getByTestId('editor-sidebar-edit-conditions').contains('2');
+    });
+
+    it('in production should only allow edit and view conditions on variant list item', function () {
+      const channel = 'chat';
+      createWorkflow(`Production Variant Actions`);
+
+      dragAndDrop(channel);
+      editChannel(channel);
+      fillEditorContent(channel);
+      goBack();
+
+      showStepActions(channel);
+      addVariantActionClick(channel);
+      addConditions();
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      navigateAndPromoteAllChanges();
+
+      switchEnvironment('Production');
+
+      navigateAndOpenFirstWorkflow();
+
+      editChannel(channel);
+
+      cy.getByTestId('variant-item-card-0').getByTestId('conditions-action').should('be.visible').contains('1');
+      cy.getByTestId('variant-item-card-0').trigger('mouseover');
+      cy.getByTestId('variant-item-card-0').getByTestId('edit-action').should('be.visible');
+      cy.getByTestId('variant-item-card-0').getByTestId('add-conditions-action').should('be.visible');
+      cy.getByTestId('variant-item-card-0').getByTestId('step-actions-menu').should('not.exist');
+    });
+
+    it('in production should only allow edit the variant root list item', function () {
+      const channel = 'chat';
+      createWorkflow(`Production Variant Actions`);
+
+      dragAndDrop(channel);
+      editChannel(channel);
+      fillEditorContent(channel);
+      goBack();
+
+      showStepActions(channel);
+      addVariantActionClick(channel);
+      addConditions();
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      navigateAndPromoteAllChanges();
+
+      switchEnvironment('Production');
+
+      navigateAndOpenFirstWorkflow();
+
+      editChannel(channel);
+
+      cy.getByTestId('variant-root-card').getByTestId('conditions-action').should('be.visible').contains('No');
+      cy.getByTestId('variant-root-card').trigger('mouseover');
+      cy.getByTestId('variant-root-card').getByTestId('edit-step-action').should('be.visible');
+      cy.getByTestId('variant-root-card').getByTestId('add-conditions-action').should('not.exist');
+      cy.getByTestId('variant-root-card').getByTestId('step-actions-menu').should('not.exist');
     });
   });
 

--- a/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
+++ b/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
@@ -114,10 +114,12 @@ export const EditorSidebarHeaderActions = () => {
     setIsDeleteModalOpened(false);
   };
 
+  const conditionAction = isReadonly ? 'View' : hasNoFilters ? 'Add' : 'Edit';
+
   return (
     <>
       <Group noWrap spacing={12} ml={'auto'} sx={{ alignItems: 'flex-start' }}>
-        <When truthy={isAddVariantActionAvailable}>
+        <When truthy={isAddVariantActionAvailable && !isReadonly}>
           <ActionButton
             tooltip="Add variant"
             onClick={onAddVariant}
@@ -125,9 +127,9 @@ export const EditorSidebarHeaderActions = () => {
             data-test-id="editor-sidebar-add-variant"
           />
         </When>
-        <When truthy={hasNoFilters}>
+        <When truthy={hasNoFilters && !isReadonly}>
           <ActionButton
-            tooltip={`Add ${isUnderVariantsListPath ? 'group' : ''} conditions`}
+            tooltip={`${conditionAction} ${isUnderVariantsListPath ? 'group' : ''} conditions`}
             onClick={() => setConditionsOpened(true)}
             Icon={PlusIcon}
             data-test-id="editor-sidebar-add-conditions"
@@ -135,19 +137,21 @@ export const EditorSidebarHeaderActions = () => {
         </When>
         <When truthy={!hasNoFilters}>
           <ActionButton
-            tooltip={`Edit ${isUnderVariantsListPath ? 'group' : ''} conditions`}
+            tooltip={`${conditionAction} ${isUnderVariantsListPath ? 'group' : ''} conditions`}
             text={`${filters?.length ?? ''}`}
             onClick={() => setConditionsOpened(true)}
             Icon={ConditionsIcon}
             data-test-id="editor-sidebar-edit-conditions"
           />
         </When>
-        <ActionButton
-          tooltip={`Delete ${isUnderVariantPath ? 'variant' : 'step'}`}
-          onClick={openDeleteModal}
-          Icon={Trash}
-          data-test-id="editor-sidebar-delete"
-        />
+        <When truthy={!isReadonly}>
+          <ActionButton
+            tooltip={`Delete ${isUnderVariantPath ? 'variant' : 'step'}`}
+            onClick={openDeleteModal}
+            Icon={Trash}
+            data-test-id="editor-sidebar-delete"
+          />
+        </When>
       </Group>
       {areConditionsOpened && (
         <Conditions

--- a/apps/web/src/pages/templates/editor/TemplateEditorPage.tsx
+++ b/apps/web/src/pages/templates/editor/TemplateEditorPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { ReactFlowProvider } from 'react-flow-renderer';
 import { FieldErrors, useFormContext } from 'react-hook-form';
@@ -28,6 +28,7 @@ function BaseTemplateEditorPage() {
   const { templateId = '' } = useParams<{ templateId: string }>();
   const isTouring = tourStorage.getCurrentTour('digest', templateId) > -1;
   const basePath = useBasePath();
+  const [shouldRenderBlueprintModal, setShouldRenderBlueprintModal] = useState(false);
 
   const isCreateTemplatePage = location.pathname === ROUTES.WORKFLOWS_CREATE;
 
@@ -60,6 +61,11 @@ function BaseTemplateEditorPage() {
     }
   }, [navigate, environment, template]);
 
+  useEffect(() => {
+    const id = localStorage.getItem('blueprintId');
+    setShouldRenderBlueprintModal(!!id);
+  }, []);
+
   if (environment && environment?.name === 'Production' && isCreateTemplatePage) {
     navigate(ROUTES.WORKFLOWS);
   }
@@ -81,7 +87,7 @@ function BaseTemplateEditorPage() {
           </ReactFlowProvider>
         </form>
       </PageContainer>
-      <BlueprintModal />
+      {shouldRenderBlueprintModal && <BlueprintModal />}
       <NavigateValidatorModal
         isOpen={showNavigateValidatorModal}
         onConfirm={confirmNavigate}

--- a/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNode.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNode.tsx
@@ -124,7 +124,7 @@ export function WorkflowNode({
     stepErrorContent = getFormattedStepErrors(index, errors);
   }
 
-  const showMenu = !readonlyEnv && !dragging && hover;
+  const showMenu = !dragging && hover;
 
   useEffect(() => {
     const subscription = watch((values) => {
@@ -183,6 +183,7 @@ export function WorkflowNode({
               <WorkflowNodeActions
                 nodeType={nodeType}
                 showMenu={showMenu}
+                isReadOnly={readonlyEnv}
                 menuPosition={menuPosition}
                 conditionsCount={conditionsCount}
                 channelType={channelType}
@@ -233,6 +234,7 @@ export function WorkflowNode({
                 <WorkflowNodeActions
                   nodeType={nodeType}
                   showMenu={showMenu}
+                  isReadOnly={readonlyEnv}
                   menuPosition={menuPosition}
                   conditionsCount={conditionsCount}
                   channelType={channelType}

--- a/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
@@ -45,6 +45,13 @@ const VARIANT_TYPE_TO_EDIT_CONDITIONS: Record<NodeType, string> = {
   variantRoot: 'Edit group conditions',
 };
 
+const VARIANT_TYPE_TO_VIEW_CONDITIONS: Record<NodeType, string> = {
+  step: 'View conditions',
+  stepRoot: 'View group conditions',
+  variant: 'View conditions',
+  variantRoot: 'View group conditions',
+};
+
 const VARIANT_TYPE_TO_DELETE: Record<NodeType, string> = {
   step: 'Delete step',
   stepRoot: 'Delete step',
@@ -56,6 +63,7 @@ interface IWorkflowNodeActionsProps {
   nodeType: NodeType;
   menuPosition: IDropdownProps['position'];
   showMenu: boolean;
+  isReadOnly: boolean;
   conditionsCount: number;
   channelType: StepTypeEnum;
   onDelete?: () => void;
@@ -66,6 +74,7 @@ interface IWorkflowNodeActionsProps {
 
 export const WorkflowNodeActions = ({
   showMenu,
+  isReadOnly,
   menuPosition,
   conditionsCount,
   nodeType = 'step',
@@ -110,17 +119,22 @@ export const WorkflowNodeActions = ({
   }
 
   const isDelayedStep = DELAYED_STEPS.includes(channelType);
+  const conditionsAction = isReadOnly
+    ? VARIANT_TYPE_TO_VIEW_CONDITIONS[nodeType]
+    : conditionsCount > 0
+    ? VARIANT_TYPE_TO_EDIT_CONDITIONS[nodeType]
+    : VARIANT_TYPE_TO_ADD_CONDITIONS[nodeType];
+  const conditionsIcon = isReadOnly || conditionsCount > 0 ? ConditionsFile : ConditionPlus;
+  const isShowConditions = onAddConditions && (!isReadOnly || (isReadOnly && conditionsCount > 0));
 
   return (
     <ButtonsContainer data-test-id="step-actions">
       <When truthy={!showMenu && conditionsCount > 0}>
         <ActionButton
           onClick={onAddConditions}
-          tooltip={
-            conditionsCount > 0 ? VARIANT_TYPE_TO_EDIT_CONDITIONS[nodeType] : VARIANT_TYPE_TO_ADD_CONDITIONS[nodeType]
-          }
+          tooltip={conditionsAction}
           text={`${conditionsCount > 0 ? conditionsCount : ''}`}
-          Icon={conditionsCount > 0 ? ConditionsFile : ConditionPlus}
+          Icon={conditionsIcon}
           data-test-id="conditions-action"
         />
       </When>
@@ -134,58 +148,56 @@ export const WorkflowNodeActions = ({
               data-test-id="edit-action"
             />
           )}
-          {onAddConditions && (
+          {isShowConditions && (
             <ActionButton
               onClick={onAddConditions}
-              tooltip={
-                conditionsCount > 0
-                  ? VARIANT_TYPE_TO_EDIT_CONDITIONS[nodeType]
-                  : VARIANT_TYPE_TO_ADD_CONDITIONS[nodeType]
-              }
+              tooltip={conditionsAction}
               text={`${conditionsCount > 0 ? conditionsCount : ''}`}
-              Icon={conditionsCount > 0 ? ConditionsFile : ConditionPlus}
+              Icon={conditionsIcon}
               data-test-id="add-conditions-action"
             />
           )}
-          <Dropdown
-            withinPortal
-            position={menuPosition}
-            withArrow={false}
-            offset={0}
-            control={
-              <ActionButton
-                onClick={(e) => e.stopPropagation()}
-                Icon={DotsHorizontal}
-                data-test-id="step-actions-menu"
-              />
-            }
-            middlewares={{ flip: false, shift: false }}
-          >
-            {onAddVariant && !isDelayedStep && (
-              <Dropdown.Item
-                icon={<VariantPlus />}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onAddVariant();
-                }}
-                data-test-id="add-variant-action"
-              >
-                Add variant
-              </Dropdown.Item>
-            )}
-            {onDelete && (
-              <Dropdown.Item
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDelete();
-                }}
-                icon={<Trash width="16px" height="16px" />}
-                data-test-id="delete-step-action"
-              >
-                {VARIANT_TYPE_TO_DELETE[nodeType]}
-              </Dropdown.Item>
-            )}
-          </Dropdown>
+          <When truthy={!isReadOnly}>
+            <Dropdown
+              withinPortal
+              position={menuPosition}
+              withArrow={false}
+              offset={0}
+              control={
+                <ActionButton
+                  onClick={(e) => e.stopPropagation()}
+                  Icon={DotsHorizontal}
+                  data-test-id="step-actions-menu"
+                />
+              }
+              middlewares={{ flip: false, shift: false }}
+            >
+              {onAddVariant && !isDelayedStep && (
+                <Dropdown.Item
+                  icon={<VariantPlus />}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAddVariant();
+                  }}
+                  data-test-id="add-variant-action"
+                >
+                  Add variant
+                </Dropdown.Item>
+              )}
+              {onDelete && (
+                <Dropdown.Item
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete();
+                  }}
+                  icon={<Trash width="16px" height="16px" />}
+                  data-test-id="delete-step-action"
+                >
+                  {VARIANT_TYPE_TO_DELETE[nodeType]}
+                </Dropdown.Item>
+              )}
+            </Dropdown>
+          </When>
         </Group>
       </When>
     </ButtonsContainer>


### PR DESCRIPTION
### What change does this PR introduce?

In the production environment:

1. Step and Variant node actions: 
  - edit
  - view existing conditions - if conditions exist

2. Step and Variant Editor header actions:
  - view existing conditions - if conditions exist
  - close

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

https://github.com/novuhq/novu/assets/2607232/e2e258b4-70cc-4f44-bf29-3f8f1859ac52



