### PR TITLE
feat(worker): add raw error details for chat channel errors

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
@@ -188,6 +188,9 @@ export class SendMessageChat extends SendMessageBase {
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
+          raw: JSON.stringify({
+            reason: `webhookUrl for integrationId: ${subscriberChannel?._integrationId} is missing`,
+          }),
         })
       );
     }
@@ -216,6 +219,9 @@ export class SendMessageChat extends SendMessageBase {
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
+          raw: JSON.stringify({
+            reason: `Integration with integrationId: ${subscriberChannel?._integrationId} is either deleted or not active`,
+          }),
         })
       );
 
@@ -247,7 +253,7 @@ export class SendMessageChat extends SendMessageBase {
   }
 
   private async sendErrors(
-    chatWebhookUrl,
+    chatWebhookUrl: string,
     integration: IntegrationEntity,
     message: MessageEntity,
     command: SendMessageCommand
@@ -266,11 +272,14 @@ export class SendMessageChat extends SendMessageBase {
         CreateExecutionDetailsCommand.create({
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
-          detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_CHANNEL,
+          detail: DetailEnum.CHAT_WEBHOOK_URL_MISSING,
           source: ExecutionDetailsSourceEnum.INTERNAL,
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
+          raw: JSON.stringify({
+            reason: `webhookUrl for integrationId: ${integration?.identifier} is missing`,
+          }),
         })
       );
 
@@ -294,6 +303,9 @@ export class SendMessageChat extends SendMessageBase {
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
+          raw: JSON.stringify({
+            reason: 'Integration is either deleted or not active',
+          }),
         })
       );
 


### PR DESCRIPTION
### What change does this PR introduce?
Add raw error for `CHAT_WEBHOOK_URL_MISSING` and `SUBSCRIBER_NO_ACTIVE_INTEGRATION` so that user can debug the issue from activity feed logs
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
