### PR TITLE
fix(ci): Versions compatibility

### DIFF
--- a/.github/workflows/dev-deploy-web-component.yml
+++ b/.github/workflows/dev-deploy-web-component.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download the artifact
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@4
         with:
           name: notification-center-web-component
           path: packages/notification-center/dist/umd

--- a/.github/workflows/prod-deploy-web-component.yml
+++ b/.github/workflows/prod-deploy-web-component.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download the artifact
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4
         with:
           name: notification-center-web-component
           path: packages/notification-center/dist/umd

--- a/.github/workflows/reusable-notification-center.yml
+++ b/.github/workflows/reusable-notification-center.yml
@@ -17,7 +17,7 @@ jobs:
           projects: '@novu/notification-center'
           nxCloud: true
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: notification-center-web-component
           path: packages/notification-center/dist/umd


### PR DESCRIPTION
This PR introduce the changes to fix Notification Center Component Pipeline. The NC pipeline is not picking up a correct artifact and is not able to deploy it. The ticket is [INF-291](https://linear.app/novu/issue/INF-291/fix-notification-center-component-pipeline)

Example of the pipeline that was failed https://github.com/novuhq/novu/actions/runs/8177087539

Most likely cause is versions capability. I checked and it was confirmed, the version `actions/download-artifact@master` 
 can't work with `actions/upload-artifact@v3`. The Action was updated about 3 month ago and since then the workflow has no success. 

It's an importartant to have a comatible version. See [GitHub Documentation](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md#which-versions-of-the-artifacts-packages-are-compatible)