### PR TITLE
fix: digest with passing filters are not aggregated

### DIFF
--- a/apps/web/src/components/execution-detail/ExecutionDetailsStepHeader.tsx
+++ b/apps/web/src/components/execution-detail/ExecutionDetailsStepHeader.tsx
@@ -86,6 +86,9 @@ const generateDetailByStepAndStatus = (status, step) => {
   }
 
   if (step.type === StepTypeEnum.DIGEST) {
+    if (status === JobStatusEnum.SKIPPED) {
+      return step.executionDetails?.at(-1)?.detail;
+    }
     const { digest } = step;
 
     return `Digesting events for ${digest.amount} ${digest.unit}`;

--- a/apps/worker/src/app/workflow/usecases/queue-next-job/queue-next-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/queue-next-job/queue-next-job.usecase.ts
@@ -33,6 +33,7 @@ export class QueueNextJob {
           environmentId: command.environmentId,
           organizationId: command.organizationId,
           userId: command.userId,
+          job,
         })
       );
 

--- a/libs/dal/src/repositories/job/job.repository.ts
+++ b/libs/dal/src/repositories/job/job.repository.ts
@@ -182,8 +182,7 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
     job: JobEntity,
     digestKey?: string,
     digestValue?: string | number,
-    digestMeta?: IDigestRegularMetadata,
-    filtered = false
+    digestMeta?: IDigestRegularMetadata
   ): Promise<IDelayOrDigestJobResult> {
     const isBackoff = job.digest?.type === DigestTypeEnum.BACKOFF || (job.digest as IDigestRegularMetadata)?.backoff;
     if (isBackoff) {
@@ -206,27 +205,6 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
           digestResult: DigestCreationResultEnum.SKIPPED,
         };
       }
-    }
-
-    if (filtered) {
-      await this._model.updateOne(
-        {
-          _environmentId: job._environmentId,
-          _templateId: job._templateId,
-          _subscriberId: job._subscriberId,
-          _id: job._id,
-        },
-        {
-          $set: {
-            status: JobStatusEnum.DELAYED,
-          },
-        }
-      );
-
-      return {
-        activeDigestId: job._id,
-        digestResult: DigestCreationResultEnum.CREATED,
-      };
     }
 
     const delayedDigestJob = await this._model.findOne(

--- a/libs/dal/src/repositories/job/job.repository.ts
+++ b/libs/dal/src/repositories/job/job.repository.ts
@@ -182,7 +182,8 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
     job: JobEntity,
     digestKey?: string,
     digestValue?: string | number,
-    digestMeta?: IDigestRegularMetadata
+    digestMeta?: IDigestRegularMetadata,
+    filtered = false
   ): Promise<IDelayOrDigestJobResult> {
     const isBackoff = job.digest?.type === DigestTypeEnum.BACKOFF || (job.digest as IDigestRegularMetadata)?.backoff;
     if (isBackoff) {
@@ -205,6 +206,27 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
           digestResult: DigestCreationResultEnum.SKIPPED,
         };
       }
+    }
+
+    if (filtered) {
+      await this._model.updateOne(
+        {
+          _environmentId: job._environmentId,
+          _templateId: job._templateId,
+          _subscriberId: job._subscriberId,
+          _id: job._id,
+        },
+        {
+          $set: {
+            status: JobStatusEnum.DELAYED,
+          },
+        }
+      );
+
+      return {
+        activeDigestId: job._id,
+        digestResult: DigestCreationResultEnum.CREATED,
+      };
     }
 
     const delayedDigestJob = await this._model.findOne(

--- a/packages/application-generic/src/usecases/add-job/add-job.usecase.ts
+++ b/packages/application-generic/src/usecases/add-job/add-job.usecase.ts
@@ -75,7 +75,7 @@ export class AddJob {
       Logger.debug(`Digest step amount is: ${digestAmount}`, LOG_CONTEXT);
 
       digestCreationResult = await this.mergeOrCreateDigestUsecase.execute(
-        MergeOrCreateDigestCommand.create({ job })
+        MergeOrCreateDigestCommand.create({ job, filtered: command.filtered })
       );
 
       if (digestCreationResult === DigestCreationResultEnum.MERGED) {

--- a/packages/application-generic/src/usecases/add-job/merge-or-create-digest.command.ts
+++ b/packages/application-generic/src/usecases/add-job/merge-or-create-digest.command.ts
@@ -1,4 +1,4 @@
-import { IsDefined } from 'class-validator';
+import { IsDefined, IsOptional } from 'class-validator';
 import { JobEntity } from '@novu/dal';
 
 import { BaseCommand } from '../../commands/base.command';
@@ -6,4 +6,7 @@ import { BaseCommand } from '../../commands/base.command';
 export class MergeOrCreateDigestCommand extends BaseCommand {
   @IsDefined()
   job: JobEntity;
+
+  @IsOptional()
+  filtered?: boolean;
 }

--- a/packages/application-generic/src/usecases/add-job/merge-or-create-digest.usecase.ts
+++ b/packages/application-generic/src/usecases/add-job/merge-or-create-digest.usecase.ts
@@ -56,13 +56,14 @@ export class MergeOrCreateDigest {
     const digestKey = digestMeta?.digestKey;
     const digestValue = getNestedValue(job.payload, digestKey);
 
-    const digestAction = await this.shouldDelayDigestOrMergeWithLock(
-      job,
-      digestKey,
-      digestValue,
-      digestMeta,
-      command.filtered
-    );
+    const digestAction = command.filtered
+      ? { digestResult: DigestCreationResultEnum.SKIPPED }
+      : await this.shouldDelayDigestOrMergeWithLock(
+          job,
+          digestKey,
+          digestValue,
+          digestMeta
+        );
 
     switch (digestAction.digestResult) {
       case DigestCreationResultEnum.MERGED:
@@ -72,7 +73,7 @@ export class MergeOrCreateDigest {
           digestAction.activeNotificationId
         );
       case DigestCreationResultEnum.SKIPPED:
-        return await this.processSkippedDigest(job);
+        return await this.processSkippedDigest(job, command.filtered);
       case DigestCreationResultEnum.CREATED:
         return await this.processCreatedDigest(digestMeta, job);
       default:
@@ -139,19 +140,23 @@ export class MergeOrCreateDigest {
 
   @Instrument()
   private async processSkippedDigest(
-    job: JobEntity
+    job: JobEntity,
+    filtered = false
   ): Promise<DigestCreationResultEnum> {
-    await this.jobRepository.update(
-      {
-        _environmentId: job._environmentId,
-        _id: job._id,
-      },
-      {
-        $set: {
-          status: JobStatusEnum.SKIPPED,
+    await Promise.all([
+      this.jobRepository.update(
+        {
+          _environmentId: job._environmentId,
+          _id: job._id,
         },
-      }
-    );
+        {
+          $set: {
+            status: JobStatusEnum.SKIPPED,
+          },
+        }
+      ),
+      this.digestSkippedExecutionDetails(job, filtered),
+    ]);
 
     return DigestCreationResultEnum.SKIPPED;
   }
@@ -173,8 +178,7 @@ export class MergeOrCreateDigest {
     job: JobEntity,
     digestKey?: string,
     digestValue?: string | number,
-    digestMeta?: any,
-    filtered?: boolean
+    digestMeta?: any
   ): Promise<IDelayOrDigestJobResult> {
     const TTL = 1500;
     const resourceKey = this.getLockKey(job, digestKey, digestValue);
@@ -184,8 +188,7 @@ export class MergeOrCreateDigest {
         job,
         digestKey,
         digestValue,
-        digestMeta,
-        filtered
+        digestMeta
       );
 
     const result =
@@ -208,6 +211,25 @@ export class MergeOrCreateDigest {
         ...metadata,
         ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
         detail: DetailEnum.DIGEST_MERGED,
+        source: ExecutionDetailsSourceEnum.INTERNAL,
+        status: ExecutionDetailsStatusEnum.SUCCESS,
+        isTest: false,
+        isRetry: false,
+      }),
+      job._organizationId
+    );
+  }
+  private async digestSkippedExecutionDetails(
+    job: JobEntity,
+    filtered: boolean
+  ): Promise<void> {
+    const metadata = CreateExecutionDetailsCommand.getExecutionLogMetadata();
+    await this.executionLogQueueService.add(
+      metadata._id,
+      CreateExecutionDetailsCommand.create({
+        ...metadata,
+        ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
+        detail: filtered ? DetailEnum.FILTER_STEPS : DetailEnum.DIGEST_SKIPPED,
         source: ExecutionDetailsSourceEnum.INTERNAL,
         status: ExecutionDetailsStatusEnum.SUCCESS,
         isTest: false,

--- a/packages/application-generic/src/usecases/add-job/merge-or-create-digest.usecase.ts
+++ b/packages/application-generic/src/usecases/add-job/merge-or-create-digest.usecase.ts
@@ -60,7 +60,8 @@ export class MergeOrCreateDigest {
       job,
       digestKey,
       digestValue,
-      digestMeta
+      digestMeta,
+      command.filtered
     );
 
     switch (digestAction.digestResult) {
@@ -172,7 +173,8 @@ export class MergeOrCreateDigest {
     job: JobEntity,
     digestKey?: string,
     digestValue?: string | number,
-    digestMeta?: any
+    digestMeta?: any,
+    filtered?: boolean
   ): Promise<IDelayOrDigestJobResult> {
     const TTL = 1500;
     const resourceKey = this.getLockKey(job, digestKey, digestValue);
@@ -182,7 +184,8 @@ export class MergeOrCreateDigest {
         job,
         digestKey,
         digestValue,
-        digestMeta
+        digestMeta,
+        filtered
       );
 
     const result =

--- a/packages/application-generic/src/usecases/create-execution-details/types/index.ts
+++ b/packages/application-generic/src/usecases/create-execution-details/types/index.ts
@@ -33,6 +33,7 @@ export enum DetailEnum {
   WEBHOOK_FILTER_FAILED_RETRY = 'Webhook filter failed, retry will be executed',
   WEBHOOK_FILTER_FAILED_LAST_RETRY = 'Failed to get response from remote webhook filter on last retry',
   DIGEST_MERGED = 'Digest was merged with other digest',
+  DIGEST_SKIPPED = 'Digest was skipped, first backoff event',
   DELAY_FINISHED = 'Delay is finished',
   PUSH_MISSING_DEVICE_TOKENS = 'Subscriber credentials is missing the tokens for sending a push notification message',
   VARIANT_CHOSEN = 'Variant was chosen by the provided condition criteria',


### PR DESCRIPTION
### What change does this PR introduce?

For a digest with filters that passes - it sent separate message for each trigger, instead of aggregating the events into one message. 
Another problem fixed in this PR, is that a digest that is filtered (message should be sent immediately) was merged into a current delayed digest.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
Closes #4957
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
