### PR TITLE
fix(web): pagination search params on activity feed page

### DIFF
--- a/apps/web/src/api/hooks/notification-templates/useCreateDigestDemoWorkflow.ts
+++ b/apps/web/src/api/hooks/notification-templates/useCreateDigestDemoWorkflow.ts
@@ -10,6 +10,7 @@ import { errorMessage } from '../../../utils/notifications';
 import { useNotificationGroup, useTemplates } from '../../../hooks';
 import { v4 as uuid4 } from 'uuid';
 import { TemplateCreationSourceEnum } from '../../../pages/templates/shared';
+import { FIRST_100_WORKFLOWS } from '../../../constants/workflowConstants';
 
 export const useCreateDigestDemoWorkflow = () => {
   const navigate = useNavigate();
@@ -26,10 +27,7 @@ export const useCreateDigestDemoWorkflow = () => {
       errorMessage('Failed to create Digest Workflow');
     },
   });
-  const { templates = [], loading: templatesLoading } = useTemplates({
-    pageIndex: 0,
-    pageSize: 100,
-  });
+  const { templates = [], loading: templatesLoading } = useTemplates(FIRST_100_WORKFLOWS);
   const digestOnboardingTemplate = 'Digest Workflow Example';
 
   const createDigestDemoWorkflow = useCallback(() => {

--- a/apps/web/src/api/hooks/notification-templates/useCreateDigestDemoWorkflow.ts
+++ b/apps/web/src/api/hooks/notification-templates/useCreateDigestDemoWorkflow.ts
@@ -26,7 +26,10 @@ export const useCreateDigestDemoWorkflow = () => {
       errorMessage('Failed to create Digest Workflow');
     },
   });
-  const { templates = [], loading: templatesLoading } = useTemplates();
+  const { templates = [], loading: templatesLoading } = useTemplates({
+    pageIndex: 0,
+    pageSize: 100,
+  });
   const digestOnboardingTemplate = 'Digest Workflow Example';
 
   const createDigestDemoWorkflow = useCallback(() => {

--- a/apps/web/src/components/quick-start/in-app-onboarding/TriggerNode.tsx
+++ b/apps/web/src/components/quick-start/in-app-onboarding/TriggerNode.tsx
@@ -19,6 +19,7 @@ import { NodeStep } from '../../workflow';
 import { useSegment } from '../../providers/SegmentProvider';
 import { errorMessage } from '../../../utils/notifications';
 import { TemplateCreationSourceEnum } from '../../../pages/templates/shared';
+import { FIRST_100_WORKFLOWS } from '../../../constants/workflowConstants';
 
 const useStyles = createStyles((theme) => ({
   dropdown: {
@@ -57,10 +58,7 @@ export function TriggerNode({ data }: { data: { label: string; email?: string } 
 
 function TriggerButton({ setOpened }: { setOpened: (value: boolean) => void }) {
   const [notificationNumber, setNotificationNumber] = useState(1);
-  const { templates = [], loading: templatesLoading } = useTemplates({
-    pageIndex: 0,
-    pageSize: 100,
-  });
+  const { templates = [], loading: templatesLoading } = useTemplates(FIRST_100_WORKFLOWS);
 
   const segment = useSegment();
 

--- a/apps/web/src/components/quick-start/in-app-onboarding/TriggerNode.tsx
+++ b/apps/web/src/components/quick-start/in-app-onboarding/TriggerNode.tsx
@@ -57,7 +57,10 @@ export function TriggerNode({ data }: { data: { label: string; email?: string } 
 
 function TriggerButton({ setOpened }: { setOpened: (value: boolean) => void }) {
   const [notificationNumber, setNotificationNumber] = useState(1);
-  const { templates = [], loading: templatesLoading } = useTemplates();
+  const { templates = [], loading: templatesLoading } = useTemplates({
+    pageIndex: 0,
+    pageSize: 100,
+  });
 
   const segment = useSegment();
 

--- a/apps/web/src/constants/workflowConstants.ts
+++ b/apps/web/src/constants/workflowConstants.ts
@@ -1,0 +1,4 @@
+export const FIRST_100_WORKFLOWS = {
+  pageIndex: 0,
+  pageSize: 100,
+};

--- a/apps/web/src/hooks/useTemplates.ts
+++ b/apps/web/src/hooks/useTemplates.ts
@@ -1,4 +1,5 @@
 import { INotificationTemplate, WorkflowIntegrationStatus } from '@novu/shared';
+import { IUsePaginationStateOptions } from '@novu/design-system';
 
 import { useEnvController } from './useEnvController';
 import { getNotificationsList } from '../api/notification-templates';
@@ -16,7 +17,10 @@ export function useTemplates({
   pageIndex,
   pageSize,
   areSearchParamsEnabled = false,
-}: { pageIndex?: number; pageSize?: number; areSearchParamsEnabled?: boolean } = {}) {
+}: {
+  pageIndex?: IUsePaginationStateOptions['startingPageNumber'];
+  pageSize?: IUsePaginationStateOptions['startingPageSize'];
+} & Pick<IUsePaginationStateOptions, 'areSearchParamsEnabled'> = {}) {
   const { environment } = useEnvController();
 
   const {

--- a/apps/web/src/hooks/useTemplates.ts
+++ b/apps/web/src/hooks/useTemplates.ts
@@ -12,7 +12,11 @@ export type INotificationTemplateExtended = INotificationTemplate & {
 };
 
 /** allow override of paginated inputs */
-export function useTemplates(pageIndex?: number, pageSize?: number) {
+export function useTemplates({
+  pageIndex,
+  pageSize,
+  areSearchParamsEnabled = false,
+}: { pageIndex?: number; pageSize?: number; areSearchParamsEnabled?: boolean } = {}) {
   const { environment } = useEnvController();
 
   const {
@@ -30,10 +34,15 @@ export function useTemplates(pageIndex?: number, pageSize?: number) {
     buildQueryFn:
       ({ pageIndex: ctxPageIndex, pageSize: ctxPageSize }) =>
       () =>
-        getNotificationsList(pageIndex ?? ctxPageIndex, pageSize ?? ctxPageSize),
+        getNotificationsList(ctxPageIndex, ctxPageSize),
     getTotalItemCount: (resp) => resp.totalCount,
     queryOptions: {
       keepPreviousData: true,
+    },
+    paginationOptions: {
+      areSearchParamsEnabled,
+      startingPageNumber: (pageIndex ?? 0) + 1,
+      startingPageSize: pageSize,
     },
   });
 

--- a/apps/web/src/pages/activities/ActivitiesPage.tsx
+++ b/apps/web/src/pages/activities/ActivitiesPage.tsx
@@ -38,7 +38,7 @@ const initialFormState: IFiltersForm = {
 };
 
 export function ActivitiesPage() {
-  const { templates, loading: loadingTemplates } = useTemplates(0, 100);
+  const { templates, loading: loadingTemplates } = useTemplates({ pageIndex: 0, pageSize: 100 });
   const [page, setPage] = useState<number>(0);
   const [isModalOpen, setToggleModal] = useState<boolean>(false);
   const [notificationId, setNotificationId] = useState<string>('');
@@ -52,10 +52,6 @@ export function ActivitiesPage() {
   function onFiltersChange(formData: Partial<IFiltersForm>) {
     setFilters((old) => ({ ...old, ...formData }));
   }
-
-  const debouncedTransactionIdChange = useDebounce((transactionId: string) => {
-    onFiltersChange({ transactionId });
-  }, 500);
 
   function handleTableChange(pageIndex) {
     setPage(pageIndex);

--- a/apps/web/src/pages/activities/ActivitiesPage.tsx
+++ b/apps/web/src/pages/activities/ActivitiesPage.tsx
@@ -15,6 +15,7 @@ import { ActivityList } from './components/ActivityList';
 import { ExecutionDetailsModal } from '../../components/execution-detail/ExecutionDetailsModal';
 import { IActivityGraphStats } from './interfaces';
 import { Flex } from '@mantine/core';
+import { FIRST_100_WORKFLOWS } from '../../constants/workflowConstants';
 
 const FiltersContainer = styled.div`
   gap: 15px;
@@ -38,7 +39,7 @@ const initialFormState: IFiltersForm = {
 };
 
 export function ActivitiesPage() {
-  const { templates, loading: loadingTemplates } = useTemplates({ pageIndex: 0, pageSize: 100 });
+  const { templates, loading: loadingTemplates } = useTemplates(FIRST_100_WORKFLOWS);
   const [page, setPage] = useState<number>(0);
   const [isModalOpen, setToggleModal] = useState<boolean>(false);
   const [notificationId, setNotificationId] = useState<string>('');

--- a/apps/web/src/pages/templates/WorkflowListPage.tsx
+++ b/apps/web/src/pages/templates/WorkflowListPage.tsx
@@ -163,7 +163,7 @@ function WorkflowListPage() {
     setCurrentPageNumber,
     setPageSize,
     pageSize,
-  } = useTemplates();
+  } = useTemplates({ areSearchParamsEnabled: true });
   const isLoading = areNotificationGroupLoading || loading;
   const navigate = useNavigate();
   const { blueprintsGroupedAndPopular: { general, popular } = {}, isLoading: areBlueprintsLoading } =

--- a/libs/design-system/src/pagination/usePaginationState.spec.tsx
+++ b/libs/design-system/src/pagination/usePaginationState.spec.tsx
@@ -1,8 +1,14 @@
 import { act, waitFor } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
-import { MemoryRouter } from 'react-router-dom';
-import { expect, it } from 'vitest';
+import { MemoryRouter, useSearchParams } from 'react-router-dom';
+import * as ReactRouterDOM from 'react-router-dom';
+import { afterEach, expect, it, vi } from 'vitest';
 import { IUsePaginationStateOptions, usePaginationState } from './usePaginationState'; // Replace with the actual file path
+
+const startingPageNumber = 1;
+const pageSizes = [10, 20, 30];
+const pageNumberParamName = 'page';
+const pageSizeParamName = 'size';
 
 const callHook = (options: IUsePaginationStateOptions, initialParams?: { page: number; size: number }) => {
   const paramStr = initialParams ? `?page=${initialParams.page}&size=${initialParams.size}` : '';
@@ -12,10 +18,22 @@ const callHook = (options: IUsePaginationStateOptions, initialParams?: { page: n
   });
 };
 
-it('usePaginationState uses defaults', async () => {
-  const pageNumberParamName = 'page';
-  const pageSizeParamName = 'size';
+const setSearchParams = vi.fn();
 
+const mockUseSearchParams = (): ReturnType<typeof useSearchParams> => {
+  const params = new URLSearchParams();
+  return [params, setSearchParams];
+};
+
+vi.spyOn(ReactRouterDOM, 'useSearchParams').mockImplementation(mockUseSearchParams);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+it('usePaginationState uses defaults', async () => {
+  const page = startingPageNumber;
+  const size = pageSizes[0];
   const options: IUsePaginationStateOptions = {
     pageNumberParamName,
     pageSizeParamName,
@@ -26,16 +44,30 @@ it('usePaginationState uses defaults', async () => {
 
   await waitFor(() => {
     // Verify that state is updated based on URL parameters on mount
-    expect(result.current.currentPageNumber).toBe(1);
-    expect(result.current.pageSize).toBe(10);
+    expect(result.current.currentPageNumber).toBe(page);
+    expect(result.current.pageSize).toBe(size);
   });
+
+  expect(setSearchParams).toHaveBeenCalledWith(
+    {
+      [pageNumberParamName]: `${page}`,
+      [pageSizeParamName]: `${size}`,
+    },
+    { replace: true }
+  );
 });
 
 it('usePaginationState updates state based on URL parameters on mount', async () => {
-  const startingPageNumber = 1;
-  const pageSizes = [10, 20, 30];
-  const pageNumberParamName = 'page';
-  const pageSizeParamName = 'size';
+  const page = 2;
+  const size = 20;
+  const mockUseSearchParamsNew = (): ReturnType<typeof useSearchParams> => {
+    const params = new URLSearchParams();
+    params.set('page', `${page}`);
+    params.set('size', `${size}`);
+    return [params, setSearchParams];
+  };
+
+  vi.spyOn(ReactRouterDOM, 'useSearchParams').mockImplementationOnce(mockUseSearchParamsNew);
 
   const options: IUsePaginationStateOptions = {
     startingPageNumber,
@@ -45,19 +77,23 @@ it('usePaginationState updates state based on URL parameters on mount', async ()
   };
 
   // Render hook
-  const { result } = callHook(options, { page: 2, size: 20 });
+  const { result } = callHook(options, { page, size });
 
   // Verify that state is updated based on URL parameters on mount
-  expect(result.current.currentPageNumber).toBe(2);
-  expect(result.current.pageSize).toBe(20);
+  expect(result.current.currentPageNumber).toBe(page);
+  expect(result.current.pageSize).toBe(size);
+  expect(setSearchParams).toHaveBeenCalledWith(
+    {
+      [pageNumberParamName]: `${page}`,
+      [pageSizeParamName]: `${size}`,
+    },
+    { replace: true }
+  );
 });
 
 it('usePaginationState updates URL parameters on state change', async () => {
-  const startingPageNumber = 1;
-  const pageSizes = [10, 20, 30];
-  const pageNumberParamName = 'page';
-  const pageSizeParamName = 'size';
-
+  const page = 3;
+  const size = 30;
   const options: IUsePaginationStateOptions = {
     startingPageNumber,
     pageSizes,
@@ -70,11 +106,38 @@ it('usePaginationState updates URL parameters on state change', async () => {
 
   // Update state to trigger URL parameter update
   act(() => {
-    result.current.setPageSize(30);
-    result.current.setCurrentPageNumber(3);
+    result.current.setPageSize(size);
+    result.current.setCurrentPageNumber(page);
   });
 
   // Verify that URL parameters are updated on state change
-  expect(result.current.pageSize).toBe(30);
-  expect(result.current.currentPageNumber).toBe(3);
+  expect(result.current.pageSize).toBe(size);
+  expect(result.current.currentPageNumber).toBe(page);
+  expect(setSearchParams).toHaveBeenCalledWith(
+    {
+      [pageNumberParamName]: `${page}`,
+      [pageSizeParamName]: `${size}`,
+    },
+    { replace: true }
+  );
+});
+
+it('usePaginationState does not update URL parameters when areSearchParamsEnabled is false', async () => {
+  const options: IUsePaginationStateOptions = {
+    areSearchParamsEnabled: false,
+    startingPageNumber,
+    pageSizes,
+    pageNumberParamName,
+    pageSizeParamName,
+  };
+
+  // Render hook
+  const { result } = callHook(options);
+
+  await waitFor(() => {
+    // Verify that state is updated based on URL parameters on mount
+    expect(result.current.currentPageNumber).toBe(1);
+    expect(result.current.pageSize).toBe(10);
+    expect(setSearchParams).not.toHaveBeenCalled();
+  });
 });

--- a/libs/design-system/src/pagination/usePaginationState.spec.tsx
+++ b/libs/design-system/src/pagination/usePaginationState.spec.tsx
@@ -22,6 +22,7 @@ const setSearchParams = vi.fn();
 
 const mockUseSearchParams = (): ReturnType<typeof useSearchParams> => {
   const params = new URLSearchParams();
+
   return [params, setSearchParams];
 };
 
@@ -64,6 +65,7 @@ it('usePaginationState updates state based on URL parameters on mount', async ()
     const params = new URLSearchParams();
     params.set('page', `${page}`);
     params.set('size', `${size}`);
+
     return [params, setSearchParams];
   };
 

--- a/libs/design-system/src/pagination/usePaginationState.ts
+++ b/libs/design-system/src/pagination/usePaginationState.ts
@@ -31,7 +31,9 @@ export const usePaginationState = ({
   );
 
   useEffect(() => {
-    if (!areSearchParamsEnabled) return;
+    if (!areSearchParamsEnabled) {
+      return;
+    }
 
     setSearchParams(
       {

--- a/libs/design-system/src/pagination/usePaginationState.ts
+++ b/libs/design-system/src/pagination/usePaginationState.ts
@@ -1,18 +1,22 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { DEFAULT_PAGINATION_PAGE_SIZES, FIRST_PAGE_NUMBER } from './Pagination.const';
+import { DEFAULT_PAGE_SIZE, DEFAULT_PAGINATION_PAGE_SIZES, FIRST_PAGE_NUMBER } from './Pagination.const';
 
 const URL_PARAM_NAME_PAGE_SIZE = 'size';
 const URL_PARAM_NAME_PAGE_NUMBER = 'page';
 export interface IUsePaginationStateOptions {
+  areSearchParamsEnabled?: boolean;
   startingPageNumber?: number;
+  startingPageSize?: number;
   pageSizes?: number[];
   pageSizeParamName?: string;
   pageNumberParamName?: string;
 }
 
 export const usePaginationState = ({
+  areSearchParamsEnabled = true,
   startingPageNumber = FIRST_PAGE_NUMBER,
+  startingPageSize = DEFAULT_PAGE_SIZE,
   pageSizes = DEFAULT_PAGINATION_PAGE_SIZES,
   pageNumberParamName = URL_PARAM_NAME_PAGE_NUMBER,
   pageSizeParamName = URL_PARAM_NAME_PAGE_SIZE,
@@ -20,13 +24,15 @@ export const usePaginationState = ({
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [pageSize, setPageSize] = useState<number>(
-    getValidatedPageSizeFromUrl(searchParams.get(pageSizeParamName), pageSizes)
+    getValidatedPageSizeFromUrl(searchParams.get(pageSizeParamName), startingPageSize, pageSizes)
   );
   const [currentPageNumber, setCurrentPageNumber] = useState<number>(
     getValidatedPageNumberFromUrl(searchParams.get(pageNumberParamName), startingPageNumber)
   );
 
   useEffect(() => {
+    if (!areSearchParamsEnabled) return;
+
     setSearchParams(
       {
         [pageNumberParamName]: `${currentPageNumber}`,
@@ -50,8 +56,14 @@ function getValidatedPageNumberFromUrl(pageNumberStr: string | undefined, starti
   return pageNumberUnchecked && pageNumberUnchecked > 0 ? pageNumberUnchecked : startingPageNumber;
 }
 
-function getValidatedPageSizeFromUrl(pageSizeStr: string | undefined, pageSizes: number[]): number {
+function getValidatedPageSizeFromUrl(
+  pageSizeStr: string | undefined,
+  startingPageSize: number,
+  pageSizes: number[]
+): number {
   const sizeValUnchecked = parseInt(pageSizeStr ?? 'NaN', 10);
 
-  return pageSizes.includes(sizeValUnchecked) && sizeValUnchecked > 0 ? sizeValUnchecked : pageSizes[0];
+  return pageSizes.includes(sizeValUnchecked) && sizeValUnchecked > 0
+    ? sizeValUnchecked
+    : startingPageSize ?? pageSizes[0];
 }


### PR DESCRIPTION
### What change does this PR introduce?

This PR fixes a few problems:
- the paginated search params on the Activity Feed page from the `useTemplates` hook
- query cache issue when navigating between Workflows and Activity Feed pages (on slow network)

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

Before:


https://github.com/novuhq/novu/assets/2607232/49629106-d507-4fea-aba5-e53fe38fbde3


Now:



https://github.com/novuhq/novu/assets/2607232/dba64f00-8b05-4d81-a13a-58c006c790f8

