### PR TITLE
fix: headless api client remove/refetch query scenarios

### DIFF
--- a/packages/headless/src/lib/headless.service.ts
+++ b/packages/headless/src/lib/headless.service.ts
@@ -337,7 +337,7 @@ export class HeadlessService {
         WebSocketEventEnum.RECEIVED,
         (data?: { message: IMessage }) => {
           if (data?.message) {
-            this.queryClient.removeQueries(NOTIFICATIONS_QUERY_KEY, {
+            this.queryClient.refetchQueries(NOTIFICATIONS_QUERY_KEY, {
               exact: false,
             });
             listener(data.message);
@@ -365,9 +365,6 @@ export class HeadlessService {
         WebSocketEventEnum.UNSEEN,
         (data?: { unseenCount: number }) => {
           if (Number.isInteger(data?.unseenCount)) {
-            this.queryClient.removeQueries(NOTIFICATIONS_QUERY_KEY, {
-              exact: false,
-            });
             this.queryClient.setQueryData<{ count: number }>(
               UNSEEN_COUNT_QUERY_KEY,
               (oldData) => ({ count: data?.unseenCount ?? oldData.count })
@@ -397,9 +394,6 @@ export class HeadlessService {
         WebSocketEventEnum.UNREAD,
         (data?: { unreadCount: number }) => {
           if (Number.isInteger(data?.unreadCount)) {
-            this.queryClient.removeQueries(NOTIFICATIONS_QUERY_KEY, {
-              exact: false,
-            });
             this.queryClient.setQueryData<{ count: number }>(
               UNREAD_COUNT_QUERY_KEY,
               (oldData) => ({ count: data?.unreadCount ?? oldData.count })
@@ -789,7 +783,7 @@ export class HeadlessService {
       options: {
         mutationFn: (variables) => this.api.removeMessage(variables.messageId),
         onSuccess: (data) => {
-          this.queryClient.removeQueries(NOTIFICATIONS_QUERY_KEY, {
+          this.queryClient.refetchQueries(NOTIFICATIONS_QUERY_KEY, {
             exact: false,
           });
         },
@@ -982,7 +976,7 @@ export class HeadlessService {
         mutationFn: (variables) =>
           this.api.removeAllMessages(variables?.feedId),
         onSuccess: (data) => {
-          this.queryClient.refetchQueries(NOTIFICATIONS_QUERY_KEY, {
+          this.queryClient.removeQueries(NOTIFICATIONS_QUERY_KEY, {
             exact: false,
           });
         },


### PR DESCRIPTION
### What change does this PR introduce?
Here , I have fixed the issues over remove/refetch scenarios in Headless api methods
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
In headless API we use a set of events like markAs, listenNotificationReceive, deleteNotification, deleteNotifications,etc. While we use these methods to integrate our custom component with novu we have found some issues. When we make changes to notifications it should refetch the queries at certain events and remove them for certain events.

1. When a single notification is deleted , the queries must be refetched.
2. When we receive a new notification , the queries must be refetched.
3. When all notifications are removed . the queries must be removed.
4. When unseenCount changed , the queries must not be removed.
5. When unreadCount changed, the queries must not be removed.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

`Closes #5011`  : [https://github.com/novuhq/novu/issues/5011](url)


### Other information (Screenshots)

<!-- Add notes or any other information here -->

I have tested the scenarios in my local environment.

<!-- Also add all the screenshots which support your changes -->
