### PR TITLE
feat(worker): add topics fanout in batches by cursor

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-multicast.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-multicast.e2e.ts
@@ -7,13 +7,20 @@ import { SubscribersService, UserSession } from '@novu/testing';
 import {
   ExternalSubscriberId,
   ISubscribersDefine,
+  ITopic,
   SubscriberSourceEnum,
   TopicId,
   TopicKey,
   TriggerRecipients,
   TriggerRecipientsTypeEnum,
 } from '@novu/shared';
-import { SubscriberProcessQueueService, TriggerMulticast, TriggerMulticastCommand } from '@novu/application-generic';
+import {
+  IProcessSubscriberBulkJobDto,
+  mapSubscribersToJobs,
+  SubscriberProcessQueueService,
+  TriggerMulticast,
+  TriggerMulticastCommand,
+} from '@novu/application-generic';
 import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
 
 import { SharedModule } from '../../shared/shared.module';
@@ -27,23 +34,62 @@ const TOPIC_KEY_PREFIX = 'topic-key-trigger-event_';
 const TOPIC_NAME_PREFIX = 'topic-name-trigger-event_';
 
 export class MockSubscriberProcessQueueService {
-  addBulk() {}
+  addBulk(data: IProcessSubscriberBulkJobDto[]) {}
 }
 
 function mapSubscriberToSubscriberDefine(firstTopicSubscribers: SubscriberEntity[]) {
   return firstTopicSubscribers.map((subscriber) => ({ subscriberId: subscriber.subscriberId }));
 }
 
+function expectBulkTopicStub(secondCallStubArgs: IProcessSubscriberBulkJobDto[], jobs: IProcessSubscriberBulkJobDto[]) {
+  for (const stubJobAny of secondCallStubArgs) {
+    const stubJob: IProcessSubscriberBulkJobDto = stubJobAny;
+    const job = jobs.find((xJob) => xJob.name === stubJob.name);
+    if (!job) {
+      expect(job).to.be.ok;
+
+      return;
+    }
+    expect(job.name).to.be.equal(stubJob.name);
+    expect(job.groupId).to.be.equal(stubJob.groupId);
+    expect(job.options).to.be.equal(stubJob.options);
+
+    const { subscriber, ...jobDataWithoutSubscriber } = job.data;
+    const { subscriber: stubSubscriber, ...stubJobDataWithoutSubscriber } = stubJob.data;
+
+    expect(subscriber.subscriberId).to.be.equal(stubSubscriber.subscriberId);
+    expect(jobDataWithoutSubscriber).to.deep.equal(stubJobDataWithoutSubscriber);
+  }
+}
+
+function expectBulkSingleSubscriberStub(
+  secondCallStubArgs: IProcessSubscriberBulkJobDto[],
+  jobs: IProcessSubscriberBulkJobDto[]
+) {
+  for (const stubJobAny of secondCallStubArgs) {
+    const stubJob: IProcessSubscriberBulkJobDto = stubJobAny;
+    const job = jobs.find((xJob) => xJob.name === stubJob.name);
+    if (!job) {
+      expect(job).to.be.ok;
+
+      return;
+    }
+    expect(job.name).to.be.equal(stubJob.name);
+    expect(job.groupId).to.be.equal(stubJob.groupId);
+    expect(job.options).to.be.equal(stubJob.options);
+    expect(job.data).to.deep.equal(stubJob.data);
+  }
+}
+
 describe('TriggerMulticast', () => {
   let triggerMulticast: TriggerMulticast;
   let subscriberProcessQueueService: SubscriberProcessQueueService;
-  let sendToProcessSubscriberServiceStub: sinon.SinonStub;
+  let addBulkStub: sinon.SinonStub;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [SharedModule, EventsModule],
       providers: [
-        // SubscriberProcessQueueService,
         TriggerMulticast,
         {
           provide: SubscriberProcessQueueService,
@@ -54,371 +100,334 @@ describe('TriggerMulticast', () => {
 
     triggerMulticast = moduleRef.get<TriggerMulticast>(TriggerMulticast);
     subscriberProcessQueueService = moduleRef.get<SubscriberProcessQueueService>(SubscriberProcessQueueService);
-    sendToProcessSubscriberServiceStub = sinon.stub(triggerMulticast, 'sendToProcessSubscriberService');
+    addBulkStub = sinon.stub(subscriberProcessQueueService, 'addBulk');
   });
 
   afterEach(() => {
-    sendToProcessSubscriberServiceStub.restore(); // Restore the original method after each test
+    addBulkStub.restore();
   });
 
-  describe('E2E tests', () => {
-    let session: UserSession;
-    let template: NotificationTemplateEntity;
-    let firstSubscriber: SubscriberEntity;
-    let secondSubscriber: SubscriberEntity;
-    let thirdSubscriber: SubscriberEntity;
-    let forthSubscriber: SubscriberEntity;
-    let subscriberService: SubscribersService;
-    let bootstrapFirstTopic: { _id: TopicId; key: TopicKey };
-    let bootstrapSecondTopic: { _id: TopicId; key: TopicKey };
-    let to: TriggerRecipients;
-    let firstTopicSubscribers: SubscriberEntity[];
-    let secondTopicSubscribers: SubscriberEntity[];
+  let session: UserSession;
+  let template: NotificationTemplateEntity;
+  let firstSubscriber: SubscriberEntity;
+  let secondSubscriber: SubscriberEntity;
+  let thirdSubscriber: SubscriberEntity;
+  let forthSubscriber: SubscriberEntity;
+  let subscriberService: SubscribersService;
+  let bootstrapFirstTopic: ITopic & { _id: TopicId };
+  let bootstrapSecondTopic: ITopic & { _id: TopicId };
+  let to: TriggerRecipients;
+  let firstTopicSubscribers: SubscriberEntity[];
+  let secondTopicSubscribers: SubscriberEntity[];
 
-    async function initializeTopic(subscribersToAdd: SubscriberEntity[], topicIndex: string) {
-      const firstTopicKey = TOPIC_KEY_PREFIX + topicIndex;
-      const firstTopicName = TOPIC_NAME_PREFIX + topicIndex;
-      const createdTopic: { _id: TopicId; key: TopicKey } = await createTopic(session, firstTopicKey, firstTopicName);
-      await addSubscribersToTopic(session, createdTopic, subscribersToAdd);
+  async function initializeTopic(subscribersToAdd: SubscriberEntity[], topicIndex: string) {
+    const firstTopicKey = TOPIC_KEY_PREFIX + topicIndex;
+    const firstTopicName = TOPIC_NAME_PREFIX + topicIndex;
+    const createdTopic: { _id: TopicId; key: TopicKey } = await createTopic(session, firstTopicKey, firstTopicName);
+    await addSubscribersToTopic(
+      session,
+      { topicKey: createdTopic.key, type: TriggerRecipientsTypeEnum.TOPIC },
+      subscribersToAdd
+    );
 
-      return createdTopic;
+    const res: ITopic & { _id: TopicId } = {
+      _id: createdTopic._id,
+      topicKey: createdTopic.key,
+      type: TriggerRecipientsTypeEnum.TOPIC,
+    };
+
+    return res;
+  }
+
+  beforeEach(async () => {
+    process.env.LAUNCH_DARKLY_SDK_KEY = '';
+    process.env.IS_TOPIC_NOTIFICATION_ENABLED = 'true';
+    session = new UserSession();
+    await session.initialize();
+    template = await session.createTemplate();
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+
+    firstSubscriber = await subscriberService.createSubscriber();
+    secondSubscriber = await subscriberService.createSubscriber();
+    firstTopicSubscribers = [firstSubscriber, secondSubscriber];
+    bootstrapFirstTopic = await initializeTopic(firstTopicSubscribers, '1');
+    to = [bootstrapFirstTopic];
+
+    thirdSubscriber = await subscriberService.createSubscriber();
+    forthSubscriber = await subscriberService.createSubscriber();
+    secondTopicSubscribers = [thirdSubscriber, forthSubscriber];
+    bootstrapSecondTopic = await initializeTopic(secondTopicSubscribers, '2');
+  });
+
+  it('should call addBulk with correct parameters', async () => {
+    const command: TriggerMulticastCommand = triggerMulticastCommandMock as any;
+
+    const subscribers: ISubscribersDefine[] = [{ subscriberId: command.to[0] }];
+
+    await triggerMulticast.execute(command);
+
+    expect(addBulkStub.callCount).to.be.equal(1);
+
+    const firstCallStubData = addBulkStub.getCall(0).args[0];
+    const firstJobs = mapSubscribersToJobs(SubscriberSourceEnum.SINGLE, subscribers, command);
+
+    expectBulkSingleSubscriberStub(firstCallStubData, firstJobs);
+  });
+
+  it('should fail on if provided topic key is not exists', async () => {
+    const invalidTopicKey = 'none_existing_topic_key';
+    const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+      to: [...to, { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: invalidTopicKey }],
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      userId: session.user._id,
+    }) as any;
+
+    const res = await getErrorMessage(async () => await triggerMulticast.execute(command));
+
+    expect(res).to.be.equal(`Topic with key ${invalidTopicKey} not found in current environment`);
+  });
+
+  it('should send only single subscribers forward to processing', async () => {
+    const singleSubscribers = firstTopicSubscribers;
+    const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+      to: singleSubscribers,
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      userId: session.user._id,
+    }) as any;
+
+    await triggerMulticast.execute(command);
+
+    expect(addBulkStub.callCount).to.be.equal(1);
+
+    const firstCallStubData = addBulkStub.getCall(0).args[0];
+    const firstJobs = mapSubscribersToJobs(SubscriberSourceEnum.SINGLE, singleSubscribers, command);
+
+    expectBulkSingleSubscriberStub(firstCallStubData, firstJobs);
+  });
+
+  it('should fan-out only subscriber from topic to processing', async () => {
+    const firstTopic: TriggerRecipients = [bootstrapFirstTopic];
+    const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+      to: firstTopic,
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      userId: session.user._id,
+    }) as any;
+
+    await triggerMulticast.execute(command);
+
+    expect(addBulkStub.callCount).to.be.equal(1);
+
+    const firstCallStubData = addBulkStub.getCall(0).args[0];
+    const firstJobs = mapSubscribersToJobs(SubscriberSourceEnum.TOPIC, firstTopicSubscribers, command);
+    expectBulkTopicStub(firstCallStubData, firstJobs);
+  });
+
+  it('should send single subscribers and fan-out subscriber from topic forward to to processing', async () => {
+    const singleSubscribers = secondTopicSubscribers;
+    const firstTopic: TriggerRecipients = [bootstrapFirstTopic];
+    const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+      to: [...singleSubscribers, ...firstTopic],
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      userId: session.user._id,
+    }) as any;
+
+    await triggerMulticast.execute(command);
+
+    expect(addBulkStub.callCount).to.be.equal(2);
+
+    const firstCallStubData = addBulkStub.getCall(0).args[0];
+    const firstJobs = mapSubscribersToJobs(SubscriberSourceEnum.SINGLE, singleSubscribers, command);
+
+    expectBulkSingleSubscriberStub(firstCallStubData, firstJobs);
+
+    const secondJobs = mapSubscribersToJobs(SubscriberSourceEnum.TOPIC, firstTopicSubscribers, command);
+    const secondCallStubData: IProcessSubscriberBulkJobDto[] = addBulkStub.getCall(1).args[0];
+
+    expectBulkTopicStub(secondCallStubData, secondJobs);
+  });
+
+  it('should exclude the actor from the topic fan-out', async () => {
+    const actor = firstSubscriber;
+    const firstTopic: TriggerRecipients = [bootstrapFirstTopic];
+    const subscribersDefine = mapSubscriberToSubscriberDefine(firstTopicSubscribers);
+    const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+      to: [...firstTopic],
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      userId: session.user._id,
+      actor: actor,
+    }) as any;
+
+    await triggerMulticast.execute(command);
+
+    expect(addBulkStub.callCount).to.be.equal(1);
+
+    const topicSubscribersWithoutActor = subscribersDefine.filter(
+      (subscriber) => subscriber.subscriberId !== actor.subscriberId
+    );
+
+    const firstCallStubData = addBulkStub.getCall(0).args[0];
+    const firstJobs = mapSubscribersToJobs(SubscriberSourceEnum.TOPIC, topicSubscribersWithoutActor, command);
+
+    expectBulkTopicStub(firstCallStubData, firstJobs);
+  });
+
+  it('should deduplicate single subscriber from topic fan-out', async () => {
+    const singleSubscribers = firstTopicSubscribers;
+    const newSubscriber = await subscriberService.createSubscriber();
+    await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
+
+    /*
+     * in this case we send the same subscriber twice,
+     * but the newSubscriber that is not duplicated and should be sent only once by topic
+     * singleSubscribers contains: A, B
+     * firstTopic contains: A, B, newSubscriber
+     */
+    const firstTopic: TriggerRecipients = [bootstrapFirstTopic];
+    const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+      to: [...singleSubscribers, ...firstTopic],
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      userId: session.user._id,
+    }) as any;
+
+    await triggerMulticast.execute(command);
+
+    expect(addBulkStub.callCount).to.be.equal(2);
+
+    const firstCallStubData = addBulkStub.getCall(0).args[0];
+    const firstJobs = mapSubscribersToJobs(SubscriberSourceEnum.SINGLE, singleSubscribers, command);
+    expectBulkSingleSubscriberStub(firstCallStubData, firstJobs);
+
+    const secondCallStubData = addBulkStub.getCall(1).args[0];
+    const secondJobs = mapSubscribersToJobs(SubscriberSourceEnum.TOPIC, [newSubscriber], command);
+    expectBulkTopicStub(secondCallStubData, secondJobs);
+  });
+
+  it('should deduplicate subscribers across topics', async () => {
+    // first topic: subscribers A, B
+    const firstTopic: TriggerRecipients = [bootstrapFirstTopic];
+
+    // second topic: subscribers C, D
+    const secondTopic: TriggerRecipients = [bootstrapSecondTopic];
+
+    /*
+     * add to second topic subscribers from first topic,
+     * now second topic(A, B, C, D) contains duplication with first topic(A, B) subscribers
+     */
+    await addSubscribersToTopic(session, bootstrapSecondTopic, firstTopicSubscribers);
+
+    /*
+     * in this case we have the same subscriber twice,
+     * firstTopic contains: A, B
+     * secondTopic contains: A, B, C, D
+     */
+    const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+      to: [...firstTopic, ...secondTopic],
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      userId: session.user._id,
+    }) as any;
+
+    await triggerMulticast.execute(command);
+
+    expect(addBulkStub.callCount).to.be.equal(1);
+
+    const firstCallStubData = addBulkStub.getCall(0).args[0];
+    const firstJobs = mapSubscribersToJobs(
+      SubscriberSourceEnum.TOPIC,
+      [...firstTopicSubscribers, ...secondTopicSubscribers],
+      command
+    );
+    expectBulkTopicStub(firstCallStubData, firstJobs);
+  });
+
+  it('should deduplicate subscribers across single subscribers and topics', async () => {
+    const newSubscriber = await subscriberService.createSubscriber();
+    await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
+
+    // first topic: subscribers A, B
+    const firstTopic: TriggerRecipients = [bootstrapFirstTopic];
+
+    // second topic: subscribers C, D
+    const secondTopic: TriggerRecipients = [bootstrapSecondTopic];
+
+    /*
+     * add to second topic subscribers from first topic,
+     * now second topic(A, B, C, D) contains duplication with first topic(A, B) subscribers
+     */
+    await addSubscribersToTopic(session, bootstrapSecondTopic, firstTopicSubscribers);
+
+    const singleSubscribers = firstTopicSubscribers;
+    /*
+     * in this case we have the same subscriber twice,
+     * however, the newSubscriber is not duplicated and should be sent only once by topic
+     * singleSubscribers contains: A, B
+     * firstTopic contains: A, B, newSubscriber
+     * secondTopic contains: A, B, C, D
+     */
+    const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+      to: [...singleSubscribers, ...firstTopic, ...secondTopic],
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      userId: session.user._id,
+    }) as any;
+
+    await triggerMulticast.execute(command);
+
+    expect(addBulkStub.callCount).to.be.equal(2);
+
+    // we check by single subscribers (A, B)
+    const firstCallStubData = addBulkStub.getCall(0).args[0];
+    const firstJobs = mapSubscribersToJobs(SubscriberSourceEnum.SINGLE, singleSubscribers, command);
+    expectBulkSingleSubscriberStub(firstCallStubData, firstJobs);
+
+    // we check by second topic subscribers with newSubscriber (C, D, newSubscriber)
+    const modifiedSecondTopicSubscribersDefine = mapSubscriberToSubscriberDefine([
+      ...secondTopicSubscribers,
+      newSubscriber,
+    ]);
+    const secondCallStubData = addBulkStub.getCall(1).args[0];
+    const secondJobs = mapSubscribersToJobs(SubscriberSourceEnum.TOPIC, modifiedSecondTopicSubscribersDefine, command);
+
+    expectBulkTopicStub(secondCallStubData, secondJobs);
+  });
+
+  it('should batch topic subscribers by 100', async () => {
+    for (let i = 0; i < 234; i++) {
+      const newSubscriber = await subscriberService.createSubscriber();
+      await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
     }
-    beforeEach(async () => {
-      process.env.LAUNCH_DARKLY_SDK_KEY = '';
-      process.env.IS_TOPIC_NOTIFICATION_ENABLED = 'true';
-      session = new UserSession();
-      await session.initialize();
-      template = await session.createTemplate();
-      subscriberService = new SubscribersService(session.organization._id, session.environment._id);
 
-      firstSubscriber = await subscriberService.createSubscriber();
-      secondSubscriber = await subscriberService.createSubscriber();
-      firstTopicSubscribers = [firstSubscriber, secondSubscriber];
-      bootstrapFirstTopic = await initializeTopic(firstTopicSubscribers, '1');
-      to = [{ type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' }];
+    // first topic: subscribers A, B
+    const firstTopic: TriggerRecipients = [bootstrapFirstTopic];
 
-      thirdSubscriber = await subscriberService.createSubscriber();
-      forthSubscriber = await subscriberService.createSubscriber();
-      secondTopicSubscribers = [thirdSubscriber, forthSubscriber];
-      bootstrapSecondTopic = await initializeTopic(secondTopicSubscribers, '2');
-    });
+    const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+      to: [...firstTopic],
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      userId: session.user._id,
+    }) as any;
 
-    it('should call subscriberProcessQueueService with correct parameters', async () => {
-      const command: TriggerMulticastCommand = triggerMulticastCommandMock as any;
+    await triggerMulticast.execute(command);
 
-      const subscribers: ISubscribersDefine[] = [{ subscriberId: command.to[0] }];
+    expect(addBulkStub.callCount).to.be.equal(3);
 
-      await triggerMulticast.execute(command);
+    const firstCallStubData: IProcessSubscriberBulkJobDto[] = addBulkStub.getCall(0).args[0];
+    expect(firstCallStubData.length).to.equal(100);
+    expect(firstCallStubData[0].data._subscriberSource).to.equal(SubscriberSourceEnum.TOPIC);
 
-      expect(sendToProcessSubscriberServiceStub.calledWith(command, subscribers, command.requestCategory)).to.equal(
-        true
-      );
-    });
+    const secondCallStubData: IProcessSubscriberBulkJobDto[] = addBulkStub.getCall(1).args[0];
+    expect(secondCallStubData.length).to.equal(100);
+    expect(secondCallStubData[0].data._subscriberSource).to.equal(SubscriberSourceEnum.TOPIC);
 
-    it('should fail on if provided topic key is not exists', async () => {
-      const invalidTopicKey = 'none_existing_topic_key';
-      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
-        to: [...to, { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: invalidTopicKey }],
-        organizationId: session.organization._id,
-        environmentId: session.environment._id,
-        userId: session.user._id,
-      }) as any;
-
-      const res = await getErrorMessage(async () => await triggerMulticast.execute(command));
-
-      expect(res).to.be.equal('Topic with key none_existing_topic_key not found in current environment');
-    });
-
-    it('should send only single subscribers forward to to processing', async () => {
-      const singleSubscribers = firstTopicSubscribers;
-      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
-        to: singleSubscribers,
-        organizationId: session.organization._id,
-        environmentId: session.environment._id,
-        userId: session.user._id,
-      }) as any;
-
-      await triggerMulticast.execute(command);
-
-      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
-
-      expect(
-        sendToProcessSubscriberServiceStub
-          .getCall(0)
-          .calledWith(command, singleSubscribers, SubscriberSourceEnum.SINGLE)
-      ).to.be.true;
-
-      expect(sendToProcessSubscriberServiceStub.callCount).to.be.equal(1);
-    });
-
-    it('should fan-out only subscriber from topic forward to to processing', async () => {
-      const firstTopic: TriggerRecipients = [
-        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
-      ];
-      const subscribersDefine = mapSubscriberToSubscriberDefine(firstTopicSubscribers);
-      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
-        to: firstTopic,
-        organizationId: session.organization._id,
-        environmentId: session.environment._id,
-        userId: session.user._id,
-      }) as any;
-
-      await triggerMulticast.execute(command);
-
-      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
-
-      expect(sendToProcessSubscriberServiceStub.getCall(0).calledWith(command, [], SubscriberSourceEnum.SINGLE)).to.be
-        .true;
-
-      // we check second call because the first call is for the single subscriber
-      expect(
-        sendToProcessSubscriberServiceStub.getCall(1).calledWith(command, subscribersDefine, SubscriberSourceEnum.TOPIC)
-      ).to.be.true;
-    });
-
-    it('should send single subscribers and fan-out subscriber from topic forward to to processing', async () => {
-      const singleSubscribers = secondTopicSubscribers;
-      const firstTopic: TriggerRecipients = [
-        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
-      ];
-      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
-        to: [...singleSubscribers, ...firstTopic],
-        organizationId: session.organization._id,
-        environmentId: session.environment._id,
-        userId: session.user._id,
-      }) as any;
-      const firstTopicSubscribersDefine = mapSubscriberToSubscriberDefine(firstTopicSubscribers);
-
-      await triggerMulticast.execute(command);
-
-      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
-
-      expect(
-        sendToProcessSubscriberServiceStub
-          .getCall(0)
-          .calledWith(command, singleSubscribers, SubscriberSourceEnum.SINGLE)
-      ).to.be.true;
-
-      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
-      expect(secondCallStubArgs[0]).to.deep.equal(command);
-      expect(secondCallStubArgs[1]).to.include.deep.members(firstTopicSubscribersDefine);
-      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
-    });
-
-    it('should exclude the actor from the topic fan-out', async () => {
-      const actor = firstSubscriber;
-      const firstTopic: TriggerRecipients = [
-        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
-      ];
-      const subscribersDefine = mapSubscriberToSubscriberDefine(firstTopicSubscribers);
-      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
-        to: [...firstTopic],
-        organizationId: session.organization._id,
-        environmentId: session.environment._id,
-        userId: session.user._id,
-        actor: actor,
-      }) as any;
-
-      await triggerMulticast.execute(command);
-
-      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
-
-      const topicSubscribersWithoutActor = subscribersDefine.filter(
-        (subscriber) => subscriber.subscriberId !== actor.subscriberId
-      );
-
-      // we check second call because the first call is for the single subscriber
-      expect(
-        sendToProcessSubscriberServiceStub
-          .getCall(1)
-          .calledWith(command, topicSubscribersWithoutActor, SubscriberSourceEnum.TOPIC)
-      ).to.be.true;
-    });
-
-    it('should deduplicate single subscriber from topic fan-out', async () => {
-      const singleSubscribers = firstTopicSubscribers;
-      const newSubscriber = await subscriberService.createSubscriber();
-      await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
-
-      /*
-       * in this case we send the same subscriber twice,
-       * but the newSubscriber that is not duplicated and should be sent only once by topic
-       * singleSubscribers contains: A, B
-       * firstTopic contains: A, B, newSubscriber
-       */
-      const firstTopic: TriggerRecipients = [
-        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
-      ];
-      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
-        to: [...singleSubscribers, ...firstTopic],
-        organizationId: session.organization._id,
-        environmentId: session.environment._id,
-        userId: session.user._id,
-      }) as any;
-
-      await triggerMulticast.execute(command);
-
-      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
-
-      expect(
-        sendToProcessSubscriberServiceStub
-          .getCall(0)
-          .calledWith(command, singleSubscribers, SubscriberSourceEnum.SINGLE)
-      ).to.be.true;
-
-      const newSubscriberDefine = mapSubscriberToSubscriberDefine([newSubscriber]);
-      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
-      expect(secondCallStubArgs[0]).to.deep.equal(command);
-      expect(secondCallStubArgs[1]).to.include.deep.members(newSubscriberDefine);
-      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
-    });
-
-    it('should deduplicate subscribers across topics', async () => {
-      // first topic: subscribers A, B
-      const firstTopic: TriggerRecipients = [
-        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
-      ];
-
-      // second topic: subscribers B, D
-      const secondTopic: TriggerRecipients = [
-        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '2' },
-      ];
-
-      /*
-       * add subscribers to second topic from first topic ,
-       * now second topic subscribers are not duplicated with first topic subscribers (A, B, C, D)
-       */
-      await addSubscribersToTopic(session, bootstrapFirstTopic, firstTopicSubscribers);
-
-      /*
-       * in this case we send the same subscriber twice,
-       * but the newSubscriber that is not duplicated and should be sent only once by topic
-       * singleSubscribers contains: A, B
-       * firstTopic contains: A, B
-       */
-      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
-        to: [...firstTopic, ...secondTopic],
-        organizationId: session.organization._id,
-        environmentId: session.environment._id,
-        userId: session.user._id,
-      }) as any;
-
-      await triggerMulticast.execute(command);
-
-      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
-
-      const singleSubscribersDefine = mapSubscriberToSubscriberDefine(firstTopicSubscribers);
-
-      const firstCallStubArgs = sendToProcessSubscriberServiceStub.getCall(0).args;
-      expect(firstCallStubArgs[0]).to.deep.equal(command);
-      expect(firstCallStubArgs[1]).to.include.deep.members([]);
-      expect(firstCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.SINGLE);
-
-      // we check by second topic subscribers without duplication
-      const secondTopicSubscriberDefine = mapSubscriberToSubscriberDefine(secondTopicSubscribers);
-
-      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
-      expect(secondCallStubArgs[0]).to.deep.equal(command);
-      expect(secondCallStubArgs[1]).to.include.deep.members(secondTopicSubscriberDefine);
-      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
-    });
-
-    it('should deduplicate subscribers across single subscribers and topics', async () => {
-      const newSubscriber = await subscriberService.createSubscriber();
-      await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
-
-      // first topic: subscribers A, B
-      const firstTopic: TriggerRecipients = [
-        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
-      ];
-
-      // second topic: subscribers B, D
-      const secondTopic: TriggerRecipients = [
-        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '2' },
-      ];
-
-      /*
-       * add subscribers to second topic from first topic ,
-       * now second topic subscribers are not duplicated with first topic subscribers (A, B, C, D)
-       */
-      await addSubscribersToTopic(session, bootstrapFirstTopic, firstTopicSubscribers);
-
-      const singleSubscribers = firstTopicSubscribers;
-      /*
-       * in this case we send the same subscriber twice,
-       * but the newSubscriber that is not duplicated and should be sent only once by topic
-       * singleSubscribers contains: A, B
-       * firstTopic contains: A, B
-       * secondTopic contains: A, B, C, D
-       */
-      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
-        to: [...singleSubscribers, ...firstTopic, ...secondTopic],
-        organizationId: session.organization._id,
-        environmentId: session.environment._id,
-        userId: session.user._id,
-      }) as any;
-
-      await triggerMulticast.execute(command);
-
-      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
-
-      // we check by single subscribers (A, B)
-      const firstCallStubArgs = sendToProcessSubscriberServiceStub.getCall(0).args;
-      expect(firstCallStubArgs[0]).to.deep.equal(command);
-      expect(firstCallStubArgs[1]).to.include.deep.members(singleSubscribers);
-      expect(firstCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.SINGLE);
-
-      // we check by second topic subscribers without duplication (C, D)
-      const secondTopicSubscribersDefine = mapSubscriberToSubscriberDefine(secondTopicSubscribers);
-
-      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
-      expect(secondCallStubArgs[0]).to.deep.equal(command);
-      expect(secondCallStubArgs[1]).to.include.deep.members(secondTopicSubscribersDefine);
-      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
-    });
-
-    it('should batch topic subscribers by 100', async () => {
-      for (let i = 0; i < 234; i++) {
-        const newSubscriber = await subscriberService.createSubscriber();
-        await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
-      }
-
-      // first topic: subscribers A, B
-      const firstTopic: TriggerRecipients = [
-        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
-      ];
-
-      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
-        to: [...firstTopic],
-        organizationId: session.organization._id,
-        environmentId: session.environment._id,
-        userId: session.user._id,
-      }) as any;
-
-      await triggerMulticast.execute(command);
-
-      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
-
-      const firstCallStubArgs = sendToProcessSubscriberServiceStub.getCall(0).args;
-      expect(firstCallStubArgs[0]).to.deep.equal(command);
-      expect(firstCallStubArgs[1].length).to.equal(0);
-      expect(firstCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.SINGLE);
-
-      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
-      expect(secondCallStubArgs[0]).to.deep.equal(command);
-      expect(secondCallStubArgs[1].length).to.equal(100);
-      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
-
-      const thirdCallStubArgs = sendToProcessSubscriberServiceStub.getCall(2).args;
-      expect(thirdCallStubArgs[0]).to.deep.equal(command);
-      expect(thirdCallStubArgs[1].length).to.equal(100);
-      expect(thirdCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
-
-      const forthCallStubArgs = sendToProcessSubscriberServiceStub.getCall(3).args;
-      expect(forthCallStubArgs[0]).to.deep.equal(command);
-      expect(forthCallStubArgs[1].length).to.equal(36);
-      expect(forthCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
-    });
+    const thirdCallStubData: IProcessSubscriberBulkJobDto[] = addBulkStub.getCall(2).args[0];
+    expect(thirdCallStubData.length).to.equal(36);
+    expect(thirdCallStubData[0].data._subscriberSource).to.equal(SubscriberSourceEnum.TOPIC);
   });
 });
 
@@ -547,7 +556,7 @@ const triggerMulticastCommandMock = {
 
 const addSubscribersToTopic = async (
   session: UserSession,
-  createdTopicDto: { _id: TopicId; key: TopicKey },
+  createdTopicDto: ITopic,
   subscribers: SubscriberEntity[]
 ) => {
   const subscriberIds: ExternalSubscriberId[] = subscribers.map(
@@ -555,7 +564,7 @@ const addSubscribersToTopic = async (
   );
 
   const response = await axiosInstance.post(
-    `${session.serverUrl}${TOPIC_PATH}/${createdTopicDto.key}/subscribers`,
+    `${session.serverUrl}${TOPIC_PATH}/${createdTopicDto.topicKey}/subscribers`,
     {
       subscribers: subscriberIds,
     },
@@ -567,7 +576,5 @@ const addSubscribersToTopic = async (
   );
 
   expect(response.status).to.be.eq(200);
-  expect(response.data.data).to.be.eql({
-    succeeded: subscriberIds,
-  });
+  expect(response.data.data.succeeded).to.have.deep.members(subscriberIds);
 };

--- a/apps/api/src/app/events/e2e/trigger-multicast.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-multicast.e2e.ts
@@ -1,0 +1,573 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Test } from '@nestjs/testing';
+import axios from 'axios';
+
+import { SubscribersService, UserSession } from '@novu/testing';
+import {
+  ExternalSubscriberId,
+  ISubscribersDefine,
+  SubscriberSourceEnum,
+  TopicId,
+  TopicKey,
+  TriggerRecipients,
+  TriggerRecipientsTypeEnum,
+} from '@novu/shared';
+import { SubscriberProcessQueueService, TriggerMulticast, TriggerMulticastCommand } from '@novu/application-generic';
+import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
+
+import { SharedModule } from '../../shared/shared.module';
+import { EventsModule } from '../events.module';
+import { createTopic } from '../../topics/e2e/helpers';
+
+const axiosInstance = axios.create();
+
+const TOPIC_PATH = '/v1/topics';
+const TOPIC_KEY_PREFIX = 'topic-key-trigger-event_';
+const TOPIC_NAME_PREFIX = 'topic-name-trigger-event_';
+
+export class MockSubscriberProcessQueueService {
+  addBulk() {}
+}
+
+function mapSubscriberToSubscriberDefine(firstTopicSubscribers: SubscriberEntity[]) {
+  return firstTopicSubscribers.map((subscriber) => ({ subscriberId: subscriber.subscriberId }));
+}
+
+describe('TriggerMulticast', () => {
+  let triggerMulticast: TriggerMulticast;
+  let subscriberProcessQueueService: SubscriberProcessQueueService;
+  let sendToProcessSubscriberServiceStub: sinon.SinonStub;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SharedModule, EventsModule],
+      providers: [
+        // SubscriberProcessQueueService,
+        TriggerMulticast,
+        {
+          provide: SubscriberProcessQueueService,
+          useClass: MockSubscriberProcessQueueService,
+        },
+      ],
+    }).compile();
+
+    triggerMulticast = moduleRef.get<TriggerMulticast>(TriggerMulticast);
+    subscriberProcessQueueService = moduleRef.get<SubscriberProcessQueueService>(SubscriberProcessQueueService);
+    sendToProcessSubscriberServiceStub = sinon.stub(triggerMulticast, 'sendToProcessSubscriberService');
+  });
+
+  afterEach(() => {
+    sendToProcessSubscriberServiceStub.restore(); // Restore the original method after each test
+  });
+
+  describe('E2E tests', () => {
+    let session: UserSession;
+    let template: NotificationTemplateEntity;
+    let firstSubscriber: SubscriberEntity;
+    let secondSubscriber: SubscriberEntity;
+    let thirdSubscriber: SubscriberEntity;
+    let forthSubscriber: SubscriberEntity;
+    let subscriberService: SubscribersService;
+    let bootstrapFirstTopic: { _id: TopicId; key: TopicKey };
+    let bootstrapSecondTopic: { _id: TopicId; key: TopicKey };
+    let to: TriggerRecipients;
+    let firstTopicSubscribers: SubscriberEntity[];
+    let secondTopicSubscribers: SubscriberEntity[];
+
+    async function initializeTopic(subscribersToAdd: SubscriberEntity[], topicIndex: string) {
+      const firstTopicKey = TOPIC_KEY_PREFIX + topicIndex;
+      const firstTopicName = TOPIC_NAME_PREFIX + topicIndex;
+      const createdTopic: { _id: TopicId; key: TopicKey } = await createTopic(session, firstTopicKey, firstTopicName);
+      await addSubscribersToTopic(session, createdTopic, subscribersToAdd);
+
+      return createdTopic;
+    }
+    beforeEach(async () => {
+      process.env.LAUNCH_DARKLY_SDK_KEY = '';
+      process.env.IS_TOPIC_NOTIFICATION_ENABLED = 'true';
+      session = new UserSession();
+      await session.initialize();
+      template = await session.createTemplate();
+      subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+
+      firstSubscriber = await subscriberService.createSubscriber();
+      secondSubscriber = await subscriberService.createSubscriber();
+      firstTopicSubscribers = [firstSubscriber, secondSubscriber];
+      bootstrapFirstTopic = await initializeTopic(firstTopicSubscribers, '1');
+      to = [{ type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' }];
+
+      thirdSubscriber = await subscriberService.createSubscriber();
+      forthSubscriber = await subscriberService.createSubscriber();
+      secondTopicSubscribers = [thirdSubscriber, forthSubscriber];
+      bootstrapSecondTopic = await initializeTopic(secondTopicSubscribers, '2');
+    });
+
+    it('should call subscriberProcessQueueService with correct parameters', async () => {
+      const command: TriggerMulticastCommand = triggerMulticastCommandMock as any;
+
+      const subscribers: ISubscribersDefine[] = [{ subscriberId: command.to[0] }];
+
+      await triggerMulticast.execute(command);
+
+      expect(sendToProcessSubscriberServiceStub.calledWith(command, subscribers, command.requestCategory)).to.equal(
+        true
+      );
+    });
+
+    it('should fail on if provided topic key is not exists', async () => {
+      const invalidTopicKey = 'none_existing_topic_key';
+      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+        to: [...to, { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: invalidTopicKey }],
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        userId: session.user._id,
+      }) as any;
+
+      const res = await getErrorMessage(async () => await triggerMulticast.execute(command));
+
+      expect(res).to.be.equal('Topic with key none_existing_topic_key not found in current environment');
+    });
+
+    it('should send only single subscribers forward to to processing', async () => {
+      const singleSubscribers = firstTopicSubscribers;
+      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+        to: singleSubscribers,
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        userId: session.user._id,
+      }) as any;
+
+      await triggerMulticast.execute(command);
+
+      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
+
+      expect(
+        sendToProcessSubscriberServiceStub
+          .getCall(0)
+          .calledWith(command, singleSubscribers, SubscriberSourceEnum.SINGLE)
+      ).to.be.true;
+
+      expect(sendToProcessSubscriberServiceStub.callCount).to.be.equal(1);
+    });
+
+    it('should fan-out only subscriber from topic forward to to processing', async () => {
+      const firstTopic: TriggerRecipients = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
+      ];
+      const subscribersDefine = mapSubscriberToSubscriberDefine(firstTopicSubscribers);
+      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+        to: firstTopic,
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        userId: session.user._id,
+      }) as any;
+
+      await triggerMulticast.execute(command);
+
+      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
+
+      expect(sendToProcessSubscriberServiceStub.getCall(0).calledWith(command, [], SubscriberSourceEnum.SINGLE)).to.be
+        .true;
+
+      // we check second call because the first call is for the single subscriber
+      expect(
+        sendToProcessSubscriberServiceStub.getCall(1).calledWith(command, subscribersDefine, SubscriberSourceEnum.TOPIC)
+      ).to.be.true;
+    });
+
+    it('should send single subscribers and fan-out subscriber from topic forward to to processing', async () => {
+      const singleSubscribers = secondTopicSubscribers;
+      const firstTopic: TriggerRecipients = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
+      ];
+      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+        to: [...singleSubscribers, ...firstTopic],
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        userId: session.user._id,
+      }) as any;
+      const firstTopicSubscribersDefine = mapSubscriberToSubscriberDefine(firstTopicSubscribers);
+
+      await triggerMulticast.execute(command);
+
+      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
+
+      expect(
+        sendToProcessSubscriberServiceStub
+          .getCall(0)
+          .calledWith(command, singleSubscribers, SubscriberSourceEnum.SINGLE)
+      ).to.be.true;
+
+      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
+      expect(secondCallStubArgs[0]).to.deep.equal(command);
+      expect(secondCallStubArgs[1]).to.include.deep.members(firstTopicSubscribersDefine);
+      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
+    });
+
+    it('should exclude the actor from the topic fan-out', async () => {
+      const actor = firstSubscriber;
+      const firstTopic: TriggerRecipients = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
+      ];
+      const subscribersDefine = mapSubscriberToSubscriberDefine(firstTopicSubscribers);
+      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+        to: [...firstTopic],
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        userId: session.user._id,
+        actor: actor,
+      }) as any;
+
+      await triggerMulticast.execute(command);
+
+      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
+
+      const topicSubscribersWithoutActor = subscribersDefine.filter(
+        (subscriber) => subscriber.subscriberId !== actor.subscriberId
+      );
+
+      // we check second call because the first call is for the single subscriber
+      expect(
+        sendToProcessSubscriberServiceStub
+          .getCall(1)
+          .calledWith(command, topicSubscribersWithoutActor, SubscriberSourceEnum.TOPIC)
+      ).to.be.true;
+    });
+
+    it('should deduplicate single subscriber from topic fan-out', async () => {
+      const singleSubscribers = firstTopicSubscribers;
+      const newSubscriber = await subscriberService.createSubscriber();
+      await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
+
+      /*
+       * in this case we send the same subscriber twice,
+       * but the newSubscriber that is not duplicated and should be sent only once by topic
+       * singleSubscribers contains: A, B
+       * firstTopic contains: A, B, newSubscriber
+       */
+      const firstTopic: TriggerRecipients = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
+      ];
+      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+        to: [...singleSubscribers, ...firstTopic],
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        userId: session.user._id,
+      }) as any;
+
+      await triggerMulticast.execute(command);
+
+      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
+
+      expect(
+        sendToProcessSubscriberServiceStub
+          .getCall(0)
+          .calledWith(command, singleSubscribers, SubscriberSourceEnum.SINGLE)
+      ).to.be.true;
+
+      const newSubscriberDefine = mapSubscriberToSubscriberDefine([newSubscriber]);
+      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
+      expect(secondCallStubArgs[0]).to.deep.equal(command);
+      expect(secondCallStubArgs[1]).to.include.deep.members(newSubscriberDefine);
+      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
+    });
+
+    it('should deduplicate subscribers across topics', async () => {
+      // first topic: subscribers A, B
+      const firstTopic: TriggerRecipients = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
+      ];
+
+      // second topic: subscribers B, D
+      const secondTopic: TriggerRecipients = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '2' },
+      ];
+
+      /*
+       * add subscribers to second topic from first topic ,
+       * now second topic subscribers are not duplicated with first topic subscribers (A, B, C, D)
+       */
+      await addSubscribersToTopic(session, bootstrapFirstTopic, firstTopicSubscribers);
+
+      /*
+       * in this case we send the same subscriber twice,
+       * but the newSubscriber that is not duplicated and should be sent only once by topic
+       * singleSubscribers contains: A, B
+       * firstTopic contains: A, B
+       */
+      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+        to: [...firstTopic, ...secondTopic],
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        userId: session.user._id,
+      }) as any;
+
+      await triggerMulticast.execute(command);
+
+      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
+
+      const singleSubscribersDefine = mapSubscriberToSubscriberDefine(firstTopicSubscribers);
+
+      const firstCallStubArgs = sendToProcessSubscriberServiceStub.getCall(0).args;
+      expect(firstCallStubArgs[0]).to.deep.equal(command);
+      expect(firstCallStubArgs[1]).to.include.deep.members([]);
+      expect(firstCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.SINGLE);
+
+      // we check by second topic subscribers without duplication
+      const secondTopicSubscriberDefine = mapSubscriberToSubscriberDefine(secondTopicSubscribers);
+
+      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
+      expect(secondCallStubArgs[0]).to.deep.equal(command);
+      expect(secondCallStubArgs[1]).to.include.deep.members(secondTopicSubscriberDefine);
+      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
+    });
+
+    it('should deduplicate subscribers across single subscribers and topics', async () => {
+      const newSubscriber = await subscriberService.createSubscriber();
+      await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
+
+      // first topic: subscribers A, B
+      const firstTopic: TriggerRecipients = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
+      ];
+
+      // second topic: subscribers B, D
+      const secondTopic: TriggerRecipients = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '2' },
+      ];
+
+      /*
+       * add subscribers to second topic from first topic ,
+       * now second topic subscribers are not duplicated with first topic subscribers (A, B, C, D)
+       */
+      await addSubscribersToTopic(session, bootstrapFirstTopic, firstTopicSubscribers);
+
+      const singleSubscribers = firstTopicSubscribers;
+      /*
+       * in this case we send the same subscriber twice,
+       * but the newSubscriber that is not duplicated and should be sent only once by topic
+       * singleSubscribers contains: A, B
+       * firstTopic contains: A, B
+       * secondTopic contains: A, B, C, D
+       */
+      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+        to: [...singleSubscribers, ...firstTopic, ...secondTopic],
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        userId: session.user._id,
+      }) as any;
+
+      await triggerMulticast.execute(command);
+
+      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
+
+      // we check by single subscribers (A, B)
+      const firstCallStubArgs = sendToProcessSubscriberServiceStub.getCall(0).args;
+      expect(firstCallStubArgs[0]).to.deep.equal(command);
+      expect(firstCallStubArgs[1]).to.include.deep.members(singleSubscribers);
+      expect(firstCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.SINGLE);
+
+      // we check by second topic subscribers without duplication (C, D)
+      const secondTopicSubscribersDefine = mapSubscriberToSubscriberDefine(secondTopicSubscribers);
+
+      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
+      expect(secondCallStubArgs[0]).to.deep.equal(command);
+      expect(secondCallStubArgs[1]).to.include.deep.members(secondTopicSubscribersDefine);
+      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
+    });
+
+    it('should batch topic subscribers by 100', async () => {
+      for (let i = 0; i < 234; i++) {
+        const newSubscriber = await subscriberService.createSubscriber();
+        await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
+      }
+
+      // first topic: subscribers A, B
+      const firstTopic: TriggerRecipients = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: TOPIC_KEY_PREFIX + '1' },
+      ];
+
+      const command: TriggerMulticastCommand = buildTriggerMulticastCommandMock({
+        to: [...firstTopic],
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        userId: session.user._id,
+      }) as any;
+
+      await triggerMulticast.execute(command);
+
+      expect(sendToProcessSubscriberServiceStub.called).to.be.true;
+
+      const firstCallStubArgs = sendToProcessSubscriberServiceStub.getCall(0).args;
+      expect(firstCallStubArgs[0]).to.deep.equal(command);
+      expect(firstCallStubArgs[1].length).to.equal(0);
+      expect(firstCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.SINGLE);
+
+      const secondCallStubArgs = sendToProcessSubscriberServiceStub.getCall(1).args;
+      expect(secondCallStubArgs[0]).to.deep.equal(command);
+      expect(secondCallStubArgs[1].length).to.equal(100);
+      expect(secondCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
+
+      const thirdCallStubArgs = sendToProcessSubscriberServiceStub.getCall(2).args;
+      expect(thirdCallStubArgs[0]).to.deep.equal(command);
+      expect(thirdCallStubArgs[1].length).to.equal(100);
+      expect(thirdCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
+
+      const forthCallStubArgs = sendToProcessSubscriberServiceStub.getCall(3).args;
+      expect(forthCallStubArgs[0]).to.deep.equal(command);
+      expect(forthCallStubArgs[1].length).to.equal(36);
+      expect(forthCallStubArgs[2]).to.be.equal(SubscriberSourceEnum.TOPIC);
+    });
+  });
+});
+
+const getErrorMessage = async (callback) => {
+  let res;
+
+  try {
+    res = await callback();
+  } catch (error) {
+    res = error.message;
+  }
+
+  return res;
+};
+
+type TriggerMulticastCommandOverrides = Partial<TriggerMulticastCommand> & {
+  organizationId: string;
+  environmentId: string;
+};
+const buildTriggerMulticastCommandMock = (overrides: TriggerMulticastCommandOverrides): TriggerMulticastCommand => {
+  return { ...(triggerMulticastCommandMock as any), ...overrides };
+};
+
+const triggerMulticastCommandMock = {
+  userId: '65ccfbfb374a4f35856d76ef',
+  environmentId: '65ccfbfb374a4f35856d76f7',
+  organizationId: '65ccfbfb374a4f35856d76f1',
+  identifier: 'test-event-b0a06229-98d2-4a15-b062-10146d10ef53',
+  payload: {
+    customVar: 'Testing of User Name',
+  },
+  overrides: {},
+  to: ['65ccfbfb374a4f35856d7754'],
+  transactionId: '428fa85a-2529-4186-80ad-3bf29d365de2',
+  addressingType: 'multicast',
+  requestCategory: 'single',
+  tenant: null,
+  template: {
+    preferenceSettings: {
+      email: true,
+      sms: true,
+      in_app: true,
+      chat: true,
+      push: true,
+    },
+    _id: '65ccfbfb374a4f35856d775c',
+    name: 'Central Assurance Analyst',
+    description: 'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, tha',
+    active: true,
+    draft: false,
+    critical: false,
+    isBlueprint: false,
+    _notificationGroupId: '65ccfbfb374a4f35856d76fa',
+    tags: ['test-tag'],
+    triggers: [
+      {
+        type: 'event',
+        identifier: 'test-event-b0a06229-98d2-4a15-b062-10146d10ef53',
+        variables: [
+          {
+            name: 'firstName',
+            _id: '65ccfbfb374a4f35856d775e',
+            id: '65ccfbfb374a4f35856d775e',
+          },
+          {
+            name: 'lastName',
+            _id: '65ccfbfb374a4f35856d775f',
+            id: '65ccfbfb374a4f35856d775f',
+          },
+          {
+            name: 'urlVariable',
+            _id: '65ccfbfb374a4f35856d7760',
+            id: '65ccfbfb374a4f35856d7760',
+          },
+        ],
+        _id: '65ccfbfb374a4f35856d775d',
+        reservedVariables: [],
+        subscriberVariables: [],
+        id: '65ccfbfb374a4f35856d775d',
+      },
+    ],
+    steps: [
+      {
+        metadata: {
+          timed: {
+            weekDays: [],
+            monthDays: [],
+          },
+        },
+        active: true,
+        shouldStopOnFail: false,
+        filters: [],
+        _templateId: '65ccfbfb374a4f35856d775a',
+        variants: [],
+        _id: '65ccfbfb374a4f35856d7761',
+        id: '65ccfbfb374a4f35856d7761',
+        template: {
+          _id: '65ccfbfb374a4f35856d775a',
+          type: 'sms',
+          active: true,
+          variables: [],
+          content: 'Hello world {{customVar}}',
+          _environmentId: '65ccfbfb374a4f35856d76f7',
+          _organizationId: '65ccfbfb374a4f35856d76f1',
+          _creatorId: '65ccfbfb374a4f35856d76ef',
+          _feedId: '65ccfbfb374a4f35856d7726',
+          _layoutId: '65ccfbfb374a4f35856d76fc',
+          deleted: false,
+          createdAt: '2024-02-14T17:44:27.529Z',
+          updatedAt: '2024-02-14T17:44:27.529Z',
+          __v: 0,
+          id: '65ccfbfb374a4f35856d775a',
+        },
+      },
+    ],
+    _environmentId: '65ccfbfb374a4f35856d76f7',
+    _organizationId: '65ccfbfb374a4f35856d76f1',
+    _creatorId: '65ccfbfb374a4f35856d76ef',
+    deleted: false,
+    createdAt: '2024-02-14T17:44:27.532Z',
+    updatedAt: '2024-02-14T17:44:27.532Z',
+    __v: 0,
+    id: '65ccfbfb374a4f35856d775c',
+  },
+};
+
+const addSubscribersToTopic = async (
+  session: UserSession,
+  createdTopicDto: { _id: TopicId; key: TopicKey },
+  subscribers: SubscriberEntity[]
+) => {
+  const subscriberIds: ExternalSubscriberId[] = subscribers.map(
+    (subscriber: SubscriberEntity) => subscriber.subscriberId
+  );
+
+  const response = await axiosInstance.post(
+    `${session.serverUrl}${TOPIC_PATH}/${createdTopicDto.key}/subscribers`,
+    {
+      subscribers: subscriberIds,
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+
+  expect(response.status).to.be.eq(200);
+  expect(response.data.data).to.be.eql({
+    succeeded: subscriberIds,
+  });
+};

--- a/apps/api/src/app/events/e2e/trigger-multicast.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-multicast.e2e.ts
@@ -350,7 +350,7 @@ describe('TriggerMulticast', () => {
     const newSubscriber = await subscriberService.createSubscriber();
     await addSubscribersToTopic(session, bootstrapFirstTopic, [newSubscriber]);
 
-    // first topic: subscribers A, B
+    // first topic: subscribers A, B, newSubscriber
     const firstTopic: TriggerRecipients = [bootstrapFirstTopic];
 
     // second topic: subscribers C, D

--- a/apps/api/src/app/events/e2e/trigger-multicast.spec.ts
+++ b/apps/api/src/app/events/e2e/trigger-multicast.spec.ts
@@ -1,0 +1,307 @@
+import { expect } from 'chai';
+
+import { ITopic, SubscriberSourceEnum, TriggerRecipientsTypeEnum, TriggerRecipientSubscriber } from '@novu/shared';
+import {
+  buildSubscriberDefine,
+  IProcessSubscriberBulkJobDto,
+  mapSubscribersToJobs,
+  splitByRecipientType,
+  validateSubscriberDefine,
+} from '@novu/application-generic';
+import { ISubscribersDefine } from '@novu/shared';
+
+describe('TriggerMulticast Spec', () => {
+  describe('splitByRecipientType', () => {
+    it('should split recipients into singleSubscribers and topicKeys', async () => {
+      const recipients: Array<ISubscribersDefine | ITopic> = [
+        { subscriberId: '1', firstName: 'John', lastName: 'Doe' },
+        { subscriberId: '2', firstName: 'Jane', lastName: 'Doe' },
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: 'topic1' },
+        { subscriberId: '3', firstName: 'Bob', lastName: 'Smith' },
+      ];
+
+      const result = splitByRecipientType(recipients);
+
+      expect(result.singleSubscribers.size).to.be.equal(3);
+      expect(result.topicKeys.size).to.be.equal(1);
+      expect(result.topicKeys.has('topic1')).to.be.equal(true);
+    });
+
+    it('should handle empty array of recipients', async () => {
+      const recipients: Array<ISubscribersDefine | ITopic> = [];
+
+      const result = splitByRecipientType(recipients);
+
+      expect(result.singleSubscribers.size).to.be.equal(0);
+      expect(result.topicKeys.size).to.be.equal(0);
+    });
+
+    it('should handle null/undefined values in the array', async () => {
+      const recipients: Array<ISubscribersDefine | ITopic | null | undefined> = [
+        null,
+        undefined,
+        { subscriberId: '1', firstName: 'John', lastName: 'Doe' },
+        null,
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: 'topic1' },
+        undefined,
+      ];
+
+      const result = splitByRecipientType(recipients as any);
+
+      expect(result.singleSubscribers.size).to.be.equal(1);
+      expect(result.topicKeys.size).to.be.equal(1);
+    });
+
+    it('should handle arrays with only topics', async () => {
+      const recipients: Array<ISubscribersDefine | ITopic> = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: 'topic1' },
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: 'topic2' },
+      ];
+
+      const result = splitByRecipientType(recipients);
+
+      expect(result.singleSubscribers.size).to.be.equal(0);
+      expect(result.topicKeys.size).to.be.equal(2);
+    });
+
+    it('should handle arrays with only subscribers', async () => {
+      const recipients: Array<ISubscribersDefine | ITopic> = [
+        { subscriberId: '1', firstName: 'John', lastName: 'Doe' },
+        { subscriberId: '2', firstName: 'Jane', lastName: 'Doe' },
+      ];
+
+      const result = splitByRecipientType(recipients);
+
+      expect(result.singleSubscribers.size).to.be.equal(2);
+      expect(result.topicKeys.size).to.be.equal(0);
+    });
+
+    it('should handle arrays with duplicate subscriber IDs', async () => {
+      const recipients: Array<ISubscribersDefine | ITopic> = [
+        { subscriberId: '1', firstName: 'John', lastName: 'Doe' },
+        { subscriberId: '2', firstName: 'Jane', lastName: 'Doe' },
+        { subscriberId: '1', firstName: 'Bob', lastName: 'Smith' },
+      ];
+
+      const result = splitByRecipientType(recipients);
+
+      expect(result.singleSubscribers.size).to.be.equal(2);
+      expect(result.topicKeys.size).to.be.equal(0);
+    });
+
+    it('should handle arrays with duplicate topics', async () => {
+      const recipients: Array<ISubscribersDefine | ITopic> = [
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: 'topic1' },
+        { subscriberId: '1', firstName: 'John', lastName: 'Doe' },
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: 'topic2' },
+        { type: TriggerRecipientsTypeEnum.TOPIC, topicKey: 'topic1' },
+        { subscriberId: '2', firstName: 'Jane', lastName: 'Doe' },
+      ];
+
+      const result = splitByRecipientType(recipients);
+
+      expect(result.singleSubscribers.size).to.be.equal(2);
+      expect(result.topicKeys.size).to.be.equal(2);
+    });
+  });
+
+  describe('buildSubscriberDefine', () => {
+    it('should build ISubscribersDefine from string subscriber ID', async () => {
+      const recipient: TriggerRecipientSubscriber = '123';
+
+      const result = buildSubscriberDefine(recipient);
+
+      expect(result).to.be.ok;
+      expect(result.subscriberId).to.be.equal('123'); // Ensure correct subscriber ID
+    });
+
+    it('should build ISubscribersDefine from ISubscribersDefine object', async () => {
+      const recipient: TriggerRecipientSubscriber = {
+        subscriberId: '123',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+      };
+
+      const result = buildSubscriberDefine(recipient);
+
+      expect(result).to.be.ok;
+      expect(result).to.be.equal(recipient);
+    });
+
+    it('should throw error for invalid ISubscribersDefine object', async () => {
+      const recipient = [{ subscriberId: '123' }];
+
+      expect(() => buildSubscriberDefine(recipient as any)).to.throw(
+        'subscriberId under property to is type array, which is not allowed please make sure all subscribers ids are strings'
+      );
+    });
+  });
+
+  describe('validateSubscriberDefine', () => {
+    it('should throw error if recipient is an array', async () => {
+      const recipient: any = ['subscriber123'];
+
+      expect(() => validateSubscriberDefine(recipient)).to.throw(
+        'subscriberId under property to is type array, which is not allowed please make sure all subscribers ids are strings'
+      );
+    });
+
+    it('should throw error if recipient is null or undefined', async () => {
+      const recipient: any = null;
+
+      expect(() => validateSubscriberDefine(recipient)).to.throw(
+        'subscriberId under property to is not configured, please make sure all subscribers contains subscriberId property'
+      );
+
+      const recipient2: any = undefined;
+
+      expect(() => validateSubscriberDefine(recipient2)).to.throw(
+        'subscriberId under property to is not configured, please make sure all subscribers contains subscriberId property'
+      );
+    });
+
+    it('should throw error if recipient does not have subscriberId property', async () => {
+      const recipient: any = {};
+
+      expect(() => validateSubscriberDefine(recipient)).to.throw(
+        'subscriberId under property to is not configured, please make sure all subscribers contains subscriberId property'
+      );
+    });
+
+    it('should not throw error if recipient is valid', async () => {
+      const recipient: ISubscribersDefine = {
+        subscriberId: 'subscriber123',
+        firstName: 'John',
+        lastName: 'Doe',
+      };
+
+      expect(() => validateSubscriberDefine(recipient)).not.to.throw();
+    });
+  });
+
+  describe('mapSubscribersToJobs', () => {
+    const subscriberSource: SubscriberSourceEnum = SubscriberSourceEnum.SINGLE;
+    const subscribers: ISubscribersDefine[] = [
+      { subscriberId: 'subscriber123', firstName: 'John', lastName: 'Doe' },
+      { subscriberId: 'subscriber456', firstName: 'Jane', lastName: 'Doe' },
+    ];
+
+    it('should map subscribers to jobs with correct data', async () => {
+      const jobs: IProcessSubscriberBulkJobDto[] = mapSubscribersToJobs(
+        subscriberSource,
+        subscribers,
+        triggerMulticastCommandMock as any
+      );
+
+      expect(jobs.length).to.be.equal(2);
+      expect(jobs[0].name).to.be.equal('428fa85a-2529-4186-80ad-3bf29d365de2subscriber123');
+      expect(jobs[0].data.environmentId).to.be.equal('65ccfbfb374a4f35856d76f7');
+      expect(jobs[1].name).to.be.equal('428fa85a-2529-4186-80ad-3bf29d365de2subscriber456');
+      expect(jobs[1].data.environmentId).to.be.equal('65ccfbfb374a4f35856d76f7');
+    });
+  });
+});
+
+const triggerMulticastCommandMock = {
+  userId: '65ccfbfb374a4f35856d76ef',
+  environmentId: '65ccfbfb374a4f35856d76f7',
+  organizationId: '65ccfbfb374a4f35856d76f1',
+  identifier: 'test-event-b0a06229-98d2-4a15-b062-10146d10ef53',
+  payload: {
+    customVar: 'Testing of User Name',
+  },
+  overrides: {},
+  to: ['65ccfbfb374a4f35856d7754'],
+  transactionId: '428fa85a-2529-4186-80ad-3bf29d365de2',
+  addressingType: 'multicast',
+  requestCategory: 'single',
+  tenant: null,
+  template: {
+    preferenceSettings: {
+      email: true,
+      sms: true,
+      in_app: true,
+      chat: true,
+      push: true,
+    },
+    _id: '65ccfbfb374a4f35856d775c',
+    name: 'Central Assurance Analyst',
+    description: 'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, tha',
+    active: true,
+    draft: false,
+    critical: false,
+    isBlueprint: false,
+    _notificationGroupId: '65ccfbfb374a4f35856d76fa',
+    tags: ['test-tag'],
+    triggers: [
+      {
+        type: 'event',
+        identifier: 'test-event-b0a06229-98d2-4a15-b062-10146d10ef53',
+        variables: [
+          {
+            name: 'firstName',
+            _id: '65ccfbfb374a4f35856d775e',
+            id: '65ccfbfb374a4f35856d775e',
+          },
+          {
+            name: 'lastName',
+            _id: '65ccfbfb374a4f35856d775f',
+            id: '65ccfbfb374a4f35856d775f',
+          },
+          {
+            name: 'urlVariable',
+            _id: '65ccfbfb374a4f35856d7760',
+            id: '65ccfbfb374a4f35856d7760',
+          },
+        ],
+        _id: '65ccfbfb374a4f35856d775d',
+        reservedVariables: [],
+        subscriberVariables: [],
+        id: '65ccfbfb374a4f35856d775d',
+      },
+    ],
+    steps: [
+      {
+        metadata: {
+          timed: {
+            weekDays: [],
+            monthDays: [],
+          },
+        },
+        active: true,
+        shouldStopOnFail: false,
+        filters: [],
+        _templateId: '65ccfbfb374a4f35856d775a',
+        variants: [],
+        _id: '65ccfbfb374a4f35856d7761',
+        id: '65ccfbfb374a4f35856d7761',
+        template: {
+          _id: '65ccfbfb374a4f35856d775a',
+          type: 'sms',
+          active: true,
+          variables: [],
+          content: 'Hello world {{customVar}}',
+          _environmentId: '65ccfbfb374a4f35856d76f7',
+          _organizationId: '65ccfbfb374a4f35856d76f1',
+          _creatorId: '65ccfbfb374a4f35856d76ef',
+          _feedId: '65ccfbfb374a4f35856d7726',
+          _layoutId: '65ccfbfb374a4f35856d76fc',
+          deleted: false,
+          createdAt: '2024-02-14T17:44:27.529Z',
+          updatedAt: '2024-02-14T17:44:27.529Z',
+          __v: 0,
+          id: '65ccfbfb374a4f35856d775a',
+        },
+      },
+    ],
+    _environmentId: '65ccfbfb374a4f35856d76f7',
+    _organizationId: '65ccfbfb374a4f35856d76f1',
+    _creatorId: '65ccfbfb374a4f35856d76ef',
+    deleted: false,
+    createdAt: '2024-02-14T17:44:27.532Z',
+    updatedAt: '2024-02-14T17:44:27.532Z',
+    __v: 0,
+    id: '65ccfbfb374a4f35856d775c',
+  },
+};

--- a/apps/api/src/app/topics/e2e/helpers/index.ts
+++ b/apps/api/src/app/topics/e2e/helpers/index.ts
@@ -26,7 +26,7 @@ export const createTopic = async (
   session: UserSession,
   topicKey: TopicKey,
   topicName: TopicName
-): Promise<{ _id: TopicId }> => {
+): Promise<{ _id: TopicId; key: TopicKey }> => {
   const response = await session.testAgent.post(BASE_PATH).send({
     key: topicKey,
     name: topicName,
@@ -40,7 +40,7 @@ export const createTopic = async (
   expect(_id).to.be.string;
   expect(key).to.eq(topicKey);
 
-  return { _id };
+  return { _id, key };
 };
 
 export const getTopic = async (

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -92,6 +92,19 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
     }
   }
 
+  async *aggregateBatch(
+    query: any,
+    select = '',
+    options: { limit?: number; sort?: any; skip?: number } = {},
+    batchSize = 500
+  ) {
+    for await (const doc of this._model
+      .aggregate<FilterQuery<T_DBModel> & T_Enforcement>(query, { batchSize: batchSize })
+      .cursor()) {
+      yield this.mapEntity(doc);
+    }
+  }
+
   private calcExpireDate(modelName: string, data: FilterQuery<T_DBModel> & T_Enforcement) {
     let startDate: Date = new Date();
     if (data.expireAt) {

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -92,19 +92,6 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
     }
   }
 
-  async *aggregateBatch(
-    query: any,
-    select = '',
-    options: { limit?: number; sort?: any; skip?: number } = {},
-    batchSize = 500
-  ) {
-    for await (const doc of this._model
-      .aggregate<FilterQuery<T_DBModel> & T_Enforcement>(query, { batchSize: batchSize })
-      .cursor()) {
-      yield this.mapEntity(doc);
-    }
-  }
-
   private calcExpireDate(modelName: string, data: FilterQuery<T_DBModel> & T_Enforcement) {
     let startDate: Date = new Date();
     if (data.expireAt) {

--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -23,7 +23,7 @@ export class TopicSubscribersRepository extends BaseRepository<
     await this.upsertMany(subscribers);
   }
 
-  async getTopicDistinctSubscribersCursor({
+  async *getTopicDistinctSubscribers({
     query,
     batchSize = 500,
   }: {
@@ -54,7 +54,9 @@ export class TopicSubscribersRepository extends BaseRepository<
       },
     ];
 
-    return this._model.aggregate(aggregatePipeline, { batchSize: batchSize }).cursor();
+    for await (const doc of this._model.aggregate(aggregatePipeline, { batchSize: batchSize }).cursor()) {
+      yield this.mapEntity(doc);
+    }
   }
 
   async findOneByTopicKeyAndExternalSubscriberId(

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -64,12 +64,15 @@ export class TriggerMulticast {
 
       const { singleSubscribers, topicKeys } =
         splitByRecipientType(mappedRecipients);
+      const subscribersToProcess = Array.from(singleSubscribers.values());
 
-      await this.sendToProcessSubscriberService(
-        command,
-        Array.from(singleSubscribers.values()),
-        SubscriberSourceEnum.SINGLE
-      );
+      if (subscribersToProcess.length > 0) {
+        await this.sendToProcessSubscriberService(
+          command,
+          subscribersToProcess,
+          SubscriberSourceEnum.SINGLE
+        );
+      }
 
       const isEnabled = await this.getFeatureFlag.execute(
         GetFeatureFlagCommand.create({

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import * as _ from 'lodash';
 
 import {
@@ -6,31 +6,42 @@ import {
   JobRepository,
   NotificationTemplateRepository,
   SubscriberRepository,
+  TopicEntity,
+  TopicRepository,
+  TopicSubscribersRepository,
 } from '@novu/dal';
 import {
-  ChannelTypeEnum,
+  FeatureFlagsKeysEnum,
   ISubscribersDefine,
-  ISubscribersSource,
-  ProvidersIdEnum,
+  ITopic,
+  SubscriberSourceEnum,
+  TriggerRecipient,
+  TriggerRecipientsTypeEnum,
+  TriggerRecipientSubscriber,
 } from '@novu/shared';
 
 import { ProcessSubscriber } from '../process-subscriber';
 import { PinoLogger } from '../../logging';
-import { Instrument, InstrumentUsecase } from '../../instrumentation';
-import {
-  buildNotificationTemplateIdentifierKey,
-  CachedEntity,
-} from '../../services/cache';
+import { InstrumentUsecase } from '../../instrumentation';
 import { ApiException } from '../../utils/exceptions';
 import { ProcessTenant } from '../process-tenant';
 import { MapTriggerRecipients } from '../map-trigger-recipients/map-trigger-recipients.use-case';
 import { SubscriberProcessQueueService } from '../../services/queues/subscriber-process-queue.service';
 import { TriggerMulticastCommand } from './trigger-multicast.command';
-import { MapTriggerRecipientsCommand } from '../map-trigger-recipients';
 import { IProcessSubscriberBulkJobDto } from '../../dtos';
+import { GetFeatureFlag, GetFeatureFlagCommand } from '../get-feature-flag';
+import { GetTopicSubscribersUseCase } from '../get-topic-subscribers';
 
 const LOG_CONTEXT = 'TriggerMulticastUseCase';
 const QUEUE_CHUNK_SIZE = Number(process.env.MULTICAST_QUEUE_CHUNK_SIZE) || 100;
+
+const isNotTopic = (
+  recipient: TriggerRecipient
+): recipient is TriggerRecipientSubscriber => !isTopic(recipient);
+
+const isTopic = (recipient: TriggerRecipient): recipient is ITopic =>
+  (recipient as ITopic).type &&
+  (recipient as ITopic).type === TriggerRecipientsTypeEnum.TOPIC;
 
 @Injectable()
 export class TriggerMulticast {
@@ -43,97 +54,159 @@ export class TriggerMulticast {
     private processTenant: ProcessTenant,
     private logger: PinoLogger,
     private mapTriggerRecipients: MapTriggerRecipients,
-    private subscriberProcessQueueService: SubscriberProcessQueueService
+    private subscriberProcessQueueService: SubscriberProcessQueueService,
+    private getTopicSubscribers: GetTopicSubscribersUseCase,
+    private topicSubscribersRepository: TopicSubscribersRepository,
+    private topicRepository: TopicRepository,
+    private getFeatureFlag: GetFeatureFlag
   ) {}
 
   @InstrumentUsecase()
   async execute(command: TriggerMulticastCommand) {
     {
-      const mappedRecipients = await this.mapTriggerRecipients.execute(
-        MapTriggerRecipientsCommand.create({
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-          recipients: command.to,
-          transactionId: command.transactionId,
-          userId: command.userId,
-          actor: command.actor,
+      const {
+        environmentId,
+        organizationId,
+        to: recipients,
+        actor,
+        userId,
+      } = command;
+
+      const mappedRecipients = Array.isArray(recipients)
+        ? recipients
+        : [recipients];
+
+      const { singleSubscribers, topicKeys } =
+        this.splitByRecipientType(mappedRecipients);
+
+      await this.sendToProcessSubscriberService(
+        command,
+        Array.from(singleSubscribers.values()),
+        SubscriberSourceEnum.SINGLE
+      );
+
+      const isEnabled = await this.getFeatureFlag.execute(
+        GetFeatureFlagCommand.create({
+          environmentId,
+          organizationId,
+          userId,
+          key: FeatureFlagsKeysEnum.IS_TOPIC_NOTIFICATION_ENABLED,
         })
       );
 
-      await this.validateSubscriberIdProperty(mappedRecipients);
+      if (!isEnabled) {
+        return;
+      }
 
-      const jobs = this.mapSubscribersToJobs(mappedRecipients, command);
+      const topics = await this.getTopicsByTopicKeys(
+        organizationId,
+        environmentId,
+        topicKeys
+      );
 
-      await this.subscriberProcessQueueAddBulk(jobs);
+      this.validateTopicExist(topics, topicKeys);
+
+      const topicIds = topics.map((topic) => topic._id);
+      const singleSubscriberIds = Array.from(singleSubscribers.keys());
+      const subscriberFetchBatchSize = 500;
+      let subscribersList: ISubscribersDefine[] = [];
+
+      for await (const topicSubscriber of this.topicSubscribersRepository.getTopicDistinctSubscribers(
+        {
+          _organizationId: organizationId,
+          _environmentId: environmentId,
+          topicIds: topicIds,
+          excludeSubscribers: singleSubscriberIds,
+        }
+      )) {
+        const externalSubscriberId = topicSubscriber._id;
+
+        if (actor && actor.subscriberId === externalSubscriberId) {
+          continue;
+        }
+
+        subscribersList.push({ subscriberId: externalSubscriberId });
+
+        if (subscribersList.length === subscriberFetchBatchSize) {
+          await this.sendToProcessSubscriberService(
+            command,
+            subscribersList,
+            SubscriberSourceEnum.TOPIC
+          );
+
+          subscribersList = [];
+        }
+      }
+
+      if (subscribersList.length > 0) {
+        await this.sendToProcessSubscriberService(
+          command,
+          subscribersList,
+          SubscriberSourceEnum.TOPIC
+        );
+      }
     }
   }
 
-  @CachedEntity({
-    builder: (command: { triggerIdentifier: string; environmentId: string }) =>
-      buildNotificationTemplateIdentifierKey({
-        _environmentId: command.environmentId,
-        templateIdentifier: command.triggerIdentifier,
-      }),
-  })
-  private async getNotificationTemplateByTriggerIdentifier(command: {
-    triggerIdentifier: string;
-    environmentId: string;
-  }) {
-    return await this.notificationTemplateRepository.findByTriggerIdentifier(
-      command.environmentId,
-      command.triggerIdentifier
-    );
-  }
-
-  @Instrument()
-  private async validateSubscriberIdProperty(
-    to: ISubscribersSource[]
-  ): Promise<boolean> {
-    for (const subscriber of to) {
-      const subscriberIdExists =
-        typeof subscriber === 'string' ? subscriber : subscriber.subscriberId;
-
-      if (Array.isArray(subscriberIdExists)) {
-        throw new ApiException(
-          'subscriberId under property to is type array, which is not allowed please make sure all subscribers ids are strings'
-        );
-      }
-
-      if (!subscriberIdExists) {
-        throw new ApiException(
-          'subscriberId under property to is not configured, please make sure all subscribers contains subscriberId property'
-        );
-      }
-    }
-
-    return true;
-  }
-
-  @Instrument()
-  private async getProviderId(
+  private async getTopicsByTopicKeys(
+    organizationId: string,
     environmentId: string,
-    channelType: ChannelTypeEnum
-  ): Promise<ProvidersIdEnum> {
-    const integration = await this.integrationRepository.findOne(
+    topicKeys: Set<string>
+  ): Promise<TopicEntity[]> {
+    return await this.topicRepository.find(
       {
+        _organizationId: organizationId,
         _environmentId: environmentId,
-        active: true,
-        channel: channelType,
+        key: { $in: Array.from(topicKeys) },
       },
-      'providerId'
+      '_id'
     );
+  }
 
-    return integration?.providerId as ProvidersIdEnum;
+  private validateTopicExist(topics: TopicEntity[], topicKeys: Set<string>) {
+    if (topics.length !== topicKeys.size) {
+      topicKeys.forEach((topicKey) => {
+        if (!topics.find((topic) => topic.key === topicKey)) {
+          throw new NotFoundException(
+            `Topic with key ${topicKey} not found in current environment`
+          );
+        }
+      });
+    }
+  }
+
+  private splitByRecipientType(mappedRecipients: TriggerRecipient[]): {
+    singleSubscribers: Map<string, ISubscribersDefine>;
+    topicKeys: Set<string>;
+  } {
+    return mappedRecipients.reduce(
+      (acc, recipient) => {
+        if (isTopic(recipient)) {
+          acc.topicKeys.add(recipient.topicKey);
+        } else {
+          const subscribersDefine = this.buildSubscriberDefine(recipient);
+
+          acc.singleSubscribers.set(
+            subscribersDefine.subscriberId,
+            subscribersDefine
+          );
+        }
+
+        return acc;
+      },
+      {
+        singleSubscribers: new Map<string, ISubscribersDefine>(),
+        topicKeys: new Set<string>(),
+      }
+    );
   }
 
   private mapSubscribersToJobs(
-    subscribers: ISubscribersSource[],
+    _subscriberSource: SubscriberSourceEnum,
+    subscribers: ISubscribersDefine[],
     command: TriggerMulticastCommand
   ): IProcessSubscriberBulkJobDto[] {
     return subscribers.map((subscriber) => {
-      const { _subscriberSource, ...subscribersDefineParams } = subscriber;
-      const subscribersDefine: ISubscribersDefine = subscribersDefineParams;
-
       const job: IProcessSubscriberBulkJobDto = {
         name: command.transactionId + subscriber.subscriberId,
         data: {
@@ -144,7 +217,7 @@ export class TriggerMulticast {
           identifier: command.identifier,
           payload: command.payload,
           overrides: command.overrides,
-          subscriber: subscribersDefine,
+          subscriber: subscriber,
           templateId: command.template._id,
           _subscriberSource: _subscriberSource,
           requestCategory: command.requestCategory,
@@ -163,6 +236,32 @@ export class TriggerMulticast {
     });
   }
 
+  private buildSubscriberDefine(
+    recipient: TriggerRecipientSubscriber
+  ): ISubscribersDefine {
+    if (typeof recipient === 'string') {
+      return { subscriberId: recipient };
+    } else {
+      this.validateSubscriberDefine(recipient);
+
+      return recipient;
+    }
+  }
+
+  private validateSubscriberDefine(recipient: ISubscribersDefine) {
+    if (Array.isArray(recipient)) {
+      throw new ApiException(
+        'subscriberId under property to is type array, which is not allowed please make sure all subscribers ids are strings'
+      );
+    }
+
+    if (!recipient) {
+      throw new ApiException(
+        'subscriberId under property to is not configured, please make sure all subscribers contains subscriberId property'
+      );
+    }
+  }
+
   private async subscriberProcessQueueAddBulk(
     jobs: IProcessSubscriberBulkJobDto[]
   ) {
@@ -172,5 +271,23 @@ export class TriggerMulticast {
           this.subscriberProcessQueueService.addBulk(chunk)
       )
     );
+  }
+
+  private async sendToProcessSubscriberService(
+    command: TriggerMulticastCommand,
+    subscribers: ISubscribersDefine[],
+    _subscriberSource: SubscriberSourceEnum
+  ) {
+    if (subscribers.length === 0) {
+      return;
+    }
+
+    const jobs = this.mapSubscribersToJobs(
+      _subscriberSource,
+      subscribers,
+      command
+    );
+
+    return await this.subscriberProcessQueueAddBulk(jobs);
   }
 }

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -102,20 +102,18 @@ export class TriggerMulticast {
       const singleSubscriberIds = Array.from(singleSubscribers.keys());
       const subscriberFetchBatchSize = 500;
       let subscribersList: ISubscribersDefine[] = [];
-      const cursor =
-        await this.topicSubscribersRepository.getTopicDistinctSubscribersCursor(
-          {
-            query: {
-              _organizationId: organizationId,
-              _environmentId: environmentId,
-              topicIds: topicIds,
-              excludeSubscribers: singleSubscriberIds,
-            },
-            batchSize: subscriberFetchBatchSize,
-          }
-        );
+      const getTopicDistinctSubscribersGenerator =
+        await this.topicSubscribersRepository.getTopicDistinctSubscribers({
+          query: {
+            _organizationId: organizationId,
+            _environmentId: environmentId,
+            topicIds: topicIds,
+            excludeSubscribers: singleSubscriberIds,
+          },
+          batchSize: subscriberFetchBatchSize,
+        });
 
-      for await (const topicSubscriber of cursor) {
+      for await (const topicSubscriber of getTopicDistinctSubscribersGenerator) {
         const externalSubscriberId = topicSubscriber._id;
 
         if (actor && actor.subscriberId === externalSubscriberId) {

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -110,15 +110,20 @@ export class TriggerMulticast {
       const singleSubscriberIds = Array.from(singleSubscribers.keys());
       const subscriberFetchBatchSize = 500;
       let subscribersList: ISubscribersDefine[] = [];
+      const cursor =
+        await this.topicSubscribersRepository.getTopicDistinctSubscribersCursor(
+          {
+            query: {
+              _organizationId: organizationId,
+              _environmentId: environmentId,
+              topicIds: topicIds,
+              excludeSubscribers: singleSubscriberIds,
+            },
+            batchSize: subscriberFetchBatchSize,
+          }
+        );
 
-      for await (const topicSubscriber of this.topicSubscribersRepository.getTopicDistinctSubscribers(
-        {
-          _organizationId: organizationId,
-          _environmentId: environmentId,
-          topicIds: topicIds,
-          excludeSubscribers: singleSubscriberIds,
-        }
-      )) {
+      for await (const topicSubscriber of cursor) {
         const externalSubscriberId = topicSubscriber._id;
 
         if (actor && actor.subscriberId === externalSubscriberId) {

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -46,16 +46,8 @@ const isTopic = (recipient: TriggerRecipient): recipient is ITopic =>
 @Injectable()
 export class TriggerMulticast {
   constructor(
-    private processSubscriber: ProcessSubscriber,
-    private integrationRepository: IntegrationRepository,
-    private subscriberRepository: SubscriberRepository,
-    private jobRepository: JobRepository,
-    private notificationTemplateRepository: NotificationTemplateRepository,
-    private processTenant: ProcessTenant,
     private logger: PinoLogger,
-    private mapTriggerRecipients: MapTriggerRecipients,
     private subscriberProcessQueueService: SubscriberProcessQueueService,
-    private getTopicSubscribers: GetTopicSubscribersUseCase,
     private topicSubscribersRepository: TopicSubscribersRepository,
     private topicRepository: TopicRepository,
     private getFeatureFlag: GetFeatureFlag


### PR DESCRIPTION
### What change does this PR introduce?

Currently the process to pull all of the subscribers for a topic works until we start having the size of 2 million. This gives us a clue that we have not optimized this database call to efficiently get an "infinite" amount of subscriber.

However, this does put more issues in terms of idempotency to the system as what happens if a worker fails to create all of the jobs.

We should also consider caching topic calls pass as redis keys hold upto 512MB, however we are unsure if parsing that big of a document would be faster then calling mongodb

### Why was this change needed?

Fixing this will allow large companies with large topics to send them messages without failure at the database level.

### Definition of Done

* mongo qurey uses pagination
* paginated query must be able to be used for other models

 References
https://medium.com/swlh/mongodb-pagination-fast-consistent-ece2a97070f3

https://github.com/novuhq/novu/blob/517b4fa662a8b5a72d62a1518bff9d68c21f5909/packages/application-generic/src/usecases/get-topic-subscribers/get-topic-subscribers.use-case.ts#L30

use keyset for the offset command, but must have the ids in order to do correctly
