### PR TITLE
fix(provider): add better proxy support for brevo mail provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5996,9 +5996,12 @@ importers:
       '@novu/stateless':
         specifier: ^0.22.0
         version: link:../../packages/stateless
-      axios:
-        specifier: ^1.6.2
-        version: 1.6.2
+      cross-fetch:
+        specifier: ^4.0.0
+        version: 4.0.0
+      proxy-agent:
+        specifier: ^6.3.0
+        version: 6.3.0
     devDependencies:
       '@istanbuljs/nyc-config-typescript':
         specifier: ^1.0.1
@@ -17925,7 +17928,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       consola: 2.15.3
-      node-fetch: 2.6.9
+      node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
 
@@ -32558,6 +32561,14 @@ packages:
       - encoding
     dev: false
 
+  /cross-fetch@4.0.0:
+    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /cross-spawn@6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
     engines: {node: '>=4.8'}
@@ -36663,7 +36674,7 @@ packages:
       extend: 3.0.2
       https-proxy-agent: 5.0.1
       is-stream: 2.0.1
-      node-fetch: 2.6.9
+      node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -43705,6 +43716,7 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: false
 
   /node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -51484,7 +51496,7 @@ packages:
     dependencies:
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      node-fetch: 2.6.9
+      node-fetch: 2.7.0
       stream-events: 1.0.5
       uuid: 9.0.1
     transitivePeerDependencies:

--- a/providers/sendinblue/package.json
+++ b/providers/sendinblue/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "@novu/stateless": "^0.22.0",
-    "axios": "^1.6.2"
+    "cross-fetch": "^4.0.0",
+    "proxy-agent": "^6.3.1"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",


### PR DESCRIPTION
### What change does this PR introduce?

Add better proxy for brevo mail provider as axios may leads to 502 error when having proxy over HTTPS

### Why was this change needed?

Using actual provider leads to 502 error (Squid proxy error with zero size reply) as axios have some issues with HTTPS over proxy.

### Other information (Screenshots)

Using cross-fetch with proxy-agent to have better proxy management
