### PR TITLE
NV-2381 - 🚀 Feature: API endpoint to fetch execution details by transactionId

### DIFF
--- a/apps/api/src/app/execution-details/dtos/execution-details-response.dto.ts
+++ b/apps/api/src/app/execution-details/dtos/execution-details-response.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ExecutionDetailsEntity } from '@novu/dal';
+
+export class ExecutionDetailsPaginatedResponseDto {
+  @ApiProperty()
+  totalCount: number;
+
+  @ApiProperty()
+  data: ExecutionDetailsEntity[];
+
+  @ApiProperty()
+  hasMore: boolean;
+
+  @ApiProperty()
+  pageSize: number;
+
+  @ApiProperty()
+  page: number;
+}

--- a/apps/api/src/app/execution-details/dtos/execution-details-transaction-request.dto.ts
+++ b/apps/api/src/app/execution-details/dtos/execution-details-transaction-request.dto.ts
@@ -1,0 +1,4 @@
+import { IsDefined, IsNumber } from 'class-validator';
+import { PaginationRequestDto } from '../../shared/dtos/pagination-request';
+
+export class GetExecutionDetailsForTransactionIdRequestDto extends PaginationRequestDto(10, 100) {}

--- a/apps/api/src/app/execution-details/e2e/get-execution-details-transaction.e2e.ts
+++ b/apps/api/src/app/execution-details/e2e/get-execution-details-transaction.e2e.ts
@@ -1,0 +1,41 @@
+import { ExecutionDetailsRepository } from '@novu/dal';
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe('Execution details - Get execution details by transaction id - /v1/execution-details/transaction/:transactionId (GET)', function () {
+  let session: UserSession;
+  const executionDetailsRepository: ExecutionDetailsRepository = new ExecutionDetailsRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  it('should get execution details by transactionId', async function () {
+    const transactionId = ExecutionDetailsRepository.createObjectId();
+    const detail = await executionDetailsRepository.create({
+      _jobId: ExecutionDetailsRepository.createObjectId(),
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      _notificationId: ExecutionDetailsRepository.createObjectId(),
+      _notificationTemplateId: ExecutionDetailsRepository.createObjectId(),
+      _subscriberId: session.subscriberId,
+      providerId: '',
+      transactionId: transactionId,
+      channel: StepTypeEnum.EMAIL,
+      detail: '',
+      source: ExecutionDetailsSourceEnum.INTERNAL,
+      status: ExecutionDetailsStatusEnum.SUCCESS,
+      isTest: false,
+      isRetry: false,
+    });
+
+    const { body } = await session.testAgent.get(`/v1/execution-details/transaction/${transactionId}`);
+
+    const responseDetail = body.data[0];
+    expect(responseDetail.transactionId).to.equal(transactionId);
+    expect(responseDetail.channel).to.equal(detail.channel);
+    expect(responseDetail._id).to.equal(detail._id);
+  });
+});

--- a/apps/api/src/app/execution-details/execution-details.controller.ts
+++ b/apps/api/src/app/execution-details/execution-details.controller.ts
@@ -1,4 +1,4 @@
-import { ClassSerializerInterceptor, Controller, Get, Query, UseGuards, UseInterceptors } from '@nestjs/common';
+import { ClassSerializerInterceptor, Controller, Get, Param, Query, UseGuards, UseInterceptors } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { IJwtPayload } from '@novu/shared';
 import { ExecutionDetailsResponseDto } from '@novu/application-generic';
@@ -8,13 +8,23 @@ import { ExternalApiAccessible } from '../auth/framework/external-api.decorator'
 import { GetExecutionDetails, GetExecutionDetailsCommand } from './usecases/get-execution-details';
 import { ApiResponse } from '../shared/framework/response.decorator';
 import { ExecutionDetailsRequestDto } from './dtos/execution-details-request.dto';
+import { ExecutionDetailsPaginatedResponseDto } from './dtos/execution-details-response.dto';
+
+import { GetExecutionDetailsForTransactionIdRequestDto } from './dtos/execution-details-transaction-request.dto';
+import {
+  GetExecutionDetailsByTransactionId,
+  GetExecutionDetailsByTransactionIdCommand,
+} from './usecases/get-execution-details-transactionId';
 
 @Controller('/execution-details')
 @UseInterceptors(ClassSerializerInterceptor)
 @UseGuards(JwtAuthGuard)
 @ApiTags('Execution Details')
 export class ExecutionDetailsController {
-  constructor(private getExecutionDetails: GetExecutionDetails) {}
+  constructor(
+    private getExecutionDetails: GetExecutionDetails,
+    private getExecutionDetailsByTransactionId: GetExecutionDetailsByTransactionId
+  ) {}
 
   @Get('/')
   @ApiOperation({
@@ -33,6 +43,29 @@ export class ExecutionDetailsController {
         userId: user._id,
         notificationId: query.notificationId,
         subscriberId: query.subscriberId,
+      })
+    );
+  }
+
+  @Get('/transactions/:transactionId')
+  @ApiResponse(ExecutionDetailsPaginatedResponseDto)
+  @ApiOperation({
+    summary: 'Get execution details by transaction id',
+  })
+  @ExternalApiAccessible()
+  async getExecutionDetailsFilterByTransactionId(
+    @UserSession() user: IJwtPayload,
+    @Param('transactionId') transactionId: string,
+    @Query() query: GetExecutionDetailsForTransactionIdRequestDto
+  ): Promise<ExecutionDetailsPaginatedResponseDto> {
+    return this.getExecutionDetailsByTransactionId.execute(
+      GetExecutionDetailsByTransactionIdCommand.create({
+        transactionId,
+        organizationId: user.organizationId,
+        userId: user._id,
+        environmentId: user.environmentId,
+        page: query.page ?? 0,
+        limit: query.limit ?? 10,
       })
     );
   }

--- a/apps/api/src/app/execution-details/usecases/get-execution-details-transactionId/get-execution-details-transactionId.command.ts
+++ b/apps/api/src/app/execution-details/usecases/get-execution-details-transactionId/get-execution-details-transactionId.command.ts
@@ -1,0 +1,13 @@
+import { EnvironmentWithUserCommand } from '@novu/application-generic';
+import { IsDefined, IsNumber } from 'class-validator';
+
+export class GetExecutionDetailsByTransactionIdCommand extends EnvironmentWithUserCommand {
+  @IsNumber()
+  page: number;
+
+  @IsNumber()
+  limit: number;
+
+  @IsDefined()
+  transactionId: string;
+}

--- a/apps/api/src/app/execution-details/usecases/get-execution-details-transactionId/get-execution-details-transactionId.usecase.ts
+++ b/apps/api/src/app/execution-details/usecases/get-execution-details-transactionId/get-execution-details-transactionId.usecase.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { ExecutionDetailsRepository } from '@novu/dal';
+import { GetExecutionDetailsByTransactionIdCommand } from './get-execution-details-transactionId.command';
+import { ExecutionDetailsPaginatedResponseDto } from '../../dtos/execution-details-response.dto';
+
+@Injectable()
+export class GetExecutionDetailsByTransactionId {
+  constructor(private executionDetailsRepository: ExecutionDetailsRepository) {}
+
+  async execute(command: GetExecutionDetailsByTransactionIdCommand): Promise<ExecutionDetailsPaginatedResponseDto> {
+    const COUNT_LIMIT = 1000;
+
+    if (command.limit > COUNT_LIMIT) {
+      throw new Error(`Limit cannot be greater than ${COUNT_LIMIT}`);
+    }
+
+    const { data, totalCount } = await this.executionDetailsRepository.findAllNotificationExecutionsByTransactionId(
+      command.transactionId,
+      command.environmentId,
+      command.page * command.limit,
+      command.limit
+    );
+
+    const hasMore = this.getHasMore(command.page, command.limit, data, totalCount);
+
+    return {
+      data: data || [],
+      totalCount: totalCount || 0,
+      hasMore,
+      pageSize: command.limit,
+      page: command.page,
+    };
+  }
+
+  private getHasMore(page: number, LIMIT: number, data, totalCount) {
+    const currentPaginationTotal = page * LIMIT + data.length;
+
+    return currentPaginationTotal < totalCount;
+  }
+}

--- a/apps/api/src/app/execution-details/usecases/get-execution-details-transactionId/index.ts
+++ b/apps/api/src/app/execution-details/usecases/get-execution-details-transactionId/index.ts
@@ -1,0 +1,2 @@
+export { GetExecutionDetailsByTransactionId } from './get-execution-details-transactionId.usecase';
+export { GetExecutionDetailsByTransactionIdCommand } from './get-execution-details-transactionId.command';

--- a/apps/api/src/app/execution-details/usecases/index.ts
+++ b/apps/api/src/app/execution-details/usecases/index.ts
@@ -1,5 +1,11 @@
 import { BulkCreateExecutionDetails, CreateExecutionDetails } from '@novu/application-generic';
 
 import { GetExecutionDetails } from './get-execution-details';
+import { GetExecutionDetailsByTransactionId } from './get-execution-details-transactionId';
 
-export const USE_CASES = [CreateExecutionDetails, BulkCreateExecutionDetails, GetExecutionDetails];
+export const USE_CASES = [
+  CreateExecutionDetails,
+  BulkCreateExecutionDetails,
+  GetExecutionDetails,
+  GetExecutionDetailsByTransactionId,
+];

--- a/libs/dal/src/repositories/execution-details/execution-details.repository.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.repository.ts
@@ -44,4 +44,26 @@ export class ExecutionDetailsRepository extends BaseRepository<
       _notificationId: notificationId,
     });
   }
+
+  /**
+   * Activity feed might need to retrieve all the executions of a notification by transactionId.
+   */
+  public async findAllNotificationExecutionsByTransactionId(
+    transactionId: string,
+    environmentId: string,
+    skip = 0,
+    limit = 10
+  ) {
+    const requestQuery = {
+      _environmentId: environmentId,
+      transactionId: transactionId,
+    };
+
+    const [items, totalCount] = await Promise.all([
+      this.find(requestQuery, '', { sort: { createdAt: -1 }, skip, limit }),
+      this.count(requestQuery),
+    ]);
+
+    return { totalCount, data: this.mapEntities(items) };
+  }
 }

--- a/libs/dal/src/repositories/execution-details/execution-details.schema.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.schema.ts
@@ -110,6 +110,10 @@ executionDetailsSchema.index({
 });
 
 executionDetailsSchema.index({
+  transactionId: 1,
+});
+
+executionDetailsSchema.index({
   _environmentId: 1,
 });
 


### PR DESCRIPTION
 ### What change does this PR introduce?
This feature enables users to filter execution details by transactionId

 ### Why was this change needed?
closes https://github.com/novuhq/novu/issues/3473

### Other information

Happy hacking! 🎉

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
