### PR TITLE
fix: autocomplete i18n files with quotations

### DIFF
--- a/apps/web/src/pages/templates/components/CustomCodeEditor.tsx
+++ b/apps/web/src/pages/templates/components/CustomCodeEditor.tsx
@@ -9,6 +9,13 @@ import { useQuery } from '@tanstack/react-query';
 import { editor as NEditor } from 'monaco-editor';
 import { createTranslationMarks } from './createTranslationMarks';
 
+export const getTextToInsert = (text, key) => {
+  if (key === 'translations') {
+    return `i18n "${text}"`;
+  }
+
+  return text;
+};
 export const CustomCodeEditor = ({
   onChange,
   value,
@@ -81,7 +88,7 @@ const CustomCodeEditorBase = ({
                     label: `${key === 'translations' ? 'i18n ' : ''}${name}.${subName}`,
                     kind: monaco.languages.CompletionItemKind.Variable,
                     detail: type[subName],
-                    insertText: `${key === 'translations' ? 'i18n ' : ''}${name}.${subName}`,
+                    insertText: getTextToInsert(`${name}.${subName}`, key),
                     range: range,
                   };
                 });
@@ -91,7 +98,7 @@ const CustomCodeEditorBase = ({
                 label: `${key === 'translations' ? 'i18n ' : ''}${name}`,
                 kind: monaco.languages.CompletionItemKind.Variable,
                 detail: type,
-                insertText: `${key === 'translations' ? 'i18n ' : ''}${name}`,
+                insertText: getTextToInsert(name, key),
                 range: range,
               };
             })

--- a/apps/web/src/pages/templates/components/email-editor/AutoSuggestionsDropdown.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/AutoSuggestionsDropdown.tsx
@@ -5,6 +5,7 @@ import { HandlebarHelpers } from '@novu/shared';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { getWorkflowVariables } from '../../../../api/notification-templates';
+import { getTextToInsert } from '../CustomCodeEditor';
 
 type AutoSuggestionsDropdownProps = {
   autoSuggestionsCoordinates: {
@@ -38,9 +39,8 @@ export function AutoSuggestionsDropdown({
               return Object.keys(type).map((subName) => {
                 return {
                   label: `${key === 'translations' ? 'i18n ' : ''}${name}.${subName}`,
-
                   detail: type[subName],
-                  insertText: `${key === 'translations' ? 'i18n ' : ''}${name}.${subName}`,
+                  insertText: getTextToInsert(`${name}.${subName}`, key),
                 };
               });
             }
@@ -48,7 +48,7 @@ export function AutoSuggestionsDropdown({
             return {
               label: `${key === 'translations' ? 'i18n ' : ''}${name}`,
               detail: type,
-              insertText: `${key === 'translations' ? 'i18n ' : ''}${name}`,
+              insertText: getTextToInsert(name, key),
             };
           })
           .flat();


### PR DESCRIPTION
### What change does this PR introduce?
In i18n autocomplete, it completes to file.key but the usage is "file.key".

It should complete with the quotations
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
