### PR TITLE
Nv 2991 endpoint to return all the template variables

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -18,6 +18,6 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/enterprise" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/.source" vcs="Git" />
   </component>
 </project>

--- a/apps/api/src/app/workflows/dto/index.ts
+++ b/apps/api/src/app/workflows/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './change-workflow-status-request.dto';
 export * from './create-workflow.request.dto';
 export * from './update-workflow-request.dto';
+export * from './variables.response.dto';

--- a/apps/api/src/app/workflows/dto/variables.response.dto.ts
+++ b/apps/api/src/app/workflows/dto/variables.response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VariablesResponseDto {
+  @ApiProperty()
+  translations: Record<string, any>;
+
+  @ApiProperty()
+  system: Record<string, any>;
+}

--- a/apps/api/src/app/workflows/usecases/get-workflow-variables/get-workflow-variables.command.ts
+++ b/apps/api/src/app/workflows/usecases/get-workflow-variables/get-workflow-variables.command.ts
@@ -1,8 +1,3 @@
-import { IsDefined, IsMongoId } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class GetWorkflowVariablesCommand extends EnvironmentWithUserCommand {
-  @IsDefined()
-  @IsMongoId()
-  workflowId: string;
-}
+export class GetWorkflowVariablesCommand extends EnvironmentWithUserCommand {}

--- a/apps/api/src/app/workflows/usecases/get-workflow-variables/get-workflow-variables.command.ts
+++ b/apps/api/src/app/workflows/usecases/get-workflow-variables/get-workflow-variables.command.ts
@@ -1,0 +1,8 @@
+import { IsDefined, IsMongoId } from 'class-validator';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class GetWorkflowVariablesCommand extends EnvironmentWithUserCommand {
+  @IsDefined()
+  @IsMongoId()
+  workflowId: string;
+}

--- a/apps/api/src/app/workflows/usecases/get-workflow-variables/get-workflow-variables.usecase.ts
+++ b/apps/api/src/app/workflows/usecases/get-workflow-variables/get-workflow-variables.usecase.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { NotificationTemplateRepository } from '@novu/dal';
+import { GetWorkflowVariablesCommand } from './get-workflow-variables.command';
+import { ApiException } from '../../../shared/exceptions/api.exception';
+import { ModuleRef } from '@nestjs/core';
+import { SystemVariablesWithTypes, TemplateVariableTypeEnum } from '@novu/shared';
+import { set, get } from 'lodash';
+import { buildVariablesKey, CachedEntity } from '@novu/application-generic';
+
+@Injectable()
+export class GetWorkflowVariables {
+  constructor(private notificationTemplateRepository: NotificationTemplateRepository, private moduleRef: ModuleRef) {}
+
+  async execute(command: GetWorkflowVariablesCommand) {
+    const { workflowId, environmentId, organizationId } = command;
+    const workflow = await this.notificationTemplateRepository.findById(workflowId, environmentId);
+    if (!workflow) {
+      throw new NotFoundException(`Workflow with id ${workflowId} not found`);
+    }
+    const variableTypeHumanize = {
+      [TemplateVariableTypeEnum.STRING]: 'string',
+      [TemplateVariableTypeEnum.ARRAY]: 'array',
+      [TemplateVariableTypeEnum.BOOLEAN]: 'boolean',
+    };
+
+    const variables = workflow?.triggers[0].variables;
+
+    const stepVariables: Record<string, any> = {};
+    variables
+      .filter((variable) => variable?.type !== TemplateVariableTypeEnum.ARRAY)
+      .forEach((variable) => {
+        set(stepVariables, variable.name, variable.type && variableTypeHumanize[variable.type]);
+      });
+    variables
+      .filter((variable) => variable?.type === TemplateVariableTypeEnum.ARRAY)
+      .forEach((variable) => {
+        set(stepVariables, variable.name, [get(stepVariables, variable.name, [])]);
+      });
+
+    const variablesWithTypes = await this.fetchVariables({
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+    });
+
+    return { ...variablesWithTypes, variables: stepVariables };
+  }
+
+  @CachedEntity({
+    builder: (command: { _environmentId: string; _organizationId: string }) =>
+      buildVariablesKey({
+        _environmentId: command._environmentId,
+        _organizationId: command._organizationId,
+      }),
+  })
+  private async fetchVariables({
+    _environmentId,
+    _organizationId,
+  }: {
+    _environmentId: string;
+    _organizationId: string;
+  }) {
+    let translationVariables = [];
+
+    try {
+      if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
+        if (!require('@novu/ee-translation')?.TranslationsService) {
+          throw new ApiException('Translation module is not loaded');
+        }
+        const service = this.moduleRef.get(require('@novu/ee-translation')?.TranslationsService, { strict: false });
+        translationVariables = await service.getTranslationVariables(_environmentId, _organizationId);
+      }
+    } catch (e) {
+      Logger.error(e, `Unexpected error while importing enterprise modules`, 'TranslationsService');
+    }
+
+    return {
+      translations: translationVariables,
+      system: SystemVariablesWithTypes,
+    };
+  }
+}

--- a/apps/api/src/app/workflows/usecases/index.ts
+++ b/apps/api/src/app/workflows/usecases/index.ts
@@ -5,6 +5,7 @@ import { GetNotificationTemplates } from './get-notification-templates/get-notif
 import { CreateNotificationTemplate } from './create-notification-template';
 import { GetNotificationTemplate } from './get-notification-template/get-notification-template.usecase';
 import { DeleteNotificationTemplate } from './delete-notification-template/delete-notification-template.usecase';
+import { GetWorkflowVariables } from './get-workflow-variables/get-workflow-variables.usecase';
 
 export const USE_CASES = [
   GetActiveIntegrationsStatus,
@@ -14,4 +15,5 @@ export const USE_CASES = [
   CreateNotificationTemplate,
   GetNotificationTemplate,
   DeleteNotificationTemplate,
+  GetWorkflowVariables,
 ];

--- a/apps/api/src/app/workflows/workflow.controller.ts
+++ b/apps/api/src/app/workflows/workflow.controller.ts
@@ -36,6 +36,8 @@ import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.de
 import { DataBooleanDto } from '../shared/dtos/data-wrapper-dto';
 import { CreateWorkflowQuery } from './queries';
 import { ApiOkResponse } from '../shared/framework/response.decorator';
+import { GetWorkflowVariables } from './usecases/get-workflow-variables/get-workflow-variables.usecase';
+import { GetWorkflowVariablesCommand } from './usecases/get-workflow-variables/get-workflow-variables.command';
 
 @ApiCommonResponses()
 @Controller('/workflows')
@@ -47,6 +49,7 @@ export class WorkflowController {
     private getWorkflowsUsecase: GetNotificationTemplates,
     private createWorkflowUsecase: CreateNotificationTemplate,
     private getWorkflowUsecase: GetNotificationTemplate,
+    private getWorkflowVariablesUsecase: GetWorkflowVariables,
     private updateWorkflowByIdUsecase: UpdateNotificationTemplate,
     private deleteWorkflowByIdUsecase: DeleteNotificationTemplate,
     private changeWorkflowActiveStatusUsecase: ChangeTemplateActiveStatus
@@ -141,6 +144,24 @@ export class WorkflowController {
         organizationId: user.organizationId,
         userId: user._id,
         templateId: workflowId,
+      })
+    );
+  }
+
+  @Get('/:workflowId/variables')
+  @ApiResponse(WorkflowResponse)
+  @ApiOperation({
+    summary: 'Get workflow variables',
+    description: 'Get workflow variables',
+  })
+  @ExternalApiAccessible()
+  getWorkflowVariables(@UserSession() user: IJwtPayload, @Param('workflowId') workflowId: string) {
+    return this.getWorkflowVariablesUsecase.execute(
+      GetWorkflowVariablesCommand.create({
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        userId: user._id,
+        workflowId,
       })
     );
   }

--- a/apps/api/src/app/workflows/workflow.controller.ts
+++ b/apps/api/src/app/workflows/workflow.controller.ts
@@ -16,7 +16,12 @@ import { UserSession } from '../shared/framework/user.decorator';
 import { GetNotificationTemplates } from './usecases/get-notification-templates/get-notification-templates.usecase';
 import { GetNotificationTemplatesCommand } from './usecases/get-notification-templates/get-notification-templates.command';
 import { CreateNotificationTemplate, CreateNotificationTemplateCommand } from './usecases/create-notification-template';
-import { ChangeWorkflowStatusRequestDto, CreateWorkflowRequestDto, UpdateWorkflowRequestDto } from './dto';
+import {
+  ChangeWorkflowStatusRequestDto,
+  CreateWorkflowRequestDto,
+  UpdateWorkflowRequestDto,
+  VariablesResponseDto,
+} from './dto';
 import { GetNotificationTemplate } from './usecases/get-notification-template/get-notification-template.usecase';
 import { GetNotificationTemplateCommand } from './usecases/get-notification-template/get-notification-template.command';
 import { UpdateNotificationTemplate } from './usecases/update-notification-template/update-notification-template.usecase';
@@ -127,6 +132,23 @@ export class WorkflowController {
     );
   }
 
+  @Get('/variables')
+  @ApiResponse(VariablesResponseDto)
+  @ApiOperation({
+    summary: 'Get available variables',
+    description: 'Get the variables that can be used in the workflow',
+  })
+  @ExternalApiAccessible()
+  getWorkflowVariables(@UserSession() user: IJwtPayload): Promise<VariablesResponseDto> {
+    return this.getWorkflowVariablesUsecase.execute(
+      GetWorkflowVariablesCommand.create({
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        userId: user._id,
+      })
+    );
+  }
+
   @Get('/:workflowId')
   @ApiResponse(WorkflowResponse)
   @ApiOperation({
@@ -147,25 +169,6 @@ export class WorkflowController {
       })
     );
   }
-
-  @Get('/:workflowId/variables')
-  @ApiResponse(WorkflowResponse)
-  @ApiOperation({
-    summary: 'Get workflow variables',
-    description: 'Get workflow variables',
-  })
-  @ExternalApiAccessible()
-  getWorkflowVariables(@UserSession() user: IJwtPayload, @Param('workflowId') workflowId: string) {
-    return this.getWorkflowVariablesUsecase.execute(
-      GetWorkflowVariablesCommand.create({
-        environmentId: user.environmentId,
-        organizationId: user.organizationId,
-        userId: user._id,
-        workflowId,
-      })
-    );
-  }
-
   @Post('')
   @ExternalApiAccessible()
   @UseGuards(RootEnvironmentGuard)

--- a/libs/shared/src/consts/handlebar-helpers/getTemplateVariables.ts
+++ b/libs/shared/src/consts/handlebar-helpers/getTemplateVariables.ts
@@ -14,6 +14,10 @@ export function getTemplateVariables(bod: any[]): IMustacheVariable[] {
     .filter((body) => body.type === 'MustacheStatement')
     .flatMap((body) => {
       const varName = body.params[0]?.original || (body.path.original as string);
+
+      if (body.path.original === HandlebarHelpersEnum.I18N) {
+        return [];
+      }
       if (!shouldAddVariable(varName)) {
         return [];
       }

--- a/packages/application-generic/src/services/cache/key-builders/entities.ts
+++ b/packages/application-generic/src/services/cache/key-builders/entities.ts
@@ -1,12 +1,12 @@
 import {
   BLUEPRINT_IDENTIFIER,
+  buildCommonEnvironmentKey,
   buildCommonKey,
   buildKeyById,
   CacheKeyPrefixEnum,
   CacheKeyTypeEnum,
   IdentifierPrefixEnum,
   OrgScopePrefixEnum,
-  prefixWrapper,
   ServiceConfigIdentifierEnum,
 } from './shared';
 
@@ -23,6 +23,19 @@ const buildSubscriberKey = ({
     environmentId: _environmentId,
     identifierPrefix: IdentifierPrefixEnum.SUBSCRIBER_ID,
     identifier: subscriberId,
+  });
+
+const buildVariablesKey = ({
+  _environmentId,
+  _organizationId,
+}: {
+  _environmentId: string;
+  _organizationId: string;
+}): string =>
+  buildCommonEnvironmentKey({
+    type: CacheKeyTypeEnum.ENTITY,
+    keyEntity: CacheKeyPrefixEnum.WORKFLOW_VARIABLES,
+    environmentId: _environmentId,
   });
 
 const buildUserKey = ({ _id }: { _id: string }): string =>
@@ -145,4 +158,5 @@ export {
   buildMaximumApiRateLimitKey,
   buildEvaluateApiRateLimitKey,
   buildServiceConfigApiRateLimitMaximumKey,
+  buildVariablesKey,
 };

--- a/packages/application-generic/src/services/cache/key-builders/shared.ts
+++ b/packages/application-generic/src/services/cache/key-builders/shared.ts
@@ -21,6 +21,22 @@ export const buildCommonKey = ({
   );
 
 /**
+ * Use this to build a key for entities that are scoped to an environment
+ */
+export const buildCommonEnvironmentKey = ({
+  type,
+  keyEntity,
+  environmentIdPrefix = OrgScopePrefixEnum.ENVIRONMENT_ID,
+  environmentId,
+}: {
+  type: CacheKeyTypeEnum;
+  keyEntity: CacheKeyPrefixEnum;
+  environmentIdPrefix?: OrgScopePrefixEnum;
+  environmentId: string;
+}): string =>
+  prefixWrapper(`${type}:${keyEntity}:${environmentIdPrefix}=${environmentId}`);
+
+/**
  * Use this to build a key for entities that are unscoped (do not belong to a hierarchy)
  */
 export const buildKeyById = ({
@@ -47,6 +63,7 @@ export enum CacheKeyPrefixEnum {
   FEED = 'feed',
   SUBSCRIBER = 'subscriber',
   NOTIFICATION_TEMPLATE = 'notification_template',
+  WORKFLOW_VARIABLES = 'workflow_variables',
   USER = 'user',
   INTEGRATION = 'integration',
   ENVIRONMENT_BY_API_KEY = 'environment_by_api_key',


### PR DESCRIPTION
### What change does this PR introduce?
Implement the endpoint that will return for a given template all the system and translation variables.

We need to provide the information about what variables are accessible to the user when editing the template content in the editor. We have introduced the translation variables which are dynamic and based on the uploaded translation files.. System variables are hardcoded on the FE, which is bad. All of the above is a reason for creating the new endpoint.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
