### PR TITLE
chore: update npm badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
   <a href="https://novu.co?utm_source=github" target="_blank">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/2233092/213641039-220ac15f-f367-4d13-9eaf-56e79433b8c1.png">
-    ![Novu Logo]<img src="https://user-images.githubusercontent.com/2233092/213641043-3bbb3f21-3c53-4e67-afe5-755aeb222159.png" width="280"/>
+    <img alt="Novu Logo" src="https://user-images.githubusercontent.com/2233092/213641043-3bbb3f21-3c53-4e67-afe5-755aeb222159.png" width="280"/>
   </picture>
   </a>
 </div> <br/>
 
 <p align="center">
-    <a href="https://www.npmjs.com/package/novu">
-    <img src="https://img.shields.io/npm/v/novu" alt="NPM">
+  <a href="https://www.npmjs.com/package/@novu/node">
+    <img src="https://img.shields.io/npm/v/@novu/node" alt="NPM">
   </a>
-    <a href="https://www.npmjs.com/package/novu">
-    <img src="https://img.shields.io/npm/dm/novu" alt="npm downloads">
+  <a href="https://www.npmjs.com/package/@novu/node">
+    <img src="https://img.shields.io/npm/dm/@novu/node" alt="npm downloads">
   </a>
   <img src="https://img.shields.io/github/license/novuhq/novu" alt="MIT">
 </p>


### PR DESCRIPTION
### What change does this PR introduce?

Changes package in npm badges from `novu` to `@novu/node`.
It also fixes some weird line with mixed markdown syntax and HTML.

### Why was this change needed?

In my opinion we should show `@novu/node` package in readme badges. Why? Because this is package that developers are going to use and it also has 50k+ downloads/month, so it will show better numbers.

### Other information (Screenshots)

HTML and markdown shouldn't be mixed in single line:

<img width="400px" src="https://github.com/novuhq/novu/assets/43048524/c40d2a66-8f3e-4e53-996d-5f813eb836b6" />

> This is how README looks like in official GitHub Mobile app
