### PR TITLE
fix(provider): Change payload + allow http legacy SSL renegotiation

### DIFF
--- a/providers/gupshup/package.json
+++ b/providers/gupshup/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@novu/stateless": "^0.23.1",
+    "axios": "^1.6.7",
     "node-fetch": "^3.2.10"
   },
   "devDependencies": {

--- a/providers/gupshup/src/lib/gupshup.provider.ts
+++ b/providers/gupshup/src/lib/gupshup.provider.ts
@@ -46,12 +46,7 @@ export class GupshupSmsProvider implements ISmsProvider {
       }),
     };
 
-    const response = await axios.post(GupshupSmsProvider.BASE_URL, params, {
-      httpsAgent: new Agent({
-        rejectUnauthorized: false,
-        secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
-      }),
-    });
+    const response = await axios.post(GupshupSmsProvider.BASE_URL, params);
 
     const body = response.data;
     const result = body.split(' | ');

--- a/providers/gupshup/src/lib/gupshup.provider.ts
+++ b/providers/gupshup/src/lib/gupshup.provider.ts
@@ -4,6 +4,9 @@ import {
   ISmsOptions,
   ISmsProvider,
 } from '@novu/stateless';
+import { Agent } from 'https';
+import crypto from 'crypto';
+import axios from 'axios';
 
 if (!globalThis.fetch) {
   // eslint-disable-next-line global-require
@@ -12,7 +15,7 @@ if (!globalThis.fetch) {
 
 export class GupshupSmsProvider implements ISmsProvider {
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
-  public static BASE_URL = 'http://enterprise.smsgupshup.com/GatewayAPI/rest';
+  public static BASE_URL = 'https://enterprise.smsgupshup.com/GatewayAPI/rest';
 
   constructor(
     private config: {
@@ -33,7 +36,7 @@ export class GupshupSmsProvider implements ISmsProvider {
       method: 'sendMessage',
       format: 'text',
       v: '1.1',
-      userId: this.config.userId,
+      userid: this.config.userId,
       password: this.config.password,
       ...(options.customData?.principalEntityId && {
         principalEntityId: options.customData?.principalEntityId,
@@ -43,16 +46,14 @@ export class GupshupSmsProvider implements ISmsProvider {
       }),
     };
 
-    const opts = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(params),
-    };
+    const response = await axios.post(GupshupSmsProvider.BASE_URL, params, {
+      httpsAgent: new Agent({
+        rejectUnauthorized: false,
+        secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
+      }),
+    });
 
-    const response = await fetch(GupshupSmsProvider.BASE_URL, opts);
-    const body = await response.text();
+    const body = response.data;
     const result = body.split(' | ');
 
     if (result[0] === 'error') {


### PR DESCRIPTION
### What change does this PR introduce?

1. Changed Gupshup (Provider) BASE URL
2. Changed provider request "Content-Type" to accept "application/json"
3. Added httpsAgent to allow legacy SSL renegoation for Gupshup API endpoint

### Why was this change needed?

1. To allow delivery of Gupshup (provider) SMS

### Other information (Screenshots)
