### PR TITLE
Fix client payload on remove messages

### DIFF
--- a/packages/client/src/api/api.service.ts
+++ b/packages/client/src/api/api.service.ts
@@ -71,9 +71,9 @@ export class ApiService {
     return await this.httpClient.delete(`/widgets/messages/${messageId}`, {});
   }
 
-  async removeMessages(messageId: string[]): Promise<any> {
+  async removeMessages(messageIds: string[]): Promise<any> {
     return await this.httpClient.post(`/widgets/messages/bulk/delete`, {
-      messageId: messageId,
+      messageIds: messageIds,
     });
   }
 

--- a/packages/notification-center/src/hooks/index.ts
+++ b/packages/notification-center/src/hooks/index.ts
@@ -16,4 +16,5 @@ export * from './useFetchUserPreferences';
 export * from './useFetchUserGlobalPreferences';
 export * from './useMarkNotificationsAs';
 export * from './useRemoveNotification';
+export * from './useRemoveNotifications';
 export * from './useRemoveAllNotifications';


### PR DESCRIPTION
### What change does this PR introduce?

Fixes the payload on bulk remove messages in the API client.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
