### PR TITLE
fix(api): Add spelling for rate limiting to cpsell dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -530,7 +530,12 @@
     "maildata",
     "brevo",
     "Getstream",
-    "getstream"
+    "getstream",
+    "upstash",
+    "Upstash",
+    "Krakend",
+    "ratelimit",
+    "Ratelimit",
   ],
   "flagWords": [],
   "patterns": [


### PR DESCRIPTION
### What change does this PR introduce?
* Adds rate limit terms to cspell dictionary

### Why was this change needed?
* The cspell check did not run on the original PR for an unknown reason.

### Other information (Screenshots)
N/A
<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
