### PR TITLE
chore(web): marketing utm campaign on doc links

### DIFF
--- a/apps/web/cypress/tests/digest-playground.spec.ts
+++ b/apps/web/cypress/tests/digest-playground.spec.ts
@@ -16,7 +16,7 @@ describe('Digest Playground Workflow Page', function () {
     cy.url().should('include', '/digest-playground');
     cy.contains('Digest Workflow Playground');
 
-    cy.get('a[href="https://docs.novu.co/workflows/digest/?utm_campaign=in-app"]').contains('Learn more in docs');
+    cy.get('a[href="https://docs.novu.co/workflows/digest?utm_campaign=in-app"]').contains('Learn more in docs');
   });
 
   it('the set up digest workflow should redirect to template edit page', function () {

--- a/apps/web/cypress/tests/digest-playground.spec.ts
+++ b/apps/web/cypress/tests/digest-playground.spec.ts
@@ -16,7 +16,7 @@ describe('Digest Playground Workflow Page', function () {
     cy.url().should('include', '/digest-playground');
     cy.contains('Digest Workflow Playground');
 
-    cy.get('a[href="https://docs.novu.co/workflows/digest"]').contains('Learn more in docs');
+    cy.get('a[href="https://docs.novu.co/workflows/digest/?utm_campaign=in-app"]').contains('Learn more in docs');
   });
 
   it('the set up digest workflow should redirect to template edit page', function () {

--- a/apps/web/cypress/tests/integrations-list-modal.spec.ts
+++ b/apps/web/cypress/tests/integrations-list-modal.spec.ts
@@ -773,7 +773,7 @@ describe('Integrations List Modal', function () {
       'Select a framework to set up credentials to start sending notifications.'
     );
     cy.getByTestId('update-provider-sidebar')
-      .find('a[href="https://docs.novu.co/notification-center/introduction"]')
+      .find('a[href="https://docs.novu.co/notification-center/introduction/?utm_campaign=in-app"]')
       .contains('Explore set-up guide');
     cy.getByTestId('is_active_id').should('have.value', 'true');
     cy.window().then((win) => {

--- a/apps/web/cypress/tests/integrations-list-modal.spec.ts
+++ b/apps/web/cypress/tests/integrations-list-modal.spec.ts
@@ -773,7 +773,7 @@ describe('Integrations List Modal', function () {
       'Select a framework to set up credentials to start sending notifications.'
     );
     cy.getByTestId('update-provider-sidebar')
-      .find('a[href="https://docs.novu.co/notification-center/introduction/?utm_campaign=in-app"]')
+      .find('a[href="https://docs.novu.co/notification-center/introduction?utm_campaign=in-app"]')
       .contains('Explore set-up guide');
     cy.getByTestId('is_active_id').should('have.value', 'true');
     cy.window().then((win) => {

--- a/apps/web/cypress/tests/integrations-list-page.spec.ts
+++ b/apps/web/cypress/tests/integrations-list-page.spec.ts
@@ -924,7 +924,7 @@ describe('Integrations List Page', function () {
       'Select a framework to set up credentials to start sending notifications.'
     );
     cy.getByTestId('update-provider-sidebar')
-      .find('a[href="https://docs.novu.co/notification-center/introduction"]')
+      .find('a[href="https://docs.novu.co/notification-center/introduction/?utm_campaign=in-app"]')
       .contains('Explore set-up guide');
     cy.getByTestId('is_active_id').should('have.value', 'true');
     cy.window().then((win) => {

--- a/apps/web/cypress/tests/integrations-list-page.spec.ts
+++ b/apps/web/cypress/tests/integrations-list-page.spec.ts
@@ -924,7 +924,7 @@ describe('Integrations List Page', function () {
       'Select a framework to set up credentials to start sending notifications.'
     );
     cy.getByTestId('update-provider-sidebar')
-      .find('a[href="https://docs.novu.co/notification-center/introduction/?utm_campaign=in-app"]')
+      .find('a[href="https://docs.novu.co/notification-center/introduction?utm_campaign=in-app"]')
       .contains('Explore set-up guide');
     cy.getByTestId('is_active_id').should('have.value', 'true');
     cy.window().then((win) => {

--- a/apps/web/cypress/tests/layout/side-menu.spec.ts
+++ b/apps/web/cypress/tests/layout/side-menu.spec.ts
@@ -17,7 +17,7 @@ describe('Side Menu', function () {
     cy.getByTestId('side-nav-bottom-link-support').should('have.attr', 'href').should('eq', 'https://discord.novu.co');
     cy.getByTestId('side-nav-bottom-link-documentation')
       .should('have.attr', 'href')
-      .should('eq', 'https://docs.novu.co');
+      .should('eq', 'https://docs.novu.co/?utm_campaign=in-app');
 
     cy.getByTestId('side-nav-bottom-link-share-feedback')
       .should('have.attr', 'href')

--- a/apps/web/cypress/tests/layout/side-menu.spec.ts
+++ b/apps/web/cypress/tests/layout/side-menu.spec.ts
@@ -17,7 +17,7 @@ describe('Side Menu', function () {
     cy.getByTestId('side-nav-bottom-link-support').should('have.attr', 'href').should('eq', 'https://discord.novu.co');
     cy.getByTestId('side-nav-bottom-link-documentation')
       .should('have.attr', 'href')
-      .should('eq', 'https://docs.novu.co/?utm_campaign=in-app');
+      .should('eq', 'https://docs.novu.co?utm_campaign=in-app');
 
     cy.getByTestId('side-nav-bottom-link-share-feedback')
       .should('have.attr', 'href')

--- a/apps/web/src/components/layout/components/SideNav.tsx
+++ b/apps/web/src/components/layout/components/SideNav.tsx
@@ -218,7 +218,7 @@ export function SideNav({}: Props) {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href={`https://docs.novu.co/${UTM_CAMPAIGN_QUERY_PARAM}`}
+            href={`https://docs.novu.co${UTM_CAMPAIGN_QUERY_PARAM}`}
             data-test-id="side-nav-bottom-link-documentation"
           >
             Docs

--- a/apps/web/src/components/layout/components/SideNav.tsx
+++ b/apps/web/src/components/layout/components/SideNav.tsx
@@ -30,7 +30,7 @@ import { currentOnboardingStep } from '../../../pages/quick-start/components/rou
 import { useSpotlightContext } from '../../providers/SpotlightProvider';
 import { ChangesCountBadge } from './ChangesCountBadge';
 import OrganizationSelect from './OrganizationSelect';
-import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { FeatureFlagsKeysEnum, UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
 
 const usePopoverStyles = createStyles(({ colorScheme }) => ({
   dropdown: {
@@ -218,7 +218,7 @@ export function SideNav({}: Props) {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://docs.novu.co"
+            href={`https://docs.novu.co/${UTM_CAMPAIGN_QUERY_PARAM}`}
             data-test-id="side-nav-bottom-link-documentation"
           >
             Docs

--- a/apps/web/src/components/quick-start/digest-demo-flow/consts.ts
+++ b/apps/web/src/components/quick-start/digest-demo-flow/consts.ts
@@ -28,7 +28,7 @@ export const guidePreview: Record<string, IGuide> = {
   trigger: {
     title: GuideTitleEnum.TRIGGER_PREVIEW,
     description: 'Use the server SDK in your app for a specific trigger. ',
-    docsUrl: `https://docs.novu.co/api-reference/events/trigger-event/${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docsUrl: `https://docs.novu.co/api-reference/events/trigger-event${UTM_CAMPAIGN_QUERY_PARAM}`,
     sequence: {
       1: { open: false, opacity: HINT_HIDDEN_OPACITY },
       2: { open: true, opacity: HINT_VISIBLE_OPACITY },
@@ -40,7 +40,7 @@ export const guidePreview: Record<string, IGuide> = {
   digest: {
     title: GuideTitleEnum.DIGEST_PREVIEW,
     description: 'Aggregates multiple events into a precise notification. ',
-    docsUrl: `https://docs.novu.co/workflows/digest/${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docsUrl: `https://docs.novu.co/workflows/digest${UTM_CAMPAIGN_QUERY_PARAM}`,
     sequence: {
       1: { open: false, opacity: HINT_HIDDEN_OPACITY },
       2: { open: false, opacity: HINT_HIDDEN_OPACITY },
@@ -52,7 +52,7 @@ export const guidePreview: Record<string, IGuide> = {
   email: {
     title: GuideTitleEnum.CHANNELS_PREVIEW,
     description: 'Build desired order of channels. ',
-    docsUrl: `https://docs.novu.co/channels-and-providers/integration-store/${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docsUrl: `https://docs.novu.co/channels-and-providers/integration-store${UTM_CAMPAIGN_QUERY_PARAM}`,
     sequence: {
       1: { open: false, opacity: HINT_HIDDEN_OPACITY },
       2: { open: false, opacity: HINT_HIDDEN_OPACITY },

--- a/apps/web/src/components/quick-start/digest-demo-flow/consts.ts
+++ b/apps/web/src/components/quick-start/digest-demo-flow/consts.ts
@@ -1,3 +1,5 @@
+import { UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
+
 export enum GuideTitleEnum {
   TRIGGER_PREVIEW = 'Trigger',
   TRIGGER_PLAYGROUND = 'Run trigger multiple times',
@@ -26,7 +28,7 @@ export const guidePreview: Record<string, IGuide> = {
   trigger: {
     title: GuideTitleEnum.TRIGGER_PREVIEW,
     description: 'Use the server SDK in your app for a specific trigger. ',
-    docsUrl: 'https://docs.novu.co/api-reference/events/trigger-event',
+    docsUrl: `https://docs.novu.co/api-reference/events/trigger-event/${UTM_CAMPAIGN_QUERY_PARAM}`,
     sequence: {
       1: { open: false, opacity: HINT_HIDDEN_OPACITY },
       2: { open: true, opacity: HINT_VISIBLE_OPACITY },
@@ -38,7 +40,7 @@ export const guidePreview: Record<string, IGuide> = {
   digest: {
     title: GuideTitleEnum.DIGEST_PREVIEW,
     description: 'Aggregates multiple events into a precise notification. ',
-    docsUrl: 'https://docs.novu.co/workflows/digest',
+    docsUrl: `https://docs.novu.co/workflows/digest/${UTM_CAMPAIGN_QUERY_PARAM}`,
     sequence: {
       1: { open: false, opacity: HINT_HIDDEN_OPACITY },
       2: { open: false, opacity: HINT_HIDDEN_OPACITY },
@@ -50,7 +52,7 @@ export const guidePreview: Record<string, IGuide> = {
   email: {
     title: GuideTitleEnum.CHANNELS_PREVIEW,
     description: 'Build desired order of channels. ',
-    docsUrl: 'https://docs.novu.co/channels-and-providers/integration-store',
+    docsUrl: `https://docs.novu.co/channels-and-providers/integration-store/${UTM_CAMPAIGN_QUERY_PARAM}`,
     sequence: {
       1: { open: false, opacity: HINT_HIDDEN_OPACITY },
       2: { open: false, opacity: HINT_HIDDEN_OPACITY },

--- a/apps/web/src/components/utils/Spotlight.tsx
+++ b/apps/web/src/components/utils/Spotlight.tsx
@@ -2,8 +2,10 @@ import { SpotlightProvider } from '@mantine/spotlight';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Activity, Bolt, Box, Settings, Repeat, Team, Brand, Chat } from '@novu/design-system';
-import { useSpotlightContext } from '../providers/SpotlightProvider';
+import { UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
+
 import { ROUTES } from '../../constants/routes.enum';
+import { useSpotlightContext } from '../providers/SpotlightProvider';
 
 export const SpotLight = ({ children }) => {
   const navigate = useNavigate();
@@ -57,7 +59,7 @@ export const SpotLight = ({ children }) => {
         id: 'navigate-docs',
         title: 'Go to Documentation',
         onTrigger: () => {
-          window?.open('https://docs.novu.co/', '_blank')?.focus();
+          window?.open(`https://docs.novu.co/${UTM_CAMPAIGN_QUERY_PARAM}`, '_blank')?.focus();
         },
       },
       {

--- a/apps/web/src/components/utils/Spotlight.tsx
+++ b/apps/web/src/components/utils/Spotlight.tsx
@@ -59,7 +59,7 @@ export const SpotLight = ({ children }) => {
         id: 'navigate-docs',
         title: 'Go to Documentation',
         onTrigger: () => {
-          window?.open(`https://docs.novu.co/${UTM_CAMPAIGN_QUERY_PARAM}`, '_blank')?.focus();
+          window?.open(`https://docs.novu.co${UTM_CAMPAIGN_QUERY_PARAM}`, '_blank')?.focus();
         },
       },
       {

--- a/apps/web/src/pages/auth/components/SignUpForm.tsx
+++ b/apps/web/src/pages/auth/components/SignUpForm.tsx
@@ -4,8 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { Center } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-
-import { passwordConstraints } from '@novu/shared';
+import { passwordConstraints, UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
 import { PasswordInput, Button, colors, Input, Text, Checkbox } from '@novu/design-system';
 
 import { useAuthContext } from '../../../components/providers/AuthProvider';
@@ -223,13 +222,18 @@ function Accept() {
   return (
     <>
       <span>I accept the </span>
-      <a style={{ textDecoration: 'underline' }} href="https://novu.co/terms" target="_blank" rel="noopener noreferrer">
+      <a
+        style={{ textDecoration: 'underline' }}
+        href={`https://novu.co/terms/${UTM_CAMPAIGN_QUERY_PARAM}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Terms and Conditions
       </a>
       <span> and have read the </span>
       <a
         style={{ textDecoration: 'underline' }}
-        href="https://novu.co/privacy"
+        href={`https://novu.co/privacy/${UTM_CAMPAIGN_QUERY_PARAM}`}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/apps/web/src/pages/auth/components/SignUpForm.tsx
+++ b/apps/web/src/pages/auth/components/SignUpForm.tsx
@@ -224,7 +224,7 @@ function Accept() {
       <span>I accept the </span>
       <a
         style={{ textDecoration: 'underline' }}
-        href={`https://novu.co/terms/${UTM_CAMPAIGN_QUERY_PARAM}`}
+        href={`https://novu.co/terms${UTM_CAMPAIGN_QUERY_PARAM}`}
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -233,7 +233,7 @@ function Accept() {
       <span> and have read the </span>
       <a
         style={{ textDecoration: 'underline' }}
-        href={`https://novu.co/privacy/${UTM_CAMPAIGN_QUERY_PARAM}`}
+        href={`https://novu.co/privacy${UTM_CAMPAIGN_QUERY_PARAM}`}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/apps/web/src/pages/integrations/components/FrameworkDisplay.tsx
+++ b/apps/web/src/pages/integrations/components/FrameworkDisplay.tsx
@@ -2,6 +2,8 @@ import { Text, UnstyledButton, Group, useMantineTheme } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { colors } from '@novu/notification-center';
 import { AngularGradient, Copy, ReactGradient, VueGradient, JsGradient, CodeGradient } from '@novu/design-system';
+import { UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
+
 import { useEnvController } from '../../../hooks';
 import { FrameworkEnum } from '../../quick-start/consts';
 
@@ -82,7 +84,7 @@ export const FrameworkDisplay = ({ setFramework }: { setFramework: (framework: s
       </Group>
       <Group spacing={16} mt={16} grow>
         <a
-          href="https://docs.novu.co/notification-center/client/web-component"
+          href={`https://docs.novu.co/notification-center/client/web-component/${UTM_CAMPAIGN_QUERY_PARAM}`}
           onClick={() => {
             setFramework('');
           }}
@@ -96,7 +98,7 @@ export const FrameworkDisplay = ({ setFramework }: { setFramework: (framework: s
           </Group>
         </a>
         <a
-          href="https://docs.novu.co/notification-center/client/headless/get-started"
+          href={`https://docs.novu.co/notification-center/client/headless/get-started/${UTM_CAMPAIGN_QUERY_PARAM}`}
           onClick={() => {
             setFramework('');
           }}

--- a/apps/web/src/pages/integrations/components/FrameworkDisplay.tsx
+++ b/apps/web/src/pages/integrations/components/FrameworkDisplay.tsx
@@ -84,7 +84,7 @@ export const FrameworkDisplay = ({ setFramework }: { setFramework: (framework: s
       </Group>
       <Group spacing={16} mt={16} grow>
         <a
-          href={`https://docs.novu.co/notification-center/client/web-component/${UTM_CAMPAIGN_QUERY_PARAM}`}
+          href={`https://docs.novu.co/notification-center/client/web-component${UTM_CAMPAIGN_QUERY_PARAM}`}
           onClick={() => {
             setFramework('');
           }}
@@ -98,7 +98,7 @@ export const FrameworkDisplay = ({ setFramework }: { setFramework: (framework: s
           </Group>
         </a>
         <a
-          href={`https://docs.novu.co/notification-center/client/headless/get-started/${UTM_CAMPAIGN_QUERY_PARAM}`}
+          href={`https://docs.novu.co/notification-center/client/headless/get-started${UTM_CAMPAIGN_QUERY_PARAM}`}
           onClick={() => {
             setFramework('');
           }}

--- a/apps/web/src/pages/integrations/components/NovuInAppForm.tsx
+++ b/apps/web/src/pages/integrations/components/NovuInAppForm.tsx
@@ -130,7 +130,7 @@ export const NovuInAppForm = ({
           <CircleArrowRightStyled
             onClick={() => {
               window.open(
-                `https://docs.novu.co/notification-center/client/iframe/${UTM_CAMPAIGN_QUERY_PARAM}#enabling-hmac-encryption`
+                `https://docs.novu.co/notification-center/client/iframe${UTM_CAMPAIGN_QUERY_PARAM}#enabling-hmac-encryption`
               );
             }}
           />

--- a/apps/web/src/pages/integrations/components/NovuInAppForm.tsx
+++ b/apps/web/src/pages/integrations/components/NovuInAppForm.tsx
@@ -3,11 +3,11 @@ import styled from '@emotion/styled/macro';
 import { Title, Text, Grid, Stack, useMantineColorScheme } from '@mantine/core';
 import { useMutation } from '@tanstack/react-query';
 import { Controller, useForm } from 'react-hook-form';
-import { ICredentialsDto } from '@novu/shared';
+import { ICredentialsDto, UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
+import { Switch, Button, colors, CircleArrowRight } from '@novu/design-system';
 
 import { IIntegratedProvider } from '../types';
 import { updateIntegration } from '../../../api/integration';
-import { Switch, Button, colors, CircleArrowRight } from '@novu/design-system';
 import { When } from '../../../components/utils/When';
 import { errorMessage, successMessage } from '../../../utils/notifications';
 
@@ -129,7 +129,9 @@ export const NovuInAppForm = ({
           </Text>
           <CircleArrowRightStyled
             onClick={() => {
-              window.open('https://docs.novu.co/notification-center/client/iframe#enabling-hmac-encryption');
+              window.open(
+                `https://docs.novu.co/notification-center/client/iframe/${UTM_CAMPAIGN_QUERY_PARAM}#enabling-hmac-encryption`
+              );
             }}
           />
         </WarningMessage>

--- a/apps/web/src/pages/integrations/components/NovuInAppFrameworks.tsx
+++ b/apps/web/src/pages/integrations/components/NovuInAppFrameworks.tsx
@@ -47,12 +47,12 @@ const frameworks = [
   {
     icon: JavaScriptLogo,
     name: 'Web Component',
-    href: `https://docs.novu.co/notification-center/client/web-component/${UTM_CAMPAIGN_QUERY_PARAM}`,
+    href: `https://docs.novu.co/notification-center/client/web-component${UTM_CAMPAIGN_QUERY_PARAM}`,
   },
   {
     icon: JavaScriptLogo,
     name: 'Headless',
-    href: `https://docs.novu.co/notification-center/client/headless/get-started/${UTM_CAMPAIGN_QUERY_PARAM}`,
+    href: `https://docs.novu.co/notification-center/client/headless/get-started${UTM_CAMPAIGN_QUERY_PARAM}`,
   },
   { icon: VueLogo, name: 'Vue', frameworkEnum: FrameworkEnum.VUE },
   { icon: IframeLogo, name: 'iFrame', frameworkEnum: FrameworkEnum.JS },

--- a/apps/web/src/pages/integrations/components/NovuInAppFrameworks.tsx
+++ b/apps/web/src/pages/integrations/components/NovuInAppFrameworks.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
-
 import { colors, Text, ReactLogo, AngularLogo, JavaScriptLogo, VueLogo, IframeLogo } from '@novu/design-system';
+import { UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
+
 import { FrameworkEnum } from '../../quick-start/consts';
 
 const NovuInAppFrameworksHolder = styled.div`
@@ -46,12 +47,12 @@ const frameworks = [
   {
     icon: JavaScriptLogo,
     name: 'Web Component',
-    href: 'https://docs.novu.co/notification-center/client/web-component',
+    href: `https://docs.novu.co/notification-center/client/web-component/${UTM_CAMPAIGN_QUERY_PARAM}`,
   },
   {
     icon: JavaScriptLogo,
     name: 'Headless',
-    href: 'https://docs.novu.co/notification-center/client/headless/get-started',
+    href: `https://docs.novu.co/notification-center/client/headless/get-started/${UTM_CAMPAIGN_QUERY_PARAM}`,
   },
   { icon: VueLogo, name: 'Vue', frameworkEnum: FrameworkEnum.VUE },
   { icon: IframeLogo, name: 'iFrame', frameworkEnum: FrameworkEnum.JS },

--- a/apps/web/src/pages/integrations/components/NovuProviderBase.tsx
+++ b/apps/web/src/pages/integrations/components/NovuProviderBase.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { Stack, Text, useMantineColorScheme } from '@mantine/core';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
+import { colors, Close } from '@novu/design-system';
+
 import { When } from '../../../components/utils/When';
 import { CONTEXT_PATH } from '../../../config';
-import { colors, Close } from '@novu/design-system';
 import { useIntegrationLimit } from '../../../hooks';
 import { LimitBar } from './LimitBar';
 
@@ -53,7 +54,7 @@ export function NovuProviderBase({ onClose, senderInformation, channel }: NovuPr
           <InlineDiv>
             <span>Read more about Integrations in</span>
             <a
-              href="https://docs.novu.co/channels-and-providers/integration-store"
+              href={`https://docs.novu.co/channels-and-providers/integration-store/${UTM_CAMPAIGN_QUERY_PARAM}`}
               target="_blank"
               rel="noreferrer"
               style={{ color: '#DD2476 ', textDecoration: 'underline' }}

--- a/apps/web/src/pages/integrations/components/NovuProviderBase.tsx
+++ b/apps/web/src/pages/integrations/components/NovuProviderBase.tsx
@@ -54,7 +54,7 @@ export function NovuProviderBase({ onClose, senderInformation, channel }: NovuPr
           <InlineDiv>
             <span>Read more about Integrations in</span>
             <a
-              href={`https://docs.novu.co/channels-and-providers/integration-store/${UTM_CAMPAIGN_QUERY_PARAM}`}
+              href={`https://docs.novu.co/channels-and-providers/integration-store${UTM_CAMPAIGN_QUERY_PARAM}`}
               target="_blank"
               rel="noreferrer"
               style={{ color: '#DD2476 ', textDecoration: 'underline' }}

--- a/apps/web/src/pages/quick-start/consts.tsx
+++ b/apps/web/src/pages/quick-start/consts.tsx
@@ -1,9 +1,9 @@
 import React, { Dispatch } from 'react';
 import { Stack } from '@mantine/core';
 import { NavigateFunction } from 'react-router-dom';
-import { ChannelTypeEnum } from '@novu/shared';
-
+import { ChannelTypeEnum, UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
 import { Bell, Chat, Mail, Mobile, Sms } from '@novu/design-system';
+
 import { ROUTES } from '../../constants/routes.enum';
 import { WIDGET_EMBED_PATH } from '../../config';
 
@@ -19,8 +19,8 @@ export const BACKEND_SOCKET_URL = '<BACKEND_SOCKET_URL>';
 export const setupProject = `cd notification-center-demo && npm run setup:onboarding -- ${APPLICATION_IDENTIFIER} ${API_KEY} ${BACKEND_API_URL} ${BACKEND_SOCKET_URL}`;
 export const npmRunCommand = 'npm run dev';
 export const frameworkSetupTitle = 'Choose your go-to framework';
-export const faqUrl = 'https://docs.novu.co/notification-center/introduction';
-export const notificationCenterDocsUrl = 'https://docs.novu.co/notification-center/introduction';
+export const faqUrl = `https://docs.novu.co/notification-center/introduction/${UTM_CAMPAIGN_QUERY_PARAM}`;
+export const notificationCenterDocsUrl = `https://docs.novu.co/notification-center/introduction/${UTM_CAMPAIGN_QUERY_PARAM}`;
 export const discordInviteUrl = 'https://discord.gg/novu';
 export const demoSetupSecondaryTitle = 'Follow the installation steps to connect your app';
 

--- a/apps/web/src/pages/quick-start/consts.tsx
+++ b/apps/web/src/pages/quick-start/consts.tsx
@@ -19,8 +19,8 @@ export const BACKEND_SOCKET_URL = '<BACKEND_SOCKET_URL>';
 export const setupProject = `cd notification-center-demo && npm run setup:onboarding -- ${APPLICATION_IDENTIFIER} ${API_KEY} ${BACKEND_API_URL} ${BACKEND_SOCKET_URL}`;
 export const npmRunCommand = 'npm run dev';
 export const frameworkSetupTitle = 'Choose your go-to framework';
-export const faqUrl = `https://docs.novu.co/notification-center/introduction/${UTM_CAMPAIGN_QUERY_PARAM}`;
-export const notificationCenterDocsUrl = `https://docs.novu.co/notification-center/introduction/${UTM_CAMPAIGN_QUERY_PARAM}`;
+export const faqUrl = `https://docs.novu.co/notification-center/introduction${UTM_CAMPAIGN_QUERY_PARAM}`;
+export const notificationCenterDocsUrl = `https://docs.novu.co/notification-center/introduction${UTM_CAMPAIGN_QUERY_PARAM}`;
 export const discordInviteUrl = 'https://discord.gg/novu';
 export const demoSetupSecondaryTitle = 'Follow the installation steps to connect your app';
 

--- a/apps/web/src/pages/quick-start/steps/GetStarted.tsx
+++ b/apps/web/src/pages/quick-start/steps/GetStarted.tsx
@@ -73,7 +73,7 @@ function LearnMoreRef() {
 
   return (
     <a
-      href={`https://docs.novu.co/quickstarts/01-introduction/${UTM_CAMPAIGN_QUERY_PARAM}`}
+      href={`https://docs.novu.co/quickstarts/01-introduction${UTM_CAMPAIGN_QUERY_PARAM}`}
       style={{ color: '#DD2476', textDecoration: 'underline', fontSize: '18px' }}
       onClick={() => handleOnClick}
       target="_blank"

--- a/apps/web/src/pages/quick-start/steps/GetStarted.tsx
+++ b/apps/web/src/pages/quick-start/steps/GetStarted.tsx
@@ -1,9 +1,9 @@
-import styled from '@emotion/styled';
-import { ChannelTypeEnum } from '@novu/shared';
 import { useEffect, useState } from 'react';
+import styled from '@emotion/styled';
+import { ChannelTypeEnum, UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
+import { ArrowRight } from '@novu/design-system';
 
 import { useSegment } from '../../../components/providers/SegmentProvider';
-import { ArrowRight } from '@novu/design-system';
 import { IntegrationsListModal } from '../../integrations/IntegrationsListModal';
 import { ChannelsConfiguration } from '../components/ChannelsConfiguration';
 import { GetStartedLayout } from '../components/layout/GetStartedLayout';
@@ -73,7 +73,7 @@ function LearnMoreRef() {
 
   return (
     <a
-      href={'https://docs.novu.co/quickstarts/01-introduction'}
+      href={`https://docs.novu.co/quickstarts/01-introduction/${UTM_CAMPAIGN_QUERY_PARAM}`}
       style={{ color: '#DD2476', textDecoration: 'underline', fontSize: '18px' }}
       onClick={() => handleOnClick}
       target="_blank"

--- a/apps/web/src/pages/templates/TemplatesDigestPlaygroundPage.tsx
+++ b/apps/web/src/pages/templates/TemplatesDigestPlaygroundPage.tsx
@@ -1,17 +1,18 @@
+import { useCallback } from 'react';
 import { Stack } from '@mantine/core';
 import styled from '@emotion/styled';
 import { ReactFlowProvider } from 'react-flow-renderer';
 import { useNavigate, useParams } from 'react-router-dom';
+import { UTM_CAMPAIGN_QUERY_PARAM } from '@novu/shared';
+import { ArrowButton, colors, Title, Text, Button } from '@novu/design-system';
 
 import PageContainer from '../../components/layout/components/PageContainer';
-import { ArrowButton, colors, Title, Text, Button } from '@novu/design-system';
 import { parseUrl } from '../../utils/routeUtils';
 import { ROUTES } from '../../constants/routes.enum';
 import { DigestDemoFlow } from '../../components';
 import { useSegment } from '../../components/providers/SegmentProvider';
 import { DigestPlaygroundAnalyticsEnum } from './constants';
 import { useTourStorage } from './hooks/useTourStorage';
-import { useCallback } from 'react';
 
 const Heading = styled(Title)`
   color: ${colors.B40};
@@ -81,7 +82,7 @@ export const TemplatesDigestPlaygroundPage = () => {
           <LinkStyled
             target="_blank"
             rel="noopener noreferrer"
-            href="https://docs.novu.co/workflows/digest"
+            href={`https://docs.novu.co/workflows/digest/${UTM_CAMPAIGN_QUERY_PARAM}`}
             onClick={handleLearnMoreClick}
           >
             Learn more in docs

--- a/apps/web/src/pages/templates/TemplatesDigestPlaygroundPage.tsx
+++ b/apps/web/src/pages/templates/TemplatesDigestPlaygroundPage.tsx
@@ -82,7 +82,7 @@ export const TemplatesDigestPlaygroundPage = () => {
           <LinkStyled
             target="_blank"
             rel="noopener noreferrer"
-            href={`https://docs.novu.co/workflows/digest/${UTM_CAMPAIGN_QUERY_PARAM}`}
+            href={`https://docs.novu.co/workflows/digest${UTM_CAMPAIGN_QUERY_PARAM}`}
             onClick={handleLearnMoreClick}
           >
             Learn more in docs

--- a/libs/design-system/src/iconsV2/IconProvider.tsx
+++ b/libs/design-system/src/iconsV2/IconProvider.tsx
@@ -10,6 +10,7 @@ const iconClassName = css`
 
 export const IconProvider: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   const theme = useMantineTheme();
+
   return (
     <IconContext.Provider
       value={{

--- a/libs/shared/src/consts/providers/channels/chat.ts
+++ b/libs/shared/src/consts/providers/channels/chat.ts
@@ -2,8 +2,8 @@ import { IConfigCredentials, IProviderConfig } from '../provider.interface';
 import { grafanaOnCallConfig, slackConfig, getstreamConfig, rocketChatConfig } from '../credentials';
 
 import { ChatProviderIdEnum } from '../provider.enum';
-
 import { ChannelTypeEnum } from '../../../types';
+import { UTM_CAMPAIGN_QUERY_PARAM } from '../../../ui';
 
 export const chatProviders: IProviderConfig[] = [
   {
@@ -11,7 +11,7 @@ export const chatProviders: IProviderConfig[] = [
     displayName: 'Slack',
     channel: ChannelTypeEnum.CHAT,
     credentials: slackConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/chat/slack',
+    docReference: `https://docs.novu.co/channels-and-providers/chat/slack${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'slack.svg', dark: 'slack.svg' },
   },
   {
@@ -19,7 +19,7 @@ export const chatProviders: IProviderConfig[] = [
     displayName: 'Discord',
     channel: ChannelTypeEnum.CHAT,
     credentials: [] as IConfigCredentials[],
-    docReference: 'https://docs.novu.co/channels-and-providers/chat/discord',
+    docReference: `https://docs.novu.co/channels-and-providers/chat/discord${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'discord.svg', dark: 'discord.svg' },
   },
   {
@@ -35,7 +35,7 @@ export const chatProviders: IProviderConfig[] = [
     displayName: 'MSTeams',
     channel: ChannelTypeEnum.CHAT,
     credentials: [] as IConfigCredentials[],
-    docReference: 'https://docs.novu.co/channels-and-providers/chat/ms-teams',
+    docReference: `https://docs.novu.co/channels-and-providers/chat/ms-teams${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'msteams.svg', dark: 'msteams.svg' },
   },
   {
@@ -59,7 +59,7 @@ export const chatProviders: IProviderConfig[] = [
     displayName: 'Zulip',
     channel: ChannelTypeEnum.CHAT,
     credentials: [] as IConfigCredentials[],
-    docReference: 'https://docs.novu.co/channels-and-providers/chat/zulip',
+    docReference: `https://docs.novu.co/channels-and-providers/chat/zulip${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'zulip.svg', dark: 'zulip.svg' },
   },
   {

--- a/libs/shared/src/consts/providers/channels/email.ts
+++ b/libs/shared/src/consts/providers/channels/email.ts
@@ -20,8 +20,8 @@ import {
 } from '../credentials';
 import { IProviderConfig } from '../provider.interface';
 import { EmailProviderIdEnum } from '../provider.enum';
-
 import { ChannelTypeEnum } from '../../../types';
+import { UTM_CAMPAIGN_QUERY_PARAM } from '../../../ui';
 
 export const emailProviders: IProviderConfig[] = [
   {
@@ -29,7 +29,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Novu Email',
     channel: ChannelTypeEnum.EMAIL,
     credentials: [],
-    docReference: 'https://docs.novu.co/channels-and-providers/default-providers#novu-email-provider',
+    docReference: `https://docs.novu.co/channels-and-providers/default-providers${UTM_CAMPAIGN_QUERY_PARAM}#novu-email-provider`,
     logoFileName: { light: 'novu.png', dark: 'novu.png' },
   },
   {
@@ -37,7 +37,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Mailgun',
     channel: ChannelTypeEnum.EMAIL,
     credentials: mailgunConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/mailgun',
+    docReference: `https://docs.novu.co/channels-and-providers/email/mailgun${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'mailgun.svg', dark: 'mailgun.svg' },
   },
   {
@@ -45,7 +45,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Mailjet',
     channel: ChannelTypeEnum.EMAIL,
     credentials: mailjetConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/mailjet',
+    docReference: `https://docs.novu.co/channels-and-providers/email/mailjet${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'mailjet.png', dark: 'mailjet.png' },
   },
   {
@@ -53,7 +53,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Mailtrap',
     channel: ChannelTypeEnum.EMAIL,
     credentials: mailtrapConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/mailtrap',
+    docReference: `https://docs.novu.co/channels-and-providers/email/mailtrap${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'mailtrap.svg', dark: 'mailtrap.svg' },
   },
   {
@@ -61,7 +61,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Mandrill',
     channel: ChannelTypeEnum.EMAIL,
     credentials: mandrillConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/mandrill',
+    docReference: `https://docs.novu.co/channels-and-providers/email/mandrill${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'mandrill.svg', dark: 'mandrill.svg' },
   },
   {
@@ -69,7 +69,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Postmark',
     channel: ChannelTypeEnum.EMAIL,
     credentials: postmarkConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/postmark',
+    docReference: `https://docs.novu.co/channels-and-providers/email/postmark${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'postmark.png', dark: 'postmark.png' },
   },
   {
@@ -77,7 +77,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'SendGrid',
     channel: ChannelTypeEnum.EMAIL,
     credentials: sendgridConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/sendgrid',
+    docReference: `https://docs.novu.co/channels-and-providers/email/sendgrid${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sendgrid.png', dark: 'sendgrid.png' },
   },
   {
@@ -85,7 +85,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Sendinblue',
     channel: ChannelTypeEnum.EMAIL,
     credentials: sendinblueConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/sendinblue',
+    docReference: `https://docs.novu.co/channels-and-providers/email/sendinblue${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sendinblue.png', dark: 'sendinblue.png' },
   },
   {
@@ -93,7 +93,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'SES',
     channel: ChannelTypeEnum.EMAIL,
     credentials: sesConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/amazonses',
+    docReference: `https://docs.novu.co/channels-and-providers/email/amazonses${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'ses.svg', dark: 'ses.svg' },
   },
   {
@@ -101,7 +101,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Netcore',
     channel: ChannelTypeEnum.EMAIL,
     credentials: netCoreConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/netcore',
+    docReference: `https://docs.novu.co/channels-and-providers/email/netcore${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'netcore.png', dark: 'netcore.png' },
   },
   {
@@ -109,7 +109,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Custom SMTP',
     channel: ChannelTypeEnum.EMAIL,
     credentials: nodemailerConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/custom-smtp',
+    docReference: `https://docs.novu.co/channels-and-providers/email/custom-smtp${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'custom_smtp.svg', dark: 'custom_smtp.svg' },
   },
   {
@@ -117,7 +117,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'MailerSend',
     channel: ChannelTypeEnum.EMAIL,
     credentials: mailerSendConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/mailersend',
+    docReference: `https://docs.novu.co/channels-and-providers/email/mailersend${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'mailersend.svg', dark: 'mailersend.svg' },
   },
   {
@@ -125,7 +125,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Microsoft Outlook365',
     channel: ChannelTypeEnum.EMAIL,
     credentials: outlook365Config,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/outlook365',
+    docReference: `https://docs.novu.co/channels-and-providers/email/outlook365${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'outlook365.png', dark: 'outlook365.png' },
   },
   {
@@ -133,7 +133,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Infobip',
     channel: ChannelTypeEnum.EMAIL,
     credentials: infobipEmailConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/infobip',
+    docReference: `https://docs.novu.co/channels-and-providers/email/infobip${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'infobip.png', dark: 'infobip.png' },
   },
   {
@@ -149,7 +149,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Resend',
     channel: ChannelTypeEnum.EMAIL,
     credentials: resendConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/resend',
+    docReference: `https://docs.novu.co/channels-and-providers/email/resend${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'resend.svg', dark: 'resend.svg' },
   },
   {
@@ -157,7 +157,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Plunk',
     channel: ChannelTypeEnum.EMAIL,
     credentials: plunkConfig,
-    docReference: 'https://docs.novu.co/channels/email/plunk',
+    docReference: `https://docs.novu.co/channels/email/plunk${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'plunk.png', dark: 'plunk.png' },
   },
   {
@@ -165,7 +165,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'SparkPost',
     channel: ChannelTypeEnum.EMAIL,
     credentials: sparkpostConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/email/sparkpost',
+    docReference: `https://docs.novu.co/channels-and-providers/email/sparkpost${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sparkpost.svg', dark: 'sparkpost.svg' },
   },
   {
@@ -174,7 +174,7 @@ export const emailProviders: IProviderConfig[] = [
     channel: ChannelTypeEnum.EMAIL,
     credentials: emailWebhookConfig,
     betaVersion: true,
-    docReference: 'https://docs.novu.co/channels/email/email-webhook/',
+    docReference: `https://docs.novu.co/channels/email/email-webhook${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'email_webhook.svg', dark: 'email_webhook.svg' },
   },
 ];

--- a/libs/shared/src/consts/providers/channels/in-app.ts
+++ b/libs/shared/src/consts/providers/channels/in-app.ts
@@ -4,6 +4,7 @@ import { InAppProviderIdEnum } from '../provider.enum';
 import { IProviderConfig } from '../provider.interface';
 
 import { ChannelTypeEnum } from '../../../types';
+import { UTM_CAMPAIGN_QUERY_PARAM } from '../../../ui';
 
 export const inAppProviders: IProviderConfig[] = [
   {
@@ -11,7 +12,7 @@ export const inAppProviders: IProviderConfig[] = [
     displayName: 'Novu In-App',
     channel: ChannelTypeEnum.IN_APP,
     credentials: novuInAppConfig,
-    docReference: 'https://docs.novu.co/notification-center/introduction',
+    docReference: `https://docs.novu.co/notification-center/introduction/${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'novu.png', dark: 'novu.png' },
   },
 ];

--- a/libs/shared/src/consts/providers/channels/in-app.ts
+++ b/libs/shared/src/consts/providers/channels/in-app.ts
@@ -12,7 +12,7 @@ export const inAppProviders: IProviderConfig[] = [
     displayName: 'Novu In-App',
     channel: ChannelTypeEnum.IN_APP,
     credentials: novuInAppConfig,
-    docReference: `https://docs.novu.co/notification-center/introduction/${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/notification-center/introduction${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'novu.png', dark: 'novu.png' },
   },
 ];

--- a/libs/shared/src/consts/providers/channels/push.ts
+++ b/libs/shared/src/consts/providers/channels/push.ts
@@ -12,6 +12,7 @@ import { PushProviderIdEnum } from '../provider.enum';
 import { IProviderConfig } from '../provider.interface';
 
 import { ChannelTypeEnum } from '../../../types';
+import { UTM_CAMPAIGN_QUERY_PARAM } from '../../../ui';
 
 export const pushProviders: IProviderConfig[] = [
   {
@@ -19,7 +20,7 @@ export const pushProviders: IProviderConfig[] = [
     displayName: 'OneSignal',
     channel: ChannelTypeEnum.PUSH,
     credentials: oneSignalConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/push/onesignal',
+    docReference: `https://docs.novu.co/channels-and-providers/push/onesignal${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'one-signal.svg', dark: 'one-signal.svg' },
   },
   {
@@ -27,7 +28,7 @@ export const pushProviders: IProviderConfig[] = [
     displayName: 'Pushpad',
     channel: ChannelTypeEnum.PUSH,
     credentials: pushpadConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/push/pushpad',
+    docReference: `https://docs.novu.co/channels-and-providers/push/pushpad${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'pushpad.svg', dark: 'pushpad.svg' },
   },
   {
@@ -35,7 +36,7 @@ export const pushProviders: IProviderConfig[] = [
     displayName: 'Firebase Cloud Messaging',
     channel: ChannelTypeEnum.PUSH,
     credentials: fcmConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/push/fcm',
+    docReference: `https://docs.novu.co/channels-and-providers/push/fcm${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'fcm.svg', dark: 'fcm.svg' },
   },
   {
@@ -43,7 +44,7 @@ export const pushProviders: IProviderConfig[] = [
     displayName: 'Expo Push',
     channel: ChannelTypeEnum.PUSH,
     credentials: expoConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/push/expo-push',
+    docReference: `https://docs.novu.co/channels-and-providers/push/expo-push${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'expo.svg', dark: 'expo.svg' },
   },
   {
@@ -51,7 +52,7 @@ export const pushProviders: IProviderConfig[] = [
     displayName: 'APNs',
     channel: ChannelTypeEnum.PUSH,
     credentials: apnsConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/push/apns',
+    docReference: `https://docs.novu.co/channels-and-providers/push/apns${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'apns.png', dark: 'apns.png' },
     betaVersion: true,
   },
@@ -60,7 +61,7 @@ export const pushProviders: IProviderConfig[] = [
     displayName: 'Push Webhook',
     channel: ChannelTypeEnum.PUSH,
     credentials: pushWebhookConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/push/push-webhook',
+    docReference: `https://docs.novu.co/channels-and-providers/push/push-webhook${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'push-webhook.svg', dark: 'push-webhook.svg' },
     betaVersion: true,
   },
@@ -69,7 +70,7 @@ export const pushProviders: IProviderConfig[] = [
     displayName: 'Pusher Beams',
     channel: ChannelTypeEnum.PUSH,
     credentials: pusherBeamsConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/push/pusher-beams',
+    docReference: `https://docs.novu.co/channels-and-providers/push/pusher-beams${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'pusher-beams.svg', dark: 'pusher-beams.svg' },
   },
 ];

--- a/libs/shared/src/consts/providers/channels/sms.ts
+++ b/libs/shared/src/consts/providers/channels/sms.ts
@@ -32,6 +32,7 @@ import {
 import { SmsProviderIdEnum } from '../provider.enum';
 
 import { ChannelTypeEnum } from '../../../types';
+import { UTM_CAMPAIGN_QUERY_PARAM } from '../../../ui';
 
 export const smsProviders: IProviderConfig[] = [
   {
@@ -39,7 +40,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Novu SMS',
     channel: ChannelTypeEnum.SMS,
     credentials: [],
-    docReference: 'https://docs.novu.co/channels-and-providers/default-providers#novu-sms-provider',
+    docReference: `https://docs.novu.co/channels-and-providers/default-providers${UTM_CAMPAIGN_QUERY_PARAM}#novu-sms-provider`,
     logoFileName: { light: 'novu.png', dark: 'novu.png' },
   },
   {
@@ -47,7 +48,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Nexmo',
     channel: ChannelTypeEnum.SMS,
     credentials: nexmoConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/nexmo',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/nexmo${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'nexmo.png', dark: 'nexmo.png' },
   },
   {
@@ -55,7 +56,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Plivo',
     channel: ChannelTypeEnum.SMS,
     credentials: plivoConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/plivo',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/plivo${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'plivo.png', dark: 'plivo.png' },
   },
 
@@ -64,7 +65,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'sms77',
     channel: ChannelTypeEnum.SMS,
     credentials: sms77Config,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/sms77',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/sms77${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sms77.svg', dark: 'sms77.svg' },
   },
   {
@@ -72,7 +73,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'SNS',
     channel: ChannelTypeEnum.SMS,
     credentials: snsConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/aws-sns',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/aws-sns${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sns.svg', dark: 'sns.svg' },
   },
   {
@@ -80,7 +81,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Telnyx',
     channel: ChannelTypeEnum.SMS,
     credentials: telnyxConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/telnyx',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/telnyx${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'telnyx.png', dark: 'telnyx.png' },
   },
   {
@@ -96,7 +97,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Twilio',
     channel: ChannelTypeEnum.SMS,
     credentials: twilioConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/twilio',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/twilio${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'twilio.png', dark: 'twilio.png' },
   },
   {
@@ -120,7 +121,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Infobip',
     channel: ChannelTypeEnum.SMS,
     credentials: infobipSMSConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/infobip',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/infobip${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'infobip.png', dark: 'infobip.png' },
   },
   {
@@ -194,7 +195,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Termii',
     channel: ChannelTypeEnum.SMS,
     credentials: termiiConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/termii',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/termii${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'termii.png', dark: 'termii.png' },
   },
   {
@@ -202,7 +203,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: `Africa's Talking`,
     channel: ChannelTypeEnum.SMS,
     credentials: africasTalkingConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/africas-talking',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/africas-talking${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'africas-talking.svg', dark: 'africas-talking.svg' },
   },
   {
@@ -210,7 +211,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: `Sendchamp`,
     channel: ChannelTypeEnum.SMS,
     credentials: sendchampConfig,
-    docReference: 'https://docs.novu.co/channels-and-providers/sms/sendchamp',
+    docReference: `https://docs.novu.co/channels-and-providers/sms/sendchamp${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sendchamp.svg', dark: 'sendchamp.svg' },
   },
   {
@@ -218,7 +219,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: `Generic SMS`,
     channel: ChannelTypeEnum.SMS,
     credentials: genericSmsConfig,
-    docReference: 'https://docs.novu.co/channels/sms/generic-sms',
+    docReference: `https://docs.novu.co/channels/sms/generic-sms${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'generic-sms.svg', dark: 'generic-sms.svg' },
   },
   {

--- a/libs/shared/src/ui/index.ts
+++ b/libs/shared/src/ui/index.ts
@@ -1,1 +1,2 @@
 export * from './utils';
+export * from './marketing';

--- a/libs/shared/src/ui/marketing.ts
+++ b/libs/shared/src/ui/marketing.ts
@@ -1,0 +1,1 @@
+export const UTM_CAMPAIGN_QUERY_PARAM = '?utm_campaign=in-app';


### PR DESCRIPTION
### What change does this PR introduce?

To all `https://novu.co` and `https://docs.novu.co` references in the app, we would like to add the marketing `utm_campaign=in-app` query param.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
