### PR TITLE
fix(web): prevent updating variants to have empty conditions (front-end only)

### DIFF
--- a/apps/web/cypress/tests/notification-editor/variants.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/variants.spec.ts
@@ -870,7 +870,10 @@ describe('Workflow Editor - Variants', function () {
       cy.contains('Delete').click();
 
       // submit ("Apply conditions") should be disabled
-      cy.getByTestId('apply-conditions-btn').should('be.disabled');
+      cy.getByTestId('apply-conditions-btn').should('be.disabled').click({ force: true });
+
+      // tooltip should warn the user
+      cy.get('div[role="tooltip"]').contains('At least one condition is required');
     });
   });
 

--- a/apps/web/cypress/tests/notification-editor/variants.spec.ts
+++ b/apps/web/cypress/tests/notification-editor/variants.spec.ts
@@ -841,6 +841,37 @@ describe('Workflow Editor - Variants', function () {
       cy.wait('@getWorkflow');
       cy.getByTestId('variants-count').should('not.exist');
     });
+
+    it('should not allow removing all conditions from a variant', function () {
+      createWorkflow('Test Removing All Conditions');
+
+      dragAndDrop('inApp');
+      editChannel('inApp');
+      fillEditorContent('inApp');
+      goBack();
+
+      showStepActions('inApp');
+      addVariantActionClick('inApp');
+      addConditions();
+
+      cy.getByTestId('notification-template-submit-btn').click();
+      cy.wait('@updateWorkflow');
+
+      cy.reload();
+      cy.wait('@getWorkflow');
+
+      // edit the variant condition
+      cy.getByTestId('editor-sidebar-edit-conditions').click();
+
+      // open conditions row menu
+      cy.getByTestId('conditions-row-btn').click();
+
+      // delete the condition
+      cy.contains('Delete').click();
+
+      // submit ("Apply conditions") should be disabled
+      cy.getByTestId('apply-conditions-btn').should('be.disabled');
+    });
   });
 
   describe('Variants List Errors', function () {

--- a/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
+++ b/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
@@ -166,6 +166,7 @@ export const EditorSidebarHeaderActions = () => {
           conditions={conditions}
           filterPartsList={filterPartsList}
           defaultFilter={FilterPartTypeEnum.PAYLOAD}
+          shouldDisallowEmptyConditions
         />
       )}
 

--- a/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
+++ b/apps/web/src/pages/templates/components/EditorSidebarHeaderActions.tsx
@@ -166,7 +166,7 @@ export const EditorSidebarHeaderActions = () => {
           conditions={conditions}
           filterPartsList={filterPartsList}
           defaultFilter={FilterPartTypeEnum.PAYLOAD}
-          shouldDisallowEmptyConditions
+          shouldDisallowEmptyConditions={isUnderVariantPath}
         />
       )}
 

--- a/apps/web/src/pages/templates/components/VariantItemCard.tsx
+++ b/apps/web/src/pages/templates/components/VariantItemCard.tsx
@@ -264,6 +264,7 @@ export const VariantItemCard = ({
           conditions={conditions}
           filterPartsList={filterPartsList}
           defaultFilter={FilterPartTypeEnum.PAYLOAD}
+          shouldDisallowEmptyConditions
         />
       )}
       <DeleteConfirmModal


### PR DESCRIPTION
### What change does this PR introduce?

Front-end fixes for preventing empty variant conditions
- Introduces test to catch issue with saving variants with empty conditions
- Disable submit button and add tooltip when removing all conditions from a variant

### Why was this change needed?

Fixes NV-3147 

### Other information (Screenshots)

![](https://github.com/novuhq/novu/assets/47441786/504913d7-34f2-41fe-bf55-ef6c4fa87e97)
