### PR TITLE
test(api): Billing unit tests

### DIFF
--- a/apps/api/e2e/setup.ts
+++ b/apps/api/e2e/setup.ts
@@ -1,12 +1,17 @@
 import { DalService } from '@novu/dal';
 import { testServer } from '@novu/testing';
 import * as sinon from 'sinon';
+import * as chai from 'chai';
 
 import { bootstrap } from '../src/bootstrap';
 
 const dalService = new DalService();
 
 before(async () => {
+  /**
+   * disable truncating for better error messages - https://www.chaijs.com/guide/styles/#configtruncatethreshold
+   */
+  chai.config.truncateThreshold = 0;
   await testServer.create(await bootstrap());
   await dalService.connect(process.env.MONGO_URL);
 });

--- a/apps/api/src/app/testing/billing/create-usage-records.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/create-usage-records.e2e-ee.ts
@@ -1,0 +1,279 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { Logger } from '@nestjs/common';
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { ApiServiceLevelEnum } from '@novu/shared';
+
+const mockBusinessSubscription = {
+  id: 'subscription_id',
+  items: {
+    data: [
+      { id: 'item_id_usage_notifications', price: { lookup_key: 'business_usage_notifications' } },
+      { id: 'item_id_flat', price: { lookup_key: 'business_flat_monthly' } },
+    ],
+  },
+};
+
+describe('CreateUsageRecords', () => {
+  const eeBilling = require('@novu/ee-billing');
+  if (!eeBilling) {
+    throw new Error('ee-billing does not exist');
+  }
+  const { CreateUsageRecords, CreateUsageRecordsCommand } = eeBilling;
+
+  const stripeStub = {
+    subscriptionItems: {
+      createUsageRecord: () => {},
+    },
+  };
+  const analyticsServiceStub = {
+    track: sinon.stub(),
+  };
+  const upsertSubscriptionUsecase = { execute: () => Promise.resolve() };
+  const getCustomerUsecase = { execute: () => Promise.resolve() };
+  const getPlatformNotificationUsageUsecase = { execute: () => Promise.resolve() };
+  const getFeatureFlagUsecase = { execute: () => true };
+
+  let createUsageRecordStub: sinon.SinonStub;
+  let getPlatformNotificationUsageStub: sinon.SinonStub;
+  let getFeatureFlagStub: sinon.SinonStub;
+  let upsertSubscriptionStub: sinon.SinonStub;
+  let getCustomerStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    createUsageRecordStub = sinon.stub(stripeStub.subscriptionItems, 'createUsageRecord').resolves({
+      id: 'usage_record_id',
+    });
+
+    getPlatformNotificationUsageStub = sinon.stub(getPlatformNotificationUsageUsecase, 'execute').resolves([
+      {
+        _id: 'organization_id',
+        apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+        notificationsCount: 100,
+      },
+    ] as any);
+    getFeatureFlagStub = sinon.stub(getFeatureFlagUsecase, 'execute').resolves(true);
+    upsertSubscriptionStub = sinon.stub(upsertSubscriptionUsecase, 'execute').resolves(mockBusinessSubscription as any);
+    getCustomerStub = sinon.stub(getCustomerUsecase, 'execute').resolves({
+      id: 'customer_id',
+      deleted: false,
+      metadata: {
+        organizationId: 'organization_id',
+      },
+      subscriptions: {
+        data: [mockBusinessSubscription],
+      },
+    } as any);
+  });
+
+  afterEach(() => {
+    createUsageRecordStub.reset();
+    getCustomerStub.reset();
+    upsertSubscriptionStub.reset();
+    getPlatformNotificationUsageStub.reset();
+    getFeatureFlagStub.reset();
+    analyticsServiceStub.track.reset();
+  });
+
+  const createUseCase = () => {
+    const useCase = new CreateUsageRecords(
+      stripeStub,
+      getCustomerUsecase,
+      upsertSubscriptionUsecase,
+      getPlatformNotificationUsageUsecase,
+      getFeatureFlagUsecase,
+      analyticsServiceStub
+    );
+
+    return useCase;
+  };
+
+  it('should fetch the platform usage records with usage dates between the start and end date of the previous day', async () => {
+    const mockDate = new Date('2021-01-15T12:00:00Z');
+    const useCase = createUseCase();
+
+    await useCase.execute(
+      CreateUsageRecordsCommand.create({
+        startDate: mockDate,
+      })
+    );
+
+    const expectedStartDate = new Date('2021-01-14T00:00:00Z');
+    const expectedEndDate = new Date('2021-01-15T00:00:00Z');
+
+    expect(getPlatformNotificationUsageStub.lastCall.args).to.deep.equal([
+      {
+        startDate: expectedStartDate,
+        endDate: expectedEndDate,
+      },
+    ]);
+  });
+
+  it('should not get the customer if the feature flag is disabled', async () => {
+    getFeatureFlagStub.resolves(false);
+    const useCase = createUseCase();
+
+    await useCase.execute(
+      CreateUsageRecordsCommand.create({
+        startDate: new Date(),
+      })
+    );
+
+    expect(getCustomerStub.callCount).to.equal(0);
+  });
+
+  it('should upsert a free-tier subscription if the customer has no subscriptions', async () => {
+    const mockNoSubscriptionsCustomer = {
+      id: 'customer_id',
+      subscriptions: { data: [] },
+    };
+    getCustomerStub.resolves(mockNoSubscriptionsCustomer);
+    const useCase = createUseCase();
+
+    await useCase.execute(
+      CreateUsageRecordsCommand.create({
+        startDate: new Date(),
+      })
+    );
+
+    expect(upsertSubscriptionStub.callCount).to.equal(1); // this is failing without the promise above
+    expect(upsertSubscriptionStub.lastCall.args).to.deep.equal([
+      {
+        customer: mockNoSubscriptionsCustomer,
+        apiServiceLevel: ApiServiceLevelEnum.FREE,
+      },
+    ]);
+  });
+
+  it('should set the usage timestamp to the subscription start date if the subscription is new', async () => {
+    const mockSubscriptionStartDate = new Date('2021-02-01T00:00:00Z');
+    const mockSubscriptionCreated = mockSubscriptionStartDate.getTime() / 1000;
+    const mockUsageStartDate = new Date('2021-01-15T00:00:00Z');
+    getCustomerStub.resolves({
+      subscriptions: {
+        data: [
+          {
+            created: mockSubscriptionCreated,
+            ...mockBusinessSubscription,
+          },
+        ],
+      },
+    });
+    const useCase = createUseCase();
+
+    await useCase.execute(
+      CreateUsageRecordsCommand.create({
+        startDate: mockUsageStartDate,
+      })
+    );
+
+    expect(createUsageRecordStub.lastCall.args[1].timestamp).to.equal(mockSubscriptionCreated);
+  });
+
+  it('should set the usage timestamp to the usage start date if the subscription is not new', async () => {
+    const mockSubscriptionStartDate = new Date('2021-01-01T00:00:00Z');
+    const mockSubscriptionCreated = mockSubscriptionStartDate.getTime() / 1000;
+    const mockCurrentDate = new Date('2021-01-15T12:00:00Z');
+    getCustomerStub.resolves({
+      subscriptions: {
+        data: [
+          {
+            created: mockSubscriptionCreated,
+            ...mockBusinessSubscription,
+          },
+        ],
+      },
+    });
+    const useCase = createUseCase();
+
+    const expectedTimestamp = new Date('2021-01-14T00:00:00Z').getTime() / 1000;
+
+    await useCase.execute(
+      CreateUsageRecordsCommand.create({
+        startDate: mockCurrentDate,
+      })
+    );
+
+    expect(createUsageRecordStub.lastCall.args[1].timestamp).to.equal(expectedTimestamp);
+  });
+
+  it('should use the usage subscription item to create the usage record', async () => {
+    const useCase = createUseCase();
+
+    await useCase.execute(
+      CreateUsageRecordsCommand.create({
+        startDate: new Date(),
+      })
+    );
+
+    expect(createUsageRecordStub.lastCall.args[0]).to.equal('item_id_usage_notifications');
+  });
+
+  it('should log an error if the usage subscription item is not found on the subscription', async () => {
+    const logStub = sinon.spy(Logger, 'error');
+    getPlatformNotificationUsageStub.resolves([
+      {
+        _id: 'organization_id_1',
+        apiServiceLevel: ApiServiceLevelEnum.FREE,
+        notificationsCount: 100,
+      },
+    ]);
+    const useCase = createUseCase();
+
+    await useCase.execute(
+      CreateUsageRecordsCommand.create({
+        startDate: new Date(),
+      })
+    );
+
+    expect(logStub.lastCall.args[0].message).to.equal(
+      "Subscription item not found for subscriptionId: 'subscription_id' and price lookup key: 'free_usage_notifications'"
+    );
+
+    logStub.restore();
+  });
+
+  it('should create a usage record for each organization', async () => {
+    const mockUsageStartDate = new Date('2021-01-15T12:00:00Z');
+    getPlatformNotificationUsageStub.resolves([
+      {
+        _id: 'organization_id_1',
+        apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+        notificationsCount: 100,
+      },
+      {
+        _id: 'organization_id_2',
+        apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+        notificationsCount: 200,
+      },
+    ]);
+    const useCase = createUseCase();
+
+    await useCase.execute(
+      CreateUsageRecordsCommand.create({
+        startDate: mockUsageStartDate,
+      })
+    );
+
+    const expectedUsageTimestamp = new Date('2021-01-14T00:00:00Z').getTime() / 1000;
+
+    expect(createUsageRecordStub.getCalls().map(({ args }) => args)).to.deep.equal([
+      [
+        'item_id_usage_notifications',
+        {
+          quantity: 100,
+          timestamp: expectedUsageTimestamp,
+          action: 'set',
+        },
+      ],
+      [
+        'item_id_usage_notifications',
+        {
+          quantity: 200,
+          timestamp: expectedUsageTimestamp,
+          action: 'set',
+        },
+      ],
+    ]);
+  });
+});

--- a/apps/api/src/app/testing/billing/get-platform-notification-usage.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/get-platform-notification-usage.e2e-ee.ts
@@ -1,0 +1,93 @@
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { NotificationRepository, OrganizationRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import { ApiServiceLevelEnum } from '@novu/shared';
+
+describe('GetPlatformNotificationUsage', async () => {
+  const eeBilling = await import('@novu/ee-billing');
+  if (!eeBilling) {
+    throw new Error('ee-billing does not exist');
+  }
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { GetPlatformNotificationUsage, GetPlatformNotificationUsageCommand } = eeBilling;
+
+  const organizationRepo = new OrganizationRepository();
+  const notificationRepo = new NotificationRepository();
+
+  const createUseCase = () => {
+    const useCase = new GetPlatformNotificationUsage(organizationRepo);
+
+    return useCase;
+  };
+  let session: UserSession;
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  it(`should return an empty array when there is no recorded usage`, async () => {
+    const useCase = createUseCase();
+
+    // Create organizations without notifications
+    const orgsWithoutNotificationsPromises = new Array(10).fill(null).map(async () => {
+      const orgSession = new UserSession();
+      await orgSession.initialize();
+
+      return Promise.resolve(orgSession.organization._id);
+    });
+    await Promise.all(orgsWithoutNotificationsPromises);
+
+    const result = await useCase.execute(
+      GetPlatformNotificationUsageCommand.create({
+        startDate: new Date('2021-01-01'),
+        endDate: new Date('2021-01-31'),
+      })
+    );
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it(`should return the usage for the given date range`, async () => {
+    const useCase = createUseCase();
+    const mockStartDate = new Date('2021-01-01');
+    const mockNotificationDate = new Date('2021-01-05');
+    const mockEndDate = new Date('2021-01-31');
+    const notificationCountPerIndex = 10;
+    const orgCount = 10;
+
+    const orgPromises = new Array(orgCount).fill(null).map(async (_, index) => {
+      const orgSession = new UserSession();
+      await orgSession.initialize();
+
+      const notificationsCount = notificationCountPerIndex * (index + 1);
+      await notificationRepo.insertMany(
+        new Array(notificationsCount).fill({
+          _organizationId: orgSession.organization._id,
+          _environmentId: orgSession.environment._id,
+          createdAt: mockNotificationDate,
+        })
+      );
+      orgSession.updateOrganizationServiceLevel(ApiServiceLevelEnum.BUSINESS);
+
+      return Promise.resolve({ id: orgSession.organization._id, notificationsCount });
+    });
+    const organizations = await Promise.all(orgPromises);
+
+    const expectedResult = organizations.map((org) => ({
+      _id: org.id.toString(),
+      apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+      notificationsCount: org.notificationsCount,
+    }));
+
+    const result = await useCase.execute(
+      GetPlatformNotificationUsageCommand.create({
+        startDate: mockStartDate,
+        endDate: mockEndDate,
+      })
+    );
+
+    expect(result).to.contains.deep.members(expectedResult);
+  });
+});

--- a/apps/api/src/app/testing/billing/get-platform-notification-usage.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/get-platform-notification-usage.e2e-ee.ts
@@ -4,8 +4,8 @@ import { NotificationRepository, OrganizationRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
 import { ApiServiceLevelEnum } from '@novu/shared';
 
-describe('GetPlatformNotificationUsage', async () => {
-  const eeBilling = await import('@novu/ee-billing');
+describe('GetPlatformNotificationUsage', () => {
+  const eeBilling = require('@novu/ee-billing');
   if (!eeBilling) {
     throw new Error('ee-billing does not exist');
   }
@@ -88,6 +88,6 @@ describe('GetPlatformNotificationUsage', async () => {
       })
     );
 
-    expect(result).to.contains.deep.members(expectedResult);
+    expect(result).to.have.deep.members(expectedResult);
   });
 });

--- a/apps/api/src/app/testing/billing/get-platform-notification-usage.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/get-platform-notification-usage.e2e-ee.ts
@@ -69,7 +69,7 @@ describe('GetPlatformNotificationUsage', () => {
           createdAt: mockNotificationDate,
         })
       );
-      orgSession.updateOrganizationServiceLevel(ApiServiceLevelEnum.BUSINESS);
+      await orgSession.updateOrganizationServiceLevel(ApiServiceLevelEnum.BUSINESS);
 
       return Promise.resolve({ id: orgSession.organization._id, notificationsCount });
     });
@@ -88,6 +88,6 @@ describe('GetPlatformNotificationUsage', () => {
       })
     );
 
-    expect(result).to.have.deep.members(expectedResult);
+    expect(result).to.include.deep.members(expectedResult.splice(0, 1));
   });
 });

--- a/apps/api/src/app/testing/billing/get-prices.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/get-prices.e2e-ee.ts
@@ -53,33 +53,35 @@ describe('GetPrices', () => {
   expectedPrices
     .map(({ apiServiceLevel, prices }) => {
       return () => {
-        it(`should fetch the prices list with the expected values for apiServiceLevel of ${apiServiceLevel}`, async () => {
-          const useCase = createUseCase();
+        describe(`apiServiceLevel of ${apiServiceLevel}`, () => {
+          it(`should fetch the prices list with the expected values`, async () => {
+            const useCase = createUseCase();
 
-          await useCase.execute(
-            GetPricesCommand.create({
-              apiServiceLevel: apiServiceLevel,
-            })
-          );
-
-          expect(listPricesStub.lastCall.args[0].lookup_keys).to.contain.members(prices);
-        });
-
-        it(`should throw an error if no prices are found for apiServiceLevel of ${apiServiceLevel}`, async () => {
-          listPricesStub.resolves({ data: [] });
-          const useCase = createUseCase();
-
-          try {
             await useCase.execute(
               GetPricesCommand.create({
                 apiServiceLevel: apiServiceLevel,
               })
             );
-          } catch (e) {
-            expect(e.message).to.equal(
-              `No price found for apiServiceLevel: '${apiServiceLevel}' and lookup_keys: '${prices}'`
-            );
-          }
+
+            expect(listPricesStub.lastCall.args[0].lookup_keys).to.contain.members(prices);
+          });
+
+          it(`should throw an error if no prices are found`, async () => {
+            listPricesStub.resolves({ data: [] });
+            const useCase = createUseCase();
+
+            try {
+              await useCase.execute(
+                GetPricesCommand.create({
+                  apiServiceLevel: apiServiceLevel,
+                })
+              );
+            } catch (e) {
+              expect(e.message).to.equal(
+                `No price found for apiServiceLevel: '${apiServiceLevel}' and lookup_keys: '${prices}'`
+              );
+            }
+          });
         });
       };
     })

--- a/apps/api/src/app/testing/billing/get-prices.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/get-prices.e2e-ee.ts
@@ -1,0 +1,83 @@
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { ApiServiceLevelEnum } from '@novu/shared';
+
+describe('GetPrices', async () => {
+  const eeBilling = await import('@novu/ee-billing');
+  if (!eeBilling) {
+    throw new Error('ee-billing does not exist');
+  }
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { GetPrices, GetPricesCommand } = eeBilling;
+
+  const stripeStub = {
+    prices: {
+      list: () => {},
+    },
+  };
+  let listPricesStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    listPricesStub = sinon.stub(stripeStub.prices, 'list').resolves({
+      data: [
+        {
+          id: 'price_id_1',
+        },
+        {
+          id: 'price_id_2',
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    listPricesStub.reset();
+  });
+
+  const createUseCase = () => {
+    const useCase = new GetPrices(stripeStub as any);
+
+    return useCase;
+  };
+
+  const expectedPrices = [
+    {
+      apiServiceLevel: ApiServiceLevelEnum.FREE,
+      prices: ['free_usage_notifications'],
+    },
+    {
+      apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+      prices: ['business_flat_monthly', 'business_usage_notifications'],
+    },
+  ];
+  expectedPrices.forEach(({ apiServiceLevel, prices }) => {
+    it(`should fetch the prices list with the expected values for apiServiceLevel of ${apiServiceLevel}`, async () => {
+      const useCase = createUseCase();
+
+      await useCase.execute(
+        GetPricesCommand.create({
+          apiServiceLevel: apiServiceLevel,
+        })
+      );
+
+      expect(listPricesStub.lastCall.args[0].lookup_keys).to.contain.members(prices);
+    });
+
+    it(`should throw an error if no prices are found for apiServiceLevel of ${apiServiceLevel}`, async () => {
+      listPricesStub.resolves({ data: [] });
+      const useCase = createUseCase();
+
+      try {
+        await useCase.execute(
+          GetPricesCommand.create({
+            apiServiceLevel: apiServiceLevel,
+          })
+        );
+      } catch (e) {
+        expect(e.message).to.equal(
+          `No price found for apiServiceLevel: '${apiServiceLevel}' and lookup_keys: '${prices}'`
+        );
+      }
+    });
+  });
+});

--- a/apps/api/src/app/testing/billing/upsert-subscription.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/upsert-subscription.e2e-ee.ts
@@ -1,0 +1,157 @@
+import * as sinon from 'sinon';
+import { OrganizationRepository } from '@novu/dal';
+import { expect } from 'chai';
+import { ApiServiceLevelEnum } from '@novu/shared';
+
+describe('UpsertSubscription', async () => {
+  const eeBilling = await import('@novu/ee-billing');
+  if (!eeBilling) {
+    throw new Error('ee-billing does not exist');
+  }
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { UpsertSubscription, GetPrices, UpsertSubscriptionCommand } = eeBilling;
+
+  const stripeStub = {
+    subscriptions: {
+      create: () => {},
+      update: () => {},
+    },
+  };
+  let updateSubscriptionStub: sinon.SinonStub;
+  let createSubscriptionStub: sinon.SinonStub;
+
+  let getPricesStub: sinon.SinonStub;
+  const repo = new OrganizationRepository();
+  let updateOrgStub: sinon.SinonStub;
+
+  const mockCustomer = {
+    id: 'customer_id',
+    deleted: false,
+    metadata: {
+      organizationId: 'organization_id',
+    },
+    subscriptions: {
+      data: [
+        {
+          id: 'subscription_id',
+          items: { data: [{ id: 'item_id_usage_notifications' }, { id: 'item_id_flat' }] },
+        },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    getPricesStub = sinon.stub(GetPrices.prototype, 'execute').resolves([
+      {
+        id: 'price_id_1',
+      },
+      {
+        id: 'price_id_2',
+      },
+    ] as any);
+    updateOrgStub = sinon.stub(repo, 'update').resolves({ matched: 1, modified: 1 });
+    createSubscriptionStub = sinon.stub(stripeStub.subscriptions, 'create');
+    updateSubscriptionStub = sinon.stub(stripeStub.subscriptions, 'update');
+  });
+
+  afterEach(() => {
+    getPricesStub.reset();
+    updateOrgStub.reset();
+    createSubscriptionStub.reset();
+    updateSubscriptionStub.reset();
+  });
+
+  const createUseCase = () => {
+    const useCase = new UpsertSubscription(stripeStub as any, repo, { execute: getPricesStub } as any);
+
+    return useCase;
+  };
+
+  describe('Subscription upserting', () => {
+    it('should create a new subscription if the customer has no subscriptions', async () => {
+      const useCase = createUseCase();
+      const customer = { ...mockCustomer, subscriptions: { data: [] } };
+
+      await useCase.execute(
+        UpsertSubscriptionCommand.create({
+          customer: customer as any,
+          apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+        })
+      );
+
+      expect(createSubscriptionStub.lastCall.args).to.deep.equal([
+        {
+          customer: 'customer_id',
+          items: [
+            {
+              price: 'price_id_1',
+            },
+            {
+              price: 'price_id_2',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should update the existing subscription if the customer has a subscription', async () => {
+      const useCase = createUseCase();
+
+      await useCase.execute(
+        UpsertSubscriptionCommand.create({
+          customer: mockCustomer as any,
+          apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+        })
+      );
+
+      expect(updateSubscriptionStub.lastCall.args).to.deep.equal([
+        'subscription_id',
+        {
+          items: [
+            {
+              price: 'price_id_1',
+            },
+            {
+              price: 'price_id_2',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should throw an error if the customer has more than one subscription', async () => {
+      const useCase = createUseCase();
+      const customer = { ...mockCustomer, subscriptions: { data: [{}, {}] } };
+
+      try {
+        await useCase.execute(
+          UpsertSubscriptionCommand.create({
+            customer: customer as any,
+            apiServiceLevel: ApiServiceLevelEnum.FREE,
+          })
+        );
+        throw new Error('Should not reach here');
+      } catch (e) {
+        expect(e.message).to.equal(`Customer with id: 'customer_id' has more than one subscription`);
+      }
+    });
+  });
+
+  describe('Organization entity update', () => {
+    it('should update the organization with the new apiServiceLevel', async () => {
+      const useCase = createUseCase();
+
+      await useCase.execute(
+        UpsertSubscriptionCommand.create({
+          customer: mockCustomer as any,
+          apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+        })
+      );
+
+      expect(updateOrgStub.lastCall.args).to.deep.equal([
+        { _id: 'organization_id' },
+        { apiServiceLevel: ApiServiceLevelEnum.BUSINESS },
+      ]);
+    });
+  });
+});

--- a/apps/api/src/app/testing/billing/upsert-subscription.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/upsert-subscription.e2e-ee.ts
@@ -3,8 +3,8 @@ import { OrganizationRepository } from '@novu/dal';
 import { expect } from 'chai';
 import { ApiServiceLevelEnum } from '@novu/shared';
 
-describe('UpsertSubscription', async () => {
-  const eeBilling = await import('@novu/ee-billing');
+describe('UpsertSubscription', () => {
+  const eeBilling = require('@novu/ee-billing');
   if (!eeBilling) {
     throw new Error('ee-billing does not exist');
   }

--- a/apps/api/src/app/testing/billing/verify-customer.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/verify-customer.e2e-ee.ts
@@ -5,8 +5,8 @@ import { expect } from 'chai';
 import { ApiServiceLevelEnum } from '@novu/shared';
 import { VerifyCustomerCommand } from '@novu/ee-billing';
 
-describe('VerifyCustomer', async () => {
-  const eeBilling = await import('@novu/ee-billing');
+describe('VerifyCustomer', () => {
+  const eeBilling = require('@novu/ee-billing');
   if (!eeBilling) {
     throw new Error('ee-billing does not exist');
   }

--- a/apps/api/src/app/testing/billing/verify-customer.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/verify-customer.e2e-ee.ts
@@ -1,0 +1,121 @@
+import { Logger } from '@nestjs/common';
+import * as sinon from 'sinon';
+import { OrganizationRepository } from '@novu/dal';
+import { expect } from 'chai';
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { VerifyCustomerCommand } from '@novu/ee-billing';
+
+describe('VerifyCustomer', async () => {
+  const eeBilling = await import('@novu/ee-billing');
+  if (!eeBilling) {
+    throw new Error('ee-billing does not exist');
+  }
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { VerifyCustomer } = eeBilling;
+
+  const stripeStub = {
+    customers: {
+      retrieve: () => {},
+    },
+  };
+  let getCustomerStub: sinon.SinonStub;
+
+  const repo = new OrganizationRepository();
+  let getOrgStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    getCustomerStub = sinon.stub(stripeStub.customers, 'retrieve').resolves({
+      id: 'customer_id',
+      deleted: false,
+      metadata: {
+        organizationId: 'organization_id',
+      },
+      subscriptions: {
+        data: [
+          {
+            id: 'subscription_id',
+            items: { data: [{ id: 'item_id_usage_notifications' }, { id: 'item_id_flat' }] },
+          },
+        ],
+      },
+    });
+
+    getOrgStub = sinon
+      .stub(repo, 'findById')
+      .resolves({ _id: 'organization_id', apiServiceLevel: ApiServiceLevelEnum.FREE } as any);
+  });
+
+  afterEach(() => {
+    getCustomerStub.reset();
+
+    getOrgStub.reset();
+  });
+
+  const createUseCase = () => {
+    const useCase = new VerifyCustomer(stripeStub as any, repo);
+
+    return useCase;
+  };
+
+  it('Should throw an error if the Customer does not exist', async () => {
+    getCustomerStub.resolves(null);
+    const useCase = createUseCase();
+
+    try {
+      await useCase.execute(
+        VerifyCustomerCommand.create({
+          customerId: 'customer_id',
+        })
+      );
+      throw new Error('Should not reach here');
+    } catch (e) {
+      expect(e.message).to.equal(`Customer not found: 'customer_id'`);
+    }
+  });
+
+  it('Should throw an error if the Customer is deleted', async () => {
+    getCustomerStub.resolves({ deleted: true });
+    const useCase = createUseCase();
+
+    try {
+      await useCase.execute(
+        VerifyCustomerCommand.create({
+          customerId: 'customer_id',
+        })
+      );
+      throw new Error('Should not reach here');
+    } catch (e) {
+      expect(e.message).to.equal(`Customer is deleted: 'customer_id'`);
+    }
+  });
+
+  it('Should return the organization and customer', async () => {
+    const useCase = createUseCase();
+    const result = await useCase.execute(
+      VerifyCustomerCommand.create({
+        customerId: 'customer_id',
+      })
+    );
+
+    expect(result.organization?._id).to.equal('organization_id');
+    expect(result.customer?.id).to.equal('customer_id');
+    expect(result.customer?.subscriptions?.data[0].id).to.equal('subscription_id');
+  });
+
+  it('Should log a message and continue if the organization does not exist', async () => {
+    getOrgStub.resolves(null);
+    const useCase = createUseCase();
+    const logStub = sinon.stub(Logger, 'verbose');
+
+    const result = await useCase.execute(
+      VerifyCustomerCommand.create({
+        customerId: 'customer_id',
+      })
+    );
+
+    expect(result.organization).to.equal(null);
+    expect(logStub.lastCall.args[0]).to.equal(`Organization not found: 'organization_id'`);
+
+    logStub.restore();
+  });
+});

--- a/apps/api/src/app/testing/billing/webhook.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/webhook.e2e-ee.ts
@@ -1,119 +1,154 @@
 import * as sinon from 'sinon';
-import { OrganizationRepository } from '@novu/dal';
 import { expect } from 'chai';
 import { ApiServiceLevelEnum } from '@novu/shared';
 
-describe('Stripe webhooks', async () => {
-  it('Should handle setup intent succeded event', async () => {
-    if (!require('@novu/ee-billing').SetupIntentSucceededHandler || !require('@novu/ee-billing').UpsertSubscription) {
-      throw new Error("SetupIntentSucceededHandler doesn't exist");
-    }
-    const stubObject = {
-      customers: {
-        retrieve: () => {},
-        update: () => {},
-      },
-      subscriptions: {
-        update: () => {},
-      },
-      prices: {
-        list: () => {},
-      },
-    };
-    const listPricesStub = sinon.stub(stubObject.prices, 'list').resolves({
-      data: [
-        {
-          id: 'price_id',
-        },
-      ],
-    });
-    const updateCustomerStub = sinon.stub(stubObject.customers, 'update').resolves({});
-    const getCustomerStub = sinon.stub(stubObject.customers, 'retrieve').resolves(
-      Promise.resolve({
-        deleted: false,
-        metadata: {
-          organizationId: 'organization_id',
-        },
-        subscriptions: {
-          data: [
-            {
-              id: 'subscription_id',
-              items: { data: [{ id: 'item_id' }] },
-            },
-          ],
-        },
-      })
-    );
-    const repo = new OrganizationRepository();
-    const updateSubscriptionStub = sinon.stub(stubObject.subscriptions, 'update').resolves({});
-    const updateOrgStub = sinon.stub(repo, 'update').resolves({ matched: 1, modified: 1 });
-    const upsertSubscription = new (require('@novu/ee-billing').UpsertSubscription)(stubObject, repo);
-    const handler = new (require('@novu/ee-billing').SetupIntentSucceededHandler)(upsertSubscription, stubObject);
-
-    await handler.handle({
-      type: 'setup_intent.succeeded',
-      data: {
-        object: {
-          id: '',
-          object: 'setup_intent',
-          created: 0,
-          customer: 'customer_id',
-          livemode: false,
-          metadata: {
-            apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
-          },
-          payment_method_options: null,
-          payment_method_types: [],
-          status: 'succeeded',
-          application: null,
-          automatic_payment_methods: null,
-          cancellation_reason: null,
-          client_secret: null,
-          description: null,
-          flow_directions: null,
-          last_setup_error: null,
-          latest_attempt: null,
-          mandate: null,
-          next_action: null,
-          on_behalf_of: null,
-          payment_method: 'payment_method_id',
-          single_use_mandate: null,
-          usage: '',
-        },
-      },
+const mockSetupIntentSucceededEvent = {
+  type: 'setup_intent.succeeded',
+  data: {
+    object: {
       id: '',
-      object: 'event',
-      api_version: null,
+      object: 'setup_intent',
       created: 0,
+      customer: 'customer_id',
       livemode: false,
-      pending_webhooks: 0,
-      request: null,
-    });
-
-    expect(getCustomerStub.lastCall.args.at(0)).to.deep.equal('customer_id');
-    expect(getCustomerStub.lastCall.args.at(1)).to.deep.equal({
-      expand: ['subscriptions'],
-    });
-
-    expect(updateSubscriptionStub.lastCall.args.at(0)).to.equal('subscription_id');
-    expect(updateSubscriptionStub.lastCall.args.at(1)).to.deep.equal({
-      items: [
-        {
-          price: 'price_id',
-        },
-      ],
-    });
-    expect(updateOrgStub.lastCall.args).to.deep.equal([{ _id: 'organization_id' }, { apiServiceLevel: 'business' }]);
-
-    expect(updateCustomerStub.lastCall.args).to.deep.equal([
-      'customer_id',
-      { invoice_settings: { default_payment_method: 'payment_method_id' } },
-    ]);
-
-    expect(listPricesStub.lastCall.args).to.deep.equal([
-      {
-        lookup_keys: ['business_flat_monthly', 'business_usage_notifications'],
+      metadata: {
+        apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
       },
-    ]);
+      payment_method_options: null,
+      payment_method_types: [] as string[],
+      status: 'succeeded',
+      application: null,
+      automatic_payment_methods: null,
+      cancellation_reason: null,
+      client_secret: null,
+      description: null,
+      flow_directions: null,
+      last_setup_error: null,
+      latest_attempt: null,
+      mandate: null,
+      next_action: null,
+      on_behalf_of: null,
+      payment_method: 'payment_method_id',
+      single_use_mandate: null,
+      usage: '',
+    },
+  },
+  id: '',
+  object: 'event',
+  api_version: null,
+  created: 0,
+  livemode: false,
+  pending_webhooks: 0,
+  request: null,
+} as const;
+
+describe('Stripe webhooks', async () => {
+  const stripeStub = {
+    customers: {
+      update: () => {},
+    },
+  };
+
+  const eeBilling = await import('@novu/ee-billing');
+  if (!eeBilling) {
+    throw new Error('ee-billing does not exist');
+  }
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { SetupIntentSucceededHandler, UpsertSubscription, VerifyCustomer } = eeBilling;
+
+  describe('setup_intent.succeeded', () => {
+    let updateCustomerStub: sinon.SinonStub;
+
+    let verifyCustomerStub: sinon.SinonStub;
+    let upsertSubscriptionStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      verifyCustomerStub = sinon.stub(VerifyCustomer.prototype, 'execute').resolves({
+        customer: {
+          id: 'customer_id',
+          deleted: false,
+          metadata: {
+            organizationId: 'organization_id',
+          },
+          subscriptions: {
+            data: [
+              {
+                id: 'subscription_id',
+                items: { data: [{ id: 'item_id_usage_notifications' }, { id: 'item_id_flat' }] },
+              },
+            ],
+          },
+        },
+        organization: { _id: 'organization_id', apiServiceLevel: ApiServiceLevelEnum.FREE },
+      } as any);
+      upsertSubscriptionStub = sinon.stub(UpsertSubscription.prototype, 'execute').resolves({
+        id: 'subscription_id',
+      } as any);
+      updateCustomerStub = sinon.stub(stripeStub.customers, 'update').resolves({});
+    });
+
+    const createHandler = () => {
+      const handler = new SetupIntentSucceededHandler(
+        stripeStub as any,
+        { execute: verifyCustomerStub } as any,
+        { execute: upsertSubscriptionStub } as any
+      );
+
+      return handler;
+    };
+
+    it('should exit early with invalid api service level', async () => {
+      const disallowedApiServiceLevel = ApiServiceLevelEnum.FREE;
+
+      const handler = createHandler();
+      await handler.handle({
+        ...mockSetupIntentSucceededEvent,
+        data: {
+          ...mockSetupIntentSucceededEvent.data,
+          object: {
+            ...mockSetupIntentSucceededEvent.data.object,
+            metadata: {
+              apiServiceLevel: disallowedApiServiceLevel,
+            },
+          },
+        },
+      });
+
+      expect(verifyCustomerStub.callCount).to.equal(0);
+    });
+
+    it('Should exit early with unknown organization', async () => {
+      verifyCustomerStub.resolves({ organization: null });
+      const handler = createHandler();
+      await handler.handle(mockSetupIntentSucceededEvent);
+
+      expect(updateCustomerStub.callCount).to.equal(0);
+    });
+
+    it('Should update the customer with the default payment method', async () => {
+      const handler = createHandler();
+      await handler.handle(mockSetupIntentSucceededEvent);
+
+      expect(updateCustomerStub.callCount).to.equal(1);
+    });
+
+    it('Should upsert a subscription', async () => {
+      const handler = createHandler();
+      await handler.handle(mockSetupIntentSucceededEvent);
+
+      expect(upsertSubscriptionStub.callCount).to.equal(1);
+    });
+  });
+
+  describe('customer.subscription.created', () => {
+    it('Should handle customer.subscription.created event with known organization', async () => {
+      // @TODO: Implement test
+      expect(true).to.equal(true);
+    });
+
+    it('Should exit early with unknown organization', async () => {
+      // @TODO: Implement test
+      expect(true).to.equal(true);
+    });
   });
 });

--- a/apps/api/src/app/testing/billing/webhook.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/webhook.e2e-ee.ts
@@ -42,14 +42,14 @@ const mockSetupIntentSucceededEvent = {
   request: null,
 } as const;
 
-describe('Stripe webhooks', async () => {
+describe('Stripe webhooks', () => {
   const stripeStub = {
     customers: {
       update: () => {},
     },
   };
 
-  const eeBilling = await import('@novu/ee-billing');
+  const eeBilling = require('@novu/ee-billing');
   if (!eeBilling) {
     throw new Error('ee-billing does not exist');
   }

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -18,5 +18,5 @@
     "types": ["node", "mocha"]
   },
   "include": [".eslintrc.js", "src/**/*", "src/**/*.d.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts", "**/*.e2e.ts"]
+  "exclude": ["node_modules", "**/*.spec.ts", "**/*.e2e.ts", "**/*.e2e-ee.ts"]
 }

--- a/enterprise/packages/billing/package.json
+++ b/enterprise/packages/billing/package.json
@@ -9,7 +9,8 @@
     "build:watch": "node_modules/.bin/tsc -w -p tsconfig.json",
     "test": "echo 'skip test in the ci'",
     "lint": "eslint src --no-error-on-unmatched-pattern",
-    "test-ee": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file tests/setup.ts src/**/**/*.spec.ts"
+    "test-ee": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' TZ=UTC NODE_ENV=test E2E_RUNNER=true mocha --timeout 10000 --require ts-node/register --exit --file tests/setup.ts src/**/**/*.spec.ts",
+    "start:proxy": "ngrok http http://localhost:3000"
   },
   "dependencies": {
     "@nestjs/swagger": "^7.1.8",

--- a/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.ts
+++ b/packages/application-generic/src/services/in-memory-provider/in-memory-provider.service.ts
@@ -304,7 +304,7 @@ export class InMemoryProviderService {
           LOG_CONTEXT
         );
       } catch (error) {
-        Logger.error(
+        Logger.warn(
           error,
           this.descriptiveLogMessage(
             `In-memory provider service shutdown has failed`


### PR DESCRIPTION
### What change does this PR introduce?

* Point to `next` EE submodule reference.
* Add unit tests for Billing use-cases
* Warn on in-memory shutdown failure to improve testing UX
* Stop truncating Chai error messages to improve testing UX

### Why was this change needed?

* Bringing in latest EE changes.
* Verifying the logic in Billing use-cases

### Other information (Screenshots)
_Test suite passing_
<img width="1278" alt="image" src="https://github.com/novuhq/novu/assets/32132657/d43037fc-4317-47e8-9f80-a768c65cbfaa">

_In-memory provider error changed to `warn` log, no longer showing in test cli output_
```bash
[11:56:35.970] ERROR (97434): [Provider: Elasticache] In-memory provider service shutdown has failed
    serviceName: "@novu/api"
    serviceVersion: "0.23.1"
    platform: "Docker"
    tenant: "OS"
    context: "InMemoryProviderService"
    err: {
      "type": "Error",
      "message": "Connection is closed.",
      "stack":
          Error: Connection is closed.
              at InMemoryProviderService.<anonymous> (/Users/rifont/git/novu/packages/application-generic/build/main/services/in-memory-provider/in-memory-provider.service.js:174:55)
              at Generator.next (<anonymous>)
              at /Users/rifont/git/novu/packages/application-generic/build/main/services/in-memory-provider/in-memory-provider.service.js:8:71
              at new Promise (<anonymous>)
              at __awaiter (/Users/rifont/git/novu/packages/application-generic/build/main/services/in-memory-provider/in-memory-provider.service.js:4:12)
              at InMemoryProviderService.shutdown (/Users/rifont/git/novu/packages/application-generic/build/main/services/in-memory-provider/in-memory-provider.service.js:171:16)
              at CacheInMemoryProviderService.<anonymous> (/Users/rifont/git/novu/packages/application-generic/build/main/services/in-memory-provider/cache-in-memory-provider.service.js:67:48)
              at Generator.next (<anonymous>)
              at /Users/rifont/git/novu/packages/application-generic/build/main/services/in-memory-provider/cache-in-memory-provider.service.js:8:71
              at new Promise (<anonymous>)
              at __awaiter (/Users/rifont/git/novu/packages/application-generic/build/main/services/in-memory-provider/cache-in-memory-provider.service.js:4:12)
              at CacheInMemoryProviderService.shutdown (/Users/rifont/git/novu/packages/application-generic/build/main/services/in-memory-provider/cache-in-memory-provider.service.js:66:16)
              at DistributedLockService.<anonymous> (/Users/rifont/git/novu/packages/application-generic/build/main/services/distributed-lock/distributed-lock.service.js:90:65)
              at Generator.next (<anonymous>)
              at fulfilled (/Users/rifont/git/novu/packages/application-generic/build/main/services/distributed-lock/distributed-lock.service.js:14:58)
```

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
