### PR TITLE
refactor(infra): EE symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ docker/.env
 
 # NX Build System
 .nx/cache
+
+# EE Symlinked folders
+enterprise/packages/**/src

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ docker/.env
 .vercel
 
 .pnpm-store/
+
+# NX Build System
+.nx/cache

--- a/enterprise/packages/auth/package.json
+++ b/enterprise/packages/auth/package.json
@@ -9,8 +9,7 @@
     "build:watch": "node_modules/.bin/tsc -w -p tsconfig.json",
     "lint": "eslint src --no-error-on-unmatched-pattern",
     "test": "echo 'skip test in the ci'",
-    "test-ee": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file tests/setup.ts src/**/**/*.spec.ts",
-    "symlink": "ln -s ../../../.source/auth/src ./src"
+    "test-ee": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file tests/setup.ts src/**/**/*.spec.ts"
   },
   "dependencies": {
     "@novu/application-generic": "^0.23.0",

--- a/enterprise/packages/auth/src
+++ b/enterprise/packages/auth/src
@@ -1,1 +1,0 @@
-../../../.source/auth/src

--- a/enterprise/packages/billing-web/package.json
+++ b/enterprise/packages/billing-web/package.json
@@ -21,8 +21,7 @@
     "build:watch": "npm run build:esm:watch",
     "lint": "eslint --ext .ts,.tsx src --no-error-on-unmatched-pattern",
     "test": "echo 'skip test in the ci'",
-    "start": "npm run build:watch",
-    "symlink": "ln -s ../../../.source/billing-web/src ./src"
+    "start": "npm run build:watch"
   },
   "dependencies": {
     "@emotion/css": "^11.10.5",

--- a/enterprise/packages/billing/package.json
+++ b/enterprise/packages/billing/package.json
@@ -9,8 +9,7 @@
     "build:watch": "node_modules/.bin/tsc -w -p tsconfig.json",
     "test": "echo 'skip test in the ci'",
     "lint": "eslint src --no-error-on-unmatched-pattern",
-    "test-ee": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file tests/setup.ts src/**/**/*.spec.ts",
-    "symlink": "ln -s ../../../.source/billing/src ./src"
+    "test-ee": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file tests/setup.ts src/**/**/*.spec.ts"
   },
   "dependencies": {
     "@nestjs/swagger": "^7.1.8",

--- a/enterprise/packages/libs/dal/package.json
+++ b/enterprise/packages/libs/dal/package.json
@@ -12,8 +12,7 @@
     "precommit": "lint-staged",
     "lint": "eslint src --no-error-on-unmatched-pattern",
     "test": "echo 'skip test in the ci'",
-    "lint:fix": "pnpm lint -- --fix",
-    "symlink": "ln -s ../../../../.source/libs/dal/src ./src"
+    "lint:fix": "pnpm lint -- --fix"
   },
   "author": "",
   "license": "ISC",

--- a/enterprise/packages/libs/dal/src
+++ b/enterprise/packages/libs/dal/src
@@ -1,1 +1,0 @@
-../../../../.source/libs/dal/src

--- a/enterprise/packages/translation-web/package.json
+++ b/enterprise/packages/translation-web/package.json
@@ -21,8 +21,7 @@
     "build:watch": "npm run build:esm:watch",
     "lint": "eslint --ext .ts,.tsx src --no-error-on-unmatched-pattern",
     "test": "echo 'skip test in the ci'",
-    "start": "npm run build:watch",
-    "symlink": "ln -s ../../../.source/translation-web/src ./src"
+    "start": "npm run build:watch"
   },
   "dependencies": {
     "@emotion/css": "^11.10.5",

--- a/enterprise/packages/translation-web/src
+++ b/enterprise/packages/translation-web/src
@@ -1,1 +1,0 @@
-../../../.source/translation-web/src

--- a/enterprise/packages/translation/package.json
+++ b/enterprise/packages/translation/package.json
@@ -9,8 +9,7 @@
     "build:watch": "node_modules/.bin/tsc -w -p tsconfig.json",
     "test": "echo 'skip test in the ci'",
     "lint": "eslint src --no-error-on-unmatched-pattern",
-    "test-ee": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file tests/setup.ts src/**/**/*.spec.ts",
-    "symlink": "ln -s ../../../.source/translation/src ./src"
+    "test-ee": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file tests/setup.ts src/**/**/*.spec.ts"
   },
   "dependencies": {
     "@handlebars/parser": "^2.1.0",

--- a/enterprise/packages/translation/src
+++ b/enterprise/packages/translation/src
@@ -1,1 +1,0 @@
-../../../.source/translation/src

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "jarvis": "node scripts/jarvis.js",
     "dev-environment-setup": "sh ./scripts/dev-environment-setup.sh",
     "get-affected": "node scripts/print-affected-array.mjs",
-    "symlink:submodules": "nx run-many --target=symlink --all",
+    "symlink:submodules": "pnpm --filter \"@novu/ee-*\" exec node \"$(pwd)/scripts/symlink-ee.mjs\"",
     "install:with-ee": "pnpm install && pnpm symlink:submodules"
   },
   "devDependencies": {

--- a/scripts/symlink-ee.mjs
+++ b/scripts/symlink-ee.mjs
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+// Get the current directory
+const currentDir = process.cwd();
+
+// Remove the prefix up to and including "enterprise/packages/"
+const relativePath = currentDir.split('enterprise/packages/')[1];
+
+// Count the number of slashes in the relative path to determine the depth
+const depth = (relativePath.match(/\//g) || []).length;
+
+// Generate the correct number of "../" for the symlink command
+const prefix = '../'.repeat(depth + 3);
+
+// Generate the symlink command
+const symlinkCommand = `ln -sf ${prefix}.source/${relativePath}/src`;
+
+// Execute the symlink command
+execSync(symlinkCommand);
+
+console.log(`Symlinked src for ${process.env.PNPM_PACKAGE_NAME} to ${prefix}.source/${relativePath}/src`);


### PR DESCRIPTION
### What change does this PR introduce?
* [feat: Add ee symlinking script](https://github.com/novuhq/novu/commit/145dfdf84bfa77b16ec35e14d2be51cb246f5df5)
* [fix: Add nx cache to gitignore](https://github.com/novuhq/novu/commit/17258086251b2f78b851355ab04768f29b6e4a85)
* [fix: Git ignore ee symlink binaries](https://github.com/novuhq/novu/commit/6e9d20adf23dfb94473554463b26a0969780ff23)
* [refactor: Remove redundant symlink script from ee package.json](https://github.com/novuhq/novu/commit/5a22ac94d009928500176f76e962338c41d17d32)

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
* Each EE package needed a symlink script with custom file depth, we can abstract this into a script following a common pattern.
  * Symlinks were being checked into source, this will cause broken symlinks for community contributors
  * Symlinks were recursively nesting in EE src folders
  * Without the `-f` flag on the `ln` command, the symlink creation fails on repeated script executions. Adding `-f` makes the operation idempotent without modifying the symlinking behaviour
* NX was producing cache files that could be checked in accidentally

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)
_Symlink script run (existing `pnpm symlink:submodules` script with some better logging and using new script)_
![image](https://github.com/novuhq/novu/assets/32132657/b3a608b5-16d1-41e1-b2f5-b8f972e896d6)

_Symlink recursive src folder nesting issue (fixed)_
![image](https://github.com/novuhq/novu/assets/32132657/752d8fd1-6db0-496f-aecd-52bf58fe5f09)

_Symlink pnpm script error (fixed)_
<img width="775" alt="image" src="https://github.com/novuhq/novu/assets/32132657/ba34768c-f329-47f2-ab71-94352730bcae">

_NX Cache files showing in git pre-stage (fixed)_
![image](https://github.com/novuhq/novu/assets/32132657/34692a83-748d-404c-a754-4d2b38f4c6ec)
