### PR TITLE
Nv 3475 - typeerror cannot create property buttons on string

### DIFF
--- a/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.usecase.ts
+++ b/apps/api/src/app/message-template/usecases/create-message-template/create-message-template.usecase.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { MessageTemplateEntity, MessageTemplateRepository } from '@novu/dal';
-import { ChangeEntityTypeEnum } from '@novu/shared';
+import { ChangeEntityTypeEnum, IMessageAction } from '@novu/shared';
 
 import { CreateMessageTemplateCommand } from './create-message-template.command';
 import { sanitizeMessageContent } from '../../shared/sanitizer.service';
 import { UpdateChange } from '../../../change/usecases/update-change/update-change';
 import { UpdateChangeCommand } from '../../../change/usecases/update-change/update-change.command';
 import { UpdateMessageTemplate } from '../update-message-template/update-message-template.usecase';
-import { CreateChange, CreateChangeCommand } from '@novu/application-generic';
+import { ApiException, CreateChange, CreateChangeCommand } from '@novu/application-generic';
 
 @Injectable()
 export class CreateMessageTemplate {
@@ -18,6 +18,10 @@ export class CreateMessageTemplate {
   ) {}
 
   async execute(command: CreateMessageTemplateCommand): Promise<MessageTemplateEntity> {
+    if ((command?.cta?.action as IMessageAction | undefined | '') === '') {
+      throw new ApiException('Please provide a valid CTA action');
+    }
+
     let item: MessageTemplateEntity = await this.messageTemplateRepository.create({
       cta: command.cta,
       name: command.name,

--- a/apps/api/src/app/workflows/e2e/update-notification-template.e2e.ts
+++ b/apps/api/src/app/workflows/e2e/update-notification-template.e2e.ts
@@ -354,4 +354,30 @@ describe('Update workflow by id - /workflows/:workflowId (PUT)', async () => {
     expect(updatedTemplate.steps[0].replyCallback?.active).to.equal(true);
     expect(updatedTemplate.steps[0].replyCallback?.url).to.equal('acme-corp.com/webhook');
   });
+
+  it('should not able to update step with invalid action', async function () {
+    const notificationTemplateService = new NotificationTemplateService(
+      session.user._id,
+      session.organization._id,
+      session.environment._id
+    );
+    const workflow = await notificationTemplateService.createTemplate();
+    const invalidAction = '';
+    const update: IUpdateNotificationTemplateDto = {
+      steps: [
+        {
+          template: {
+            type: StepTypeEnum.IN_APP,
+            cta: { action: invalidAction } as any,
+            content: 'This is new content for notification',
+          },
+        },
+      ],
+    };
+
+    const { body } = await session.testAgent.put(`/v1/workflows/${workflow._id}`).send(update);
+
+    expect(body.message).to.equal('Please provide a valid CTA action');
+    expect(body.statusCode).to.equal(400);
+  });
 });

--- a/apps/web/src/pages/templates/components/in-app-editor/preview/InAppWidgetPreview.tsx
+++ b/apps/web/src/pages/templates/components/in-app-editor/preview/InAppWidgetPreview.tsx
@@ -41,7 +41,7 @@ export function InAppWidgetPreview({
 
   function onRemoveTemplate() {
     setIsButtonsTemplateSelected(false);
-    onChange('');
+    onChange({});
   }
 
   const editableContent = (


### PR DESCRIPTION
### What change does this PR introduce?

Resolve the issue where the user is storing an invalid value under message-template.cta.action

### Why was this change needed?

bug

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
