### PR TITLE
fix(infra): Remove gitignore for EE symlinked src folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,6 @@ docker/.env
 # NX Build System
 .nx/cache
 
-# EE Symlinked folders
-enterprise/packages/**/src
+# EE Symlinked folders - we need these for the EE build
+# @TODO - find a way to remove the symlinks without breaking the build
+!enterprise/packages/**/src


### PR DESCRIPTION
### What change does this PR introduce?
* Adds the src symlink directories back under the git file tree

### Why was this change needed?
NX was failing to cache the `src` folder for EE repos because it [tracks the `.gitignore` file by default](https://nx.dev/reference/nxignore). This resulted in the `src` folder not being copied across into Docker when NX replays the `build` task dependency on EE packages via the `build:api` command, and therefore no `src` is available for building the API dependencies.

### Other information (Screenshots)

_Inspecting Docker file system before change_
```bash
> docker exec -it novu-api sh
/usr/src/app/apps/api $ cd ../../enterprise/packages/billing
/usr/src/app/enterprise/packages/billing $ ls -la
total 36
drwxr-xr-x    1 node     node          4096 Feb 12 13:56 .
drwxr-xr-x    1 node     node          4096 Feb 12 13:52 ..
-rw-r--r--    1 node     node          2096 Feb 12 13:52 .gitignore
-rw-r--r--    1 node     node          1420 Feb 12 13:52 check-ee.mjs
drwxr-xr-x    6 node     node          4096 Feb 12 13:56 node_modules
-rw-r--r--    1 node     node          1487 Feb 12 13:52 package.json
-rw-r--r--    1 node     node           463 Feb 12 13:52 tsconfig.json
-rw-r--r--    1 node     node           162 Feb 12 13:52 tsconfig.spec.json
```

_After change_
```bash
> docker exec -it novu-api sh
/usr/src/app/apps/api $ cd ../../enterprise/packages/billing
/usr/src/app/enterprise/packages/billing $ ls -la
total 36
drwxr-xr-x    1 node     node          4096 Feb 12 15:46 .
drwxr-xr-x    1 node     node          4096 Feb 12 15:42 ..
-rw-r--r--    1 node     node          2096 Feb 12 15:42 .gitignore
-rw-r--r--    1 node     node          1420 Feb 12 15:42 check-ee.mjs
drwxr-xr-x    5 node     node          4096 Feb 12 15:45 dist # <- DIST IS NOW PRESENT
drwxr-xr-x    6 node     node          4096 Feb 12 15:47 node_modules
-rw-r--r--    1 node     node          1487 Feb 12 15:42 package.json
-rw-r--r--    1 node     node           463 Feb 12 15:42 tsconfig.json
-rw-r--r--    1 node     node           162 Feb 12 15:42 tsconfig.spec.json
```