### PR TITLE
feat: add queue and workers dto typed

### DIFF
--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -8,6 +8,8 @@ import {
   CachedEntity,
   Instrument,
   InstrumentUsecase,
+  IWorkflowDataDto,
+  IWorkflowJobDto,
   StorageHelperService,
   WorkflowQueueService,
 } from '@novu/application-generic';
@@ -129,13 +131,13 @@ export class ParseEventRequest {
 
     command.payload = merge({}, defaultPayload, command.payload);
 
-    const jobData: ParseEventRequestCommand = {
+    const jobData: IWorkflowDataDto = {
       ...command,
       actor: command.actor,
       transactionId,
     };
 
-    await this.workflowQueueService.add(transactionId, jobData, command.organizationId);
+    await this.workflowQueueService.add({ name: transactionId, data: jobData, groupId: command.organizationId });
 
     return {
       acknowledged: true,

--- a/apps/api/src/app/inbound-parse/services/inbound-parse.worker.service.ts
+++ b/apps/api/src/app/inbound-parse/services/inbound-parse.worker.service.ts
@@ -1,6 +1,8 @@
 import {
   BullMqService,
   getInboundParseMailWorkerOptions,
+  IInboundParseDataDto,
+  IInboundParseJobDto,
   WorkerBaseService,
   WorkerOptions,
   WorkflowInMemoryProviderService,
@@ -29,7 +31,7 @@ export class InboundParseWorkerService extends WorkerBaseService {
   }
 
   public getWorkerProcessor() {
-    return async ({ data }: { data: InboundEmailParseCommand }) => {
+    return async ({ data }: { data: IInboundParseDataDto }) => {
       Logger.verbose({ data }, 'Processing the inbound parsed email', LOG_CONTEXT);
       await this.emailParseUsecase.execute(InboundEmailParseCommand.create({ ...data }));
     };

--- a/apps/api/src/app/inbound-parse/usecases/inbound-email-parse/inbound-email-parse.command.ts
+++ b/apps/api/src/app/inbound-parse/usecases/inbound-email-parse/inbound-email-parse.command.ts
@@ -1,7 +1,16 @@
 import { IsDefined, IsNumber, IsOptional, IsString } from 'class-validator';
-import { BaseCommand } from '@novu/application-generic';
+import {
+  BaseCommand,
+  IConnection,
+  IEnvelopeFrom,
+  IEnvelopeTo,
+  IFrom,
+  IHeaders,
+  IInboundParseDataDto,
+  ITo,
+} from '@novu/application-generic';
 
-export class InboundEmailParseCommand extends BaseCommand {
+export class InboundEmailParseCommand extends BaseCommand implements IInboundParseDataDto {
   @IsDefined()
   @IsString()
   html: string;
@@ -65,71 +74,4 @@ export class InboundEmailParseCommand extends BaseCommand {
 
   @IsDefined()
   envelopeTo: IEnvelopeTo[];
-}
-
-export interface IHeaders {
-  'content-type': string;
-  from: string;
-  to: string;
-  subject: string;
-  'message-id': string;
-  date: string;
-  'mime-version': string;
-}
-
-export interface IFrom {
-  address: string;
-  name: string;
-}
-
-export interface ITo {
-  address: string;
-  name: string;
-}
-
-export interface ITlsOptions {
-  name: string;
-  standardName: string;
-  version: string;
-}
-
-export interface IMailFrom {
-  address: string;
-  args: boolean;
-}
-
-export interface IRcptTo {
-  address: string;
-  args: boolean;
-}
-
-export interface IEnvelope {
-  mailFrom: IMailFrom;
-  rcptTo: IRcptTo[];
-}
-
-export interface IConnection {
-  id: string;
-  remoteAddress: string;
-  remotePort: number;
-  clientHostname: string;
-  openingCommand: string;
-  hostNameAppearsAs: string;
-  xClient: any;
-  xForward: any;
-  transmissionType: string;
-  tlsOptions: ITlsOptions;
-  envelope: IEnvelope;
-  transaction: number;
-  mailPath: string;
-}
-
-export interface IEnvelopeFrom {
-  address: string;
-  args: boolean;
-}
-
-export interface IEnvelopeTo {
-  address: string;
-  args: boolean;
 }

--- a/apps/api/src/app/widgets/usecases/mark-all-messages-as/mark-all-messages-as.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/mark-all-messages-as/mark-all-messages-as.usecase.ts
@@ -65,15 +65,15 @@ export class MarkAllMessagesAs {
       countQuery
     );
 
-    this.webSocketsQueueService.add(
-      'sendMessage',
-      {
+    this.webSocketsQueueService.add({
+      name: 'sendMessage',
+      data: {
         event: isUnreadCountChanged ? WebSocketEventEnum.UNREAD : WebSocketEventEnum.UNSEEN,
         userId: subscriber._id,
         _environmentId: command.environmentId,
       },
-      subscriber._organizationId
-    );
+      groupId: subscriber._organizationId,
+    });
 
     this.analyticsService.track(
       `Mark all messages as ${command.markAs}- [Notification Center]`,

--- a/apps/api/src/app/widgets/usecases/mark-message-as/mark-message-as.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/mark-message-as/mark-message-as.usecase.ts
@@ -85,15 +85,15 @@ export class MarkMessageAs {
   private updateSocketCount(subscriber: SubscriberEntity, mark: MarkEnum) {
     const eventMessage = mark === MarkEnum.READ ? WebSocketEventEnum.UNREAD : WebSocketEventEnum.UNSEEN;
 
-    this.webSocketsQueueService.add(
-      'sendMessage',
-      {
+    this.webSocketsQueueService.add({
+      name: 'sendMessage',
+      data: {
         event: eventMessage,
         userId: subscriber._id,
         _environmentId: subscriber._environmentId,
       },
-      subscriber._organizationId
-    );
+      groupId: subscriber._organizationId,
+    });
   }
   @CachedEntity({
     builder: (command: { subscriberId: string; _environmentId: string }) =>

--- a/apps/api/src/app/widgets/usecases/remove-message/remove-message.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/remove-message/remove-message.usecase.ts
@@ -98,14 +98,14 @@ export class RemoveMessage {
   private updateSocketCount(subscriber: SubscriberEntity, mark: MarkEnum) {
     const eventMessage = mark === MarkEnum.READ ? WebSocketEventEnum.UNREAD : WebSocketEventEnum.UNSEEN;
 
-    this.webSocketsQueueService.add(
-      'sendMessage',
-      {
+    this.webSocketsQueueService.add({
+      name: 'sendMessage',
+      data: {
         event: eventMessage,
         userId: subscriber._id,
         _environmentId: subscriber._environmentId,
       },
-      subscriber._organizationId
-    );
+      groupId: subscriber._organizationId,
+    });
   }
 }

--- a/apps/api/src/app/widgets/usecases/remove-messages/remove-all-messages.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/remove-messages/remove-all-messages.usecase.ts
@@ -100,14 +100,14 @@ export class RemoveAllMessages {
   private updateSocketCount(subscriber: SubscriberEntity, mark: string) {
     const eventMessage = mark === MarkEnum.READ ? WebSocketEventEnum.UNREAD : WebSocketEventEnum.UNSEEN;
 
-    this.webSocketsQueueService.add(
-      'sendMessage',
-      {
+    this.webSocketsQueueService.add({
+      name: 'sendMessage',
+      data: {
         event: eventMessage,
         userId: subscriber._id,
         _environmentId: subscriber._environmentId,
       },
-      subscriber._organizationId
-    );
+      groupId: subscriber._organizationId,
+    });
   }
 }

--- a/apps/inbound-mail/src/server/inbound-mail.service.ts
+++ b/apps/inbound-mail/src/server/inbound-mail.service.ts
@@ -1,10 +1,4 @@
-import {
-  BullMqService,
-  InboundParseQueueService,
-  QueueBaseOptions,
-  WorkflowInMemoryProviderService,
-} from '@novu/application-generic';
-import { JobTopicNameEnum } from '@novu/shared';
+import { InboundParseQueueService, WorkflowInMemoryProviderService } from '@novu/application-generic';
 
 export class InboundMailService {
   public inboundParseQueueService: InboundParseQueueService;

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -364,7 +364,11 @@ class Mailin extends events.EventEmitter {
         const username: string = parts[0];
         const environmentId = username.split('-nv-e=').at(-1);
 
-        inboundMailService.inboundParseQueueService.add(finalizedMessage.messageId, finalizedMessage, environmentId);
+        inboundMailService.inboundParseQueueService.add({
+          name: finalizedMessage.messageId,
+          data: finalizedMessage,
+          groupId: environmentId,
+        });
 
         return resolve();
       });

--- a/apps/worker/src/app/workflow/services/active-jobs-metric.service.ts
+++ b/apps/worker/src/app/workflow/services/active-jobs-metric.service.ts
@@ -55,16 +55,21 @@ export class ActiveJobsMetricService {
         if (!exists) {
           Logger.debug(`metricJob doesn't exist, creating it`, LOG_CONTEXT);
 
-          return await this.activeJobsMetricQueueService.add(METRIC_JOB_ID, undefined, '', {
-            jobId: METRIC_JOB_ID,
-            repeatJobKey: METRIC_JOB_ID,
-            repeat: {
-              immediately: true,
-              pattern: '* * * * * *',
+          return await this.activeJobsMetricQueueService.add({
+            name: METRIC_JOB_ID,
+            data: undefined,
+            groupId: '',
+            options: {
+              jobId: METRIC_JOB_ID,
+              repeatJobKey: METRIC_JOB_ID,
+              repeat: {
+                immediately: true,
+                pattern: '* * * * * *',
+              },
+              removeOnFail: true,
+              removeOnComplete: true,
+              attempts: 1,
             },
-            removeOnFail: true,
-            removeOnComplete: true,
-            attempts: 1,
           });
         }
 

--- a/apps/worker/src/app/workflow/services/execution-log.worker.ts
+++ b/apps/worker/src/app/workflow/services/execution-log.worker.ts
@@ -14,6 +14,7 @@ import {
   WorkflowInMemoryProviderService,
 } from '@novu/application-generic';
 import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
+import { IExecutionLogJobDataDto } from '@novu/application-generic/build/main/dtos/execution-log-job.dto';
 const LOG_CONTEXT = 'ExecutionLogWorker';
 
 @Injectable()
@@ -31,7 +32,7 @@ export class ExecutionLogWorker extends ExecutionLogWorkerService {
   }
 
   private getWorkerProcessor(): WorkerProcessor {
-    return async ({ data }: { data: CreateExecutionDetailsCommand }) => {
+    return async ({ data }: { data: IExecutionLogJobDataDto }) => {
       return await new Promise(async (resolve, reject) => {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const _this = this;

--- a/apps/worker/src/app/workflow/services/standard.worker.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.ts
@@ -1,6 +1,7 @@
 const nr = require('newrelic');
 import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
-import { IJobData, ObservabilityBackgroundTransactionEnum } from '@novu/shared';
+
+import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
 import {
   BullMqService,
   getStandardWorkerOptions,
@@ -24,6 +25,7 @@ import {
   HandleLastFailedJobCommand,
   HandleLastFailedJob,
 } from '../usecases';
+import { IStandardDataDto } from '@novu/application-generic/build/main/dtos/standard-job.dto';
 
 const LOG_CONTEXT = 'StandardWorker';
 
@@ -43,7 +45,7 @@ export class StandardWorker extends StandardWorkerService {
 
     this.initWorker(this.getWorkerProcessor(), this.getWorkerOptions());
 
-    this.worker.on('failed', async (job: Job<IJobData, void, string>, error: Error): Promise<void> => {
+    this.worker.on('failed', async (job: Job<IStandardDataDto, void, string>, error: Error): Promise<void> => {
       await this.jobHasFailed(job, error);
     });
   }
@@ -57,22 +59,26 @@ export class StandardWorker extends StandardWorkerService {
     };
   }
 
-  private extractMinimalJobData(job: any): {
+  private extractMinimalJobData(data: IStandardDataDto): {
     environmentId: string;
-    organizationId: string;
     jobId: string;
+    organizationId: string;
     userId: string;
   } {
-    const { _environmentId: environmentId, _id: jobId, _organizationId: organizationId, _userId: userId } = job;
+    const { _environmentId: environmentId, _id: jobId, _organizationId: organizationId, _userId: userId } = data;
 
     if (!environmentId || !jobId || !organizationId || !userId) {
-      const message = job.payload.message;
+      const message = data.payload?.message;
+
+      if (!message) {
+        throw new Error('Job data is missing required fields' + JSON.stringify(data));
+      }
 
       return {
         environmentId: message._environmentId,
         jobId: message._jobId,
         organizationId: message._organizationId,
-        userId: job.userId,
+        userId: userId,
       };
     }
 
@@ -85,7 +91,7 @@ export class StandardWorker extends StandardWorkerService {
   }
 
   private getWorkerProcessor() {
-    return async ({ data }: { data: IJobData | any }) => {
+    return async ({ data }: { data: IStandardDataDto }) => {
       const minimalJobData = this.extractMinimalJobData(data);
 
       Logger.verbose(`Job ${minimalJobData.jobId} is being processed in the new instance standard worker`, LOG_CONTEXT);
@@ -123,7 +129,7 @@ export class StandardWorker extends StandardWorkerService {
     };
   }
 
-  private async jobHasCompleted(job: Job<IJobData, void, string>): Promise<void> {
+  private async jobHasCompleted(job: Job<IStandardDataDto, void, string>): Promise<void> {
     let jobId;
 
     try {
@@ -144,7 +150,7 @@ export class StandardWorker extends StandardWorkerService {
     }
   }
 
-  private async jobHasFailed(job: Job<IJobData, void, string>, error: Error): Promise<void> {
+  private async jobHasFailed(job: Job<IStandardDataDto, void, string>, error: Error): Promise<void> {
     let jobId;
 
     try {

--- a/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
+++ b/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
@@ -14,6 +14,7 @@ import {
   BullMqService,
   WorkflowInMemoryProviderService,
 } from '@novu/application-generic';
+import { IProcessSubscriberDataDto } from '@novu/application-generic/build/main/dtos/process-subscriber-job.dto';
 
 const LOG_CONTEXT = 'SubscriberProcessWorker';
 
@@ -29,7 +30,7 @@ export class SubscriberProcessWorker extends SubscriberProcessWorkerService impl
   }
 
   public getWorkerProcessor() {
-    return async ({ data }: { data: SubscriberJobBoundCommand }) => {
+    return async ({ data }: { data: IProcessSubscriberDataDto }) => {
       return await new Promise(async (resolve, reject) => {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const _this = this;

--- a/apps/worker/src/app/workflow/services/workflow.worker.spec.ts
+++ b/apps/worker/src/app/workflow/services/workflow.worker.spec.ts
@@ -69,9 +69,9 @@ describe('Workflow Worker', () => {
       _environmentId,
       _organizationId,
       _userId,
-    };
+    } as any;
 
-    await workflowQueueService.add(jobId, jobData, _organizationId);
+    await workflowQueueService.add({ name: jobId, data: jobData, groupId: _organizationId });
 
     expect(await workflowQueueService.queue.getActiveCount()).to.equal(1);
     expect(await workflowQueueService.queue.getWaitingCount()).to.equal(0);

--- a/apps/worker/src/app/workflow/services/workflow.worker.ts
+++ b/apps/worker/src/app/workflow/services/workflow.worker.ts
@@ -12,6 +12,7 @@ import {
   WorkerProcessor,
   BullMqService,
   WorkflowInMemoryProviderService,
+  IWorkflowDataDto,
 } from '@novu/application-generic';
 import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
 
@@ -33,7 +34,7 @@ export class WorkflowWorker extends WorkflowWorkerService {
   }
 
   private getWorkerProcessor(): WorkerProcessor {
-    return async ({ data }: { data: TriggerEventCommand }) => {
+    return async ({ data }: { data: IWorkflowDataDto }) => {
       return await new Promise(async (resolve, reject) => {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const _this = this;

--- a/apps/worker/src/app/workflow/usecases/handle-last-failed-job/handle-last-failed-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/handle-last-failed-job/handle-last-failed-job.usecase.ts
@@ -41,9 +41,9 @@ export class HandleLastFailedJob {
       throw new PlatformException(message);
     }
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
         detail: DetailEnum.WEBHOOK_FILTER_FAILED_LAST_RETRY,
@@ -53,8 +53,8 @@ export class HandleLastFailedJob {
         isRetry: true,
         raw: JSON.stringify({ message: JSON.parse(error.message).message }),
       }),
-      job._organizationId
-    );
+      groupId: job._organizationId,
+    });
 
     if (!job?.step?.shouldStopOnFail) {
       await this.queueNextJob.execute(

--- a/apps/worker/src/app/workflow/usecases/send-message/digest/digest.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/digest.usecase.ts
@@ -57,9 +57,9 @@ export class Digest extends SendMessageType {
     const events = await getEvents(command, currentJob);
     const nextJobs = await this.getJobsToUpdate(command);
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(currentJob),
         detail: DetailEnum.DIGEST_TRIGGERED_EVENTS,
@@ -69,8 +69,8 @@ export class Digest extends SendMessageType {
         isRetry: false,
         raw: JSON.stringify(events),
       }),
-      currentJob._organizationId
-    );
+      groupId: currentJob._organizationId,
+    });
 
     await this.jobRepository.update(
       {

--- a/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/get-digest-events.usecase.ts
@@ -42,9 +42,9 @@ export abstract class GetDigestEvents {
 
     if (!currentTrigger) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(currentJob),
           detail: DetailEnum.DIGEST_TRIGGERED_EVENTS,
@@ -53,8 +53,8 @@ export abstract class GetDigestEvents {
           isTest: false,
           isRetry: false,
         }),
-        currentJob._organizationId
-      );
+        groupId: currentJob._organizationId,
+      });
       const message = `Trigger job for jobId ${currentJob._id} is not found`;
       Logger.error(message, LOG_CONTEXT);
       throw new PlatformException(message);

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
@@ -98,9 +98,9 @@ export class SendMessageChat extends SendMessageBase {
 
     if (chatChannels.length === 0) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_CHANNEL,
@@ -109,8 +109,8 @@ export class SendMessageChat extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -131,9 +131,9 @@ export class SendMessageChat extends SendMessageBase {
 
     if (allFailed) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.CHAT_ALL_CHANNELS_FAILED,
@@ -142,8 +142,8 @@ export class SendMessageChat extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
     }
   }
 
@@ -170,9 +170,9 @@ export class SendMessageChat extends SendMessageBase {
 
     if (!chatWebhookUrl) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.CHAT_WEBHOOK_URL_MISSING,
@@ -184,8 +184,8 @@ export class SendMessageChat extends SendMessageBase {
             reason: `webhookUrl for integrationId: ${subscriberChannel?._integrationId} is missing`,
           }),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
     }
 
     const message: MessageEntity = await this.messageRepository.create({
@@ -205,9 +205,9 @@ export class SendMessageChat extends SendMessageBase {
 
     if (!integration) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_INTEGRATION,
@@ -219,8 +219,8 @@ export class SendMessageChat extends SendMessageBase {
             reason: `Integration with integrationId: ${subscriberChannel?._integrationId} is either deleted or not active`,
           }),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -228,9 +228,9 @@ export class SendMessageChat extends SendMessageBase {
     await this.sendSelectedIntegrationExecution(command.job, integration);
 
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
         detail: DetailEnum.MESSAGE_CREATED,
@@ -241,8 +241,8 @@ export class SendMessageChat extends SendMessageBase {
         isRetry: false,
         raw: this.storeContent() ? JSON.stringify(content) : null,
       }),
-      command.organizationId
-    );
+      groupId: command.organizationId,
+    });
 
     if (chatWebhookUrl && integration) {
       await this.sendMessage(chatWebhookUrl, integration, content, message, command, channelSpecification);
@@ -270,9 +270,9 @@ export class SendMessageChat extends SendMessageBase {
       );
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -285,8 +285,8 @@ export class SendMessageChat extends SendMessageBase {
             reason: `webhookUrl for integrationId: ${integration?.identifier} is missing`,
           }),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -300,9 +300,9 @@ export class SendMessageChat extends SendMessageBase {
         LogCodeEnum.MISSING_CHAT_INTEGRATION
       );
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -315,8 +315,8 @@ export class SendMessageChat extends SendMessageBase {
             reason: 'Integration is either deleted or not active',
           }),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -344,9 +344,9 @@ export class SendMessageChat extends SendMessageBase {
       });
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -357,8 +357,8 @@ export class SendMessageChat extends SendMessageBase {
           isRetry: false,
           raw: JSON.stringify(result),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
     } catch (e) {
       await this.sendErrorStatus(
         message,
@@ -371,9 +371,9 @@ export class SendMessageChat extends SendMessageBase {
       );
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -384,8 +384,8 @@ export class SendMessageChat extends SendMessageBase {
           isRetry: false,
           raw: JSON.stringify(e),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
     }
   }
 }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-delay.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-delay.usecase.ts
@@ -25,9 +25,9 @@ export class SendMessageDelay extends SendMessageType {
   @InstrumentUsecase()
   public async execute(command: SendMessageCommand) {
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
         detail: DetailEnum.DELAY_FINISHED,
@@ -36,7 +36,7 @@ export class SendMessageDelay extends SendMessageType {
         isTest: false,
         isRetry: false,
       }),
-      command.organizationId
-    );
+      groupId: command.organizationId,
+    });
   }
 }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -83,9 +83,9 @@ export class SendMessageEmail extends SendMessageBase {
       });
     } catch (e) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.LIMIT_PASSED_NOVU_INTEGRATION,
@@ -95,8 +95,8 @@ export class SendMessageEmail extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -115,9 +115,9 @@ export class SendMessageEmail extends SendMessageBase {
 
     if (!integration) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_INTEGRATION,
@@ -133,8 +133,8 @@ export class SendMessageEmail extends SendMessageBase {
               }
             : {}),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -241,9 +241,9 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
         detail: DetailEnum.MESSAGE_CREATED,
@@ -254,8 +254,8 @@ export class SendMessageEmail extends SendMessageBase {
         isRetry: false,
         raw: this.storeContent() ? JSON.stringify(payload) : null,
       }),
-      command.organizationId
-    );
+      groupId: command.organizationId,
+    });
 
     const attachments = (<IAttachmentOptions[]>command.payload.attachments)?.map(
       (attachment) =>
@@ -305,9 +305,9 @@ export class SendMessageEmail extends SendMessageBase {
   private async getReplyTo(command: SendMessageCommand, messageId: string): Promise<string | null> {
     if (!command.step.replyCallback?.url) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: messageId,
@@ -317,8 +317,8 @@ export class SendMessageEmail extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return null;
     }
@@ -339,9 +339,9 @@ export class SendMessageEmail extends SendMessageBase {
           : DetailEnum.REPLY_CALLBACK_MISSING_MX_ROUTE_DOMAIN_CONFIGURATION;
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: messageId,
@@ -351,8 +351,8 @@ export class SendMessageEmail extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return null;
     }
@@ -376,9 +376,9 @@ export class SendMessageEmail extends SendMessageBase {
       );
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -388,8 +388,8 @@ export class SendMessageEmail extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -407,9 +407,9 @@ export class SendMessageEmail extends SendMessageBase {
       );
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -419,8 +419,8 @@ export class SendMessageEmail extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -441,9 +441,9 @@ export class SendMessageEmail extends SendMessageBase {
       Logger.verbose({ command }, 'Email message has been sent', LOG_CONTEXT);
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -454,8 +454,8 @@ export class SendMessageEmail extends SendMessageBase {
           isRetry: false,
           raw: JSON.stringify(result),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       Logger.verbose({ command }, 'Execution details of sending an email message have been stored', LOG_CONTEXT);
 
@@ -483,9 +483,9 @@ export class SendMessageEmail extends SendMessageBase {
       );
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -496,8 +496,8 @@ export class SendMessageEmail extends SendMessageBase {
           isRetry: false,
           raw: JSON.stringify(error),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -516,9 +516,9 @@ export class SendMessageEmail extends SendMessageBase {
       );
       if (!layoutOverride) {
         const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-        await this.executionLogQueueService.add(
-          metadata._id,
-          CreateExecutionDetailsCommand.create({
+        await this.executionLogQueueService.add({
+          name: metadata._id,
+          data: CreateExecutionDetailsCommand.create({
             ...metadata,
             ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
             detail: DetailEnum.LAYOUT_NOT_FOUND,
@@ -530,8 +530,8 @@ export class SendMessageEmail extends SendMessageBase {
               layoutIdentifier: overrideLayoutIdentifier,
             }),
           }),
-          command.organizationId
-        );
+          groupId: command.organizationId,
+        });
       }
 
       return layoutOverride?._id;

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
@@ -86,9 +86,9 @@ export class SendMessageInApp extends SendMessageBase {
 
     if (!integration) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_INTEGRATION,
@@ -97,8 +97,8 @@ export class SendMessageInApp extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -221,9 +221,9 @@ export class SendMessageInApp extends SendMessageBase {
     if (!message) throw new PlatformException('Message not found');
 
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
         ...metadata,
         messageId: message._id,
@@ -234,8 +234,8 @@ export class SendMessageInApp extends SendMessageBase {
         isTest: false,
         isRetry: false,
       }),
-      command.organizationId
-    );
+      groupId: command.organizationId,
+    });
 
     await this.webSocketsQueueService.bullMqService.add(
       'sendMessage',
@@ -255,9 +255,9 @@ export class SendMessageInApp extends SendMessageBase {
     );
 
     const meta = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      meta._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: meta._id,
+      data: CreateExecutionDetailsCommand.create({
         ...meta,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
         messageId: message._id,
@@ -268,8 +268,8 @@ export class SendMessageInApp extends SendMessageBase {
         isTest: false,
         isRetry: false,
       }),
-      command.organizationId
-    );
+      groupId: command.organizationId,
+    });
   }
 
   private async compileInAppTemplate(

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
@@ -208,9 +208,9 @@ export class SendMessagePush extends SendMessageBase {
 
   private async sendNotificationError(job: JobEntity): Promise<void> {
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
         detail: DetailEnum.NOTIFICATION_ERROR,
@@ -219,8 +219,8 @@ export class SendMessagePush extends SendMessageBase {
         isTest: false,
         isRetry: false,
       }),
-      job._organizationId
-    );
+      groupId: job._organizationId,
+    });
   }
 
   private async sendPushMissingDeviceTokensError(job: JobEntity, channel: IChannelSettings): Promise<void> {
@@ -255,9 +255,9 @@ export class SendMessagePush extends SendMessageBase {
     // We avoid to throw the errors to be able to execute all actions in the loop
     try {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
           ...metadata,
           detail,
@@ -269,8 +269,8 @@ export class SendMessagePush extends SendMessageBase {
           ...(contextData?.messageId && { messageId: contextData.messageId }),
           ...(contextData?.raw && { raw: contextData.raw }),
         }),
-        job._organizationId
-      );
+        groupId: job._organizationId,
+      });
     } catch (error) {}
   }
 
@@ -299,9 +299,9 @@ export class SendMessagePush extends SendMessageBase {
       });
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -312,8 +312,8 @@ export class SendMessagePush extends SendMessageBase {
           isRetry: false,
           raw: JSON.stringify({ result, deviceToken }),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return true;
     } catch (e) {
@@ -362,9 +362,9 @@ export class SendMessagePush extends SendMessageBase {
     });
 
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
         detail: `${DetailEnum.MESSAGE_CREATED}: ${integration.providerId}`,
@@ -375,8 +375,8 @@ export class SendMessagePush extends SendMessageBase {
         isRetry: false,
         raw: this.storeContent() ? JSON.stringify(content) : null,
       }),
-      command.organizationId
-    );
+      groupId: command.organizationId,
+    });
 
     return message;
   }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
@@ -104,9 +104,9 @@ export class SendMessageSms extends SendMessageBase {
 
     if (!integration) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.SUBSCRIBER_NO_ACTIVE_INTEGRATION,
@@ -122,8 +122,8 @@ export class SendMessageSms extends SendMessageBase {
               }
             : {}),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -157,9 +157,9 @@ export class SendMessageSms extends SendMessageBase {
     });
 
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
         detail: DetailEnum.MESSAGE_CREATED,
@@ -170,8 +170,8 @@ export class SendMessageSms extends SendMessageBase {
         isRetry: false,
         raw: this.storeContent() ? JSON.stringify(messagePayload) : null,
       }),
-      command.organizationId
-    );
+      groupId: command.organizationId,
+    });
 
     if (phone && integration) {
       await this.sendMessage(phone, integration, content, message, command, overrides);
@@ -194,9 +194,9 @@ export class SendMessageSms extends SendMessageBase {
       );
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -206,8 +206,8 @@ export class SendMessageSms extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -222,9 +222,9 @@ export class SendMessageSms extends SendMessageBase {
       );
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -234,8 +234,8 @@ export class SendMessageSms extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -249,9 +249,9 @@ export class SendMessageSms extends SendMessageBase {
         LogCodeEnum.MISSING_SMS_PROVIDER
       );
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -261,8 +261,8 @@ export class SendMessageSms extends SendMessageBase {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       return;
     }
@@ -291,9 +291,9 @@ export class SendMessageSms extends SendMessageBase {
       });
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -304,8 +304,8 @@ export class SendMessageSms extends SendMessageBase {
           isRetry: false,
           raw: JSON.stringify(result),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
 
       if (!result?.id) {
         return;
@@ -331,9 +331,9 @@ export class SendMessageSms extends SendMessageBase {
       );
 
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           messageId: message._id,
@@ -344,8 +344,8 @@ export class SendMessageSms extends SendMessageBase {
           isRetry: false,
           raw: JSON.stringify(e),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
     }
   }
 

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.base.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.base.ts
@@ -70,9 +70,9 @@ export abstract class SendMessageBase extends SendMessageType {
 
   protected async sendErrorHandlebars(job: JobEntity, error: string) {
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
         detail: DetailEnum.MESSAGE_CONTENT_NOT_GENERATED,
@@ -82,15 +82,15 @@ export abstract class SendMessageBase extends SendMessageType {
         isRetry: false,
         raw: JSON.stringify({ error }),
       }),
-      job._organizationId
-    );
+      groupId: job._organizationId,
+    });
   }
 
   protected async sendSelectedIntegrationExecution(job: JobEntity, integration: IntegrationEntity) {
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
         detail: DetailEnum.INTEGRATION_INSTANCE_SELECTED,
@@ -106,8 +106,8 @@ export abstract class SendMessageBase extends SendMessageType {
           _id: integration?._id,
         }),
       }),
-      job._organizationId
-    );
+      groupId: job._organizationId,
+    });
   }
 
   protected async processVariants(command: SendMessageCommand): Promise<IMessageTemplate> {
@@ -124,9 +124,9 @@ export abstract class SendMessageBase extends SendMessageType {
 
     if (conditions) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.VARIANT_CHOSEN,
@@ -136,8 +136,8 @@ export abstract class SendMessageBase extends SendMessageType {
           isRetry: false,
           raw: JSON.stringify({ conditions }),
         }),
-        command.job._organizationId
-      );
+        groupId: command.job._organizationId,
+      });
     }
 
     return messageTemplate;

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -126,9 +126,9 @@ export class SendMessage {
 
     if (stepType !== StepTypeEnum.DELAY) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: stepType === StepTypeEnum.DIGEST ? DetailEnum.START_DIGESTING : DetailEnum.START_SENDING,
@@ -137,8 +137,8 @@ export class SendMessage {
           isTest: false,
           isRetry: false,
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
     }
 
     const sendMessageCommand = SendMessageCommand.create({ ...command, compileContext: payload });
@@ -176,9 +176,9 @@ export class SendMessage {
 
     if (!shouldRun.passed) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
           detail: DetailEnum.FILTER_STEPS,
@@ -190,8 +190,8 @@ export class SendMessage {
             conditions: shouldRun.conditions,
           }),
         }),
-        command.organizationId
-      );
+        groupId: command.organizationId,
+      });
     }
 
     return shouldRun;
@@ -229,9 +229,9 @@ export class SendMessage {
 
     if (!globalPreferenceResult) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
           detail: DetailEnum.STEP_FILTERED_BY_GLOBAL_PREFERENCES,
@@ -241,8 +241,8 @@ export class SendMessage {
           isRetry: false,
           raw: JSON.stringify(globalPreference),
         }),
-        job._organizationId
-      );
+        groupId: job._organizationId,
+      });
 
       return false;
     }
@@ -262,9 +262,9 @@ export class SendMessage {
 
     if (!result) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
           detail: DetailEnum.STEP_FILTERED_BY_PREFERENCES,
@@ -274,8 +274,8 @@ export class SendMessage {
           isRetry: false,
           raw: JSON.stringify(preference),
         }),
-        job._organizationId
-      );
+        groupId: job._organizationId,
+      });
     }
 
     return result;
@@ -361,9 +361,9 @@ export class SendMessage {
 
   protected async sendSelectedTenantExecution(job: JobEntity, tenant: TenantEntity) {
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
         detail: DetailEnum.TENANT_CONTEXT_SELECTED,
@@ -381,8 +381,8 @@ export class SendMessage {
           _id: tenant?._id,
         }),
       }),
-      job._organizationId
-    );
+      groupId: job._organizationId,
+    });
   }
 
   protected async handleTenantExecution(job: JobEntity): Promise<TenantEntity | null> {
@@ -396,9 +396,9 @@ export class SendMessage {
       });
       if (!tenant) {
         const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-        await this.executionLogQueueService.add(
-          metadata._id,
-          CreateExecutionDetailsCommand.create({
+        await this.executionLogQueueService.add({
+          name: metadata._id,
+          data: CreateExecutionDetailsCommand.create({
             ...metadata,
             ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
             detail: DetailEnum.TENANT_NOT_FOUND,
@@ -410,8 +410,8 @@ export class SendMessage {
               tenantIdentifier: tenantIdentifier,
             }),
           }),
-          job._organizationId
-        );
+          groupId: job._organizationId,
+        });
 
         return null;
       }

--- a/apps/worker/src/app/workflow/usecases/webhook-filter-backoff-strategy/webhook-filter-backoff-strategy.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/webhook-filter-backoff-strategy/webhook-filter-backoff-strategy.usecase.ts
@@ -14,9 +14,9 @@ export class WebhookFilterBackoffStrategy {
 
     try {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
           detail: DetailEnum.WEBHOOK_FILTER_FAILED_RETRY,
@@ -26,8 +26,8 @@ export class WebhookFilterBackoffStrategy {
           isRetry: true,
           raw: JSON.stringify({ message: JSON.parse(error?.message).message, attempt: attemptsMade }),
         }),
-        job._organizationId
-      );
+        groupId: job._organizationId,
+      });
     } catch (anotherError) {
       Logger.error(
         anotherError,

--- a/apps/ws/src/socket/services/web-socket.worker.ts
+++ b/apps/ws/src/socket/services/web-socket.worker.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import {
   BullMqService,
   getWebSocketWorkerOptions,
+  IWebSocketDataDto,
   WebSocketsWorkerService,
   WorkerOptions,
   WorkflowInMemoryProviderService,
@@ -41,14 +42,16 @@ export class WebSocketWorker extends WebSocketsWorkerService {
           'WS Service',
           function () {
             const transaction = nr.getTransaction();
+            const { data: jobData } = job;
+            const data: IWebSocketDataDto = jobData;
 
             _this.externalServicesRoute
               .execute(
                 ExternalServicesRouteCommand.create({
-                  userId: job.data.userId,
-                  event: job.data.event,
-                  payload: job.data.payload,
-                  _environmentId: job.data._environmentId,
+                  userId: data.userId,
+                  event: data.event,
+                  payload: data.payload,
+                  _environmentId: data._environmentId,
                 })
               )
               .then(resolve)

--- a/packages/application-generic/src/dtos/execution-log-job.dto.ts
+++ b/packages/application-generic/src/dtos/execution-log-job.dto.ts
@@ -1,0 +1,63 @@
+import {
+  ExecutionDetailsSourceEnum,
+  ExecutionDetailsStatusEnum,
+  StepTypeEnum,
+} from '@novu/shared';
+import { EmailEventStatusEnum, SmsEventStatusEnum } from '@novu/stateless';
+
+import {
+  IBulkJobParams,
+  IJobParams,
+} from '../services/queues/queue-base.service';
+
+export interface IExecutionLogJobDataDto {
+  environmentId: string;
+
+  organizationId: string;
+
+  subscriberId: string;
+
+  jobId?: string;
+
+  notificationId: string;
+
+  notificationTemplateId?: string;
+
+  messageId?: string;
+
+  providerId?: string;
+
+  expireAt?: string;
+
+  transactionId: string;
+
+  channel?: StepTypeEnum;
+
+  detail: string;
+
+  source: ExecutionDetailsSourceEnum;
+
+  status: ExecutionDetailsStatusEnum;
+
+  isTest: boolean;
+
+  isRetry: boolean;
+
+  raw?: string | null;
+
+  _subscriberId?: string;
+
+  _id?: string;
+
+  createdAt?: Date;
+
+  webhookStatus?: EmailEventStatusEnum | SmsEventStatusEnum;
+}
+
+export interface IExecutionLogJobDto extends IJobParams {
+  data?: IExecutionLogJobDataDto;
+}
+
+export interface IExecutionLogBulkJobDto extends IBulkJobParams {
+  data: IExecutionLogJobDataDto;
+}

--- a/packages/application-generic/src/dtos/inbound-parse-job.dto.ts
+++ b/packages/application-generic/src/dtos/inbound-parse-job.dto.ts
@@ -1,0 +1,100 @@
+import {
+  IBulkJobParams,
+  IJobParams,
+} from '../services/queues/queue-base.service';
+
+export interface IInboundParseDataDto {
+  html: string;
+  text: string;
+  headers: IHeaders;
+  subject: string;
+  messageId: string;
+  priority: string;
+  from: IFrom[];
+  to: ITo[];
+  date: Date;
+  dkim: string;
+  spf: string;
+  spamScore: number;
+  language: string;
+  cc: any[];
+  attachments?: any[];
+  connection: IConnection;
+  envelopeFrom: IEnvelopeFrom;
+  envelopeTo: IEnvelopeTo[];
+}
+
+export interface IHeaders {
+  'content-type': string;
+  from: string;
+  to: string;
+  subject: string;
+  'message-id': string;
+  date: string;
+  'mime-version': string;
+}
+
+export interface IFrom {
+  address: string;
+  name: string;
+}
+
+export interface ITo {
+  address: string;
+  name: string;
+}
+
+export interface ITlsOptions {
+  name: string;
+  standardName: string;
+  version: string;
+}
+
+export interface IMailFrom {
+  address: string;
+  args: boolean;
+}
+
+export interface IRcptTo {
+  address: string;
+  args: boolean;
+}
+
+export interface IEnvelope {
+  mailFrom: IMailFrom;
+  rcptTo: IRcptTo[];
+}
+
+export interface IConnection {
+  id: string;
+  remoteAddress: string;
+  remotePort: number;
+  clientHostname: string;
+  openingCommand: string;
+  hostNameAppearsAs: string;
+  xClient: any;
+  xForward: any;
+  transmissionType: string;
+  tlsOptions: ITlsOptions;
+  envelope: IEnvelope;
+  transaction: number;
+  mailPath: string;
+}
+
+export interface IEnvelopeFrom {
+  address: string;
+  args: boolean;
+}
+
+export interface IEnvelopeTo {
+  address: string;
+  args: boolean;
+}
+
+export interface IInboundParseJobDto extends IJobParams {
+  data?: IInboundParseDataDto;
+}
+
+export interface IInboundParseBulkJobDto extends IBulkJobParams {
+  data: IInboundParseDataDto;
+}

--- a/packages/application-generic/src/dtos/index.ts
+++ b/packages/application-generic/src/dtos/index.ts
@@ -1,0 +1,5 @@
+export * from './inbound-parse-job.dto';
+export * from './process-subscriber-job.dto';
+export * from './standard-job.dto';
+export * from './web-sockets-job.dto';
+export * from './workflow-job.dto';

--- a/packages/application-generic/src/dtos/process-subscriber-job.dto.ts
+++ b/packages/application-generic/src/dtos/process-subscriber-job.dto.ts
@@ -1,0 +1,29 @@
+import { ISubscribersDefine, ITenantDefine } from '@novu/shared';
+import { SubscriberEntity } from '@novu/dal';
+
+import {
+  IBulkJobParams,
+  IJobParams,
+} from '../services/queues/queue-base.service';
+
+export interface IProcessSubscriberDataDto {
+  environmentId: string;
+  organizationId: string;
+  userId: string;
+  transactionId: string;
+  identifier: string;
+  payload: any;
+  overrides: Record<string, Record<string, unknown>>;
+  tenant?: ITenantDefine | null;
+  actor?: SubscriberEntity;
+  subscriber: ISubscribersDefine;
+  templateId: string;
+}
+
+export interface IProcessSubscriberJobDto extends IJobParams {
+  data?: IProcessSubscriberDataDto;
+}
+
+export interface IProcessSubscriberBulkJobDto extends IBulkJobParams {
+  data: IProcessSubscriberDataDto;
+}

--- a/packages/application-generic/src/dtos/standard-job.dto.ts
+++ b/packages/application-generic/src/dtos/standard-job.dto.ts
@@ -1,0 +1,23 @@
+import { IJobParams } from '../services/queues/queue-base.service';
+
+export class IStandardDataDto {
+  _userId: string;
+  _environmentId: string;
+  _organizationId: string;
+  _id: string;
+  /*
+   * payload is deprecated - todo remove 'payload' once the queue renewed
+   * payload was added due backwards compatibility, the legacy use is in standard-worker
+   */
+  payload?: {
+    message: {
+      _jobId: string;
+      _environmentId: string;
+      _organizationId: string;
+    };
+  };
+}
+
+export interface IStandardJobDto extends IJobParams {
+  data?: IStandardDataDto;
+}

--- a/packages/application-generic/src/dtos/web-sockets-job.dto.ts
+++ b/packages/application-generic/src/dtos/web-sockets-job.dto.ts
@@ -1,0 +1,30 @@
+import { WebSocketEventEnum } from '@novu/shared';
+
+import {
+  IBulkJobParams,
+  IJobParams,
+} from '../services/queues/queue-base.service';
+import { JobsOptions } from '../services/bull-mq';
+
+export interface IWebSocketDataDto {
+  event: WebSocketEventEnum;
+  userId: string;
+  _environmentId: string;
+  _organizationId?: string;
+  payload?: { messageId: string };
+}
+
+export interface IWebSocketJob extends IJobParams {
+  name: string;
+  data: any;
+  groupId?: string;
+  options?: JobsOptions;
+}
+
+export interface IWebSocketJobDto extends IWebSocketJob {
+  data: IWebSocketDataDto;
+}
+
+export interface IWebSocketBulkJobDto extends IBulkJobParams {
+  data: IWebSocketDataDto;
+}

--- a/packages/application-generic/src/dtos/workflow-job.dto.ts
+++ b/packages/application-generic/src/dtos/workflow-job.dto.ts
@@ -1,0 +1,42 @@
+import {
+  AddressingTypeEnum,
+  TriggerRecipients,
+  TriggerRecipientsPayload,
+  TriggerRecipientSubscriber,
+  TriggerTenantContext,
+} from '@novu/shared';
+import {
+  IBulkJobParams,
+  IJobParams,
+} from '../services/queues/queue-base.service';
+
+export type AddressingBroadcast = {
+  addressingType: AddressingTypeEnum.BROADCAST;
+};
+
+export type AddressingMulticast = {
+  to: TriggerRecipientsPayload;
+  addressingType: AddressingTypeEnum.MULTICAST;
+};
+
+type Addressing = AddressingBroadcast | AddressingMulticast;
+
+export type IWorkflowDataDto = {
+  environmentId: string;
+  organizationId: string;
+  userId: string;
+  identifier: string;
+  payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  overrides: Record<string, Record<string, unknown>>;
+  transactionId: string;
+  actor?: TriggerRecipientSubscriber | null;
+  tenant?: TriggerTenantContext | null;
+} & Addressing;
+
+export interface IWorkflowJobDto extends IJobParams {
+  data?: IWorkflowDataDto;
+}
+
+export interface IWorkflowBulkJobDto extends IBulkJobParams {
+  data: IWorkflowDataDto;
+}

--- a/packages/application-generic/src/index.ts
+++ b/packages/application-generic/src/index.ts
@@ -19,3 +19,4 @@ export * from './utils/digest';
 export * from './utils/object';
 export * from './decorators/external-api.decorator';
 export * from './decorators/user-session.decorator';
+export * from './dtos';

--- a/packages/application-generic/src/services/bull-mq/bull-mq.service.ts
+++ b/packages/application-generic/src/services/bull-mq/bull-mq.service.ts
@@ -193,7 +193,7 @@ export class BullMqService {
     data: {
       name: string;
       data: BullMqJobData;
-      options: BulkJobOptions;
+      options?: BulkJobOptions;
       groupId?: string;
     }[]
   ) {

--- a/packages/application-generic/src/services/queues/execution-log-queue.service.ts
+++ b/packages/application-generic/src/services/queues/execution-log-queue.service.ts
@@ -4,6 +4,14 @@ import { JobTopicNameEnum } from '@novu/shared';
 import { QueueBaseService } from './queue-base.service';
 import { BullMqService } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
+import {
+  IProcessSubscriberBulkJobDto,
+  IProcessSubscriberJobDto,
+} from '../../dtos';
+import {
+  IExecutionLogBulkJobDto,
+  IExecutionLogJobDto,
+} from '../../dtos/execution-log-job.dto';
 
 const LOG_CONTEXT = 'ExecutionLogQueueService';
 
@@ -20,5 +28,13 @@ export class ExecutionLogQueueService extends QueueBaseService {
     Logger.log(`Creating queue ${this.topic}`, LOG_CONTEXT);
 
     this.createQueue();
+  }
+
+  public async add(data: IExecutionLogJobDto) {
+    return await super.add(data);
+  }
+
+  public async addBulk(data: IExecutionLogBulkJobDto[]) {
+    return await super.addBulk(data);
   }
 }

--- a/packages/application-generic/src/services/queues/inbound-parse-queue.service.spec.ts
+++ b/packages/application-generic/src/services/queues/inbound-parse-queue.service.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import { InboundParseQueueService } from './inbound-parse-queue.service';
 import { BullMqService } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
+import { IHeaders, IInboundParseJobDto } from '../../dtos';
 
 let inboundParseQueueService: InboundParseQueueService;
 
@@ -59,17 +60,19 @@ describe('Inbound Parse Queue service', () => {
 
     it('should add a job in the queue', async () => {
       const jobId = 'inbound-parse-mail-job-id';
-      const _environmentId = 'inbound-parse-mail-environment-id';
       const _organizationId = 'inbound-parse-mail-organization-id';
-      const _userId = 'inbound-parse-mail-user-id';
       const jobData = {
-        _id: jobId,
-        test: 'inbound-parse-mail-job-data',
-        _environmentId,
-        _organizationId,
-        _userId,
+        html: '<>Hello World</>',
+        text: 'text',
+        subject: 'subject',
+        messageId: '123',
       };
-      await inboundParseQueueService.add(jobId, jobData, _organizationId);
+
+      await inboundParseQueueService.add({
+        name: jobId,
+        data: jobData as any,
+        groupId: _organizationId,
+      });
 
       expect(await inboundParseQueueService.queue.getActiveCount()).toEqual(0);
       expect(await inboundParseQueueService.queue.getWaitingCount()).toEqual(1);
@@ -94,17 +97,17 @@ describe('Inbound Parse Queue service', () => {
       const _organizationId = 'inbound-parse-mail-organization-id';
       const _userId = 'inbound-parse-mail-user-id';
       const jobData = {
-        _id: jobId,
-        test: 'inbound-parse-mail-job-data-2',
-        _environmentId,
-        _organizationId,
-        _userId,
+        html: '<>Hello World</>',
+        text: 'text',
+        subject: 'subject',
+        messageId: '123',
       };
-      await inboundParseQueueService.addMinimalJob(
-        jobId,
-        jobData,
-        _organizationId
-      );
+
+      await inboundParseQueueService.addMinimalJob({
+        name: jobId,
+        data: jobData as any,
+        groupId: _organizationId,
+      });
 
       expect(await inboundParseQueueService.queue.getActiveCount()).toEqual(0);
       expect(await inboundParseQueueService.queue.getWaitingCount()).toEqual(1);

--- a/packages/application-generic/src/services/queues/inbound-parse-queue.service.ts
+++ b/packages/application-generic/src/services/queues/inbound-parse-queue.service.ts
@@ -5,6 +5,10 @@ import { QueueBaseService } from './queue-base.service';
 
 import { BullMqService, QueueOptions } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
+import {
+  IInboundParseBulkJobDto,
+  IInboundParseJobDto,
+} from '../../dtos/inbound-parse-job.dto';
 
 const LOG_CONTEXT = 'InboundParseQueueService';
 
@@ -21,6 +25,14 @@ export class InboundParseQueueService extends QueueBaseService {
     Logger.log(`Creating queue ${this.topic}`, LOG_CONTEXT);
 
     this.createQueue(this.getOverrideOptions());
+  }
+
+  public async add(data: IInboundParseJobDto) {
+    return await super.add(data);
+  }
+
+  public async addBulk(data: IInboundParseBulkJobDto[]) {
+    return await super.addBulk(data);
   }
 
   private getOverrideOptions(): QueueOptions {

--- a/packages/application-generic/src/services/queues/queue-base.service.ts
+++ b/packages/application-generic/src/services/queues/queue-base.service.ts
@@ -1,4 +1,4 @@
-import { JobTopicNameEnum } from '@novu/shared';
+import { IJobData, JobTopicNameEnum } from '@novu/shared';
 import { Logger } from '@nestjs/common';
 
 import {
@@ -66,56 +66,64 @@ export class QueueBaseService {
     );
   }
 
-  public async addMinimalJob(
-    id: string,
-    data?: any,
-    groupId?: string,
-    options: JobsOptions = {}
-  ) {
-    const jobData = data
+  public async addMinimalJob(params: IJobParams) {
+    const { name, groupId, data, options } = params;
+
+    const jobData: IJobData = data
       ? {
           _environmentId: data._environmentId,
-          _id: id,
+          _id: data._id,
           _organizationId: data._organizationId,
           _userId: data._userId,
         }
       : undefined;
 
-    await this.add(id, jobData, groupId, {
-      removeOnComplete: true,
-      removeOnFail: true,
-      ...options,
-    });
+    await this.instance.add(
+      name,
+      jobData,
+      {
+        removeOnComplete: true,
+        removeOnFail: true,
+        ...options,
+      },
+      groupId
+    );
   }
 
-  public async add(
-    name: string,
-    data?: any,
-    groupId?: string,
-    options: JobsOptions = {}
-  ) {
+  public async add(params: IJobParams) {
     const jobOptions = {
       removeOnComplete: true,
       removeOnFail: true,
-      ...options,
+      ...params.options,
     };
 
-    await this.instance.add(name, data, jobOptions, groupId);
+    await this.instance.add(
+      params.name,
+      params.data,
+      jobOptions,
+      params.groupId
+    );
   }
-  public async addBulk(
-    data: [
-      {
-        name: string;
-        data: any;
-        options: BulkJobOptions;
-        groupId?: string;
-      }
-    ]
-  ) {
+
+  public async addBulk(data: IBulkJobParams[]) {
     await this.instance.addBulk(data);
   }
 
   async onModuleDestroy(): Promise<void> {
     await this.gracefulShutdown();
   }
+}
+
+export interface IJobParams {
+  name: string;
+  data?: any;
+  groupId?: string;
+  options?: JobsOptions;
+}
+
+export interface IBulkJobParams {
+  name: string;
+  data: any;
+  groupId?: string;
+  options?: BulkJobOptions;
 }

--- a/packages/application-generic/src/services/queues/standard-queue.service.spec.ts
+++ b/packages/application-generic/src/services/queues/standard-queue.service.spec.ts
@@ -69,7 +69,12 @@ describe('Standard Queue service', () => {
         _organizationId,
         _userId,
       };
-      await standardQueueService.add(jobId, jobData, _organizationId);
+
+      await standardQueueService.add({
+        name: jobId,
+        data: jobData,
+        groupId: _organizationId,
+      });
 
       expect(await standardQueueService.queue.getActiveCount()).toEqual(0);
       expect(await standardQueueService.queue.getWaitingCount()).toEqual(1);
@@ -99,7 +104,12 @@ describe('Standard Queue service', () => {
         _organizationId,
         _userId,
       };
-      await standardQueueService.addMinimalJob(jobId, jobData, _organizationId);
+
+      await standardQueueService.addMinimalJob({
+        name: jobId,
+        data: jobData,
+        groupId: _organizationId,
+      });
 
       expect(await standardQueueService.queue.getActiveCount()).toEqual(0);
       expect(await standardQueueService.queue.getWaitingCount()).toEqual(1);

--- a/packages/application-generic/src/services/queues/standard-queue.service.ts
+++ b/packages/application-generic/src/services/queues/standard-queue.service.ts
@@ -4,6 +4,7 @@ import { JobTopicNameEnum } from '@novu/shared';
 import { QueueBaseService } from './queue-base.service';
 import { BullMqService } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
+import { IStandardJobDto } from '../../dtos/standard-job.dto';
 
 const LOG_CONTEXT = 'StandardQueueService';
 
@@ -20,5 +21,19 @@ export class StandardQueueService extends QueueBaseService {
     Logger.log(`Creating queue ${this.topic}`, LOG_CONTEXT);
 
     this.createQueue();
+  }
+
+  public async addMinimalJob(data: IStandardJobDto) {
+    return await super.addMinimalJob(data);
+  }
+
+  public async add(data: unknown) {
+    // in order to implement we need to know what should be the data dto first
+    throw new Error('Not implemented');
+  }
+
+  public async addBulk(data: unknown[]) {
+    // in order to implement we need to know what should be the data dto first
+    throw new Error('Not implemented');
   }
 }

--- a/packages/application-generic/src/services/queues/subscriber-process-queue.service.ts
+++ b/packages/application-generic/src/services/queues/subscriber-process-queue.service.ts
@@ -4,7 +4,10 @@ import { JobTopicNameEnum } from '@novu/shared';
 import { QueueBaseService } from './queue-base.service';
 import { BullMqService } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
-import { AuthService } from '../auth';
+import {
+  IProcessSubscriberBulkJobDto,
+  IProcessSubscriberJobDto,
+} from '../../dtos/process-subscriber-job.dto';
 
 @Injectable()
 export class SubscriberProcessQueueService extends QueueBaseService {
@@ -21,5 +24,13 @@ export class SubscriberProcessQueueService extends QueueBaseService {
     Logger.log(`Creating queue ${this.topic}`, this.LOG_CONTEXT);
 
     this.createQueue();
+  }
+
+  public async add(data: IProcessSubscriberJobDto) {
+    return await super.add(data);
+  }
+
+  public async addBulk(data: IProcessSubscriberBulkJobDto[]) {
+    return await super.addBulk(data);
   }
 }

--- a/packages/application-generic/src/services/queues/web-sockets-queue.service.spec.ts
+++ b/packages/application-generic/src/services/queues/web-sockets-queue.service.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import { WebSocketsQueueService } from './web-sockets-queue.service';
 import { BullMqService } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
+import { IWebSocketJobDto } from '../../dtos';
 
 let webSocketsQueueService: WebSocketsQueueService;
 
@@ -53,12 +54,16 @@ describe('WebSockets Queue service', () => {
       const _userId = 'web-sockets-queue-user-id';
       const jobData = {
         _id: jobId,
-        test: 'web-sockets-queue-job-data',
         _environmentId,
         _organizationId,
         _userId,
-      };
-      await webSocketsQueueService.add(jobId, jobData, _organizationId);
+      } as any;
+
+      await webSocketsQueueService.add({
+        name: jobId,
+        data: jobData,
+        groupId: _organizationId,
+      });
 
       expect(await webSocketsQueueService.queue.getActiveCount()).toEqual(0);
       expect(await webSocketsQueueService.queue.getWaitingCount()).toEqual(1);
@@ -88,11 +93,12 @@ describe('WebSockets Queue service', () => {
         _organizationId,
         _userId,
       };
-      await webSocketsQueueService.addMinimalJob(
-        jobId,
-        jobData,
-        _organizationId
-      );
+
+      await webSocketsQueueService.addMinimalJob({
+        name: jobId,
+        data: jobData,
+        groupId: _organizationId,
+      });
 
       expect(await webSocketsQueueService.queue.getActiveCount()).toEqual(0);
       expect(await webSocketsQueueService.queue.getWaitingCount()).toEqual(1);

--- a/packages/application-generic/src/services/queues/web-sockets-queue.service.ts
+++ b/packages/application-generic/src/services/queues/web-sockets-queue.service.ts
@@ -4,6 +4,10 @@ import { JobTopicNameEnum } from '@novu/shared';
 import { QueueBaseService } from './queue-base.service';
 import { BullMqService } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
+import {
+  IWebSocketBulkJobDto,
+  IWebSocketJobDto,
+} from '../../dtos/web-sockets-job.dto';
 
 const LOG_CONTEXT = 'WebSocketsQueueService';
 
@@ -20,5 +24,13 @@ export class WebSocketsQueueService extends QueueBaseService {
     Logger.log(`Creating queue ${this.topic}`, LOG_CONTEXT);
 
     this.createQueue();
+  }
+
+  public async add(data: IWebSocketJobDto) {
+    return await super.add(data);
+  }
+
+  public async addBulk(data: IWebSocketBulkJobDto[]) {
+    return await super.addBulk(data);
   }
 }

--- a/packages/application-generic/src/services/queues/workflow-queue.service.spec.ts
+++ b/packages/application-generic/src/services/queues/workflow-queue.service.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import { WorkflowQueueService } from './workflow-queue.service';
 import { BullMqService } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
+import { IWorkflowDataDto } from '../../dtos';
 
 let workflowQueueService: WorkflowQueueService;
 
@@ -64,12 +65,16 @@ describe('Workflow Queue service', () => {
       const _userId = 'workflow-user-id';
       const jobData = {
         _id: jobId,
-        test: 'workflow-job-data',
         _environmentId,
         _organizationId,
         _userId,
-      };
-      await workflowQueueService.add(jobId, jobData, _organizationId);
+      } as unknown as IWorkflowDataDto;
+
+      await workflowQueueService.add({
+        name: jobId,
+        data: jobData,
+        groupId: _organizationId,
+      });
 
       expect(await workflowQueueService.queue.getActiveCount()).toEqual(0);
       expect(await workflowQueueService.queue.getWaitingCount()).toEqual(1);
@@ -99,7 +104,12 @@ describe('Workflow Queue service', () => {
         _organizationId,
         _userId,
       };
-      await workflowQueueService.addMinimalJob(jobId, jobData, _organizationId);
+
+      await workflowQueueService.addMinimalJob({
+        name: jobId,
+        data: jobData,
+        groupId: _organizationId,
+      });
 
       expect(await workflowQueueService.queue.getActiveCount()).toEqual(0);
       expect(await workflowQueueService.queue.getWaitingCount()).toEqual(1);

--- a/packages/application-generic/src/services/queues/workflow-queue.service.ts
+++ b/packages/application-generic/src/services/queues/workflow-queue.service.ts
@@ -4,6 +4,7 @@ import { JobTopicNameEnum } from '@novu/shared';
 import { QueueBaseService } from './queue-base.service';
 import { BullMqService } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
+import { IWorkflowBulkJobDto, IWorkflowJobDto } from '../../dtos';
 
 const LOG_CONTEXT = 'WorkflowQueueService';
 
@@ -20,5 +21,13 @@ export class WorkflowQueueService extends QueueBaseService {
     Logger.log(`Creating queue ${this.topic}`, LOG_CONTEXT);
 
     this.createQueue();
+  }
+
+  public async add(data: IWorkflowJobDto) {
+    return await super.add(data);
+  }
+
+  public async addBulk(data: IWorkflowBulkJobDto[]) {
+    return await super.addBulk(data);
   }
 }

--- a/packages/application-generic/src/usecases/add-job/add-job.usecase.ts
+++ b/packages/application-generic/src/usecases/add-job/add-job.usecase.ts
@@ -137,9 +137,10 @@ export class AddJob {
     }
 
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
         detail: DetailEnum.STEP_QUEUED,
@@ -148,8 +149,8 @@ export class AddJob {
         isTest: false,
         isRetry: false,
       }),
-      job._organizationId
-    );
+      groupId: job._organizationId,
+    });
 
     const delay = command.filtered ? 0 : digestAmount ?? delayAmount;
 
@@ -189,12 +190,12 @@ export class AddJob {
       LOG_CONTEXT
     );
 
-    await this.standardQueueService.addMinimalJob(
-      job._id,
-      jobData,
-      job._organizationId,
-      options
-    );
+    await this.standardQueueService.addMinimalJob({
+      name: job._id,
+      data: jobData,
+      groupId: job._organizationId,
+      options: options,
+    });
 
     if (delay) {
       const logMessage =
@@ -206,9 +207,9 @@ export class AddJob {
 
       Logger.verbose(logMessage, LOG_CONTEXT);
       const meta = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        meta._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: meta._id,
+        data: CreateExecutionDetailsCommand.create({
           ...meta,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
           detail:
@@ -221,8 +222,8 @@ export class AddJob {
           isRetry: false,
           raw: JSON.stringify({ delay }),
         }),
-        job._organizationId
-      );
+        groupId: job._organizationId,
+      });
     }
   }
 

--- a/packages/application-generic/src/usecases/add-job/merge-or-create-digest.usecase.ts
+++ b/packages/application-generic/src/usecases/add-job/merge-or-create-digest.usecase.ts
@@ -176,9 +176,9 @@ export class MergeOrCreateDigest {
 
   private async digestMergedExecutionDetails(job: JobEntity): Promise<void> {
     const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-    await this.executionLogQueueService.add(
-      metadata._id,
-      CreateExecutionDetailsCommand.create({
+    await this.executionLogQueueService.add({
+      name: metadata._id,
+      data: CreateExecutionDetailsCommand.create({
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
         detail: DetailEnum.DIGEST_MERGED,
@@ -187,7 +187,7 @@ export class MergeOrCreateDigest {
         isTest: false,
         isRetry: false,
       }),
-      job._organizationId
-    );
+      groupId: job._organizationId,
+    });
   }
 }

--- a/packages/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
+++ b/packages/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
@@ -654,9 +654,9 @@ export class ConditionsFilter extends Filter {
       );
     } catch (e: any) {
       const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
-      await this.executionLogQueueService.add(
-        metadata._id,
-        CreateExecutionDetailsCommand.create({
+      await this.executionLogQueueService.add({
+        name: metadata._id,
+        data: CreateExecutionDetailsCommand.create({
           ...metadata,
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
           detail: DetailEnum.PROCESSING_STEP_FILTER_ERROR,
@@ -666,8 +666,8 @@ export class ConditionsFilter extends Filter {
           isRetry: false,
           raw: JSON.stringify({ error: e?.message }),
         }),
-        organizationId
-      );
+        groupId: organizationId,
+      });
 
       return;
     }

--- a/packages/application-generic/src/usecases/subscriber-job-bound/subscriber-job-bound.command.ts
+++ b/packages/application-generic/src/usecases/subscriber-job-bound/subscriber-job-bound.command.ts
@@ -32,8 +32,9 @@ export class SubscriberJobBoundCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   actor?: SubscriberEntity | undefined;
 
-  @IsDefined()
-  to: ISubscribersDefine[];
+  // @IsDefined()
+
+  // to: ISubscribersDefine[];
 
   @IsDefined()
   @IsMongoId()

--- a/packages/application-generic/src/usecases/trigger-event/trigger-event.command.ts
+++ b/packages/application-generic/src/usecases/trigger-event/trigger-event.command.ts
@@ -6,10 +6,13 @@ import {
   ValidateIf,
   IsEnum,
 } from 'class-validator';
+
 import {
   AddressingTypeEnum,
-  ISubscribersDefine,
-  ITenantDefine,
+  TriggerRecipients,
+  TriggerRecipientsPayload,
+  TriggerRecipientSubscriber,
+  TriggerTenantContext,
 } from '@novu/shared';
 
 import { EnvironmentWithUserCommand } from '../../commands';
@@ -32,17 +35,17 @@ export class TriggerEventBaseCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @ValidateIf((_, value) => typeof value !== 'string')
   @ValidateNested()
-  actor?: ISubscribersDefine | null;
+  actor?: TriggerRecipientSubscriber | null;
 
   @IsOptional()
   @ValidateIf((_, value) => typeof value !== 'string')
   @ValidateNested()
-  tenant?: ITenantDefine | null;
+  tenant?: TriggerTenantContext | null;
 }
 
 export class TriggerEventMulticastCommand extends TriggerEventBaseCommand {
   @IsDefined()
-  to: ISubscribersDefine[];
+  to: TriggerRecipientsPayload;
 
   @IsEnum(AddressingTypeEnum)
   addressingType: AddressingTypeEnum.MULTICAST;


### PR DESCRIPTION
### What change does this PR introduce?

At the moment we do not validate the data we pass queue services for example SubscriberProcessQueueService.

Suggestions:
What we could do is create a middleware function 'add' in the child class, for example, SubscriberProcessQueueService with command and after then pass it to the parent 'add'.

### Why was this change needed?

We could provide an invalid object to the queue services by mistake.

### Other information and DOD's (Screenshots)

The remaining things that still need to be done:
* Refactor the job data object to be defined, at the moment we allow to pass `undefined` data. IMO it was made in order to create metric cron jobs that do not pass any data, however, this option adds complexity to the code and could lead to a failure point where someone won't pass the data object. Instead, we could add minimal data on the metric identifier.
* Make a discovery in order to make the base queue service move generic by getting the type from its child classes, this way we won't need to duplicate the methods in the services. in order to do so we will need to remove the mapping of the bull mq in the queue service and move it to the bull mq service.
* Refactor so that all of the workers will execute the creation of the Command. was not sure if it should be done in this PR or not, because it could be a breaking change.
* Align all of DTO's params to use align internal conventions, meaning if it is novu internal id it should have a prefix of `_` at the moment we sometimes use it and sometimes not. for example userId _userId. This will be a breaking change that will require backward combability support so I'd prefer to do it in separate dedicated PR.
