### PR TITLE
feat: added two finger scrolling in workflow editor

### DIFF
--- a/apps/web/src/components/quick-start/digest-demo-flow/DigestDemoFlow.tsx
+++ b/apps/web/src/components/quick-start/digest-demo-flow/DigestDemoFlow.tsx
@@ -56,7 +56,7 @@ export function DigestDemoFlow({
             zoomOnScroll={false}
             zoomOnPinch={false}
             panOnDrag={false}
-            panOnScroll={false}
+            panOnScroll
             preventScrolling={false}
           />
         )}

--- a/apps/web/src/components/quick-start/in-app-onboarding/InAppSandboxWorkflow.tsx
+++ b/apps/web/src/components/quick-start/in-app-onboarding/InAppSandboxWorkflow.tsx
@@ -23,7 +23,7 @@ export default function InAppSandboxWorkflow() {
         zoomOnScroll={false}
         zoomOnPinch={false}
         panOnDrag={false}
-        panOnScroll={false}
+        panOnScroll
         preventScrolling={false}
       >
         <Background

--- a/apps/web/src/components/workflow/FlowEditor.tsx
+++ b/apps/web/src/components/workflow/FlowEditor.tsx
@@ -318,6 +318,7 @@ export function FlowEditor({
             minZoom={minZoom}
             maxZoom={maxZoom}
             defaultZoom={defaultZoom}
+            panOnScroll
             {...restProps}
           >
             {withControls && <Controls />}


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
The linked issue required to enable two finger scrolling in workflow editor as it is in Figma, Miro, Google Maps. The workflow editor uses React Flow, so enabling onPanScroll in React Flow will enable it. reference: https://github.com/xyflow/xyflow/issues/3408
https://reactflow.dev/api-reference/react-flow#pan-on-scroll
I have tested it on local.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
This PR closes https://github.com/novuhq/novu/issues/4250

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
