### PR TITLE
chore(web): translation management handle undefined workflow variables object

### DIFF
--- a/apps/web/src/api/hooks/index.ts
+++ b/apps/web/src/api/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './notification-templates';
 export * from './useInAppActivated';
 export * from './useDeleteIntegration';
 export * from './useWebhookSupportStatus';
+export * from './notification-templates';

--- a/apps/web/src/api/hooks/notification-templates/index.ts
+++ b/apps/web/src/api/hooks/notification-templates/index.ts
@@ -2,3 +2,4 @@ export { useTemplateFetcher } from './useTemplateFetcher';
 export { useUpdateTemplate } from './useUpdateTemplate';
 export * from './useFetchBlueprints';
 export * from './useCreateTemplateFromBlueprint';
+export * from './useWorkflowVariables';

--- a/apps/web/src/api/hooks/notification-templates/useWorkflowVariables.ts
+++ b/apps/web/src/api/hooks/notification-templates/useWorkflowVariables.ts
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { HandlebarHelpers } from '@novu/shared';
+
+import { getWorkflowVariables } from '../../notification-templates';
+
+export interface IVariable {
+  label: string;
+  detail: string;
+  insertText: string;
+}
+
+const getTextToInsert = (text, key) => {
+  if (key === 'translations') {
+    return `i18n "${text}"`;
+  }
+
+  return text;
+};
+
+export const useWorkflowVariables = () => {
+  const { data: variables = {}, ...rest } = useQuery(['getVariables'], getWorkflowVariables, {
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
+  const allVariables: IVariable[] = useMemo(() => {
+    const systemVars = Object.keys(variables)
+      .map((key) => {
+        const subVariables = variables[key];
+
+        return Object.keys(subVariables)
+          .map((name) => {
+            const type = subVariables[name];
+            if (typeof type === 'object') {
+              return Object.keys(type).map((subName) => {
+                return {
+                  label: `${key === 'translations' ? 'i18n ' : ''}${name}.${subName}`,
+                  detail: type[subName],
+                  insertText: getTextToInsert(`${name}.${subName}`, key),
+                };
+              });
+            }
+
+            return {
+              label: `${key === 'translations' ? 'i18n ' : ''}${name}`,
+              detail: type,
+              insertText: getTextToInsert(name, key),
+            };
+          })
+          .flat();
+      })
+      .flat();
+
+    return [
+      ...Object.keys(HandlebarHelpers).map((name) => ({
+        label: name,
+        detail: HandlebarHelpers[name].description,
+        insertText: name,
+      })),
+      ...systemVars,
+    ];
+  }, [variables]);
+
+  return {
+    variables,
+    allVariables,
+    ...rest,
+  };
+};

--- a/apps/web/src/pages/templates/components/email-editor/TextRowContent.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/TextRowContent.tsx
@@ -1,17 +1,15 @@
 import styled from '@emotion/styled';
-import { HandlebarHelpers, TextAlignEnum } from '@novu/shared';
-import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-
 import { getHotkeyHandler } from '@mantine/hooks';
+import { TextAlignEnum } from '@novu/shared';
 import { colors } from '@novu/design-system';
-import { getWorkflowVariables } from '../../../../api/notification-templates';
+
 import { useEnvController } from '../../../../hooks';
 import { useStepFormPath } from '../../hooks/useStepFormPath';
-import { getTextToInsert } from '../CustomCodeEditor';
 import type { IForm } from '../formTypes';
 import { AutoSuggestionsDropdown } from './AutoSuggestionsDropdown';
+import { useWorkflowVariables } from '../../../../api/hooks';
 
 export function TextRowContent({ blockIndex }: { blockIndex: number }) {
   const methods = useFormContext<IForm>();
@@ -35,55 +33,15 @@ export function TextRowContent({ blockIndex }: { blockIndex: number }) {
   const [contentSnapshot, setContentSnapshot] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  const { data: variables } = useQuery(['getVariables'], () => getWorkflowVariables(), {
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-    refetchInterval: false,
-  });
+  const { allVariables } = useWorkflowVariables();
 
   const variablesList = useMemo(() => {
-    const systemVars = Object.keys(variables)
-      .map((key) => {
-        const subVariables = variables[key];
-
-        return Object.keys(subVariables)
-          .map((name) => {
-            const type = subVariables[name];
-            if (typeof type === 'object') {
-              return Object.keys(type).map((subName) => {
-                return {
-                  label: `${key === 'translations' ? 'i18n ' : ''}${name}.${subName}`,
-                  detail: type[subName],
-                  insertText: getTextToInsert(`${name}.${subName}`, key),
-                };
-              });
-            }
-
-            return {
-              label: `${key === 'translations' ? 'i18n ' : ''}${name}`,
-              detail: type,
-              insertText: getTextToInsert(name, key),
-            };
-          })
-          .flat();
-      })
-      .flat();
-
-    const allVars = [
-      ...Object.keys(HandlebarHelpers).map((name) => ({
-        label: name,
-        detail: HandlebarHelpers[name].description,
-        insertText: name,
-      })),
-      ...systemVars,
-    ];
-
     if (variableQuery) {
-      return allVars.filter((variable) => variable.label.toLowerCase().includes(variableQuery.toLowerCase()));
-    } else {
-      return allVars;
+      return allVariables.filter((variable) => variable.label.toLowerCase().includes(variableQuery.toLowerCase()));
     }
-  }, [variableQuery, variables]);
+
+    return allVariables;
+  }, [variableQuery, allVariables]);
 
   useEffect(() => {
     if (isAutoSuggestionTrigger) {

--- a/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
@@ -25,6 +25,7 @@ import { useDebounce, useProcessVariables } from '../../../../../hooks';
 import { VarItemTooltip } from './VarItemTooltip';
 import { When } from '../../../../../components/utils/When';
 import { getWorkflowVariables } from '../../../../../api/notification-templates';
+import { useWorkflowVariables } from '../../../../../api/hooks';
 
 interface IVariablesList {
   translations: Record<string, any>;
@@ -78,11 +79,7 @@ export const VariablesManagement = ({
     control,
   });
 
-  const { data: variables, isLoading: isLoadingVariables } = useQuery(['getVariables'], () => getWorkflowVariables(), {
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-    refetchInterval: false,
-  });
+  const { variables } = useWorkflowVariables();
 
   const processedVariables = useProcessVariables(variableArray, false);
   const [variablesList, setVariablesList] = useState<IVariablesList>({


### PR DESCRIPTION
### What change does this PR introduce?

1. Fixes the unhandled exception when the workflow variables object is undefined (while the request is loading).
2. Small refactor that creates a reusable `useWorkflowVariables` hook that is used everywhere in the code: editor, custom code, variables sidebar.

### Why was this change needed?


### Other information (Screenshots)
![Screenshot 2024-01-24 at 12 00 31](https://github.com/novuhq/novu/assets/2607232/b4f35985-24d0-4e1d-b0fb-f4f5f2e66730)
![Screenshot 2024-01-24 at 12 00 43](https://github.com/novuhq/novu/assets/2607232/d11aea4d-4801-40b3-a098-87dab6381a7d)
![Screenshot 2024-01-24 at 12 01 38](https://github.com/novuhq/novu/assets/2607232/c77768bf-185b-4a98-b67a-ec4dce8e7411)


