### PR TITLE
fix(web): Fixed Integrations Store's add button alignment

### DIFF
--- a/apps/web/src/pages/integrations/IntegrationsList.tsx
+++ b/apps/web/src/pages/integrations/IntegrationsList.tsx
@@ -90,7 +90,7 @@ export const IntegrationsList = ({
     <PageContainer title="Integrations">
       <PageHeader title="Integrations Store" />
       <When truthy={hasIntegrations}>
-        <Container fluid sx={{ padding: '0 30px 8px 30px' }}>
+        <Container fluid sx={{ padding: '0 24px 8px 30px' }}>
           <IntegrationsListToolbar onAddProviderClick={onAddProviderClick} areIntegrationsLoading={isLoading} />
         </Container>
       </When>


### PR DESCRIPTION
### What change does this PR introduce?
This PR fixes the incorrect alignment of the Integrations store's add button with the heading "Integrations Store".

### Why was this change needed?
The change was to perfectly align the "add a provider" button with the heading on the page as in the case of other routes like workflows as shown in the screenshot attached

Fixes #4943

expected behavior as in case of Workflows
<img width="300" alt="image" src="https://github.com/novuhq/novu/assets/102918743/378177d6-8b51-4445-ae10-24f7e6020851">

actual behavior
<img width="233" alt="image" src="https://github.com/novuhq/novu/assets/102918743/356b4f49-0054-4d94-83dd-a4c349058b1c">

after change behavior
![image](https://github.com/novuhq/novu/assets/102918743/6f9e5d13-a688-48f3-b226-61718d4c3c64)


