### PR TITLE
feat(brevo): add support for brevo email templates

### DIFF
--- a/providers/sendinblue/src/lib/brevo.provider.ts
+++ b/providers/sendinblue/src/lib/brevo.provider.ts
@@ -37,6 +37,8 @@ export class BrevoEmailProvider implements IEmailProvider {
       email: options.from || this.config.from,
       name: options.senderName || this.config.senderName,
     };
+    email.templateId = options.customData?.templateId;
+    email.params = options.customData?.templateParams;
     email.to = getFormattedTo(options.to);
     email.subject = options.subject;
     email.htmlContent = options.html;


### PR DESCRIPTION
Hi guys !

First of all, a big thank you for this great work on Novu! ❤️ 

While working with Novu, I realized that email templates for Brevo (formerly SendinBlue) were not supported. This is why I am opening this little PR.

Hoping it will be available in the next release! 🤞 

Don't hesitate if there is a need for more info or modification.

Closes #5122 