### PR TITLE
fix: filters dont apply to a delay that is the first step in workflow

### DIFF
--- a/apps/worker/src/app/workflow/usecases/queue-next-job/queue-next-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/queue-next-job/queue-next-job.usecase.ts
@@ -1,17 +1,12 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { JobEntity, JobRepository } from '@novu/dal';
-import { AddJob, ConditionsFilter, ConditionsFilterCommand, InstrumentUsecase } from '@novu/application-generic';
+import { AddJob, InstrumentUsecase } from '@novu/application-generic';
 
 import { QueueNextJobCommand } from './queue-next-job.command';
-import { StepTypeEnum } from '@novu/shared';
 
 @Injectable()
 export class QueueNextJob {
-  constructor(
-    private jobRepository: JobRepository,
-    @Inject(forwardRef(() => AddJob)) private addJobUsecase: AddJob,
-    private conditionsFilter: ConditionsFilter
-  ) {}
+  constructor(private jobRepository: JobRepository, @Inject(forwardRef(() => AddJob)) private addJobUsecase: AddJob) {}
 
   @InstrumentUsecase()
   public async execute(command: QueueNextJobCommand): Promise<JobEntity | undefined> {
@@ -24,29 +19,12 @@ export class QueueNextJob {
       return;
     }
 
-    let filtered = false;
-
-    if ([StepTypeEnum.DELAY, StepTypeEnum.DIGEST].includes(job.type as StepTypeEnum)) {
-      const shouldRun = await this.conditionsFilter.filter(
-        ConditionsFilterCommand.create({
-          filters: job.step.filters || [],
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-          userId: command.userId,
-          job,
-        })
-      );
-
-      filtered = !shouldRun.passed;
-    }
-
     await this.addJobUsecase.execute({
       userId: job._userId,
       environmentId: job._environmentId,
       organizationId: command.organizationId,
       jobId: job._id,
       job,
-      filtered,
     });
 
     return job;

--- a/packages/application-generic/src/usecases/add-job/add-job.command.ts
+++ b/packages/application-generic/src/usecases/add-job/add-job.command.ts
@@ -1,7 +1,7 @@
-import { IsDefined, IsOptional } from 'class-validator';
+import { IsDefined } from 'class-validator';
 import { JobEntity } from '@novu/dal';
 
-import { EnvironmentWithUserCommand } from '../../commands/project.command';
+import { EnvironmentWithUserCommand } from '../../commands';
 
 export class AddJobCommand extends EnvironmentWithUserCommand {
   @IsDefined()
@@ -9,7 +9,4 @@ export class AddJobCommand extends EnvironmentWithUserCommand {
 
   @IsDefined()
   job: JobEntity;
-
-  @IsOptional()
-  filtered?: boolean;
 }


### PR DESCRIPTION
### What change does this PR introduce?

Bug fix - a delay as a first step didn't apply filters, the delay was still executed. The problem was that the check of the filters for action steps was done in the queue-next-step usecase but when delay is the first step that usecase is not executed and add-job is first (there was no problem with digest because we add a trigger step for digest) 
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
