### PR TITLE
fix(pkg): User 1000 instead of root

### DIFF
--- a/libs/embed/Dockerfile
+++ b/libs/embed/Dockerfile
@@ -1,26 +1,27 @@
 FROM nikolaik/python-nodejs:python3.10-nodejs20-alpine
 
-WORKDIR /usr/src/app
-
 RUN npm install -g pnpm@8.9.0 --loglevel notice --force
 
-COPY .npmrc .
-COPY package.json .
+USER 1000
+WORKDIR /usr/src/app
 
-COPY libs/testing ./libs/testing
-COPY libs/dal ./libs/dal
-COPY libs/shared ./libs/shared
-COPY packages/client ./packages/client
-COPY packages/node ./packages/node
-COPY libs/embed ./libs/embed
-COPY packages/notification-center ./packages/notification-center
+COPY --chown=1000:1000 .npmrc .
+COPY --chown=1000:1000 package.json .
 
-COPY tsconfig.json .
-COPY tsconfig.base.json .
+COPY --chown=1000:1000 libs/testing ./libs/testing
+COPY --chown=1000:1000 libs/dal ./libs/dal
+COPY --chown=1000:1000 libs/shared ./libs/shared
+COPY --chown=1000:1000 packages/client ./packages/client
+COPY --chown=1000:1000 packages/node ./packages/node
+COPY --chown=1000:1000 libs/embed ./libs/embed
+COPY --chown=1000:1000 packages/notification-center ./packages/notification-center
 
-COPY nx.json .
-COPY pnpm-workspace.yaml .
-COPY pnpm-lock.yaml .
+COPY --chown=1000:1000 tsconfig.json .
+COPY --chown=1000:1000 tsconfig.base.json .
+
+COPY --chown=1000:1000 nx.json .
+COPY --chown=1000:1000 pnpm-workspace.yaml .
+COPY --chown=1000:1000 pnpm-lock.yaml .
 
 RUN pnpm install --reporter=silent
 RUN pnpm build


### PR DESCRIPTION
### What change does this PR introduce?

These changes will allow us to use user 1000 instead of ROOT to support running containers on k8.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

It's needed to support running containers on k8 and for security reasons. I missed the embed service when I was working on [this PR](https://github.com/novuhq/novu/pull/5084)

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)
The main process is run by user 1000 after these changes

![Screenshot from 2024-01-17 09-51-02](https://github.com/novuhq/novu/assets/141645418/e1dffbe7-f8e5-4d12-9180-9a9feed78a7a)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
