### PR TITLE
docs(providers): Fix syntax mistake

### DIFF
--- a/providers/braze/README.md
+++ b/providers/braze/README.md
@@ -5,7 +5,7 @@ A Braze email provider library for [@novu/node](https://github.com/novuhq/novu)
 ## Usage
 
 ```javascript
-import { BrazeEmailProvider } from @novu/braze;
+import { BrazeEmailProvider } from '@novu/braze';
 const provider = new BrazeEmailProvider({
     apiKey: process.env.BRAZE_API_KEY,
     apiURL: process.env.BRAZE_API_URL,


### PR DESCRIPTION
### What change does this PR introduce?

The import statement in the code was not right. The correct way to import is using ' ' quotes

### Why was this change needed?
The current code will not handle the import as there is an syntax mistake . It should be corrected for the correct working of the code

### Other information (Screenshots)

![image](https://github.com/novuhq/novu/assets/87201444/61e088bb-7aa8-4b56-9f59-a1f5697d7c17)
