### PR TITLE
feat(api): Add idempotent subscriber credential update operation

### DIFF
--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -283,7 +283,7 @@ export class SubscribersController {
   @ApiOperation({
     summary: 'Modify subscriber credentials',
     description: `Subscriber credentials associated to the delivery methods such as slack and push tokens.
-    This endpoint appends provided new credentials and deviceTokens to the existing ones.`,
+    This endpoint appends provided credentials and deviceTokens to the existing ones.`,
   })
   async modifySubscriberChannel(
     @UserSession() user: IJwtPayload,

--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -271,6 +271,35 @@ export class SubscribersController {
         credentials: body.credentials,
         integrationIdentifier: body.integrationIdentifier,
         oauthHandler: OAuthHandlerEnum.EXTERNAL,
+        isIdempotentOperation: true,
+      })
+    );
+  }
+
+  @Patch('/:subscriberId/credentials')
+  @ExternalApiAccessible()
+  @UseGuards(UserAuthGuard)
+  @ApiResponse(SubscriberResponseDto)
+  @ApiOperation({
+    summary: 'Modify subscriber credentials',
+    description: `Subscriber credentials associated to the delivery methods such as slack and push tokens.
+    This endpoint appends provided new credentials and deviceTokens to the existing ones.`,
+  })
+  async modifySubscriberChannel(
+    @UserSession() user: IJwtPayload,
+    @Param('subscriberId') subscriberId: string,
+    @Body() body: UpdateSubscriberChannelRequestDto
+  ): Promise<SubscriberResponseDto> {
+    return await this.updateSubscriberChannelUsecase.execute(
+      UpdateSubscriberChannelCommand.create({
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        subscriberId,
+        providerId: body.providerId,
+        credentials: body.credentials,
+        integrationIdentifier: body.integrationIdentifier,
+        oauthHandler: OAuthHandlerEnum.EXTERNAL,
+        isIdempotentOperation: false,
       })
     );
   }

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
@@ -79,6 +79,7 @@ export class ChatOauthCallback {
         integrationIdentifier: command.integrationIdentifier,
         credentials: subscriberCredentials,
         oauthHandler: OAuthHandlerEnum.NOVU,
+        isIdempotentOperation: false,
       })
     );
   }

--- a/apps/api/src/app/subscribers/usecases/delete-subscriber-credentials/delete-subscriber-credentials.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/delete-subscriber-credentials/delete-subscriber-credentials.spec.ts
@@ -41,6 +41,7 @@ describe('Delete subscriber provider credentials', function () {
         providerId: ChatProviderIdEnum.Discord,
         credentials: { webhookUrl: 'newWebhookUrl' },
         oauthHandler: OAuthHandlerEnum.NOVU,
+        isIdempotentOperation: false,
       })
     );
 
@@ -52,6 +53,7 @@ describe('Delete subscriber provider credentials', function () {
         providerId: PushProviderIdEnum.FCM,
         credentials: { deviceTokens: fcmTokens },
         oauthHandler: OAuthHandlerEnum.NOVU,
+        isIdempotentOperation: false,
       })
     );
 

--- a/apps/api/src/app/subscribers/usecases/update-subscriber-channel/update-subscriber-channel.command.ts
+++ b/apps/api/src/app/subscribers/usecases/update-subscriber-channel/update-subscriber-channel.command.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 import { ChatProviderIdEnum, PushProviderIdEnum } from '@novu/shared';
 import { ChannelCredentials, SubscriberChannel } from '../../../shared/dtos/subscriber-channel';
@@ -33,4 +33,7 @@ export class UpdateSubscriberChannelCommand extends EnvironmentCommand implement
   @IsOptional()
   @IsString()
   integrationIdentifier?: string;
+
+  @IsBoolean()
+  isIdempotentOperation: boolean;
 }

--- a/apps/api/src/app/subscribers/usecases/update-subscriber-channel/update-subscriber-channel.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/update-subscriber-channel/update-subscriber-channel.usecase.ts
@@ -61,7 +61,8 @@ export class UpdateSubscriberChannel {
         command.environmentId,
         existingChannel,
         updatePayload,
-        foundSubscriber
+        foundSubscriber,
+        command.isIdempotentOperation
       );
     } else {
       await this.addChannelToSubscriber(updatePayload, foundIntegration, command, foundSubscriber);
@@ -110,7 +111,8 @@ export class UpdateSubscriberChannel {
     environmentId: string,
     existingChannel: IChannelSettings,
     updatePayload: Partial<IChannelSettings>,
-    foundSubscriber: SubscriberEntity
+    foundSubscriber: SubscriberEntity,
+    isIdempotentOperation: boolean
   ) {
     const equal = isEqual(existingChannel.credentials, updatePayload.credentials);
 
@@ -121,10 +123,14 @@ export class UpdateSubscriberChannel {
     let deviceTokens: string[] = [];
 
     if (updatePayload.credentials?.deviceTokens) {
-      deviceTokens = this.unionDeviceTokens(
-        existingChannel.credentials.deviceTokens ?? [],
-        updatePayload.credentials.deviceTokens
-      );
+      if (isIdempotentOperation) {
+        deviceTokens = this.unionDeviceTokens([], updatePayload.credentials.deviceTokens);
+      } else {
+        deviceTokens = this.unionDeviceTokens(
+          existingChannel.credentials.deviceTokens ?? [],
+          updatePayload.credentials.deviceTokens
+        );
+      }
     }
 
     await this.invalidateCache.invalidateByKey({


### PR DESCRIPTION
### What change does this PR introduce?
* Modify the existing `PUT /:subscriberId/credentials` operation to be idempotent
* Add a new `PATCH /:subscriberId/credentials` operation that appends to the deviceTokens array

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
* We are not currently following the PUT specification for the endpoint in question
* API clients would like to be able to append deviceTokens to an existing list
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)
_OpenAPI spec including new PATCH operation, alongside existing PUT operation_
<img width="1295" alt="image" src="https://github.com/novuhq/novu/assets/32132657/1be82398-1c41-4915-a8f3-f5884a5dfa6d">

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
