### PR TITLE
feat(ci): Get a build process back to a docker build instead of a dep…

### DIFF
--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -37,17 +37,10 @@ runs:
       shell: bash
       run: pnpm build:api
 
-    - name: 🚢 Setup Depot
-      uses: depot/setup-action@v1
-      if: ${{ inputs.fork == 'false' }}
-      with:
-        oidc: true
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
     - name: Login To Registry
-      if: ${{ inputs.fork == 'false' }}
       shell: bash
       env:
         GH_ACTOR: ${{ github.actor }}
@@ -61,30 +54,17 @@ runs:
         echo "BULL_MQ_PRO_NPM_TOKEN=${{ inputs.bullmq_secret }}" >> $GITHUB_ENV
       if: contains( inputs.docker_name  , 'ee')
 
-    - name: Build with Depot, tag, and test - Regular
-      if: ${{ inputs.fork == 'false' }} # Use buildx for forks as they can't access secrets
+    - name: Build with Buildx, tag, and test
       shell: bash
       env:
         REGISTRY_OWNER: novuhq
         DOCKER_NAME: ${{ inputs.docker_name }}
         IMAGE_TAG: ${{ github.sha }}
-        DEPOT_PROJECT_ID: 6sj0jfv0n7
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
       run: |
         set -x
-        cd apps/api && pnpm run docker:build:depot --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN}
-
-    - name: Build with Buildx, tag, and test
-      if: ${{ inputs.fork == 'true' }} # Use buildx for forks as they can't access secrets
-      shell: bash
-      env:
-        REGISTRY_OWNER: novuhq
-        DOCKER_NAME: ${{ inputs.docker_name }}
-        IMAGE_TAG: ${{ github.sha }}
-      run: |
-        set -x
-        cd apps/api && pnpm run docker:build
+        cd apps/api && pnpm run docker:build --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN}
 
     - name: Tag and test
       id: build-image
@@ -93,7 +73,6 @@ runs:
         REGISTRY_OWNER: novuhq
         DOCKER_NAME: ${{ inputs.docker_name }}
         IMAGE_TAG: ${{ github.sha }}
-        DEPOT_PROJECT_ID: 6sj0jfv0n7
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
       run: |

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -37,11 +37,6 @@ runs:
       shell: bash
       run: pnpm build:worker
 
-    # - name: 🚢 Setup Depot
-    #   uses: depot/setup-action@v1
-    #   with:
-    #     oidc: true
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
@@ -59,28 +54,12 @@ runs:
         echo "BULL_MQ_PRO_NPM_TOKEN=${{ inputs.bullmq_secret }}" >> $GITHUB_ENV
       if: contains(inputs.docker_name , 'ee')
 
-    # - name: Build with Depot, tag, and test - Regular
-    #   if: ${{ inputs.fork == 'false' }} # Use buildx for forks as they can't access secrets
-    #   shell: bash
-    #   env:
-    #     REGISTRY_OWNER: novuhq
-    #     DOCKER_NAME: ${{ inputs.docker_name }}
-    #     IMAGE_TAG: ${{ github.sha }}
-    #     DEPOT_PROJECT_ID: 6sj0jfv0n7
-    #     GH_ACTOR: ${{ github.actor }}
-    #     GH_PASSWORD: ${{ inputs.github_token }}
-    #   run: |
-    #     set -x
-    #     cd apps/worker && pnpm run docker:build:depot --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN}
-
     - name: Build with Buildx, tag, and test
-      # if: ${{ inputs.fork == 'true' }} # Use buildx for forks as they can't access secrets
       shell: bash
       env:
         REGISTRY_OWNER: novuhq
         DOCKER_NAME: ${{ inputs.docker_name }}
         IMAGE_TAG: ${{ github.sha }}
-        DEPOT_PROJECT_ID: 6sj0jfv0n7
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
       run: |
@@ -94,7 +73,6 @@ runs:
         REGISTRY_OWNER: novuhq
         DOCKER_NAME: ${{ inputs.docker_name }}
         IMAGE_TAG: ${{ github.sha }}
-        DEPOT_PROJECT_ID: 6sj0jfv0n7
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
       run: |

--- a/.github/workflows/dev-deploy-embed.yml
+++ b/.github/workflows/dev-deploy-embed.yml
@@ -38,5 +38,4 @@ jobs:
       project_path: libs/embed
       local_tag: novu-embed
       env_tag: dev
-      depot_project_id: f88777ff6m
     secrets: inherit

--- a/.github/workflows/dev-deploy-inbound-mail.yml
+++ b/.github/workflows/dev-deploy-inbound-mail.yml
@@ -47,11 +47,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-project
 
-      - name: Setup Depot
-        uses: depot/setup-action@v1
-        with:
-          oidc: true
-
       - name: Set Bull MQ Env variable for EE
         shell: bash
         run: |
@@ -66,10 +61,9 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
-          DEPOT_PROJECT_ID: 6sj0jfv0n7
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | depot build --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load
+          cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | docker build --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
 

--- a/.github/workflows/dev-deploy-web.yml
+++ b/.github/workflows/dev-deploy-web.yml
@@ -51,5 +51,4 @@ jobs:
       project_path: apps/web
       local_tag: novu-web
       env_tag: dev
-      depot_project_id: f88777ff6m
     secrets: inherit

--- a/.github/workflows/dev-deploy-webhook.yml
+++ b/.github/workflows/dev-deploy-webhook.yml
@@ -31,7 +31,6 @@ jobs:
       health_check: true
       local_tag: novu-webhook
       env_tag: dev
-      depot_project_id: f88777ff6m
     secrets: inherit
 
   deploy_dev_webhook:

--- a/.github/workflows/dev-deploy-widget.yml
+++ b/.github/workflows/dev-deploy-widget.yml
@@ -50,5 +50,4 @@ jobs:
       project_path: apps/widget
       local_tag: novu-widget
       env_tag: dev
-      depot_project_id: f88777ff6m
     secrets: inherit

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -46,11 +46,6 @@ jobs:
       - name: build api
         run: pnpm build:api --skip-nx-cache
 
-      - name: Setup Depot
-        uses: depot/setup-action@v1
-        with:
-          oidc: true
-
       - name: Set Bull MQ Env variable for EE
         if: contains(matrix.name, 'ee')
         shell: bash
@@ -65,10 +60,9 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
-          DEPOT_PROJECT_ID: 6sj0jfv0n7
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd apps/api && pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | depot build --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} --build-arg PACKAGE_PATH=apps/api - -t novu-api --load
+          cd apps/api && pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | docker build --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} --build-arg PACKAGE_PATH=apps/api - -t novu-api --load
           docker tag novu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker tag novu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker tag novu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG

--- a/.github/workflows/prod-deploy-embed.yml
+++ b/.github/workflows/prod-deploy-embed.yml
@@ -42,5 +42,4 @@ jobs:
       project_path: libs/embed
       local_tag: novu-embed
       env_tag: prod
-      depot_project_id: f88777ff6m
     secrets: inherit

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -36,11 +36,6 @@ jobs:
       - name: build api
         run: pnpm build:inbound-mail
 
-      - name: Setup Depot
-        uses: depot/setup-action@v1
-        with:
-          oidc: true
-
       - name: Set Bull MQ Env variable for EE
         if: contains(matrix.name, 'ee')
         shell: bash
@@ -55,10 +50,9 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
-          DEPOT_PROJECT_ID: 6sj0jfv0n7
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | depot build --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load
+          cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | docker build --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG

--- a/.github/workflows/prod-deploy-web.yml
+++ b/.github/workflows/prod-deploy-web.yml
@@ -64,5 +64,4 @@ jobs:
       project_path: apps/web
       local_tag: novu-web
       env_tag: prod
-      depot_project_id: f88777ff6m
     secrets: inherit

--- a/.github/workflows/prod-deploy-webhook.yml
+++ b/.github/workflows/prod-deploy-webhook.yml
@@ -20,7 +20,6 @@ jobs:
       health_check: true
       local_tag: novu-webhook
       env_tag: prod
-      depot_project_id: f88777ff6m
     secrets: inherit
 
   deploy_prod_webhook_eu:

--- a/.github/workflows/prod-deploy-widget.yml
+++ b/.github/workflows/prod-deploy-widget.yml
@@ -59,5 +59,4 @@ jobs:
       project_path: apps/widget
       local_tag: novu-widget
       env_tag: prod
-      depot_project_id: f88777ff6m
     secrets: inherit

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -46,11 +46,6 @@ jobs:
       - name: build worker
         run: pnpm build:worker --skip-nx-cache
 
-      - name: Setup Depot
-        uses: depot/setup-action@v1
-        with:
-          oidc: true
-
       - name: Set Bull MQ Env variable for EE
         if: contains(matrix.name, 'ee')
         shell: bash
@@ -65,10 +60,9 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
-          DEPOT_PROJECT_ID: 6sj0jfv0n7
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd apps/worker && pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | depot build --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load
+          cd apps/worker && pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | docker build --build-arg BULL_MQ_PRO_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load
           docker tag novu-worker ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker tag novu-worker ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker tag novu-worker ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -16,11 +16,6 @@ on:
       project_path:
         required: true
         type: string
-      # The ID of the depot project.
-      # Note: Currently we build everything under one project (it requires to set up the OIDC for each project and I had some issues with the Depot)
-      depot_project_id:
-        required: true
-        type: string
       # The port used for testing. This is not a required input, and it defaults to '1341'.
       # This value is added, so you can test the image after it's built in test mode and by doing a health-check.
       test_port:
@@ -32,7 +27,7 @@ on:
         required: false
         default: false
         type: boolean
-      # The tag under which the image is built, it should align with the name in the project command docker:build:depot
+      # The tag under which the image is built, it should align with the name in the project command docker:build
       local_tag:
         required: true
         type: string
@@ -76,11 +71,6 @@ jobs:
           slim: 'true'
           submodules: ${{ contains (matrix.name,'-ee') }}
 
-      - name: Setup Depot
-        uses: depot/setup-action@v1
-        with:
-          oidc: true
-
       - name: Build, tag, and push image to ghcr.io
         id: build-image
         if: ${{ inputs.env_tag == 'dev' || inputs.env_tag == 'stg' }}
@@ -93,10 +83,9 @@ jobs:
           PROJECT_PATH: ${{ inputs.project_path }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
-          DEPOT_PROJECT_ID: ${{ inputs.depot_project_id }}
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd $PROJECT_PATH && npm run docker:build:depot
+          cd $PROJECT_PATH && npm run docker:build
           docker tag $LOCAL_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
           docker tag $LOCAL_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$ENV_TAG
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
@@ -114,10 +103,9 @@ jobs:
           PROJECT_PATH: ${{ inputs.project_path }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
-          DEPOT_PROJECT_ID:  ${{ inputs.depot_project_id }}
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd $PROJECT_PATH && npm run docker:build:depot
+          cd $PROJECT_PATH && npm run docker:build
           docker tag $LOCAL_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
           docker tag $LOCAL_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$ENV_TAG
           docker tag $LOCAL_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest

--- a/.github/workflows/staging-deploy-web.yml
+++ b/.github/workflows/staging-deploy-web.yml
@@ -51,5 +51,4 @@ jobs:
       project_path: apps/web
       local_tag: novu-web
       env_tag: dev
-      depot_project_id: f88777ff6m
     secrets: inherit


### PR DESCRIPTION
### What change does this PR introduce?

We want to shut down our account of depot.dev as we are not getting very much utility out of there platform. We want to move our build process back to docker buildx in the CI pipelines.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

Cost Optimization

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

Just in case, I decided not to change the "package" files.json" until we make sure everything is working fine

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
