### PR TITLE
fix: add options in resend senderName

### DIFF
--- a/providers/resend/src/lib/resend.provider.ts
+++ b/providers/resend/src/lib/resend.provider.ts
@@ -26,7 +26,7 @@ export class ResendEmailProvider implements IEmailProvider {
   async sendMessage(
     options: IEmailOptions
   ): Promise<ISendMessageSuccessResponse> {
-    const senderName = this.config?.senderName;
+    const senderName = options.senderName || this.config?.senderName;
     const fromAddress = options.from || this.config.from;
 
     const response: any = await this.resendClient.sendEmail({


### PR DESCRIPTION
### What change does this PR introduce?
Added `options.senderName` so that sendername from payload/overrides/template is used and in absence of all of three config one is used
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
