### PR TITLE
revert(api): Disabling NX cache

### DIFF
--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: ⛏️ build api
       shell: bash
-      run: pnpm build:api --skip-nx-cache
+      run: pnpm build:api
 
     - uses: crazy-max/ghaction-setup-docker@v2
       with:

--- a/.github/actions/run-api/action.yml
+++ b/.github/actions/run-api/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Build API
       shell: bash
-      run: CI='' pnpm build:api --skip-nx-cache
+      run: CI='' pnpm build:api
 
     - name: Start API
       shell: bash

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,id=pnpm-store-api,target=/root/.pnpm-store\
  --frozen-lockfile\
  --unsafe-perm
 
-RUN NODE_ENV=production NX_DAEMON=false pnpm build:api --skip-nx-cache
+RUN NODE_ENV=production NX_DAEMON=false pnpm build:api
 
 WORKDIR /usr/src/app/apps/api
 


### PR DESCRIPTION
**What?**

Revert these commits to re-enable NX Caching for API build and run tasks: 
* https://github.com/novuhq/novu/commit/14311d43cd0262116995c1a864caaa655e00a1cc
* https://github.com/novuhq/novu/commit/055e08c60caefe3c73b3d0239debe6f55fdbe9d7

**Why? (Context)**

The commit disables NX caching of the API build and run artifacts, including all providers. The build duration was 1.25 hours without caching, and re-enabling the NX cache will significantly improve build speed (see [this build](https://github.com/novuhq/novu/actions/runs/7865361667/job/21458232629?pr=5152)).

**Definition of Done**

Dev API run and build scripts are cache and run faster

**Results**
* Build API Run - 
