### PR TITLE
feat: added application identifier read only field in integration sidebar

### DIFF
--- a/apps/web/src/pages/integrations/components/UpdateIntegrationCommonFields.tsx
+++ b/apps/web/src/pages/integrations/components/UpdateIntegrationCommonFields.tsx
@@ -21,7 +21,7 @@ export const UpdateIntegrationCommonFields = ({
   provider: IIntegratedProvider | null;
   isNovuInAppProvider: boolean;
 }) => {
-    const {
+  const {
     control,
     formState: { errors },
   } = useFormContext();

--- a/apps/web/src/pages/integrations/components/UpdateIntegrationCommonFields.tsx
+++ b/apps/web/src/pages/integrations/components/UpdateIntegrationCommonFields.tsx
@@ -2,8 +2,10 @@ import { Controller, useFormContext } from 'react-hook-form';
 import styled from '@emotion/styled';
 import { useClipboard } from '@mantine/hooks';
 
-import { Input, Switch, Check, Copy } from '@novu/design-system';
+import { Input, Switch, Check, Copy, Tooltip, inputStyles } from '@novu/design-system';
 import type { IIntegratedProvider } from '../types';
+import { Input as MantineInput } from '@mantine/core';
+import { useEnvController } from '../../../hooks';
 
 const CopyWrapper = styled.div`
   cursor: pointer;
@@ -12,12 +14,21 @@ const CopyWrapper = styled.div`
   }
 `;
 
-export const UpdateIntegrationCommonFields = ({ provider }: { provider: IIntegratedProvider | null }) => {
-  const {
+export const UpdateIntegrationCommonFields = ({
+  provider,
+  isNovuInAppProvider = false,
+}: {
+  provider: IIntegratedProvider | null;
+  isNovuInAppProvider: boolean;
+}) => {
+    const {
     control,
     formState: { errors },
   } = useFormContext();
   const identifierClipboard = useClipboard({ timeout: 1000 });
+  const { environment } = useEnvController();
+  const clipboardEnvironmentIdentifier = useClipboard({ timeout: 1000 });
+  const environmentIdentifier = environment?.identifier ? environment.identifier : '';
 
   if (!provider) return null;
 
@@ -80,6 +91,26 @@ export const UpdateIntegrationCommonFields = ({ provider }: { provider: IIntegra
           />
         )}
       />
+      {isNovuInAppProvider && (
+        <MantineInput.Wrapper
+          label="Application Identifier"
+          description="The application identifier is a unique public key used by the notification center to identify your Novu account."
+          styles={inputStyles}
+        >
+          <Input
+            readOnly
+            rightSection={
+              <Tooltip label={clipboardEnvironmentIdentifier.copied ? 'Copied!' : 'Copy Key'}>
+                <CopyWrapper onClick={() => clipboardEnvironmentIdentifier.copy(environmentIdentifier)}>
+                  {clipboardEnvironmentIdentifier.copied ? <Check /> : <Copy />}
+                </CopyWrapper>
+              </Tooltip>
+            }
+            value={environmentIdentifier}
+            data-test-id="environment-id"
+          />
+        </MantineInput.Wrapper>
+      )}
     </>
   );
 };

--- a/apps/web/src/pages/integrations/components/multi-provider/UpdateProviderSidebar.tsx
+++ b/apps/web/src/pages/integrations/components/multi-provider/UpdateProviderSidebar.tsx
@@ -279,7 +279,7 @@ export function UpdateProviderSidebar({
           }
         >
           <NovuProviderSidebarContent provider={selectedProvider} />
-          <UpdateIntegrationCommonFields provider={selectedProvider} />
+          <UpdateIntegrationCommonFields provider={selectedProvider} isNovuInAppProvider={isNovuInAppProvider} />
         </Sidebar>
         <SelectPrimaryIntegrationModal />
       </FormProvider>
@@ -339,7 +339,7 @@ export function UpdateProviderSidebar({
             docReference={selectedProvider?.docReference}
           />
           {isNovuInAppProvider && <NovuInAppSetupWarning provider={selectedProvider} />}
-          <UpdateIntegrationCommonFields provider={selectedProvider} />
+          <UpdateIntegrationCommonFields provider={selectedProvider} isNovuInAppProvider={isNovuInAppProvider} />
           {selectedProvider?.credentials.map((credential: IConfigCredentials) => (
             <InputWrapper key={credential.key}>
               <Controller


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Application Identifier is added in integration sidebar for Novu In App integrations. The field is read only, has a copy button and has a description as well.

### Why was this change needed?
This PR closes https://github.com/novuhq/novu/issues/4505

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
