### PR TITLE
feat: add fallback lng

### DIFF
--- a/apps/api/src/app/content-templates/content-templates.controller.ts
+++ b/apps/api/src/app/content-templates/content-templates.controller.ts
@@ -144,7 +144,10 @@ export class ContentTemplatesController {
           throw new ApiException('Translation module is not loaded');
         }
         const service = this.moduleRef.get(require('@novu/ee-translation')?.TranslationsService, { strict: false });
-        const { namespaces, resources } = await service.getTranslationsList(environmentId, organizationId);
+        const { namespaces, resources, defaultLocale } = await service.getTranslationsList(
+          environmentId,
+          organizationId
+        );
 
         await i18next.init({
           resources,
@@ -153,6 +156,7 @@ export class ContentTemplatesController {
           nsSeparator: '.',
           lng: locale || 'en',
           compatibilityJSON: 'v2',
+          fallbackLng: defaultLocale,
           interpolation: {
             formatSeparator: ',',
             format: function (value, formatting, lng) {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.base.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.base.ts
@@ -144,7 +144,10 @@ export abstract class SendMessageBase extends SendMessageType {
           throw new PlatformException('Translation module is not loaded');
         }
         const service = this.moduleRef.get(require('@novu/ee-translation')?.TranslationsService, { strict: false });
-        const { namespaces, resources } = await service.getTranslationsList(environmentId, organizationId);
+        const { namespaces, resources, defaultLocale } = await service.getTranslationsList(
+          environmentId,
+          organizationId
+        );
 
         await i18next.init({
           resources,
@@ -153,6 +156,7 @@ export abstract class SendMessageBase extends SendMessageType {
           nsSeparator: '.',
           lng: locale || 'en',
           compatibilityJSON: 'v2',
+          fallbackLng: defaultLocale || 'en',
           interpolation: {
             formatSeparator: ',',
             format: function (value, formatting, lng) {


### PR DESCRIPTION
### What change does this PR introduce?
[enterprise PR
](https://github.com/novuhq/packages-enterprise/pull/90)
When a subscriber has a locale set for him - but there is no such locale for the translation group -> use the default locale of the organization as a fallback.

Currently - it shows the translation keys in the content.

For example:

Organization default locale is en_US

The subscriber locale is en_CA

In the editor there is {{i18n group.key}}and the group has a translation file for en_US but not one for  en_CA. 

Currently, for this subscriber it will show in the message the text group.key 

It should show the translation provided for the default locale
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
