### PR TITLE
Remove Helm Default Encryption Key

### DIFF
--- a/docker/kubernetes/helm/README.md
+++ b/docker/kubernetes/helm/README.md
@@ -9,7 +9,7 @@ Novu provides a unified API that makes it simple to send notifications through m
 ## TL;DR
 
 ```console
-helm install my-release ./
+helm install my-novu ./ --set store.encryptionKey=$(openssl rand -base64 32)
 ```
 
 ## Introduction
@@ -25,10 +25,10 @@ This chart bootstraps a [Novu](https://github.com/novuhq/novu) deployment on a [
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release`:
+To install the chart with the release name `my-novu`:
 
 ```console
-helm install my-release ./
+helm install my-novu ./ --set store.encryptionKey=$(openssl rand -base64 32)
 ```
 
 These commands deploy a Keycloak application on the Kubernetes cluster in the default configuration.
@@ -40,7 +40,7 @@ These commands deploy a Keycloak application on the Kubernetes cluster in the de
 To uninstall/delete the `my-release` deployment:
 
 ```console
-helm delete my-release
+helm delete my-novu
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/docker/kubernetes/helm/values.yaml
+++ b/docker/kubernetes/helm/values.yaml
@@ -1705,7 +1705,7 @@ store:
   ## @param store.encryption-key The encryption key used to encrypt/decrypt provider credentials
   ## Please change this for production use !
   ##
-  encryption-key: ekwUKf9yLjGPLOz939Y1GM0nJckVoVyF # you need to change this !
+  encryption-key: '' # you need to change this !
 
 ## @section Mongodb configuration
 ##


### PR DESCRIPTION
In the Helm README.md and values.yaml, the installation instructions have been changed to include command for setting the encryption key. The default encryption key in values.yaml has been removed. This is done for providing more security by advising users to set their own encryption keys during the installation process.