### PR TITLE
fix(ci): Mount token to a build svc command

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,id=pnpm-store-api,target=/root/.pnpm-store\
  --frozen-lockfile\
  --unsafe-perm
 
-RUN NODE_ENV=production NX_DAEMON=false pnpm build:api
+RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && NODE_ENV=production NX_DAEMON=false pnpm build:api
 
 WORKDIR /usr/src/app/apps/api
 

--- a/apps/inbound-mail/Dockerfile
+++ b/apps/inbound-mail/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,id=pnpm-store-inbound-mail,target=/root/.pnpm-store\
  --unsafe-perm\
  --reporter=silent
 
-RUN NODE_ENV=production pnpm build:inbound-mail
+RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && NODE_ENV=production pnpm build:inbound-mail
 
 WORKDIR /usr/src/app/apps/inbound-mail
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,id=pnpm-store-worker,target=/root/.pnpm-store\
  --unsafe-perm\
  --reporter=silent
 
-RUN NODE_ENV=production NX_DAEMON=false pnpm build:worker
+RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && NODE_ENV=production NX_DAEMON=false pnpm build:worker
 
 WORKDIR /usr/src/app/apps/worker
 


### PR DESCRIPTION
### What change does this PR introduce?

We face the issues during a docker build process:
```
#32 45.77  WARN  Issue while reading "/usr/src/app/.npmrc". Failed to replace env in config: ${BULL_MQ_PRO_NPM_TOKEN}
#32 45.77 
#32 45.77 > @novu/ee-billing@0.23.1 build /usr/src/app/enterprise/packages/billing
#32 45.77 > node ./check-ee.mjs
```
[CI page](https://github.com/novuhq/novu/actions/runs/7834909085/job/21379680417#step:6:1212)
