### PR TITLE
fix(docs): Fix Redirect Issue for "Run in Local Machine" Button

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -19,7 +19,7 @@ A web interface to browse the available endpoints is available at [api.novu.co/a
 
 ## Running the API
 
-See the docs for [Run in Local Machine](https://docs.novu.co/community/run-in-local-machin) to get setup. Then run:
+See the docs for [Run in Local Machine](https://docs.novu.co/community/run-in-local-machine) to get setup. Then run:
 
 ```bash
 # Run the API in watch mode


### PR DESCRIPTION
Resolves #4869 
### What change does this PR introduce?
This pull request addresses the issue where clicking on the "Run in Local Machine" button redirects users to the introduction page instead of the expected "Run in Local Machine" page. The fix involves updating the redirection logic to ensure that users are directed to the correct page when initiating the "Run in Local Machine" action.

### Why was this change needed?
Modified the redirection logic for the "Run in Local Machine" button.
Verified the correct behavior by testing the redirection after the fix.


