### PR TITLE
refactor: do not perform fetchsockets when service is shutting down

### DIFF
--- a/apps/ws/src/shared/subscriber-online/subscriber-online.service.ts
+++ b/apps/ws/src/shared/subscriber-online/subscriber-online.service.ts
@@ -17,12 +17,9 @@ export class SubscriberOnlineService {
     await this.updateOnlineStatus(subscriber, { isOnline });
   }
 
-  async handleDisconnection(subscriber: ISubscriberJwt, activeConnections: number) {
+  async handleDisconnection(subscriber: ISubscriberJwt) {
     const lastOnlineAt = new Date().toISOString();
-    let isOnline = false;
-    if (activeConnections > 1) {
-      isOnline = true;
-    }
+    const isOnline = false;
 
     await this.updateOnlineStatus(subscriber, { isOnline, lastOnlineAt });
   }

--- a/apps/ws/src/socket/ws.gateway.ts
+++ b/apps/ws/src/socket/ws.gateway.ts
@@ -94,8 +94,7 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return;
     }
 
-    const activeConnections = await this.getActiveConnections(connection, subscriber._id);
-    await this.subscriberOnlineService.handleDisconnection(subscriber, activeConnections);
+    await this.subscriberOnlineService.handleDisconnection(subscriber);
   }
 
   private async processConnectionRequest(connection: Socket) {
@@ -127,11 +126,5 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private disconnect(socket: Socket) {
     socket.disconnect();
-  }
-
-  private async getActiveConnections(socket: Socket, subscriberId: string) {
-    const activeSockets = await socket.in(subscriberId).fetchSockets();
-
-    return activeSockets.length;
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

When service is shutting down don't perform a look for the active sockets connections. 

### Why was this change needed?

When the server shuts down we have a spike of disconnects.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
