### PR TITLE
fix(api): eliminate number conversion for split message

### DIFF
--- a/apps/api/src/app/widgets/widgets.controller.ts
+++ b/apps/api/src/app/widgets/widgets.controller.ts
@@ -431,7 +431,7 @@ export class WidgetsController {
     let paramArray: string[] | undefined = undefined;
 
     if (param) {
-      paramArray = Array.isArray(param) ? param : param.split(',');
+      paramArray = Array.isArray(param) ? param : String(param).split(',');
     }
 
     return paramArray as string[];


### PR DESCRIPTION
### What change does this PR introduce?

Closes NV-3180

### Why was this change needed?

Trying to call split on a number causes an unexpected exception

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
