### PR TITLE
Update runner type to ubuntu-latest-large

### DIFF
--- a/.github/workflows/dev-deploy-api.yml
+++ b/.github/workflows/dev-deploy-api.yml
@@ -31,7 +31,7 @@ jobs:
   deploy_dev_api:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: test_api
     timeout-minutes: 80
     environment: Development

--- a/.github/workflows/dev-deploy-inbound-mail.yml
+++ b/.github/workflows/dev-deploy-inbound-mail.yml
@@ -29,7 +29,7 @@ jobs:
 
   dev_deploy_inbound_mail:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: test_inbound_mail
     timeout-minutes: 80
     environment: Development

--- a/.github/workflows/dev-deploy-worker.yml
+++ b/.github/workflows/dev-deploy-worker.yml
@@ -34,7 +34,7 @@ jobs:
   build_dev_worker:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: test_worker
     timeout-minutes: 80
     environment: Development

--- a/.github/workflows/dev-deploy-ws.yml
+++ b/.github/workflows/dev-deploy-ws.yml
@@ -26,7 +26,7 @@ jobs:
   # This workflow contains a single job called "build"
   deploy_ws:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: test_ws
     timeout-minutes: 80
     environment: Development

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -20,7 +20,7 @@ jobs:
   build_prod_image:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: test_api
     timeout-minutes: 80
     environment: Production

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
 
   build_prod_image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
     environment: Production
     outputs:

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -19,7 +19,7 @@ jobs:
   build_prod_image:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: test_worker
     timeout-minutes: 80
     environment: Production

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build_prod_image:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
     environment: Production
     needs:

--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -46,7 +46,7 @@ jobs:
   e2e_api:
     name: Test E2E
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
     permissions:
       contents: read

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -46,7 +46,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   reusable_docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
     environment: ${{ inputs.environment }}
     outputs:

--- a/.github/workflows/reusable-inbound-mail-e2e.yml
+++ b/.github/workflows/reusable-inbound-mail-e2e.yml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "build"
   e2e_inbound_mail:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
 
     permissions:

--- a/.github/workflows/reusable-web-e2e.yml
+++ b/.github/workflows/reusable-web-e2e.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
 
     permissions:
@@ -150,7 +150,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/reusable-webhook-e2e.yml
+++ b/.github/workflows/reusable-webhook-e2e.yml
@@ -9,7 +9,7 @@ jobs:
   # This workflow contains a single job called "build"
   e2e_webhook:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/reusable-widget-deploy.yml
+++ b/.github/workflows/reusable-widget-deploy.yml
@@ -40,7 +40,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   reusable_widget_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
     environment: ${{ inputs.environment }}
     permissions:

--- a/.github/workflows/reusable-widget-e2e.yml
+++ b/.github/workflows/reusable-widget-e2e.yml
@@ -16,7 +16,7 @@ jobs:
   # This workflow contains a single job called "build"
   e2e_widget:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
 
     strategy:

--- a/.github/workflows/reusable-worker-e2e.yml
+++ b/.github/workflows/reusable-worker-e2e.yml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "build"
   e2e_worker_service:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
 
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
 
   build_docker_api:
     name: Build Docker API
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     timeout-minutes: 80
     needs: [get-affected]
     if: ${{ contains(fromJson(needs.get-affected.outputs.test-e2e), '@novu/api') }}
@@ -134,7 +134,7 @@ jobs:
 
   test_providers:
     name: Unit Test Providers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: [get-affected]
     if: ${{ fromJson(needs.get-affected.outputs.test-providers)[0] }}
     timeout-minutes: 80
@@ -152,7 +152,7 @@ jobs:
 
   test_packages:
     name: Unit Test Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: [get-affected]
     if: ${{ fromJson(needs.get-affected.outputs.test-packages)[0] }}
     timeout-minutes: 80
@@ -186,7 +186,7 @@ jobs:
 
   test_libs:
     name: Unit Test Libs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: [get-affected]
     if: ${{ fromJson(needs.get-affected.outputs.test-libs)[0] }}
     timeout-minutes: 80
@@ -216,7 +216,7 @@ jobs:
 
   test_unit:
     name: Unit Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: [get-affected]
     if: ${{ fromJson(needs.get-affected.outputs.test-unit)[0] }}
     timeout-minutes: 80
@@ -245,7 +245,7 @@ jobs:
 
   validate_openapi:
     name: Validate OpenAPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     needs: [get-affected]
     if: ${{ fromJson(needs.get-affected.outputs.test-unit)[0] }}
     timeout-minutes: 10


### PR DESCRIPTION
The runner type for all Github Workflows has been updated to 'ubuntu-latest-large'. This change aims to provide more resources for the jobs' execution, improving performance and stability by increasing cpus and storage on critical builds

![CleanShot 2024-02-29 at 09 27 31](https://github.com/novuhq/novu/assets/43915749/980a534c-984b-403d-943a-88095360574b)
