### PR TITLE
fix(api): bulk create subscribers after they were deleted

### DIFF
--- a/libs/dal/src/repositories/subscriber/subscriber.repository.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.repository.ts
@@ -44,7 +44,7 @@ export class SubscriberRepository extends BaseRepository<SubscriberDBModel, Subs
       return {
         updateOne: {
           filter: { subscriberId, _environmentId: environmentId, _organizationId: organizationId },
-          update: { $set: rest },
+          update: { $set: { ...rest, deleted: false } },
           upsert: true,
         },
       };


### PR DESCRIPTION
### What change does this PR introduce?

When deleted subscribers are "recreated" with bulk create endpoint we will "mark" them as `deleted: false` (not deleted).

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

https://github.com/novuhq/novu/assets/2607232/247f749a-498f-4092-bee4-4bb2b161c10d



