### PR TITLE
Make multiline comments a warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
     '@typescript-eslint/lines-between-class-members': 'off',
     'react/jsx-wrap-multilines': 'off',
     'react/jsx-filename-extension': 'off',
-    'multiline-comment-style': ['error', 'starred-block'],
+    'multiline-comment-style': ['warn', 'starred-block'],
     'promise/catch-or-return': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-unused-expressions': 'off',


### PR DESCRIPTION
### What change does this PR introduce?

- Make multiline comments a warning instead of a dev-blocking error!

### Why was this change needed?

- Developer experience improvement
- [Slack conversation](https://novu.slack.com/archives/C06DU7A7BPV/p1708535026721779)

