### PR TITLE
Add support for cid based attachment in email

### DIFF
--- a/libs/shared/src/types/events/index.ts
+++ b/libs/shared/src/types/events/index.ts
@@ -17,6 +17,8 @@ export interface IAttachmentOptions {
   file: Buffer;
   name?: string;
   channels?: ChannelTypeEnum[];
+  cid?: string;
+  disposition?: string;
 }
 
 export interface IEmailOptions {

--- a/packages/stateless/src/lib/template/template.interface.ts
+++ b/packages/stateless/src/lib/template/template.interface.ts
@@ -53,6 +53,8 @@ export interface IAttachmentOptions {
   file: Buffer | null;
   name?: string;
   channels?: ChannelTypeEnum[];
+  cid?: string;
+  disposition?: string;
 }
 
 export interface IAttachmentOptionsExtended extends IAttachmentOptions {

--- a/providers/sendgrid/src/lib/sendgrid.provider.ts
+++ b/providers/sendgrid/src/lib/sendgrid.provider.ts
@@ -7,9 +7,12 @@ import {
   ICheckIntegrationResponse,
   CheckIntegrationResponseEnum,
   IEmailEventBody,
+  IAttachmentOptions,
 } from '@novu/stateless';
 
 import { MailDataRequired, MailService } from '@sendgrid/mail';
+
+type AttachmentJSON = MailDataRequired['attachments'][0];
 
 export class SendgridEmailProvider implements IEmailProvider {
   id = 'sendgrid';
@@ -74,6 +77,26 @@ export class SendgridEmailProvider implements IEmailProvider {
     delete options.customData?.dynamicTemplateData;
     delete options.customData?.templateId;
 
+    const attachments = options.attachments?.map(
+      (attachment: IAttachmentOptions) => {
+        const attachmentJson: Partial<AttachmentJSON> = {
+          content: attachment.file.toString('base64'),
+          filename: attachment.name,
+          type: attachment.mime,
+        };
+
+        if (attachment?.cid) {
+          attachmentJson.contentId = attachment?.cid;
+        }
+
+        if (attachment?.disposition) {
+          attachmentJson.disposition = attachment?.disposition;
+        }
+
+        return attachmentJson as AttachmentJSON;
+      }
+    );
+
     const mailData: Partial<MailDataRequired> = {
       from: {
         email: options.from || this.config.from,
@@ -95,13 +118,7 @@ export class SendgridEmailProvider implements IEmailProvider {
         novuSubscriberId: options.notificationDetails?.subscriberId,
         ...options.customData,
       },
-      attachments: options.attachments?.map((attachment) => {
-        return {
-          content: attachment.file.toString('base64'),
-          filename: attachment.name,
-          type: attachment.mime,
-        };
-      }),
+      attachments: attachments,
       personalizations: [
         {
           to: options.to.map((email) => ({ email })),

--- a/providers/sendgrid/src/lib/sendgrid.provider.ts
+++ b/providers/sendgrid/src/lib/sendgrid.provider.ts
@@ -79,7 +79,7 @@ export class SendgridEmailProvider implements IEmailProvider {
 
     const attachments = options.attachments?.map(
       (attachment: IAttachmentOptions) => {
-        const attachmentJson: Partial<AttachmentJSON> = {
+        const attachmentJson: AttachmentJSON = {
           content: attachment.file.toString('base64'),
           filename: attachment.name,
           type: attachment.mime,
@@ -93,7 +93,7 @@ export class SendgridEmailProvider implements IEmailProvider {
           attachmentJson.disposition = attachment?.disposition;
         }
 
-        return attachmentJson as AttachmentJSON;
+        return attachmentJson;
       }
     );
 


### PR DESCRIPTION
### What change does this PR introduce?

CID attachment is used for inline image embedding

Example:- 

To show novu logo as inline embed in html

```
<html>
  <body>
    <p>Before image</p>
    <img src="cid:novu-logo" alt="Novu logo">
    <p>After image</p>
  </body>
</html>
```
 
Sendgrid attachment example code:-

```
{
  "content": "imageFileBase64",
  "filename": "index.jpeg",
  "type": "image/jpeg",
  "disposition": "inline",
  "content_id": "novu-logo"
}
```

### Why? (Context)

Novu has 3 fields for attachments currently:-

```
{
   file: "base64 of file",
   name: 'file_name.jpeg',
   mime: 'image/jpeg',
}
```

Definition of Done

Add new fields to support CID based attachments
