### PR TITLE
fix(web): position of dropdown arrow for team page

### DIFF
--- a/apps/web/src/pages/invites/components/MembersTable.tsx
+++ b/apps/web/src/pages/invites/components/MembersTable.tsx
@@ -88,6 +88,7 @@ export function MembersTable({
                       <DotsHorizontal />
                     </div>
                   }
+                  position="left"
                   middlewares={{ flip: false, shift: false }}
                 >
                   <Dropdown.Item


### PR DESCRIPTION
### What change does this PR introduce?

NV-3227

### Why was this change needed?

Drop down was cut half in most screens.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->

Current behaviour:
![Screenshot 2023-11-23 at 12 44 44](https://github.com/novuhq/novu/assets/8872447/533ff3a8-37b6-4086-99d2-f829b64d4efd)
