### PR TITLE
fix: translation missing warning not working

### DIFF
--- a/apps/web/src/pages/templates/components/CustomCodeEditor.tsx
+++ b/apps/web/src/pages/templates/components/CustomCodeEditor.tsx
@@ -17,7 +17,7 @@ export const CustomCodeEditor = ({
   value?: string;
   height?: string;
 }) => {
-  const { allVariables, isLoading: isLoadingVariables } = useWorkflowVariables();
+  const { allVariables, variables, isLoading: isLoadingVariables } = useWorkflowVariables();
 
   const { colorScheme } = useMantineColorScheme();
   const isDark = colorScheme === 'dark';
@@ -34,7 +34,8 @@ export const CustomCodeEditor = ({
     <Card data-test-id={'custom-code-editor'} withBorder sx={styledCard}>
       <CustomCodeEditorBase
         isDark={isDark}
-        variables={allVariables}
+        allVariables={allVariables}
+        variables={variables}
         onChange={onChange}
         value={value}
         height={height}
@@ -47,13 +48,15 @@ const CustomCodeEditorBase = ({
   onChange,
   value,
   height = '300px',
+  allVariables,
   variables,
   isDark,
 }: {
   onChange?: (string) => void;
   value?: string;
   height?: string;
-  variables: IVariable[];
+  allVariables: IVariable[];
+  variables: any;
   isDark: boolean;
 }) => {
   const editorRef = useRef<NEditor.IStandaloneCodeEditor | null>(null);
@@ -68,8 +71,8 @@ const CustomCodeEditorBase = ({
   }, [isDark]);
 
   const getSuggestions = useCallback(
-    (monaco, range) => variables.map((el) => ({ ...el, kind: monaco.languages.CompletionItemKind.Function, range })),
-    [variables]
+    (monaco, range) => allVariables.map((el) => ({ ...el, kind: monaco.languages.CompletionItemKind.Function, range })),
+    [allVariables]
   );
 
   return (


### PR DESCRIPTION
### What change does this PR introduce?
Translation missing warning was not working. The wrong variable object was being sent to process
<img width="543" alt="Screen Shot 2024-01-31 at 13 44 27" src="https://github.com/novuhq/novu/assets/7778680/dc1687c3-389b-47be-8f5f-13d46018b5eb">

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
