### PR TITLE
NV-3497 - Pagination Tweaks

### DIFF
--- a/libs/design-system/src/pagination/ControlButton.tsx
+++ b/libs/design-system/src/pagination/ControlButton.tsx
@@ -29,7 +29,11 @@ const getBackgroundColor = ({ theme, isCurrentPage }: { theme: any } & StylingPr
   return isCurrentPage ? (theme.colorScheme === 'dark' ? colors.B30 : colors.BGLight) : 'none';
 };
 
-const StyledButton = styled(Button)<StylingProps>(
+const StyledButton = styled(Button, {
+  shouldForwardProp: (propName: string) => {
+    return propName !== 'isCurrentPage';
+  },
+})<StylingProps>(
   ({ theme, isCurrentPage }) => `
   font-weight: ${getFontWeight({ theme, isCurrentPage })};
   background: ${getBackgroundColor({ theme, isCurrentPage })};

--- a/libs/design-system/src/pagination/GoToPageInput.tsx
+++ b/libs/design-system/src/pagination/GoToPageInput.tsx
@@ -67,6 +67,7 @@ export const GoToPageInput: React.FC<IGoToPageInputProps> = forwardRef<HTMLInput
   ({ label, firstPageNumber = FIRST_PAGE_NUMBER, ...inputProps }, forwardedRef) => {
     const { onPageChange, totalPageCount } = useContext(PaginationContext);
     const [hasError, setHasError] = useState<boolean>(false);
+    const [goToValue, setGoToValue] = useState<number | undefined>(undefined);
 
     const validateValue = (val: number | string) => {
       const numVal = +val;
@@ -97,7 +98,7 @@ export const GoToPageInput: React.FC<IGoToPageInputProps> = forwardRef<HTMLInput
         return;
       }
       onPageChange(+val);
-      internalRef.current.value = undefined;
+      setGoToValue(undefined);
       setHasError(false);
     };
 
@@ -119,6 +120,8 @@ export const GoToPageInput: React.FC<IGoToPageInputProps> = forwardRef<HTMLInput
         >
           <NumberInput
             onKeyDown={handleKeyPress}
+            value={goToValue}
+            onChange={setGoToValue}
             id={'goToPage'}
             ref={internalRef}
             onBlur={handleBlurEvent}
@@ -127,6 +130,9 @@ export const GoToPageInput: React.FC<IGoToPageInputProps> = forwardRef<HTMLInput
             maxLength={`${totalPageCount}`.length}
             hideControls
             noClampOnBlur
+            autoCorrect={'none'}
+            aria-autocomplete={'none'}
+            autoComplete={'none'}
             disabled={totalPageCount === 1}
             {...inputProps}
           />


### PR DESCRIPTION
### What change does this PR introduce?

- Change `GoToInput` to controlled input to reset the value onBlur; uncontrolled was auto-clamping despite attempting to reset the value via a ref.
- Disable autocomplete / autosuggest -- MANTINE, WHY?!
- Remove invalid prop from being passed to the DOM

### Why was this change needed?

- Fixes [NV-3497](https://linear.app/novu/issue/NV-3497/fix-go-to-page-behaviour-for-pagination)

### Other information (Screenshots)

- [ ] I am unable to reproduce autocomplete in Dev anyway, so some help would be appreciated here!

_Note: no warnings in the console about `isCurrentPage` being an invalid DOM prop_

https://www.loom.com/share/0ec132d17e9c4167a6783720dded96d5?sid=3954ff36-da84-47ee-9c31-ec0684f952ce
