### PR TITLE
fix(api): Disable cspell on spectral file

### DIFF
--- a/apps/api/.spectral.yaml
+++ b/apps/api/.spectral.yaml
@@ -1,3 +1,5 @@
+# cSpell:disable
+
 # Spectral is a flexible JSON/YAML linter and validator, which can be used for OpenAPI, AsyncAPI, or any other purpose.
 # To run Spectral locally:
 # > pnpm lint:openapi


### PR DESCRIPTION
### What change does this PR introduce?
* Disables cspell on Spectral file

### Why was this change needed?
Cspell failed to detect changes in tests before merging to next. Spectral will continue to have many cspell errors due to the JSON pointer syntax used, hence the full disable.

### Other information (Screenshots)
N/A