### PR TITLE
refactor: use execution queue instead of writing directly to execution detail collection

### DIFF
--- a/apps/worker/src/app/workflow/services/cold-start.service.ts
+++ b/apps/worker/src/app/workflow/services/cold-start.service.ts
@@ -4,13 +4,15 @@ import { INovuWorker, ReadinessService } from '@novu/application-generic';
 import { StandardWorker } from './standard.worker';
 import { SubscriberProcessWorker } from './subscriber-process.worker';
 import { WorkflowWorker } from './workflow.worker';
+import { ExecutionLogWorker } from './execution-log.worker';
 
 const getWorkers = (app: INestApplication): INovuWorker[] => {
   const standardWorker = app.get(StandardWorker, { strict: false });
   const workflowWorker = app.get(WorkflowWorker, { strict: false });
   const subscriberProcessWorker = app.get(SubscriberProcessWorker, { strict: false });
+  const executionLogWorker = app.get(ExecutionLogWorker, { strict: false });
 
-  const workers: INovuWorker[] = [standardWorker, workflowWorker, subscriberProcessWorker];
+  const workers: INovuWorker[] = [standardWorker, workflowWorker, subscriberProcessWorker, executionLogWorker];
 
   return workers;
 };

--- a/apps/worker/src/app/workflow/services/execution-log.worker.spec.ts
+++ b/apps/worker/src/app/workflow/services/execution-log.worker.spec.ts
@@ -1,0 +1,141 @@
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import { setTimeout } from 'timers/promises';
+
+import { TriggerEvent, ExecutionLogQueueService, CreateExecutionDetails } from '@novu/application-generic';
+
+import { ExecutionLogWorker } from './execution-log.worker';
+
+import { WorkflowModule } from '../workflow.module';
+
+let executionLogQueueService: ExecutionLogQueueService;
+let executionLogWorker: ExecutionLogWorker;
+
+describe('ExecutionLog Worker', () => {
+  before(async () => {
+    process.env.IN_MEMORY_CLUSTER_MODE_ENABLED = 'false';
+    process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED = 'false';
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [WorkflowModule],
+    }).compile();
+
+    const createExecutionDetails = moduleRef.get<CreateExecutionDetails>(CreateExecutionDetails);
+
+    executionLogWorker = new ExecutionLogWorker(createExecutionDetails);
+
+    executionLogQueueService = new ExecutionLogQueueService();
+    await executionLogQueueService.queue.obliterate();
+  });
+
+  after(async () => {
+    await executionLogQueueService.queue.drain();
+    await executionLogWorker.gracefulShutdown();
+  });
+
+  it('should be initialised properly', async () => {
+    expect(executionLogWorker).to.be.ok;
+    expect(executionLogWorker).to.have.all.keys('DEFAULT_ATTEMPTS', 'instance', 'topic', 'createExecutionDetails');
+    expect(await executionLogWorker.bullMqService.getStatus()).to.deep.equal({
+      queueIsPaused: undefined,
+      queueName: undefined,
+      workerName: 'execution-logs',
+      workerIsPaused: false,
+      workerIsRunning: true,
+    });
+    expect(executionLogWorker.worker.opts).to.deep.include({
+      concurrency: 200,
+      lockDuration: 90000,
+    });
+  });
+
+  it('should be able to automatically pull a job from the queue', async () => {
+    const existingJobs = await executionLogQueueService.queue.getJobs();
+    expect(existingJobs.length).to.equal(0);
+
+    const jobId = 'execution-logs-queue-job-id';
+    const _environmentId = 'execution-logs-queue-environment-id';
+    const _organizationId = 'execution-logs-queue-organization-id';
+    const _userId = 'execution-logs-queue-user-id';
+    const jobData = {
+      _id: jobId,
+      test: 'execution-logs-queue-job-data',
+      _environmentId,
+      _organizationId,
+      _userId,
+    };
+
+    await executionLogQueueService.add(jobId, jobData, _organizationId);
+
+    expect(await executionLogQueueService.queue.getActiveCount()).to.equal(1);
+    expect(await executionLogQueueService.queue.getWaitingCount()).to.equal(0);
+
+    // When we arrive to pull the job it has been already pulled by the worker
+    const nextJob = await executionLogWorker.worker.getNextJob(jobId);
+    expect(nextJob).to.equal(undefined);
+
+    await setTimeout(100);
+
+    // No jobs left in queue
+    const queueJobs = await executionLogQueueService.queue.getJobs();
+    expect(queueJobs.length).to.equal(0);
+  });
+
+  it('should pause the worker', async () => {
+    const isPaused = await executionLogWorker.worker.isPaused();
+    expect(isPaused).to.equal(false);
+
+    const runningStatus = await executionLogWorker.bullMqService.getStatus();
+    expect(runningStatus).to.deep.equal({
+      queueIsPaused: undefined,
+      queueName: undefined,
+      workerName: 'execution-logs',
+      workerIsPaused: false,
+      workerIsRunning: true,
+    });
+
+    await executionLogWorker.pause();
+
+    const isNowPaused = await executionLogWorker.worker.isPaused();
+    expect(isNowPaused).to.equal(true);
+
+    const runningStatusChanged = await executionLogWorker.bullMqService.getStatus();
+    expect(runningStatusChanged).to.deep.equal({
+      queueIsPaused: undefined,
+      queueName: undefined,
+      workerName: 'execution-logs',
+      workerIsPaused: true,
+      workerIsRunning: true,
+    });
+  });
+
+  it('should resume the worker', async () => {
+    await executionLogWorker.pause();
+
+    const isPaused = await executionLogWorker.worker.isPaused();
+    expect(isPaused).to.equal(true);
+
+    const runningStatus = await executionLogWorker.bullMqService.getStatus();
+    expect(runningStatus).to.deep.equal({
+      queueIsPaused: undefined,
+      queueName: undefined,
+      workerName: 'execution-logs',
+      workerIsPaused: true,
+      workerIsRunning: true,
+    });
+
+    await executionLogWorker.resume();
+
+    const isNowPaused = await executionLogWorker.worker.isPaused();
+    expect(isNowPaused).to.equal(false);
+
+    const runningStatusChanged = await executionLogWorker.bullMqService.getStatus();
+    expect(runningStatusChanged).to.deep.equal({
+      queueIsPaused: undefined,
+      queueName: undefined,
+      workerName: 'execution-logs',
+      workerIsPaused: false,
+      workerIsRunning: true,
+    });
+  });
+});

--- a/apps/worker/src/app/workflow/services/execution-log.worker.ts
+++ b/apps/worker/src/app/workflow/services/execution-log.worker.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+const nr = require('newrelic');
+import {
+  getExecutionLogWorkerOptions,
+  INovuWorker,
+  PinoLogger,
+  storage,
+  Store,
+  ExecutionLogWorkerService,
+  WorkerOptions,
+  WorkerProcessor,
+  CreateExecutionDetails,
+  CreateExecutionDetailsCommand,
+} from '@novu/application-generic';
+import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
+const LOG_CONTEXT = 'ExecutionLogWorker';
+
+@Injectable()
+export class ExecutionLogWorker extends ExecutionLogWorkerService implements INovuWorker {
+  constructor(private createExecutionDetails: CreateExecutionDetails) {
+    super();
+    this.initWorker(this.getWorkerProcessor(), this.getWorkerOptions());
+  }
+  gracefulShutdown: () => Promise<void>;
+  onModuleDestroy: () => Promise<void>;
+  pause: () => Promise<void>;
+  resume: () => Promise<void>;
+
+  private getWorkerOptions(): WorkerOptions {
+    return getExecutionLogWorkerOptions();
+  }
+
+  private getWorkerProcessor(): WorkerProcessor {
+    return async ({ data }: { data: CreateExecutionDetailsCommand }) => {
+      return await new Promise(async (resolve, reject) => {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const _this = this;
+
+        Logger.verbose(`Job ${data.jobId} is being inserted into execution details collection`, LOG_CONTEXT);
+
+        nr.startBackgroundTransaction(
+          ObservabilityBackgroundTransactionEnum.EXECUTION_LOG_QUEUE,
+          'Trigger Engine',
+          function () {
+            const transaction = nr.getTransaction();
+
+            storage.run(new Store(PinoLogger.root), () => {
+              _this.createExecutionDetails
+                .execute(data)
+                .then(resolve)
+                .catch(reject)
+                .finally(() => {
+                  transaction.end();
+                });
+            });
+          }
+        );
+      });
+    };
+  }
+}

--- a/apps/worker/src/app/workflow/services/index.ts
+++ b/apps/worker/src/app/workflow/services/index.ts
@@ -2,3 +2,4 @@ export * from './active-jobs-metric.service';
 export * from './completed-jobs-metric.service';
 export * from './standard.worker';
 export * from './workflow.worker';
+export * from './execution-log.worker';

--- a/apps/worker/src/app/workflow/usecases/handle-last-failed-job/handle-last-failed-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/handle-last-failed-job/handle-last-failed-job.usecase.ts
@@ -2,9 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import { JobRepository } from '@novu/dal';
 import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
 import {
-  CreateExecutionDetails,
   CreateExecutionDetailsCommand,
   DetailEnum,
+  ExecutionLogQueueService,
   InstrumentUsecase,
 } from '@novu/application-generic';
 
@@ -19,7 +19,7 @@ const LOG_CONTEXT = 'HandleLastFailedJob';
 @Injectable()
 export class HandleLastFailedJob {
   constructor(
-    private createExecutionDetails: CreateExecutionDetails,
+    private executionLogQueueService: ExecutionLogQueueService,
     private queueNextJob: QueueNextJob,
     private jobRepository: JobRepository
   ) {}
@@ -40,9 +40,11 @@ export class HandleLastFailedJob {
       Logger.error(message, new NotFoundError(message), LOG_CONTEXT);
       throw new PlatformException(message);
     }
-
-    await this.createExecutionDetails.execute(
+    const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+    await this.executionLogQueueService.add(
+      metadata._id,
       CreateExecutionDetailsCommand.create({
+        ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
         detail: DetailEnum.WEBHOOK_FILTER_FAILED_LAST_RETRY,
         source: ExecutionDetailsSourceEnum.WEBHOOK,
@@ -50,7 +52,8 @@ export class HandleLastFailedJob {
         isTest: false,
         isRetry: true,
         raw: JSON.stringify({ message: JSON.parse(error.message).message }),
-      })
+      }),
+      job._organizationId
     );
 
     if (!job?.step?.shouldStopOnFail) {

--- a/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.spec.ts
@@ -18,12 +18,12 @@ import { MessageMatcher } from './message-matcher.usecase';
 import type { SendMessageCommand } from '../send-message/send-message.command';
 
 describe('Message filter matcher', function () {
-  const createExecutionDetails = {
-    execute: sinon.stub(),
+  const executionLogQueueService = {
+    add: sinon.stub(),
   };
   const messageMatcher = new MessageMatcher(
     undefined as any,
-    createExecutionDetails as any,
+    executionLogQueueService as any,
     undefined as any,
     undefined as any,
     undefined as any,
@@ -708,7 +708,7 @@ describe('Message filter matcher', function () {
       it('allows to process multiple filter parts', async () => {
         const matcher = new MessageMatcher(
           { findOne: () => Promise.resolve(getSubscriber()) } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -745,7 +745,7 @@ describe('Message filter matcher', function () {
                 lastName: 'Doe',
               }),
           } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -776,7 +776,7 @@ describe('Message filter matcher', function () {
                 lastName: 'Doe',
               }),
           } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -801,7 +801,7 @@ describe('Message filter matcher', function () {
       it('allows to process if the subscriber is online', async () => {
         const matcher = new MessageMatcher(
           { findOne: () => Promise.resolve(getSubscriber()) } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -826,7 +826,7 @@ describe('Message filter matcher', function () {
       it("doesn't allow to process if the subscriber is not online", async () => {
         const matcher = new MessageMatcher(
           { findOne: () => Promise.resolve(getSubscriber({ isOnline: false })) } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -855,7 +855,7 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: true }, { subDuration: { minutes: 3 } })),
           } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -893,7 +893,7 @@ describe('Message filter matcher', function () {
                 lastName: 'Doe',
               }),
           } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -921,7 +921,7 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: true }, { subDuration: { minutes: 10 } })),
           } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -949,7 +949,7 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: false }, { subDuration: { minutes: 4 } })),
           } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -977,7 +977,7 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: false }, { subDuration: { minutes: 6 } })),
           } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -1005,7 +1005,7 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: false }, { subDuration: { minutes: 30 } })),
           } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,
@@ -1033,7 +1033,7 @@ describe('Message filter matcher', function () {
           {
             findOne: () => Promise.resolve(getSubscriber({ isOnline: false }, { subDuration: { hours: 23 } })),
           } as any,
-          createExecutionDetails as any,
+          executionLogQueueService as any,
           undefined as any,
           undefined as any,
           undefined as any,

--- a/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/message-matcher/message-matcher.usecase.ts
@@ -30,7 +30,6 @@ import {
 } from '@novu/dal';
 import {
   DetailEnum,
-  CreateExecutionDetails,
   CreateExecutionDetailsCommand,
   buildSubscriberKey,
   CachedEntity,
@@ -38,6 +37,7 @@ import {
   Filter,
   FilterProcessingDetails,
   IFilterVariables,
+  ExecutionLogQueueService,
 } from '@novu/application-generic';
 import { EmailEventStatusEnum } from '@novu/stateless';
 
@@ -60,7 +60,7 @@ const differenceIn = (currentDate: Date, lastDate: Date, timeOperator: TimeOpera
 export class MessageMatcher extends Filter {
   constructor(
     private subscriberRepository: SubscriberRepository,
-    private createExecutionDetails: CreateExecutionDetails,
+    private executionLogQueueService: ExecutionLogQueueService,
     private environmentRepository: EnvironmentRepository,
     private executionDetailsRepository: ExecutionDetailsRepository,
     private messageRepository: MessageRepository,
@@ -101,8 +101,11 @@ export class MessageMatcher extends Filter {
         if (singleRule) {
           const result = await this.processFilter(variables, children[0], command, filterProcessingDetails);
           if (!prefiltering) {
-            await this.createExecutionDetails.execute(
+            const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+            await this.executionLogQueueService.add(
+              metadata._id,
               CreateExecutionDetailsCommand.create({
+                ...metadata,
                 ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
                 detail: DetailEnum.PROCESSING_STEP_FILTER,
                 source: ExecutionDetailsSourceEnum.INTERNAL,
@@ -110,7 +113,8 @@ export class MessageMatcher extends Filter {
                 isTest: false,
                 isRetry: false,
                 raw: filterProcessingDetails.toString(),
-              })
+              }),
+              command.organizationId
             );
           }
 
@@ -121,8 +125,11 @@ export class MessageMatcher extends Filter {
 
         const result = await this.handleGroupFilters(filter, variables, command, filterProcessingDetails);
         if (!prefiltering) {
-          await this.createExecutionDetails.execute(
+          const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+          await this.executionLogQueueService.add(
+            metadata._id,
             CreateExecutionDetailsCommand.create({
+              ...metadata,
               ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
               detail: DetailEnum.PROCESSING_STEP_FILTER,
               source: ExecutionDetailsSourceEnum.INTERNAL,
@@ -130,7 +137,8 @@ export class MessageMatcher extends Filter {
               isTest: false,
               isRetry: false,
               raw: filterProcessingDetails.toString(),
-            })
+            }),
+            command.organizationId
           );
         }
 

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
@@ -27,6 +27,7 @@ import {
   ChatFactory,
   SelectIntegration,
   GetNovuProviderCredentials,
+  ExecutionLogQueueService,
 } from '@novu/application-generic';
 
 import { CreateLog } from '../../../shared/logs';
@@ -45,15 +46,15 @@ export class SendMessageChat extends SendMessageBase {
     protected messageRepository: MessageRepository,
     protected tenantRepository: TenantRepository,
     protected createLogUsecase: CreateLog,
-    protected createExecutionDetails: CreateExecutionDetails,
     private compileTemplate: CompileTemplate,
     protected selectIntegration: SelectIntegration,
-    protected getNovuProviderCredentials: GetNovuProviderCredentials
+    protected getNovuProviderCredentials: GetNovuProviderCredentials,
+    protected executionLogQueueService: ExecutionLogQueueService
   ) {
     super(
       messageRepository,
       createLogUsecase,
-      createExecutionDetails,
+      executionLogQueueService,
       subscriberRepository,
       tenantRepository,
       selectIntegration,
@@ -116,15 +117,19 @@ export class SendMessageChat extends SendMessageBase {
       ) || [];
 
     if (chatChannels.length === 0) {
-      await this.createExecutionDetails.execute(
+      const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+      await this.executionLogQueueService.add(
+        metadata._id,
         CreateExecutionDetailsCommand.create({
+          ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_CHANNEL,
           source: ExecutionDetailsSourceEnum.INTERNAL,
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-        })
+        }),
+        command.organizationId
       );
 
       return;
@@ -145,15 +150,19 @@ export class SendMessageChat extends SendMessageBase {
     }
 
     if (allFailed) {
-      await this.createExecutionDetails.execute(
+      const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+      await this.executionLogQueueService.add(
+        metadata._id,
         CreateExecutionDetailsCommand.create({
+          ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.CHAT_ALL_CHANNELS_FAILED,
           source: ExecutionDetailsSourceEnum.INTERNAL,
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-        })
+        }),
+        command.organizationId
       );
     }
   }
@@ -180,15 +189,19 @@ export class SendMessageChat extends SendMessageBase {
     const channelSpecification = subscriberChannel.credentials?.channel;
 
     if (!chatWebhookUrl) {
-      await this.createExecutionDetails.execute(
+      const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+      await this.executionLogQueueService.add(
+        metadata._id,
         CreateExecutionDetailsCommand.create({
+          ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.CHAT_WEBHOOK_URL_MISSING,
           source: ExecutionDetailsSourceEnum.INTERNAL,
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-        })
+        }),
+        command.organizationId
       );
     }
 
@@ -208,15 +221,19 @@ export class SendMessageChat extends SendMessageBase {
     });
 
     if (!integration) {
-      await this.createExecutionDetails.execute(
+      const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+      await this.executionLogQueueService.add(
+        metadata._id,
         CreateExecutionDetailsCommand.create({
+          ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_INTEGRATION,
           source: ExecutionDetailsSourceEnum.INTERNAL,
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-        })
+        }),
+        command.organizationId
       );
 
       return;
@@ -224,8 +241,11 @@ export class SendMessageChat extends SendMessageBase {
 
     await this.sendSelectedIntegrationExecution(command.job, integration);
 
-    await this.createExecutionDetails.execute(
+    const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+    await this.executionLogQueueService.add(
+      metadata._id,
       CreateExecutionDetailsCommand.create({
+        ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
         detail: DetailEnum.MESSAGE_CREATED,
         source: ExecutionDetailsSourceEnum.INTERNAL,
@@ -234,7 +254,8 @@ export class SendMessageChat extends SendMessageBase {
         isTest: false,
         isRetry: false,
         raw: this.storeContent() ? JSON.stringify(content) : null,
-      })
+      }),
+      command.organizationId
     );
 
     if (chatWebhookUrl && integration) {
@@ -262,8 +283,11 @@ export class SendMessageChat extends SendMessageBase {
         'Subscriber does not have active chat channel id'
       );
 
-      await this.createExecutionDetails.execute(
+      const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+      await this.executionLogQueueService.add(
+        metadata._id,
         CreateExecutionDetailsCommand.create({
+          ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
           detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_CHANNEL,
@@ -271,7 +295,8 @@ export class SendMessageChat extends SendMessageBase {
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-        })
+        }),
+        command.organizationId
       );
 
       return;
@@ -285,8 +310,11 @@ export class SendMessageChat extends SendMessageBase {
         command,
         LogCodeEnum.MISSING_CHAT_INTEGRATION
       );
-      await this.createExecutionDetails.execute(
+      const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+      await this.executionLogQueueService.add(
+        metadata._id,
         CreateExecutionDetailsCommand.create({
+          ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
           detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_INTEGRATION,
@@ -294,7 +322,8 @@ export class SendMessageChat extends SendMessageBase {
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-        })
+        }),
+        command.organizationId
       );
 
       return;
@@ -322,8 +351,11 @@ export class SendMessageChat extends SendMessageBase {
         content,
       });
 
-      await this.createExecutionDetails.execute(
+      const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+      await this.executionLogQueueService.add(
+        metadata._id,
         CreateExecutionDetailsCommand.create({
+          ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
           detail: DetailEnum.MESSAGE_SENT,
@@ -332,7 +364,8 @@ export class SendMessageChat extends SendMessageBase {
           isTest: false,
           isRetry: false,
           raw: JSON.stringify(result),
-        })
+        }),
+        command.organizationId
       );
     } catch (e) {
       await this.sendErrorStatus(
@@ -345,8 +378,11 @@ export class SendMessageChat extends SendMessageBase {
         e
       );
 
-      await this.createExecutionDetails.execute(
+      const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+      await this.executionLogQueueService.add(
+        metadata._id,
         CreateExecutionDetailsCommand.create({
+          ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
           detail: DetailEnum.PROVIDER_ERROR,
@@ -355,7 +391,8 @@ export class SendMessageChat extends SendMessageBase {
           isTest: false,
           isRetry: false,
           raw: JSON.stringify(e),
-        })
+        }),
+        command.organizationId
       );
     }
   }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-type.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-type.usecase.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 import { MessageEntity, MessageRepository } from '@novu/dal';
 import { LogCodeEnum } from '@novu/shared';
-import { CreateExecutionDetails } from '@novu/application-generic';
+import { ExecutionLogQueueService } from '@novu/application-generic';
 
 import { CreateLog } from '../../../shared/logs';
 import { SendMessageCommand } from './send-message.command';
@@ -10,7 +10,7 @@ export abstract class SendMessageType {
   protected constructor(
     protected messageRepository: MessageRepository,
     protected createLogUsecase: CreateLog,
-    protected createExecutionDetails: CreateExecutionDetails
+    protected executionLogQueueService: ExecutionLogQueueService
   ) {}
 
   public abstract execute(command: SendMessageCommand);

--- a/apps/worker/src/app/workflow/usecases/webhook-filter-backoff-strategy/webhook-filter-backoff-strategy.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/webhook-filter-backoff-strategy/webhook-filter-backoff-strategy.usecase.ts
@@ -1,20 +1,23 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
-import { DetailEnum, CreateExecutionDetails, CreateExecutionDetailsCommand } from '@novu/application-generic';
+import { DetailEnum, CreateExecutionDetailsCommand, ExecutionLogQueueService } from '@novu/application-generic';
 
 import { WebhookFilterBackoffStrategyCommand } from './webhook-filter-backoff-strategy.command';
 
 @Injectable()
 export class WebhookFilterBackoffStrategy {
-  constructor(private createExecutionDetails: CreateExecutionDetails) {}
+  constructor(private executionLogQueueService: ExecutionLogQueueService) {}
 
   public async execute(command: WebhookFilterBackoffStrategyCommand): Promise<number> {
     const { attemptsMade, eventError: error, eventJob } = command;
     const job = eventJob.data;
 
     try {
-      await this.createExecutionDetails.execute(
+      const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+      await this.executionLogQueueService.add(
+        metadata._id,
         CreateExecutionDetailsCommand.create({
+          ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
           detail: DetailEnum.WEBHOOK_FILTER_FAILED_RETRY,
           source: ExecutionDetailsSourceEnum.WEBHOOK,
@@ -22,7 +25,8 @@ export class WebhookFilterBackoffStrategy {
           isTest: false,
           isRetry: true,
           raw: JSON.stringify({ message: JSON.parse(error?.message).message, attempt: attemptsMade }),
-        })
+        }),
+        job._organizationId
       );
     } catch (anotherError) {
       Logger.error(

--- a/apps/worker/src/app/workflow/workflow.module.ts
+++ b/apps/worker/src/app/workflow/workflow.module.ts
@@ -32,7 +32,13 @@ import {
 } from '@novu/application-generic';
 import { JobRepository } from '@novu/dal';
 
-import { ActiveJobsMetricService, CompletedJobsMetricService, StandardWorker, WorkflowWorker } from './services';
+import {
+  ExecutionLogWorker,
+  ActiveJobsMetricService,
+  CompletedJobsMetricService,
+  StandardWorker,
+  WorkflowWorker,
+} from './services';
 
 import {
   MessageMatcher,
@@ -114,6 +120,7 @@ const PROVIDERS: Provider[] = [
   CompletedJobsMetricService,
   StandardWorker,
   WorkflowWorker,
+  ExecutionLogWorker,
   SubscriberProcessWorker,
 ];
 

--- a/libs/shared/src/config/job-queue.ts
+++ b/libs/shared/src/config/job-queue.ts
@@ -1,4 +1,5 @@
 export enum JobTopicNameEnum {
+  EXECUTION_LOG = 'execution-logs',
   ACTIVE_JOBS_METRIC = 'metric-active-jobs',
   COMPLETED_JOBS_METRIC = 'metric-completed-jobs',
   INBOUND_PARSE_MAIL = 'inbound-parse-mail',
@@ -12,5 +13,6 @@ export enum ObservabilityBackgroundTransactionEnum {
   JOB_PROCESSING_QUEUE = 'job-processing-queue',
   SUBSCRIBER_PROCESSING_QUEUE = 'subscriber-processing-queue',
   TRIGGER_HANDLER_QUEUE = 'trigger-handler-queue',
+  EXECUTION_LOG_QUEUE = 'execution-log-queue',
   WS_SOCKET_QUEUE = 'ws_socket_queue',
 }

--- a/packages/application-generic/src/config/workers.ts
+++ b/packages/application-generic/src/config/workers.ts
@@ -4,6 +4,7 @@ enum WorkerEnum {
   STANDARD = 'StandardWorker',
   WEB_SOCKET = 'WebSocketWorker',
   WORKFLOW = 'WorkflowWorker',
+  EXECUTION_LOG = 'ExecutionLogWorker',
 }
 
 interface IWorkerConfig {
@@ -45,6 +46,10 @@ const getWorkerConfig = (worker: WorkerEnum): IWorkerConfig => {
       concurrency: getDefaultConcurrency() ?? 200,
       lockDuration: getDefaultLockDuration() ?? 90000,
     },
+    [WorkerEnum.EXECUTION_LOG]: {
+      concurrency: getDefaultConcurrency() ?? 200,
+      lockDuration: getDefaultLockDuration() ?? 90000,
+    },
   };
 
   return workersConfig[worker];
@@ -64,3 +69,6 @@ export const getWebSocketWorkerOptions = () =>
 
 export const getWorkflowWorkerOptions = () =>
   getWorkerConfig(WorkerEnum.WORKFLOW);
+
+export const getExecutionLogWorkerOptions = () =>
+  getWorkerConfig(WorkerEnum.EXECUTION_LOG);

--- a/packages/application-generic/src/custom-providers/index.ts
+++ b/packages/application-generic/src/custom-providers/index.ts
@@ -10,6 +10,7 @@ import {
   SubscriberProcessQueueService,
   WebSocketsQueueService,
   WorkflowQueueService,
+  ExecutionLogQueueService,
 } from '../services';
 import {
   GetIsApiRateLimitingEnabled,
@@ -127,13 +128,15 @@ export const bullMqTokenList = {
     standardQueueService: StandardQueueService,
     webSocketsQueueService: WebSocketsQueueService,
     workflowQueueService: WorkflowQueueService,
-    subscriberProcessQueueService: SubscriberProcessQueueService
+    subscriberProcessQueueService: SubscriberProcessQueueService,
+    executionLogQueueService: ExecutionLogQueueService
   ) => {
     return [
       standardQueueService,
       webSocketsQueueService,
       workflowQueueService,
       subscriberProcessQueueService,
+      executionLogQueueService,
     ];
   },
   inject: [
@@ -141,5 +144,6 @@ export const bullMqTokenList = {
     WebSocketsQueueService,
     WorkflowQueueService,
     SubscriberProcessQueueService,
+    ExecutionLogQueueService,
   ],
 };

--- a/packages/application-generic/src/modules/queues.module.ts
+++ b/packages/application-generic/src/modules/queues.module.ts
@@ -14,6 +14,7 @@ import { ReadinessService } from '../services';
 import {
   ActiveJobsMetricQueueService,
   CompletedJobsMetricQueueService,
+  ExecutionLogQueueService,
   InboundParseQueue,
   StandardQueueService,
   SubscriberProcessQueueService,
@@ -49,6 +50,7 @@ const PROVIDERS: Provider[] = [
   WebSocketsQueueServiceHealthIndicator,
   WebSocketsWorkerService,
   WorkflowQueueService,
+  ExecutionLogQueueService,
   WorkflowQueueServiceHealthIndicator,
   WorkflowWorkerService,
   SubscriberProcessQueueService,
@@ -69,6 +71,7 @@ const APP_PROVIDERS: Provider[] = [
   WebSocketsQueueService,
   WebSocketsQueueServiceHealthIndicator,
   WorkflowQueueService,
+  ExecutionLogQueueService,
   WorkflowQueueServiceHealthIndicator,
 ];
 

--- a/packages/application-generic/src/services/queues/execution-log-queue.service.spec.ts
+++ b/packages/application-generic/src/services/queues/execution-log-queue.service.spec.ts
@@ -1,0 +1,80 @@
+import { Test } from '@nestjs/testing';
+
+import { ExecutionLogQueueService } from './execution-log-queue.service';
+
+let executionLogQueueService: ExecutionLogQueueService;
+
+describe('Execution Log Queue service', () => {
+  describe('General', () => {
+    beforeAll(async () => {
+      executionLogQueueService = new ExecutionLogQueueService();
+      await executionLogQueueService.queue.drain();
+    });
+
+    beforeEach(async () => {
+      await executionLogQueueService.queue.drain();
+    });
+
+    afterEach(async () => {
+      await executionLogQueueService.queue.drain();
+    });
+
+    afterAll(async () => {
+      await executionLogQueueService.gracefulShutdown();
+    });
+
+    it('should be initialised properly', async () => {
+      expect(executionLogQueueService).toBeDefined();
+      expect(Object.keys(executionLogQueueService)).toEqual(
+        expect.arrayContaining([
+          'topic',
+          'DEFAULT_ATTEMPTS',
+          'instance',
+          'queue',
+        ])
+      );
+      expect(executionLogQueueService.DEFAULT_ATTEMPTS).toEqual(3);
+      expect(executionLogQueueService.topic).toEqual('execution-logs');
+      expect(await executionLogQueueService.bullMqService.getStatus()).toEqual({
+        queueIsPaused: false,
+        queueName: 'execution-logs',
+        workerName: undefined,
+        workerIsPaused: undefined,
+        workerIsRunning: undefined,
+      });
+      expect(await executionLogQueueService.isPaused()).toEqual(false);
+      expect(executionLogQueueService.queue).toMatchObject(
+        expect.objectContaining({
+          _events: {},
+          _eventsCount: 0,
+          _maxListeners: undefined,
+          name: 'execution-logs',
+          jobsOpts: {
+            removeOnComplete: true,
+          },
+        })
+      );
+      expect(executionLogQueueService.queue.opts.prefix).toEqual('bull');
+    });
+  });
+
+  describe('Cluster mode', () => {
+    beforeAll(async () => {
+      process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED = 'true';
+
+      executionLogQueueService = new ExecutionLogQueueService();
+      await executionLogQueueService.queue.obliterate();
+    });
+
+    afterAll(async () => {
+      await executionLogQueueService.gracefulShutdown();
+      process.env.IS_IN_MEMORY_CLUSTER_MODE_ENABLED = 'false';
+    });
+
+    it('should have prefix in cluster mode', async () => {
+      expect(executionLogQueueService.queue.opts.prefix).toEqual(
+        '{execution-logs}'
+      );
+    });
+  });
+});

--- a/packages/application-generic/src/services/queues/execution-log-queue.service.ts
+++ b/packages/application-generic/src/services/queues/execution-log-queue.service.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { JobTopicNameEnum } from '@novu/shared';
+
+import { QueueBaseService } from './queue-base.service';
+
+const LOG_CONTEXT = 'ExecutionLogQueueService';
+
+@Injectable()
+export class ExecutionLogQueueService extends QueueBaseService {
+  constructor() {
+    super(JobTopicNameEnum.EXECUTION_LOG);
+
+    Logger.log(`Creating queue ${this.topic}`, LOG_CONTEXT);
+
+    this.createQueue();
+  }
+}

--- a/packages/application-generic/src/services/queues/index.ts
+++ b/packages/application-generic/src/services/queues/index.ts
@@ -7,6 +7,7 @@ import { StandardQueueService } from './standard-queue.service';
 import { WebSocketsQueueService } from './web-sockets-queue.service';
 import { WorkflowQueueService } from './workflow-queue.service';
 import { SubscriberProcessQueueService } from './subscriber-process-queue.service';
+import { ExecutionLogQueueService } from './execution-log-queue.service';
 
 export {
   QueueBaseService,
@@ -17,4 +18,5 @@ export {
   WebSocketsQueueService,
   WorkflowQueueService,
   SubscriberProcessQueueService,
+  ExecutionLogQueueService,
 };

--- a/packages/application-generic/src/services/workers/execution-log-worker.service.ts
+++ b/packages/application-generic/src/services/workers/execution-log-worker.service.ts
@@ -1,0 +1,14 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { JobTopicNameEnum } from '@novu/shared';
+
+import { WorkerBaseService } from './index';
+
+const LOG_CONTEXT = 'ExecutionLogWorkerService';
+
+@Injectable()
+export class ExecutionLogWorkerService extends WorkerBaseService {
+  constructor() {
+    super(JobTopicNameEnum.EXECUTION_LOG);
+    Logger.log(`Worker ${this.topic} instantiated`, LOG_CONTEXT);
+  }
+}

--- a/packages/application-generic/src/services/workers/index.ts
+++ b/packages/application-generic/src/services/workers/index.ts
@@ -11,6 +11,7 @@ import { StandardWorkerService } from './standard-worker.service';
 import { SubscriberProcessWorkerService } from './subscriber-process-worker.service';
 import { WebSocketsWorkerService } from './web-sockets-worker.service';
 import { WorkflowWorkerService } from './workflow-worker.service';
+import { ExecutionLogWorkerService } from './execution-log-worker.service';
 
 export {
   ActiveJobsMetricWorkerService,
@@ -23,4 +24,5 @@ export {
   WorkerOptions,
   WorkerProcessor,
   WorkflowWorkerService,
+  ExecutionLogWorkerService,
 };

--- a/packages/application-generic/src/usecases/create-execution-details/create-execution-details.command.ts
+++ b/packages/application-generic/src/usecases/create-execution-details/create-execution-details.command.ts
@@ -1,5 +1,9 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
-import { JobEntity } from '@novu/dal';
+import { IsNotEmpty, IsOptional, IsString, IsDate } from 'class-validator';
+import {
+  JobEntity,
+  ExecutionDetailsEntity,
+  ExecutionDetailsRepository,
+} from '@novu/dal';
 import {
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
@@ -57,6 +61,14 @@ export class CreateExecutionDetailsCommand extends EnvironmentWithSubscriber {
   @IsString()
   _subscriberId?: string;
 
+  @IsOptional()
+  @IsString()
+  _id?: string;
+
+  @IsOptional()
+  @IsDate()
+  createdAt?: Date;
+
   webhookStatus?: EmailEventStatusEnum | SmsEventStatusEnum;
 
   static getDetailsFromJob(
@@ -88,6 +100,15 @@ export class CreateExecutionDetailsCommand extends EnvironmentWithSubscriber {
       transactionId: job.transactionId,
       channel: job.type,
       expireAt: job.expireAt,
+    };
+  }
+
+  static getExecutionLogMetadata(): Pick<ExecutionDetailsEntity, '_id'> & {
+    createdAt: Date;
+  } {
+    return {
+      _id: ExecutionDetailsRepository.createObjectId(),
+      createdAt: new Date(),
     };
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

- [x] Refractor the exetution detail flow to use queue in between for better performance
- [x] Adds execution log queue and worker, where usecases push the execution logs to the queue instead of directly writing to DB, worker will pickup them and writes to DB.
- [x] add tests 
- [x] add manual test results

### Why was this change needed?

closes ...

### Other information (Screenshots)

#### workflow

<img width="971" alt="Screenshot 2023-11-10 at 7 49 32 PM" src="https://github.com/novuhq/novu/assets/22556323/93fd2f70-ac28-4a0a-b6b2-b05fea6cf2a2">

#### Execution details
<img width="1296" alt="Screenshot 2023-11-10 at 7 51 12 PM" src="https://github.com/novuhq/novu/assets/22556323/37445471-c66a-43d4-951f-54c0edec7a18">

<img width="1210" alt="Screenshot 2023-11-10 at 7 51 25 PM" src="https://github.com/novuhq/novu/assets/22556323/a559b02e-9452-4610-8118-bb00575b334c">

<img width="1228" alt="Screenshot 2023-11-10 at 7 51 33 PM" src="https://github.com/novuhq/novu/assets/22556323/0483616e-1d9f-4875-8ef7-b7a7ba5970e8">

<img width="1237" alt="Screenshot 2023-11-10 at 7 51 42 PM" src="https://github.com/novuhq/novu/assets/22556323/7a932717-75be-452b-8b2b-c20c51e3c73e">


#### Notifications
<img width="1172" alt="Screenshot 2023-11-10 at 7 53 52 PM" src="https://github.com/novuhq/novu/assets/22556323/2524589f-cc65-4592-bc70-8a65d0ba9b19">

<img width="752" alt="Screenshot 2023-11-10 at 7 50 37 PM" src="https://github.com/novuhq/novu/assets/22556323/4a697167-bcce-471e-9107-33acb6eba18f">


