### PR TITLE
fix: prevent github email change from creating a new account

### DIFF
--- a/apps/api/src/app/auth/e2e/github-auth.e2e.ts
+++ b/apps/api/src/app/auth/e2e/github-auth.e2e.ts
@@ -1,0 +1,118 @@
+import { UserSession, AuthService } from '@novu/testing';
+import { AuthProviderEnum, SignUpOriginEnum } from '@novu/shared';
+import { UserRepository } from '@novu/dal';
+import { expect } from 'chai';
+import * as passport from 'passport';
+import * as githubPassport from 'passport-github2';
+import { stub } from 'sinon';
+
+const userGithubProfile = {
+  authProvider: AuthProviderEnum.GITHUB,
+  accessToken: 'gho_16C7e42F2',
+  refreshToken: 'v9hRvIfhvFfuEv11YsSHUA==',
+  profile: {
+    name: 'first last',
+    login: '',
+    email: 'test@gmail.com',
+    avatar_url: 'https://github.com/test/test_avatar',
+    id: '34567',
+  },
+  origin: SignUpOriginEnum.CLI,
+};
+
+const githubQueryParamSample = `access_token=${
+  userGithubProfile.accessToken
+}42F2&token_type=bearer&state=${JSON.stringify({})}`;
+
+let session: UserSession;
+let userRepository: UserRepository;
+
+describe('Github Auth', () => {
+  userRepository = new UserRepository();
+
+  process.env.GITHUB_OAUTH_CLIENT_ID = '12345';
+  process.env.GITHUB_OAUTH_CLIENT_SECRET = 'secret';
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+    await setPassportGithubStrategy();
+  });
+
+  it('should be able to sign up with github', async () => {
+    stubPassportAuthenticate();
+    await session.testAgent.get(`/v1/auth/github/callback?${githubQueryParamSample}`);
+    const user = await userRepository.findByEmail(userGithubProfile.profile.email);
+
+    expect(user).to.not.be.null;
+    expect(user?.email).to.equal(userGithubProfile.profile.email);
+    expect(`${user?.firstName} ${user?.lastName}`).to.equal(userGithubProfile.profile.name);
+  });
+
+  it('should sign user to same account if user github email is updated', async () => {
+    const passportStub = stubPassportAuthenticate();
+    await session.testAgent.get(`/v1/auth/github/callback?${githubQueryParamSample}`);
+    const user = await userRepository.findByEmail(userGithubProfile.profile.email);
+
+    const email = 'test2@gmail.com';
+    passportStub.restore();
+    stubPassportAuthenticate({ ...userGithubProfile, profile: { ...userGithubProfile.profile, email } });
+    await session.testAgent.get(`/v1/auth/github/callback?${githubQueryParamSample}`);
+    const user2 = await userRepository.findByEmail(email);
+
+    expect(user?._id).to.equal(user2?._id);
+  });
+
+  it('should update user account email with updated github email', async () => {
+    const passportStub = stubPassportAuthenticate();
+    await session.testAgent.get(`/v1/auth/github/callback?${githubQueryParamSample}`);
+    const user = await userRepository.findByEmail(userGithubProfile.profile.email);
+
+    const email = 'test2@gmail.com';
+    passportStub.restore();
+    stubPassportAuthenticate({ ...userGithubProfile, profile: { ...userGithubProfile.profile, email } });
+    await session.testAgent.get(`/v1/auth/github/callback?${githubQueryParamSample}`);
+    const user2 = await userRepository.findByEmail(email);
+
+    expect(user2?.email).to.equal(email);
+    expect(user?.email).to.equal(userGithubProfile.profile.email);
+    expect(user?.email).to.not.equal(user2?.email);
+  });
+});
+
+const setPassportGithubStrategy = async () => {
+  const strategy = new githubPassport.Strategy(
+    {
+      clientID: process.env.GITHUB_OAUTH_CLIENT_ID,
+      clientSecret: process.env.GITHUB_OAUTH_CLIENT_SECRET,
+      callbackURL: '/auth/github/callback',
+    },
+    async function (
+      accessToken: string,
+      refreshToken: string,
+      profile: any,
+      done: (err: unknown, user: { newUser: boolean; token: string }) => void
+    ) {
+      const authService = new AuthService();
+      const { newUser, token } = await authService.authenticate(
+        AuthProviderEnum.GITHUB,
+        accessToken ?? '',
+        refreshToken ?? '',
+        profile
+      );
+      done(null, { newUser, token });
+    }
+  );
+
+  passport.use(strategy);
+};
+
+const stubPassportAuthenticate = (githubProfile = userGithubProfile) => {
+  return stub(passport._strategies.github, 'authenticate').callsFake(function verified() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    this._verify(githubProfile.accessToken, githubProfile.refreshToken, githubProfile.profile, (_, user, info) => {
+      return self.success(user, info);
+    });
+  });
+};

--- a/libs/dal/src/repositories/user/user.repository.ts
+++ b/libs/dal/src/repositories/user/user.repository.ts
@@ -54,6 +54,15 @@ export class UserRepository extends BaseRepository<UserDBModel, UserEntity, obje
     });
   }
 
+  async findByEmailOrLoginProvider(
+    email: string,
+    { profileId, provider }: { profileId: string; provider: AuthProviderEnum }
+  ): Promise<UserEntity | null> {
+    return this.findOne({
+      $or: [{ email }, { 'tokens.providerId': profileId, 'tokens.provider': provider }],
+    });
+  }
+
   async userExists(userId: string) {
     return !!(await this.findOne(
       {

--- a/libs/testing/src/auth.service.ts
+++ b/libs/testing/src/auth.service.ts
@@ -1,0 +1,108 @@
+import { UserEntity, UserRepository } from '@novu/dal';
+import { AuthProviderEnum } from '@novu/shared';
+import { UserService } from './user.service';
+import * as request from 'supertest';
+
+export class AuthService {
+  private userService = new UserService();
+  private userRepository = new UserRepository();
+
+  constructor(public serverUrl = `http://localhost:${process.env.PORT}`) {}
+
+  async authenticate(
+    authProvider: AuthProviderEnum,
+    accessToken: string,
+    refreshToken: string,
+    profile: { name: string; login: string; email: string; avatar_url: string; id: string }
+  ) {
+    const { email } = profile;
+    let user = await this.userRepository.findByEmailOrLoginProvider(email, {
+      profileId: profile.id,
+      provider: authProvider,
+    });
+
+    let newUser = false;
+    const userCredentials = {
+      username: profile.login,
+      provider: authProvider,
+      accessToken,
+      refreshToken,
+    };
+
+    if (!user) {
+      user = await this.userService.createUser({
+        profilePicture: profile.avatar_url,
+        email: email,
+        lastName: profile.name ? profile.name.split(' ').slice(-1).join(' ') : null,
+        firstName: profile.name ? profile.name.split(' ').slice(0, -1).join(' ') : profile.login,
+        tokens: [{ ...userCredentials, providerId: profile.id, valid: true }],
+      });
+      newUser = true;
+    } else {
+      if (authProvider === AuthProviderEnum.GITHUB) {
+        const withoutUsername = user.tokens.find(
+          (i) => i.provider === AuthProviderEnum.GITHUB && !i.username && String(i.providerId) === String(profile.id)
+        );
+        // Checks if user's github primary email already exists but from a different authentication provider.
+        const withoutToken = user.tokens.findIndex((i) => i.provider === AuthProviderEnum.GITHUB) === -1;
+        const userUpdates: Promise<any>[] = [];
+
+        if (withoutUsername || email !== user.email) {
+          userUpdates.push(
+            this.userRepository.update(
+              {
+                _id: user._id,
+                'tokens.providerId': profile.id,
+              },
+              {
+                $set: {
+                  ...(withoutUsername && { 'tokens.$.username': profile.login }),
+                  ...(email !== user.email && { email }),
+                },
+              }
+            )
+          );
+        }
+        if (withoutToken) {
+          userUpdates.push(
+            this.userRepository.update(
+              { _id: user._id },
+              {
+                $push: {
+                  tokens: {
+                    ...userCredentials,
+                    providerId: profile.id,
+                    valid: true,
+                  },
+                },
+              }
+            )
+          );
+        }
+
+        if (userUpdates.length) {
+          await Promise.all(userUpdates);
+          user = await this.userRepository.findById(user._id);
+          if (!user) throw new Error('User not found');
+        }
+      }
+    }
+
+    return {
+      newUser,
+      token: await this.generateUserToken(user),
+    };
+  }
+
+  async getSignedToken(user: UserEntity, organizationId?: string, environmentId?: string): Promise<string> {
+    const response = await request(this.serverUrl).get(
+      `/v1/auth/test/token/${user._id}?environmentId=${environmentId ?? ''}&organizationId=${organizationId ?? ''}`
+    );
+
+    return `Bearer ${response.body.data}`;
+  }
+
+  async generateUserToken(user: UserEntity) {
+    return this.getSignedToken(user);
+  }
+}

--- a/libs/testing/src/index.ts
+++ b/libs/testing/src/index.ts
@@ -9,3 +9,4 @@ export * from './organization.service';
 export * from './user.service';
 export * from './jobs.service';
 export * from './testing-queue.service';
+export * from './auth.service';

--- a/libs/testing/src/user.service.ts
+++ b/libs/testing/src/user.service.ts
@@ -40,7 +40,7 @@ export class UserService {
       lastName: userEntity?.lastName ?? faker.name.lastName(),
       password: passwordHash,
       profilePicture: `https://randomuser.me/api/portraits/men/${Math.floor(Math.random() * 60) + 1}.jpg`,
-      tokens: [],
+      tokens: userEntity?.tokens ?? [],
       showOnBoardingTour: userEntity?.showOnBoardingTour ?? 2,
     });
 

--- a/packages/application-generic/src/services/auth/auth.service.ts
+++ b/packages/application-generic/src/services/auth/auth.service.ts
@@ -82,8 +82,18 @@ export class AuthService {
     origin?: SignUpOriginEnum
   ) {
     const email = normalizeEmail(profile.email);
-    let user = await this.userRepository.findByEmail(email);
+    let user = await this.userRepository.findByEmailOrLoginProvider(email, {
+      profileId: profile.id,
+      provider: authProvider,
+    });
+
     let newUser = false;
+    const userCredentials = {
+      username: profile.login,
+      provider: authProvider,
+      accessToken,
+      refreshToken,
+    };
 
     if (!user) {
       const firstName = profile.name
@@ -99,13 +109,7 @@ export class AuthService {
           email,
           firstName,
           lastName,
-          auth: {
-            username: profile.login,
-            profileId: profile.id,
-            provider: authProvider,
-            accessToken,
-            refreshToken,
-          },
+          auth: { ...userCredentials, profileId: profile.id },
         })
       );
       newUser = true;
@@ -124,6 +128,54 @@ export class AuthService {
         authProvider === AuthProviderEnum.GOOGLE
       ) {
         user = await this.updateUserUsername(user, profile, authProvider);
+
+        if (authProvider === AuthProviderEnum.GITHUB) {
+          const withoutUsername = user.tokens.find(
+            (i) => i.provider === AuthProviderEnum.GITHUB && !i.username && String(i.providerId) === String(profile.id)
+          );
+          // Checks if user's github primary email already exists but from a different authentication provider.
+          const withoutToken = user.tokens.findIndex((i) => i.provider === AuthProviderEnum.GITHUB) === -1;
+          const userUpdates: Promise<any>[] = [];
+
+          if (withoutUsername || email !== user.email) {
+            userUpdates.push(
+              this.userRepository.update(
+                {
+                  _id: user._id,
+                  'tokens.providerId': profile.id,
+                },
+                {
+                  $set: {
+                    ...(withoutUsername && { 'tokens.$.username': profile.login }),
+                    ...(email !== user.email && { email }),
+                  },
+                }
+              )
+            );
+          }
+          if (withoutToken) {
+            userUpdates.push(
+              this.userRepository.update(
+                { _id: user._id },
+                {
+                  $push: {
+                    tokens: {
+                      ...userCredentials,
+                      providerId: profile.id,
+                      valid: true,
+                    },
+                  },
+                }
+              )
+            );
+          }
+
+          if (userUpdates.length) {
+            await Promise.all(userUpdates);
+            user = await this.userRepository.findById(user._id);
+            if (!user) throw new ApiException('User not found');
+          }
+        }
       }
 
       this.analyticsService.track('[Authentication] - Login', user._id, {


### PR DESCRIPTION
 ### What change does this PR introduce?
 This changes ensure users retain their account when their github's primary email is updated.

 ### Why was this change needed?
 New account is created for users that uses github authentication provider, when they update their github account's primary email address.

### Other information
closes https://github.com/novuhq/novu/issues/2964

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
