### PR TITLE
Create a script to increase the amount of storage space on default runner

### DIFF
--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -37,6 +37,9 @@ runs:
       shell: bash
       run: pnpm build:api
 
+    # TODO Removed when migrated to action matrix for each build type
+    - uses: ./.github/actions/free-space
+
     - uses: crazy-max/ghaction-setup-docker@v2
       with:
         version: v24.0.6

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -37,6 +37,9 @@ runs:
       shell: bash
       run: pnpm build:worker
 
+    # TODO Removed when migrated to action matrix for each build type
+    - uses: ./.github/actions/free-space
+
     - uses: crazy-max/ghaction-setup-docker@v2
       with:
         version: v24.0.6

--- a/.github/actions/free-space/action.yml
+++ b/.github/actions/free-space/action.yml
@@ -57,9 +57,5 @@ echo "::endgroup::"
 sudo rm -rf /opt/hostedtoolcache/CodeQL || :
 # 1.4GB
 sudo rm -rf /opt/hostedtoolcache/go || :
-# Remove Web browser packages
-sudo apt purge -y \
-firefox \
-google-chrome-stable \
-microsoft-edge-stable
+
 df -h

--- a/.github/actions/free-space/action.yml
+++ b/.github/actions/free-space/action.yml
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -eux
+
+df -h
+echo "::group::/usr/local/*"
+du -hsc /usr/local/*
+echo "::endgroup::"
+# ~1GB
+sudo rm -rf \
+  /usr/local/aws-sam-cil \
+  /usr/local/julia* || :
+echo "::group::/usr/local/bin/*"
+  du -hsc /usr/local/bin/*
+echo "::endgroup::"
+# ~1GB (From 1.2GB to 214MB)
+sudo rm -rf \
+  /usr/local/bin/aliyun \
+  /usr/local/bin/azcopy \
+  /usr/local/bin/bicep \
+  /usr/local/bin/cmake-gui \
+  /usr/local/bin/cpack \
+  /usr/local/bin/hub \
+  /usr/local/bin/kubectl \
+  /usr/local/bin/minikube \
+  /usr/local/bin/packer \
+  /usr/local/bin/pulumi* \
+  /usr/local/bin/sam \
+  /usr/local/bin/stack || :
+# 142M
+sudo rm -rf /usr/local/bin/oc || : \
+echo "::group::/usr/local/share/*"
+du -hsc /usr/local/share/*
+echo "::endgroup::"
+# 506MB
+sudo rm -rf /usr/local/share/chromium || :
+# 1.3GB
+sudo rm -rf /usr/local/share/powershell || :
+echo "::group::/usr/local/lib/*"
+du -hsc /usr/local/lib/*
+echo "::endgroup::"
+# 15GB
+sudo rm -rf /usr/local/lib/android || :
+# 341MB
+sudo rm -rf /usr/local/lib/heroku || :
+# 679MB
+sudo rm -rf /opt/az || :
+echo "::group::/opt/microsoft/*"
+du -hsc /opt/microsoft/*
+echo "::endgroup::"
+# 197MB
+sudo rm -rf /opt/microsoft/powershell || :
+echo "::group::/opt/hostedtoolcache/*"
+du -hsc /opt/hostedtoolcache/*
+echo "::endgroup::"
+# 5.3GB
+sudo rm -rf /opt/hostedtoolcache/CodeQL || :
+# 1.4GB
+sudo rm -rf /opt/hostedtoolcache/go || :
+# Remove Web browser packages
+sudo apt purge -y \
+firefox \
+google-chrome-stable \
+microsoft-edge-stable
+df -h

--- a/.github/actions/free-space/action.yml
+++ b/.github/actions/free-space/action.yml
@@ -3,6 +3,10 @@
 set -eux
 
 df -h
+echo "::group::apt clean"
+sudo apt clean
+echo "::endgroup::"
+
 echo "::group::/usr/local/*"
 du -hsc /usr/local/*
 echo "::endgroup::"


### PR DESCRIPTION
This adds a script to the parts of the pipeline that do the docker build. 

This script is a temporary fix by removing unused and preinstalled tooling and removes apt caches.