### PR TITLE
fix: make date path and authenticate by token optional

### DIFF
--- a/libs/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/libs/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -960,14 +960,14 @@ export const genericSmsConfig: IConfigCredentials[] = [
     type: 'string',
     value: 'data.date',
     description: 'The path to the date field in the response data ex. (date, message.date, ...)',
-    required: true,
+    required: false,
   },
   {
     key: CredentialsKeyEnum.AuthenticateByToken,
     displayName: 'Authenticate by token',
     type: 'switch',
     description: 'If enabled, the API key and secret key will be sent as a token in the Authorization header',
-    required: true,
+    required: false,
   },
   {
     key: CredentialsKeyEnum.Domain,

--- a/providers/generic-sms/src/lib/generic-sms.provider.ts
+++ b/providers/generic-sms/src/lib/generic-sms.provider.ts
@@ -77,7 +77,9 @@ export class GenericSmsProvider implements ISmsProvider {
 
     return {
       id: this.getResponseValue(this.config.idPath || 'id', responseData),
-      date: this.getResponseValue(this.config.datePath || 'date', responseData),
+      date:
+        this.getResponseValue(this.config.datePath || 'date', responseData) ||
+        new Date().toISOString(),
     };
   }
 


### PR DESCRIPTION
### What change does this PR introduce?
1. Updae `datePath` and `authenticateByToken` as required false in generic SMS provider
2. Add current date as fall back date in response of generic SMS provider
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
