### PR TITLE
fix: subscriber details not available for digest filters

### DIFF
--- a/packages/application-generic/src/usecases/add-job/add-job.usecase.ts
+++ b/packages/application-generic/src/usecases/add-job/add-job.usecase.ts
@@ -85,6 +85,7 @@ export class AddJob {
           environmentId: command.environmentId,
           organizationId: command.organizationId,
           userId: command.userId,
+          step: job.step,
           job,
         })
       );


### PR DESCRIPTION
### What change does this PR introduce?
Passes step to conditionsFilter.filter so it correctly recognises when a digest filter depends on subscriber.

### Why was this change needed?

Closes #5163

