### PR TITLE
chore: Expose stripe client key to Web app

### DIFF
--- a/.github/workflows/reusable-web-deploy.yml
+++ b/.github/workflows/reusable-web-deploy.yml
@@ -85,6 +85,7 @@ jobs:
           echo REACT_APP_MAIL_SERVER_DOMAIN=${{ inputs.react_app_mail_server_domain }} >> .env
           echo REACT_APP_LAUNCH_DARKLY_CLIENT_SIDE_ID=${{ secrets.LAUNCH_DARKLY_CLIENT_SIDE_ID }} >> .env
           echo REACT_APP_HUBSPOT_EMBED=${{ inputs.react_app_hubspot_embed }} >> .env
+          echo REACT_APP_STRIPE_CLIENT_KEY=${{ secrets.STRIPE_CLIENT_KEY }} >> .env
 
       - name: Envsetup
         working-directory: apps/web


### PR DESCRIPTION
What?

Add the REACT_APP_STRIPE_CLIENT_KEY to the env config

Add secret to Github secrets

Why? (Context)

We need the Stripe env var for Stripe client components

Definition of Done

Stripe checkout loads correctly