### PR TITLE
Race condition when reading the service instance - SW Health Indicator

### DIFF
--- a/apps/ws/src/health/health.controller.ts
+++ b/apps/ws/src/health/health.controller.ts
@@ -3,13 +3,15 @@ import { HealthCheck, HealthCheckResult, HealthCheckService, HttpHealthIndicator
 import { DalServiceHealthIndicator, WebSocketsQueueServiceHealthIndicator } from '@novu/application-generic';
 
 import { version } from '../../package.json';
+import { WSHealthIndicator } from '../socket/services';
 
 @Controller('v1/health-check')
 export class HealthController {
   constructor(
     private healthCheckService: HealthCheckService,
     private dalHealthIndicator: DalServiceHealthIndicator,
-    private webSocketsQueueHealthIndicator: WebSocketsQueueServiceHealthIndicator
+    private webSocketsQueueHealthIndicator: WebSocketsQueueServiceHealthIndicator,
+    private wsHealthIndicator: WSHealthIndicator
   ) {}
 
   @Get()
@@ -18,6 +20,7 @@ export class HealthController {
     const result = await this.healthCheckService.check([
       async () => this.dalHealthIndicator.isHealthy(),
       async () => this.webSocketsQueueHealthIndicator.isHealthy(),
+      async () => this.wsHealthIndicator.isHealthy(),
       async () => {
         return {
           apiVersion: {

--- a/apps/ws/src/health/health.module.ts
+++ b/apps/ws/src/health/health.module.ts
@@ -4,9 +4,14 @@ import { QueuesModule } from '@novu/application-generic';
 
 import { HealthController } from './health.controller';
 import { SharedModule } from '../shared/shared.module';
+import { WSGateway } from '../socket/ws.gateway';
+import { WSHealthIndicator } from '../socket/services';
+
+const PROVIDERS = [WSHealthIndicator, WSGateway];
 
 @Module({
   imports: [TerminusModule, SharedModule, QueuesModule],
+  providers: PROVIDERS,
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/apps/ws/src/socket/services/index.ts
+++ b/apps/ws/src/socket/services/index.ts
@@ -1,1 +1,2 @@
 export { WebSocketWorker } from './web-socket.worker';
+export { WSHealthIndicator } from './ws-health-indicator.service';

--- a/apps/ws/src/socket/services/ws-health-indicator.service.ts
+++ b/apps/ws/src/socket/services/ws-health-indicator.service.ts
@@ -1,0 +1,25 @@
+import { HealthIndicator, HealthIndicatorResult } from '@nestjs/terminus';
+import { Injectable } from '@nestjs/common';
+
+import { IHealthIndicator } from '@novu/application-generic';
+
+import { WSGateway } from '../ws.gateway';
+
+@Injectable()
+export class WSHealthIndicator extends HealthIndicator implements IHealthIndicator {
+  private INDICATOR_KEY = 'ws';
+
+  constructor(private wsGateway: WSGateway) {
+    super();
+  }
+
+  async isHealthy(): Promise<HealthIndicatorResult> {
+    const status = !!this.wsGateway.server;
+
+    return this.getStatus(this.INDICATOR_KEY, status);
+  }
+
+  isActive(): Promise<HealthIndicatorResult> {
+    return this.isHealthy();
+  }
+}

--- a/packages/application-generic/src/health/index.ts
+++ b/packages/application-generic/src/health/index.ts
@@ -7,3 +7,4 @@ export * from './standard-queue.health-indicator';
 export * from './web-sockets-queue.health-indicator';
 export * from './workflow-queue.health-indicator';
 export * from './subscriber-process-queue.health-indicator';
+export * from './health-indicator.interface';


### PR DESCRIPTION
### What change does this PR introduce?

Reproduction Steps

There is a race condition happening in the WS service when reading the server instance sockets. The error message that was noticed has been like Cannot read proprties of sockets of null. 

The code part where it is happening:

```
private async connectionExist(command: ExternalServicesRouteCommand) {
  return !!(await this.wsGateway.server.sockets.in(command.userId).fetchSockets()).length;
}
```

The issue should be reproducible when spinning the service (or a few instances).
### Why was this change needed?

Will validate the WS server health.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
