### PR TITLE
docs(providers): Clickatell documentation incorrectly shows TwilioSmsProvider 

### DIFF
--- a/providers/clickatell/README.md
+++ b/providers/clickatell/README.md
@@ -8,12 +8,12 @@ A ClickatellSmsProvider sms provider library for [@novu/node](https://github.com
 import { ClickatellSmsProvider } from '@novu/clickatell';
 
 // one way sms integration
-const provider = new TwilioSmsProvider({
+const provider = new ClickatellSmsProvider({
   apiKey: process.env.CLICKATELL_API_KEY,
 });
 
 // two way sms integration
-const provider = new TwilioSmsProvider({
+const provider = new ClickatellSmsProvider({
   apiKey: process.env.CLICKATELL_API_KEY,
   isTwoWayIntegration: true
 });


### PR DESCRIPTION
Clickatell documentation incorrectly shows TwilioSmsProvider  instead of ClickatellSmsProvider

### What change does this PR introduce?

Fixes a typo of TwilioSmsProvider in when it should be ClickatellSmsProvider 

### Why was this change needed?

Fixes documentation.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
