### PR TITLE
fix(worker): Properly Unescape Button Templates (fixes #4851)

### DIFF
--- a/apps/api/e2e/compile-email-template.e2e.ts
+++ b/apps/api/e2e/compile-email-template.e2e.ts
@@ -216,4 +216,160 @@ describe('Compile E-mail Template', function () {
       expect(subject).to.equal('A title for Header Test');
     });
   });
+
+  describe('Escaping', function () {
+    it('should escape editor text in double curly braces', async function () {
+      const { html } = await useCase.execute(
+        CompileEmailTemplateCommand.create({
+          organizationId: session.organization._id,
+          environmentId: session.environment._id,
+          layoutId: null,
+          preheader: null,
+          content: [
+            {
+              type: EmailBlockTypeEnum.TEXT,
+              content: '<div>{{textUrl}}</div>',
+            },
+          ],
+          payload: {
+            textUrl: 'https://example.com?email=text+testing@example.com',
+          },
+          userId: session.user._id,
+          contentType: 'editor',
+          subject: 'Editor Text Escape Test',
+        })
+      );
+
+      expect(html).to.contain('<div>https://example.com?email&#x3D;text+testing@example.com</div>');
+    });
+
+    it('should not escape editor text in triple curly braces', async function () {
+      const { html } = await useCase.execute(
+        CompileEmailTemplateCommand.create({
+          organizationId: session.organization._id,
+          environmentId: session.environment._id,
+          layoutId: null,
+          preheader: null,
+          content: [
+            {
+              type: EmailBlockTypeEnum.TEXT,
+              content: '<div>{{{textUrl}}}</div>',
+            },
+          ],
+          payload: {
+            textUrl: 'https://example.com?email=text+testing@example.com',
+          },
+          userId: session.user._id,
+          contentType: 'editor',
+          subject: 'Editor Text No Escape Test',
+        })
+      );
+
+      expect(html).to.contain('<div>https://example.com?email=text+testing@example.com</div>');
+    });
+
+    it('should escape button text in double curly braces', async function () {
+      const { html } = await useCase.execute(
+        CompileEmailTemplateCommand.create({
+          organizationId: session.organization._id,
+          environmentId: session.environment._id,
+          layoutId: null,
+          preheader: null,
+          content: [
+            {
+              type: EmailBlockTypeEnum.BUTTON,
+              content: '{{buttonText}}',
+              url: 'https://example.com',
+            },
+          ],
+          payload: {
+            buttonText: 'https://example.com?email=button+testing@example.com',
+          },
+          userId: session.user._id,
+          contentType: 'editor',
+          subject: 'Editor Button Escape Test',
+        })
+      );
+
+      expect(html).to.contain('https://example.com?email&#x3D;button+testing@example.com');
+    });
+
+    it('should not escape button text in triple curly braces', async function () {
+      const { html } = await useCase.execute(
+        CompileEmailTemplateCommand.create({
+          organizationId: session.organization._id,
+          environmentId: session.environment._id,
+          layoutId: null,
+          preheader: null,
+          content: [
+            {
+              type: EmailBlockTypeEnum.BUTTON,
+              content: '{{{buttonText}}}',
+              url: 'https://example.com',
+            },
+          ],
+          payload: {
+            buttonText: 'https://example.com?email=button+testing@example.com',
+          },
+          userId: session.user._id,
+          contentType: 'editor',
+          subject: 'Editor Button Escape Test',
+        })
+      );
+
+      expect(html).to.contain('https://example.com?email=button+testing@example.com');
+    });
+
+    it('should escape button url in double curly braces', async function () {
+      const { html } = await useCase.execute(
+        CompileEmailTemplateCommand.create({
+          organizationId: session.organization._id,
+          environmentId: session.environment._id,
+          layoutId: null,
+          preheader: null,
+          content: [
+            {
+              type: EmailBlockTypeEnum.BUTTON,
+              content: 'Click Here To Go To Link!',
+              url: '{{buttonUrl}}',
+            },
+          ],
+          payload: {
+            buttonUrl: 'https://example.com?email=button+testing@example.com',
+          },
+          userId: session.user._id,
+          contentType: 'editor',
+          subject: 'Editor Button Escape Test',
+        })
+      );
+
+      expect(html).to.contain('https://example.com?email&#x3D;button+testing@example.com');
+    });
+
+    it('should not escape button url in triple curly braces', async function () {
+      const { html } = await useCase.execute(
+        CompileEmailTemplateCommand.create({
+          organizationId: session.organization._id,
+          environmentId: session.environment._id,
+          layoutId: null,
+          preheader: null,
+          content: [
+            {
+              type: EmailBlockTypeEnum.BUTTON,
+              content: 'Click Here To Go To Link!',
+              url: '{{{buttonUrl}}}',
+            },
+          ],
+          payload: {
+            buttonUrl: 'https://example.com?email=button+testing@example.com',
+          },
+          userId: session.user._id,
+          contentType: 'editor',
+          subject: 'Editor Button No Escape Test',
+        })
+      );
+
+      expect(html).to.contain('https://example.com?email=button+testing@example.com');
+    });
+  });
 });

--- a/packages/application-generic/src/usecases/compile-email-template/templates/basic.handlebars
+++ b/packages/application-generic/src/usecases/compile-email-template/templates/basic.handlebars
@@ -35,9 +35,9 @@
             border-color: {{#if ../branding.color}}{{../branding.color}}{{else}}#ff6f61{{/if}};
             text-decoration: none;
             "
-             href="{{url}}"
+             href="{{{url}}}"
              target="_blank">
-            {{content}}
+            {{{content}}}
           </a>
         </div>
       </div>


### PR DESCRIPTION
### What change does this PR introduce?

This PR changes [basic.handlebars](https://github.com/novuhq/novu/compare/next...JoeyEamigh:novu:fix/editor-button-escaping?expand=1#diff-5e57d7ef68eade062d5ddaf60f552d53c66e6800074a7abe13ac5517d2b284dfL38-R40) to use triple curly braces for button content, as [compile-email-template.usecase.ts](https://github.com/JoeyEamigh/novu/blob/cece21e27e9e535a51622e27d61326b7d10fa09e/packages/application-generic/src/usecases/compile-email-template/compile-email-template.usecase.ts#L108-L114) already escapes the content of a button if the template is using double curly braces. Fixes my issue #4851 and may be related to #2063 and #2564.

### Why was this change needed?

When providing a complex URL like `https://example.com?email=button+testing@example.com` to the button template, it would be escaped regardless of whether double or triple braces were used in the editor. If you used double braces, the content would actually be escaped twice, causing all sorts of problems.

### Other information

I added tests to [compile-email-template.e2e.ts](https://github.com/novuhq/novu/compare/next...JoeyEamigh:novu:fix/editor-button-escaping?expand=1#diff-a96a5193dd1f1190ce222491aea94f01c500efb473f9c0ca6e2a7df47284010dR219-R374) as it seemed like the most relevant place to put them. Those tests check for properly escaping and not escaping content in both text and buttons in templates.

#### Quick Test Run

```bash
git clone https://github.com/JoeyEamigh/novu.git --branch fix/editor-button-escaping novu-editor-button
cd novu-editor-button
nvm use
npx -y pnpm@8.9.0 setup:project
cd apps/api
npx -y pnpm@8.9.0 cross-env TS_NODE_COMPILER_OPTIONS='{"strictNullChecks": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file e2e/setup.ts e2e/compile-email-template.e2e.ts
```
