### PR TITLE
fix(ci): CSpell action version update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: streetsidesoftware/cspell-action@v2
+      - uses: streetsidesoftware/cspell-action@v5
 
   get-affected:
     name: Get Affected Packages


### PR DESCRIPTION
### What change does this PR introduce?

In some cases, the CSpell github action fails to pickup spelling errors before merging to next branch. This results in next having failed builds for subsequent PRs. 
Reference PR which had incorrect spelling but failed to be detected in CI prior to merge:

https://github.com/novuhq/novu/actions/runs/7114670957/job/19369189668?pr=4922#step:3:13

The same spelling error is presented in a new PR CI check:

https://github.com/novuhq/novu/actions/runs/7182546230/job/19559313593#step:3:27

We decided in the beginning to try to update the version because it's not easy to reproduce the BUG. Then if we see the same issue we reopen this ticket and kick off a deep investigation of it.

### Why was this change needed?

It will be useful to update the action and try to fix the error, which happens very rarely

### Other information (Screenshots)


