### PR TITLE
chore(web): make apns provider production field optional

### DIFF
--- a/libs/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/libs/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -627,7 +627,7 @@ export const apnsConfig: IConfigCredentials[] = [
     key: CredentialsKeyEnum.Secure,
     displayName: 'Production',
     type: 'switch',
-    required: true,
+    required: false,
   },
 
   ...pushConfigBase,


### PR DESCRIPTION
### What change does this PR introduce?

Make APNS provider `Production` field to be optional and default to `false`.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)


https://github.com/novuhq/novu/assets/2607232/3d17361b-f429-45d9-a286-22846bd4fd62


https://github.com/novuhq/novu/assets/2607232/377246cb-7c31-44cb-935d-16e720d998d7


