### PR TITLE
chore(web): update the conditions icon

### DIFF
--- a/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
+++ b/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
@@ -63,9 +63,6 @@ export const EditorSidebarHeaderActions = () => {
   const conditions = isNewVariantCreationUrl ? [] : watch(`${stepFormPath}.filters`);
   const formPathName = watch(`${stepFormPath}.name`);
   const name = isNewVariantCreationUrl ? `V${variantsCount + 1} ${formPathName}` : formPathName;
-
-  const PlusIcon = isUnderVariantsListPath ? ConditionsFile : ConditionPlus;
-  const ConditionsIcon = isUnderVariantsListPath ? ConditionsFile : Condition;
   const hasNoFilters = (filters && filters?.length === 0) || !filters || isNewVariantCreationUrl;
   const isDelayedStep = DELAYED_STEPS.includes(channel as StepTypeEnum);
   const isAddVariantActionAvailable = (isUnderTheStepPath || isUnderVariantsListPath) && !isDelayedStep;
@@ -137,7 +134,7 @@ export const EditorSidebarHeaderActions = () => {
           <ActionButton
             tooltip={`${conditionAction} ${isUnderVariantsListPath ? 'group' : ''} conditions`}
             onClick={() => setConditionsOpened(true)}
-            Icon={PlusIcon}
+            Icon={ConditionPlus}
             data-test-id="editor-sidebar-add-conditions"
           />
         </When>
@@ -146,7 +143,7 @@ export const EditorSidebarHeaderActions = () => {
             tooltip={`${conditionAction} ${isUnderVariantsListPath ? 'group' : ''} conditions`}
             text={`${filters?.length ?? ''}`}
             onClick={() => setConditionsOpened(true)}
-            Icon={ConditionsIcon}
+            Icon={Condition}
             data-test-id="editor-sidebar-edit-conditions"
           />
         </When>

--- a/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
+++ b/apps/web/src/pages/templates/workflow/workflow/node-types/WorkflowNodeActions.tsx
@@ -6,7 +6,7 @@ import {
   Dropdown,
   IDropdownProps,
   ConditionPlus,
-  ConditionsFile,
+  Condition,
   DotsHorizontal,
   NoConditions,
   PencilOutlined,
@@ -124,7 +124,7 @@ export const WorkflowNodeActions = ({
     : conditionsCount > 0
     ? VARIANT_TYPE_TO_EDIT_CONDITIONS[nodeType]
     : VARIANT_TYPE_TO_ADD_CONDITIONS[nodeType];
-  const conditionsIcon = isReadOnly || conditionsCount > 0 ? ConditionsFile : ConditionPlus;
+  const conditionsIcon = isReadOnly || conditionsCount > 0 ? Condition : ConditionPlus;
   const isShowConditions = onAddConditions && (!isReadOnly || (isReadOnly && conditionsCount > 0));
 
   return (


### PR DESCRIPTION
### What change does this PR introduce?

Updated the conditions icon on the Workflow Editor node and in the Variants List sidebar.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)


https://github.com/novuhq/novu/assets/2607232/26cb108a-7d57-4a70-8078-d4c62ea9b481


