### PR TITLE
feat(infra): select provider from environment variables

### DIFF
--- a/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.spec.ts
+++ b/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.spec.ts
@@ -2,18 +2,23 @@ import { InMemoryProviderService } from './in-memory-provider.service';
 import { getClusterProvider, getSingleInstanceProvider } from './providers';
 import { InMemoryProviderEnum } from './types';
 
-const redis = getSingleInstanceProvider();
-const redisCluster = getClusterProvider(InMemoryProviderEnum.REDIS_CLUSTER);
-
 let inMemoryProviderService: InMemoryProviderService;
 
 describe('In-memory Provider Service', () => {
   describe('Non cluster mode', () => {
+    const redis = getSingleInstanceProvider();
+
     beforeEach(async () => {
+      const provider = redis;
+      const config = redis.getConfig(undefined, {
+        showFriendlyErrorStack: false,
+      });
+      const isCluster = provider.isCluster;
+
       inMemoryProviderService = new InMemoryProviderService(
-        redis,
-        redis.getConfig({ showFriendlyErrorStack: false }),
-        false
+        provider,
+        config,
+        isCluster
       );
 
       await inMemoryProviderService.delayUntilReadiness();
@@ -88,11 +93,19 @@ describe('In-memory Provider Service', () => {
   });
 
   describe('Cluster mode', () => {
+    const redisCluster = getClusterProvider(InMemoryProviderEnum.REDIS_CLUSTER);
+
     beforeEach(async () => {
+      const provider = redisCluster;
+      const config = redisCluster.getConfig(undefined, {
+        showFriendlyErrorStack: false,
+      });
+      const isCluster = provider.isCluster;
+
       inMemoryProviderService = new InMemoryProviderService(
-        redisCluster,
-        redisCluster.getConfig({ showFriendlyErrorStack: false }),
-        true
+        provider,
+        config,
+        isCluster
       );
       await inMemoryProviderService.delayUntilReadiness();
 
@@ -107,7 +120,7 @@ describe('In-memory Provider Service', () => {
       it('enableAutoPipelining is enabled', async () => {
         const clusterWithPipelining = new InMemoryProviderService(
           redisCluster,
-          redisCluster.getConfig({
+          redisCluster.getConfig(undefined, {
             enableAutoPipelining: true,
             showFriendlyErrorStack: false,
           }),

--- a/packages/application-generic/src/services/in-memory-provider/providers/azure-cache-for-redis-cluster-provider.ts
+++ b/packages/application-generic/src/services/in-memory-provider/providers/azure-cache-for-redis-cluster-provider.ts
@@ -7,6 +7,7 @@ import {
   Cluster,
   ClusterNode,
   ClusterOptions,
+  IEnvironmentConfigOptions,
   IProviderClusterConfigOptions,
   Redis,
 } from '../types';
@@ -48,22 +49,38 @@ export interface IAzureCacheForRedisClusterProviderConfig {
 }
 
 export const getAzureCacheForRedisClusterProviderConfig = (
+  envOptions?: IEnvironmentConfigOptions,
   options?: IProviderClusterConfigOptions
 ): IAzureCacheForRedisClusterProviderConfig => {
-  const redisClusterConfig: IAzureCacheForRedisClusterConfig = {
-    host: convertStringValues(
-      process.env.AZURE_CACHE_FOR_REDIS_CLUSTER_SERVICE_HOST
-    ),
-    port: convertStringValues(
-      process.env.AZURE_CACHE_FOR_REDIS_CLUSTER_SERVICE_PORT
-    ),
+  let redisClusterConfig: Partial<IAzureCacheForRedisClusterConfig>;
+
+  if (envOptions) {
+    redisClusterConfig = {
+      host: convertStringValues(envOptions.host),
+      password: convertStringValues(envOptions.password),
+      port: convertStringValues(envOptions.ports),
+      username: convertStringValues(envOptions.username),
+    };
+  } else {
+    redisClusterConfig = {
+      host: convertStringValues(
+        process.env.AZURE_CACHE_FOR_REDIS_CLUSTER_SERVICE_HOST
+      ),
+      password: convertStringValues(
+        process.env.AZURE_CACHE_FOR_REDIS_CLUSTER_SERVICE_PASSWORD
+      ),
+      port: convertStringValues(
+        process.env.AZURE_CACHE_FOR_REDIS_CLUSTER_SERVICE_PORT
+      ),
+      username: convertStringValues(
+        process.env.AZURE_CACHE_FOR_REDIS_CLUSTER_SERVICE_USERNAME
+      ),
+    };
+  }
+
+  redisClusterConfig = {
+    ...redisClusterConfig,
     ttl: convertStringValues(process.env.REDIS_CLUSTER_TTL),
-    username: convertStringValues(
-      process.env.AZURE_CACHE_FOR_REDIS_CLUSTER_SERVICE_USERNAME
-    ),
-    password: convertStringValues(
-      process.env.AZURE_CACHE_FOR_REDIS_CLUSTER_SERVICE_PASSWORD
-    ),
     connectTimeout: convertStringValues(
       process.env.REDIS_CLUSTER_CONNECTION_TIMEOUT
     ),

--- a/packages/application-generic/src/services/in-memory-provider/providers/index.ts
+++ b/packages/application-generic/src/services/in-memory-provider/providers/index.ts
@@ -4,4 +4,7 @@ export {
   InMemoryProviderConfig,
   IProviderCluster,
   IProviderRedis,
+  IProviders,
+  IRedisProviderConfig,
+  isProviderAllowed,
 } from './providers';

--- a/packages/application-generic/src/services/in-memory-provider/providers/memory-db-cluster-provider.ts
+++ b/packages/application-generic/src/services/in-memory-provider/providers/memory-db-cluster-provider.ts
@@ -7,6 +7,7 @@ import {
   Cluster,
   ClusterNode,
   ClusterOptions,
+  IEnvironmentConfigOptions,
   IProviderClusterConfigOptions,
   Redis,
 } from '../types';
@@ -48,18 +49,35 @@ export interface IMemoryDbClusterProviderConfig {
 }
 
 export const getMemoryDbClusterProviderConfig = (
+  envOptions?: IEnvironmentConfigOptions,
   options?: IProviderClusterConfigOptions
 ): IMemoryDbClusterProviderConfig => {
-  const redisClusterConfig: IMemoryDbClusterConfig = {
-    host: convertStringValues(process.env.MEMORY_DB_CLUSTER_SERVICE_HOST),
-    port: convertStringValues(process.env.MEMORY_DB_CLUSTER_SERVICE_PORT),
+  let redisClusterConfig: Partial<IMemoryDbClusterConfig>;
+
+  if (envOptions) {
+    redisClusterConfig = {
+      host: convertStringValues(envOptions.host),
+      password: convertStringValues(envOptions.password),
+      port: convertStringValues(envOptions.ports),
+      username: convertStringValues(envOptions.username),
+    };
+  } else {
+    redisClusterConfig = {
+      host: convertStringValues(process.env.MEMORY_DB_CLUSTER_SERVICE_HOST),
+      password: convertStringValues(
+        process.env.MEMORY_DB_CLUSTER_SERVICE_PASSWORD
+      ),
+
+      port: convertStringValues(process.env.MEMORY_DB_CLUSTER_SERVICE_PORT),
+      username: convertStringValues(
+        process.env.MEMORY_DB_CLUSTER_SERVICE_USERNAME
+      ),
+    };
+  }
+
+  redisClusterConfig = {
+    ...redisClusterConfig,
     ttl: convertStringValues(process.env.MEMORY_DB_CLUSTER_SERVICE_TTL),
-    username: convertStringValues(
-      process.env.MEMORY_DB_CLUSTER_SERVICE_USERNAME
-    ),
-    password: convertStringValues(
-      process.env.MEMORY_DB_CLUSTER_SERVICE_PASSWORD
-    ),
     connectTimeout: convertStringValues(
       process.env.MEMORY_DB_CLUSTER_SERVICE_CONNECTION_TIMEOUT
     ),

--- a/packages/application-generic/src/services/in-memory-provider/providers/redis-cluster-provider.ts
+++ b/packages/application-generic/src/services/in-memory-provider/providers/redis-cluster-provider.ts
@@ -7,6 +7,7 @@ import {
   Cluster,
   ClusterNode,
   ClusterOptions,
+  IEnvironmentConfigOptions,
   IProviderClusterConfigOptions,
   Redis,
 } from '../types';
@@ -29,6 +30,7 @@ interface IRedisClusterConfig {
   ports?: string;
   tls?: ConnectionOptions;
   ttl?: string;
+  username?: string;
 }
 
 export interface IRedisClusterProviderConfig {
@@ -43,16 +45,34 @@ export interface IRedisClusterProviderConfig {
   ports?: number[];
   tls?: ConnectionOptions;
   ttl: number;
+  username?: string;
 }
 
 export const getRedisClusterProviderConfig = (
+  envOptions?: IEnvironmentConfigOptions,
   options?: IProviderClusterConfigOptions
 ): IRedisClusterProviderConfig => {
-  const redisClusterConfig: IRedisClusterConfig = {
-    host: convertStringValues(process.env.REDIS_CLUSTER_SERVICE_HOST),
-    ports: convertStringValues(process.env.REDIS_CLUSTER_SERVICE_PORTS),
+  let redisClusterConfig: Partial<IRedisClusterConfig>;
+
+  if (envOptions) {
+    redisClusterConfig = {
+      host: convertStringValues(envOptions.host),
+      password: convertStringValues(envOptions.password),
+      ports: convertStringValues(envOptions.ports),
+      username: convertStringValues(envOptions.username),
+    };
+  } else {
+    redisClusterConfig = {
+      host: convertStringValues(process.env.REDIS_CLUSTER_SERVICE_HOST),
+      password: convertStringValues(process.env.REDIS_CLUSTER_PASSWORD),
+      ports: convertStringValues(process.env.REDIS_CLUSTER_SERVICE_PORTS),
+      username: convertStringValues(process.env.REDIS_CLUSTER_USERNAME),
+    };
+  }
+
+  redisClusterConfig = {
+    ...redisClusterConfig,
     ttl: convertStringValues(process.env.REDIS_CLUSTER_TTL),
-    password: convertStringValues(process.env.REDIS_CLUSTER_PASSWORD),
     connectTimeout: convertStringValues(
       process.env.REDIS_CLUSTER_CONNECTION_TIMEOUT
     ),
@@ -67,6 +87,7 @@ export const getRedisClusterProviderConfig = (
     ? JSON.parse(redisClusterConfig.ports)
     : [];
   const password = redisClusterConfig.password;
+  const username = redisClusterConfig.username;
   const connectTimeout = redisClusterConfig.connectTimeout
     ? Number(redisClusterConfig.connectTimeout)
     : DEFAULT_CONNECT_TIMEOUT;
@@ -90,6 +111,7 @@ export const getRedisClusterProviderConfig = (
     ports,
     instances,
     password,
+    username,
     connectTimeout,
     family,
     keepAlive,

--- a/packages/application-generic/src/services/in-memory-provider/providers/redis-provider.ts
+++ b/packages/application-generic/src/services/in-memory-provider/providers/redis-provider.ts
@@ -2,6 +2,7 @@ import { convertStringValues } from './variable-mappers';
 
 import {
   ConnectionOptions,
+  IEnvironmentConfigOptions,
   IRedisConfigOptions,
   Redis,
   RedisOptions,
@@ -28,6 +29,7 @@ interface IRedisConfig {
   port?: string;
   tls?: ConnectionOptions;
   ttl?: string;
+  username?: string;
 }
 
 export interface IRedisProviderConfig {
@@ -46,14 +48,31 @@ export interface IRedisProviderConfig {
 }
 
 export const getRedisProviderConfig = (
+  envOptions?: IEnvironmentConfigOptions,
   options?: IRedisConfigOptions
 ): IRedisProviderConfig => {
-  const redisConfig: IRedisConfig = {
+  let redisConfig: Partial<IRedisConfig>;
+
+  if (envOptions) {
+    redisConfig = {
+      host: convertStringValues(envOptions.host),
+      password: convertStringValues(envOptions.password),
+      port: convertStringValues(envOptions.ports),
+      username: convertStringValues(envOptions.username),
+    };
+  } else {
+    redisConfig = {
+      host: convertStringValues(process.env.REDIS_HOST),
+      password: convertStringValues(process.env.REDIS_PASSWORD),
+      port: convertStringValues(process.env.REDIS_PORT),
+      username: convertStringValues(process.env.REDIS_USERNAME),
+    };
+  }
+
+  redisConfig = {
+    ...redisConfig,
     db: convertStringValues(process.env.REDIS_DB_INDEX),
-    host: convertStringValues(process.env.REDIS_HOST),
-    port: convertStringValues(process.env.REDIS_PORT),
     ttl: convertStringValues(process.env.REDIS_TTL),
-    password: convertStringValues(process.env.REDIS_PASSWORD),
     connectTimeout: convertStringValues(process.env.REDIS_CONNECT_TIMEOUT),
     keepAlive: convertStringValues(process.env.REDIS_KEEP_ALIVE),
     family: convertStringValues(process.env.REDIS_FAMILY),
@@ -65,6 +84,7 @@ export const getRedisProviderConfig = (
   const port = redisConfig.port ? Number(redisConfig.port) : DEFAULT_PORT;
   const host = redisConfig.host || DEFAULT_HOST;
   const password = redisConfig.password;
+  const username = redisConfig.username;
   const connectTimeout = redisConfig.connectTimeout
     ? Number(redisConfig.connectTimeout)
     : DEFAULT_CONNECT_TIMEOUT;
@@ -83,6 +103,7 @@ export const getRedisProviderConfig = (
     host,
     port,
     password,
+    username,
     connectTimeout,
     family,
     keepAlive,

--- a/packages/application-generic/src/services/in-memory-provider/types.ts
+++ b/packages/application-generic/src/services/in-memory-provider/types.ts
@@ -38,3 +38,11 @@ export interface IProviderClusterConfigOptions {
 export interface IRedisConfigOptions {
   showFriendlyErrorStack?: boolean;
 }
+
+export interface IEnvironmentConfigOptions {
+  host: string;
+  ports: string;
+  providerId?: string;
+  username?: string;
+  password?: string;
+}

--- a/packages/application-generic/src/services/in-memory-provider/workflow-in-memory-provider.service.ts
+++ b/packages/application-generic/src/services/in-memory-provider/workflow-in-memory-provider.service.ts
@@ -4,16 +4,22 @@ import { InMemoryProviderService } from './in-memory-provider.service';
 import {
   getClusterProvider,
   getSingleInstanceProvider,
+  InMemoryProviderConfig,
   IProviderCluster,
   IProviderRedis,
+  IProviders,
+  IRedisProviderConfig,
+  isProviderAllowed,
 } from './providers';
 import {
   InMemoryProviderEnum,
   InMemoryProviderClient,
   IProviderClusterConfigOptions,
+  IEnvironmentConfigOptions,
 } from './types';
 
 import { GetIsInMemoryClusterModeEnabled } from '../../usecases';
+
 const LOG_CONTEXT = 'WorkflowInMemoryProviderService';
 
 export class WorkflowInMemoryProviderService {
@@ -26,12 +32,13 @@ export class WorkflowInMemoryProviderService {
     this.getIsInMemoryClusterModeEnabled =
       new GetIsInMemoryClusterModeEnabled();
 
-    this.isCluster = this.isClusterMode();
-    this.loadedProvider = this.selectProvider();
+    const { provider, config } = this.selectProvider();
+    this.loadedProvider = provider;
+    this.isCluster = this.loadedProvider.isCluster;
 
     this.inMemoryProviderService = new InMemoryProviderService(
       this.loadedProvider,
-      this.loadedProvider.getConfig(this.getWorkflowConfigOptions()),
+      config,
       this.isCluster
     );
   }
@@ -47,6 +54,54 @@ export class WorkflowInMemoryProviderService {
     };
   }
 
+  private getWorkflowProvider(): IEnvironmentConfigOptions {
+    const providerId = process.env.WORKFLOW_PROVIDER_ID;
+    const host = process.env.WORKFLOW_HOST;
+    const password = process.env.WORKFLOW_PASSWORD;
+    const ports = process.env.WORKFLOW_PORTS;
+    const username = process.env.WORKFLOW_USERNAME;
+
+    return {
+      providerId,
+      host,
+      password,
+      ports,
+      username,
+    };
+  }
+
+  /**
+   * New way of selecting provider with priority to select through environment variables
+   * and fallback to the previous way retro compatible
+   */
+  private selectProvider(): {
+    provider: IProviders;
+    config: InMemoryProviderConfig;
+  } {
+    const { providerId, host, password, ports, username } =
+      this.getWorkflowProvider();
+
+    if (isProviderAllowed(providerId)) {
+      const envProvider = getClusterProvider(
+        providerId as InMemoryProviderEnum
+      );
+
+      const envProviderConfig = envProvider.getConfig(
+        { host, ports, username, password },
+        this.getWorkflowConfigOptions()
+      );
+
+      if (envProvider.validate(envProviderConfig)) {
+        return {
+          provider: envProvider,
+          config: envProviderConfig,
+        };
+      }
+    }
+
+    return this.selectProviderRetroCompatible();
+  }
+
   /**
    * Rules for the provider selection:
    * - For our self hosted users we assume all of them have a single node Redis
@@ -56,7 +111,10 @@ export class WorkflowInMemoryProviderService {
    * if MemoryDB not configured properly. If Redis Cluster is wrong too, we will
    * fall back to Redis single instance.
    */
-  private selectProvider(): IProviderCluster | IProviderRedis {
+  private selectProviderRetroCompatible(): {
+    provider: IProviders;
+    config: IRedisProviderConfig | InMemoryProviderConfig;
+  } {
     if (this.isClusterMode()) {
       const providerIds = [
         InMemoryProviderEnum.MEMORY_DB,
@@ -64,24 +122,38 @@ export class WorkflowInMemoryProviderService {
       ];
 
       let selectedProvider = undefined;
+      let selectedProviderConfig = undefined;
       for (const providerId of providerIds) {
         const clusterProvider = getClusterProvider(providerId);
         const clusterProviderConfig = clusterProvider.getConfig(
+          undefined,
           this.getWorkflowConfigOptions()
         );
 
         if (clusterProvider.validate(clusterProviderConfig)) {
           selectedProvider = clusterProvider;
+          selectedProviderConfig = clusterProviderConfig;
           break;
         }
       }
 
       if (selectedProvider) {
-        return selectedProvider;
+        return {
+          provider: selectedProvider,
+          config: selectedProviderConfig,
+        };
       }
     }
 
-    return getSingleInstanceProvider();
+    const singleInstance = getSingleInstanceProvider();
+
+    return {
+      provider: singleInstance,
+      config: singleInstance.getConfig(
+        undefined,
+        this.getWorkflowConfigOptions()
+      ),
+    };
   }
 
   private isClusterMode(): boolean {


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Allows to select from environment variables the provider for the Workflow Engine and the Cache Service. In the case of not being set up by the new method it will fall back to the retro-compatible current way.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
To simplify the configuration of the providers for the Workflow Engine and the Cache service and allow the users to choose their own providers.

### Other information (Screenshots)

New environment variables to set up the providers:
```
process.env.CACHE_PROVIDER_ID;
process.env.CACHE_HOST;
process.env.CACHE_PORTS;
process.env.CACHE_USERNAME;
process.env.CACHE_PASSWORD;
process.env.WORKFLOW_PROVIDER_ID;
process.env.WORKFLOW_HOST;
process.env.WORKFLOW_PORTS;
process.env.WORKFLOW_USERNAME;
process.env.WORKFLOW_PASSWORD;
```
Potentially we can add the rest of the configuration. That could be done further down the line.

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
