### PR TITLE
fix: Done [NV-3300] most recent change should be on the top in change…

### DIFF
--- a/apps/web/src/pages/changes/components/ChangesTableLayout.tsx
+++ b/apps/web/src/pages/changes/components/ChangesTableLayout.tsx
@@ -138,7 +138,7 @@ export const ChangesTable = ({
     <Table
       data-test-id={dataTestId}
       loading={loading}
-      data={changes || []}
+      data={changes?.slice()?.reverse() || []}
       columns={columns}
       pagination={{
         pageSize: pageSize,

--- a/apps/web/src/pages/changes/components/ChangesTableLayout.tsx
+++ b/apps/web/src/pages/changes/components/ChangesTableLayout.tsx
@@ -138,7 +138,7 @@ export const ChangesTable = ({
     <Table
       data-test-id={dataTestId}
       loading={loading}
-      data={changes?.slice()?.reverse() || []}
+      data={changes || []}
       columns={columns}
       pagination={{
         pageSize: pageSize,

--- a/libs/dal/src/repositories/change/change.repository.ts
+++ b/libs/dal/src/repositories/change/change.repository.ts
@@ -61,6 +61,7 @@ export class ChangeRepository extends BaseRepository<ChangeDBModel, ChangeEntity
       enabled,
       _parentId: { $exists: false, $eq: null },
     })
+      .sort({ createdAt: -1 })
       .skip(skip)
       .limit(limit)
       .populate('user', userSelect);


### PR DESCRIPTION
### What change does this PR introduce?

Fixed [NV-3300] most recent change should be on the top in changes page #5006

### Why was this change needed?

The changed was needed because the recent workflows were coming in bottom below the list

### Other information (Screenshots)

Before:
![Screenshot from 2023-12-21 01-18-49](https://github.com/novuhq/novu/assets/72218888/6e487d57-26e7-4ead-998e-88c10c5df753)

After:
![Screenshot from 2023-12-21 01-27-32](https://github.com/novuhq/novu/assets/72218888/32e2b72e-5d39-403e-b56c-8a1b5bbe0d03)



