### PR TITLE
Update groups for new default language

### DIFF
--- a/apps/api/src/app/testing/translations/update-default-locale.e2e-ee.ts
+++ b/apps/api/src/app/testing/translations/update-default-locale.e2e-ee.ts
@@ -1,0 +1,52 @@
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+import { OrganizationRepository } from '@novu/dal';
+
+describe('Update default locale and add new translations - /translations/language (PATCH)', async () => {
+  let session: UserSession;
+  const organizationRepository = new OrganizationRepository();
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+    await session.testAgent.put(`/v1/organizations/language`).send({
+      locale: 'en_US',
+    });
+  });
+
+  it('should update default locale and add that locale to groups', async () => {
+    await session.testAgent.post(`/v1/translations/groups`).send({
+      name: 'test',
+      identifier: 'test',
+      locales: ['en_US', 'sv_SE'],
+    });
+
+    await session.applyChanges({
+      enabled: false,
+    });
+
+    await session.testAgent.patch(`/v1/translations/language`).send({
+      locale: 'en_GB',
+    });
+
+    const org = await organizationRepository.findById(session.organization._id);
+    expect(org?.defaultLocale).to.be.equal('en_GB');
+
+    const result = await session.testAgent.get(`/v1/translations/groups/test`).send();
+    let group = result.body.data;
+
+    let locales = group.translations.map((t) => t.isoLanguage);
+
+    expect(locales).to.deep.equal(['en_US', 'sv_SE', 'en_GB']);
+
+    await session.applyChanges({
+      enabled: false,
+    });
+    await session.switchToProdEnvironment();
+
+    const data = await session.testAgent.get(`/v1/translations/groups/test`).send();
+    group = data.body.data;
+    locales = group.translations.map((t) => t.isoLanguage);
+    expect(locales).to.deep.equal(['en_US', 'sv_SE', 'en_GB']);
+  });
+});


### PR DESCRIPTION
### What change does this PR introduce?
[Enterprise PR
](https://github.com/novuhq/packages-enterprise/pull/103)
When the default language is changed for the organization we should also update all associated translation groups with that new default language, meaning we should create a new empty translation but only when it doesn't exist.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
