### PR TITLE
Adds seen read reliable update endpoint

### DIFF
--- a/apps/api/src/app/widgets/dtos/mark-as-request.dto.ts
+++ b/apps/api/src/app/widgets/dtos/mark-as-request.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { MarkMessagesAsEnum } from '@novu/shared';
+import { IsDefined, IsEnum } from 'class-validator';
+
+export class MessageMarkAsRequestDto {
+  @ApiProperty({
+    oneOf: [
+      { type: 'string' },
+      {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+      },
+    ],
+  })
+  messageId: string | string[];
+
+  @ApiProperty({
+    enum: MarkMessagesAsEnum,
+  })
+  @IsDefined()
+  @IsEnum(MarkMessagesAsEnum)
+  markAs: MarkMessagesAsEnum;
+}

--- a/apps/api/src/app/widgets/e2e/mark-as-by-mark.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/mark-as-by-mark.e2e.ts
@@ -1,0 +1,201 @@
+import { expect } from 'chai';
+import axios from 'axios';
+
+import { UserSession } from '@novu/testing';
+import {
+  MessageEntity,
+  MessageRepository,
+  NotificationTemplateEntity,
+  SubscriberEntity,
+  SubscriberRepository,
+} from '@novu/dal';
+import { ChannelTypeEnum, MarkMessagesAsEnum } from '@novu/shared';
+
+describe('Mark as Seen - /widgets/messages/mark-as (POST)', async () => {
+  const messageRepository = new MessageRepository();
+  const subscriberRepository = new SubscriberRepository();
+  let session: UserSession;
+  let template: NotificationTemplateEntity;
+  let subscriberId;
+  let subscriberToken: string;
+  let subscriber: SubscriberEntity;
+  let message: MessageEntity;
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+    subscriberId = SubscriberRepository.createObjectId();
+    template = await session.createTemplate();
+
+    const { body } = await session.testAgent
+      .post('/v1/widgets/session/initialize')
+      .send({
+        applicationIdentifier: session.environment.identifier,
+        subscriberId,
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'test@example.com',
+      })
+      .expect(201);
+    subscriberToken = body.data.token;
+    subscriber = await getSubscriber(session, subscriberRepository, subscriberId);
+  });
+
+  beforeEach(async () => {
+    await session.triggerEvent(template.triggers[0].identifier, subscriberId);
+    await session.awaitRunningJobs(template._id);
+
+    message = await getMessage(session, messageRepository, subscriber);
+
+    expect(message.seen).to.equal(false);
+    expect(message.read).to.equal(false);
+    expect(message.lastSeenDate).to.be.not.ok;
+    expect(message.lastReadDate).to.be.not.ok;
+  });
+
+  afterEach(async () => {
+    await pruneMessages(messageRepository);
+  });
+
+  it('should change the seen status', async function () {
+    await markAs(subscriberToken, message._id, MarkMessagesAsEnum.SEEN);
+
+    const updatedMessage = await getMessage(session, messageRepository, subscriber);
+
+    expect(updatedMessage.seen).to.equal(true);
+    expect(updatedMessage.read).to.equal(false);
+    expect(updatedMessage.lastSeenDate).to.be.ok;
+    expect(updatedMessage.lastReadDate).to.be.not.ok;
+  });
+
+  it('should change the read status', async function () {
+    await markAs(subscriberToken, message._id, MarkMessagesAsEnum.READ);
+
+    const updatedMessage = await getMessage(session, messageRepository, subscriber);
+
+    expect(updatedMessage.seen).to.equal(true);
+    expect(updatedMessage.read).to.equal(true);
+    expect(updatedMessage.lastSeenDate).to.be.ok;
+    expect(updatedMessage.lastReadDate).to.be.ok;
+  });
+
+  it('should change the seen status to unseen', async function () {
+    // simulate user seen
+    await markAs(subscriberToken, message._id, MarkMessagesAsEnum.SEEN);
+
+    const seenMessage = await getMessage(session, messageRepository, subscriber);
+    expect(seenMessage.seen).to.equal(true);
+    expect(seenMessage.read).to.equal(false);
+    expect(seenMessage.lastSeenDate).to.be.ok;
+    expect(seenMessage.lastReadDate).to.be.not.ok;
+
+    await markAs(subscriberToken, message._id, MarkMessagesAsEnum.UNSEEN);
+
+    const updatedMessage = await getMessage(session, messageRepository, subscriber);
+    expect(updatedMessage.seen).to.equal(false);
+    expect(updatedMessage.read).to.equal(false);
+    expect(updatedMessage.lastSeenDate).to.be.ok;
+    expect(updatedMessage.lastReadDate).to.be.not.ok;
+  });
+
+  it('should change the read status to unread', async function () {
+    // simulate user read
+    await markAs(subscriberToken, message._id, MarkMessagesAsEnum.READ);
+
+    const readMessage = await getMessage(session, messageRepository, subscriber);
+    expect(readMessage.seen).to.equal(true);
+    expect(readMessage.read).to.equal(true);
+    expect(readMessage.lastSeenDate).to.be.ok;
+    expect(readMessage.lastReadDate).to.be.ok;
+
+    await markAs(subscriberToken, message._id, MarkMessagesAsEnum.UNREAD);
+    const updateMessage = await getMessage(session, messageRepository, subscriber);
+    expect(updateMessage.seen).to.equal(true);
+    expect(updateMessage.read).to.equal(false);
+    expect(updateMessage.lastSeenDate).to.be.ok;
+    expect(updateMessage.lastReadDate).to.be.ok;
+  });
+
+  it('should throw exception if messages were not provided', async function () {
+    const failureMessage = 'should not reach here, should throw error';
+
+    try {
+      await markAs(subscriberToken, undefined, MarkMessagesAsEnum.SEEN);
+
+      expect.fail(failureMessage);
+    } catch (e) {
+      if (e.message === failureMessage) {
+        expect(e.message).to.be.empty;
+      }
+
+      expect(e.response.data.message).to.equal('messageId is required');
+      expect(e.response.data.statusCode).to.equal(400);
+    }
+
+    try {
+      await markAs(subscriberToken, [], MarkMessagesAsEnum.SEEN);
+
+      expect.fail(failureMessage);
+    } catch (e) {
+      if (e.message === failureMessage) {
+        expect(e.message).to.be.empty;
+      }
+
+      expect(e.response.data.message).to.equal('messageId is required');
+      expect(e.response.data.statusCode).to.equal(400);
+    }
+  });
+});
+
+async function getMessage(
+  session: UserSession,
+  messageRepository: MessageRepository,
+  subscriber: SubscriberEntity
+): Promise<MessageEntity> {
+  const message = await messageRepository.findOne({
+    _environmentId: session.environment._id,
+    _subscriberId: subscriber._id,
+    channel: ChannelTypeEnum.IN_APP,
+  });
+
+  if (!message) {
+    expect(message).to.be.ok;
+    throw new Error('message not found');
+  }
+
+  return message;
+}
+
+async function markAs(subscriberToken: string, messageIds: string | string[] | undefined, mark: MarkMessagesAsEnum) {
+  return await axios.post(
+    `http://127.0.0.1:${process.env.PORT}/v1/widgets/messages/mark-as`,
+    { messageId: messageIds, markAs: mark },
+    {
+      headers: {
+        Authorization: `Bearer ${subscriberToken}`,
+      },
+    }
+  );
+}
+
+async function getSubscriber(
+  session: UserSession,
+  subscriberRepository: SubscriberRepository,
+  subscriberId: string
+): Promise<SubscriberEntity> {
+  const subscriberRes = await subscriberRepository.findOne({
+    _environmentId: session.environment._id,
+    subscriberId: subscriberId,
+  });
+
+  if (!subscriberRes) {
+    expect(subscriberRes).to.be.ok;
+    throw new Error('subscriber not found');
+  }
+
+  return subscriberRes;
+}
+
+async function pruneMessages(messageRepository) {
+  await messageRepository.deleteMany({});
+}

--- a/apps/api/src/app/widgets/e2e/mark-as.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/mark-as.e2e.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { ChannelTypeEnum } from '@novu/shared';
 import { expect } from 'chai';
 
-describe('Mark as Seen - /widgets/messages/:messageId/seen (POST)', async () => {
+describe('Mark as Seen - /widgets/messages/markAs (POST)', async () => {
   const messageRepository = new MessageRepository();
   let session: UserSession;
   let template: NotificationTemplateEntity;

--- a/apps/api/src/app/widgets/usecases/index.ts
+++ b/apps/api/src/app/widgets/usecases/index.ts
@@ -8,6 +8,7 @@ import { RemoveMessage } from './remove-message/remove-message.usecase';
 import { MarkAllMessagesAs } from './mark-all-messages-as/mark-all-messages-as.usecase';
 import { RemoveAllMessages } from './remove-messages/remove-all-messages.usecase';
 import { RemoveMessagesBulk } from './remove-messages-bulk/remove-messages-bulk.usecase';
+import { MarkMessageAsByMark } from './mark-message-as-by-mark/mark-message-as-by-mark.usecase';
 
 export const USE_CASES = [
   GetOrganizationData,
@@ -20,5 +21,6 @@ export const USE_CASES = [
   RemoveAllMessages,
   MarkAllMessagesAs,
   RemoveMessagesBulk,
+  MarkMessageAsByMark,
   //
 ];

--- a/apps/api/src/app/widgets/usecases/mark-all-messages-as/mark-all-messages-as.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/mark-all-messages-as/mark-all-messages-as.usecase.ts
@@ -53,22 +53,15 @@ export class MarkAllMessagesAs {
       channel: ChannelTypeEnum.IN_APP,
     });
 
-    const isUnreadCountChanged =
-      command.markAs === MarkMessagesAsEnum.READ || command.markAs === MarkMessagesAsEnum.UNREAD;
-
-    const countQuery = isUnreadCountChanged ? { read: false } : { seen: false };
-
-    const count = await this.messageRepository.getCount(
-      command.environmentId,
-      subscriber._id,
-      ChannelTypeEnum.IN_APP,
-      countQuery
-    );
+    const eventMessage =
+      command.markAs === MarkMessagesAsEnum.READ || command.markAs === MarkMessagesAsEnum.UNREAD
+        ? WebSocketEventEnum.UNREAD
+        : WebSocketEventEnum.UNSEEN;
 
     this.webSocketsQueueService.add({
       name: 'sendMessage',
       data: {
-        event: isUnreadCountChanged ? WebSocketEventEnum.UNREAD : WebSocketEventEnum.UNSEEN,
+        event: eventMessage,
         userId: subscriber._id,
         _environmentId: command.environmentId,
       },

--- a/apps/api/src/app/widgets/usecases/mark-message-as-by-mark/mark-message-as-by-mark.command.ts
+++ b/apps/api/src/app/widgets/usecases/mark-message-as-by-mark/mark-message-as-by-mark.command.ts
@@ -1,0 +1,16 @@
+import { IsArray, IsDefined, IsEnum, IsString } from 'class-validator';
+import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
+import { MarkMessagesAsEnum } from '@novu/shared';
+
+export class MarkMessageAsByMarkCommand extends EnvironmentWithSubscriber {
+  @IsArray()
+  messageIds: string[];
+
+  @IsDefined()
+  @IsEnum(MarkMessagesAsEnum)
+  markAs: MarkMessagesAsEnum;
+
+  @IsDefined()
+  @IsString()
+  __source: 'notification_center' | 'api';
+}

--- a/apps/api/src/app/widgets/usecases/mark-message-as-by-mark/mark-message-as-by-mark.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/mark-message-as-by-mark/mark-message-as-by-mark.usecase.ts
@@ -1,0 +1,116 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { MessageEntity, MessageRepository, SubscriberRepository, SubscriberEntity } from '@novu/dal';
+import { MarkMessagesAsEnum, WebSocketEventEnum } from '@novu/shared';
+import {
+  WebSocketsQueueService,
+  AnalyticsService,
+  InvalidateCacheService,
+  CachedEntity,
+  buildFeedKey,
+  buildMessageCountKey,
+  buildSubscriberKey,
+} from '@novu/application-generic';
+
+import { MarkMessageAsByMarkCommand } from './mark-message-as-by-mark.command';
+
+@Injectable()
+export class MarkMessageAsByMark {
+  constructor(
+    private invalidateCache: InvalidateCacheService,
+    private messageRepository: MessageRepository,
+    private webSocketsQueueService: WebSocketsQueueService,
+    private analyticsService: AnalyticsService,
+    private subscriberRepository: SubscriberRepository
+  ) {}
+
+  async execute(command: MarkMessageAsByMarkCommand): Promise<MessageEntity[]> {
+    await this.invalidateCache.invalidateQuery({
+      key: buildFeedKey().invalidate({
+        subscriberId: command.subscriberId,
+        _environmentId: command.environmentId,
+      }),
+    });
+
+    await this.invalidateCache.invalidateQuery({
+      key: buildMessageCountKey().invalidate({
+        subscriberId: command.subscriberId,
+        _environmentId: command.environmentId,
+      }),
+    });
+
+    const subscriber = await this.fetchSubscriber({
+      _environmentId: command.environmentId,
+      subscriberId: command.subscriberId,
+    });
+
+    if (!subscriber) throw new NotFoundException(`Subscriber ${command.subscriberId} not found`);
+
+    await this.messageRepository.changeMessagesStatus({
+      environmentId: command.environmentId,
+      subscriberId: subscriber._id,
+      messageIds: command.messageIds,
+      markAs: command.markAs,
+    });
+
+    const messages = await this.messageRepository.find({
+      _environmentId: command.environmentId,
+      _id: {
+        $in: command.messageIds,
+      },
+    });
+
+    await this.updateServices(command, subscriber, messages, command.markAs);
+
+    return messages;
+  }
+
+  private async updateServices(command: MarkMessageAsByMarkCommand, subscriber, messages, markAs: MarkMessagesAsEnum) {
+    this.updateSocketCount(subscriber, markAs);
+    const analyticMessage =
+      command.__source === 'notification_center'
+        ? `Mark as ${markAs} - [Notification Center]`
+        : `Mark as ${markAs} - [API]`;
+
+    for (const message of messages) {
+      this.analyticsService.mixpanelTrack(analyticMessage, '', {
+        _subscriber: message._subscriberId,
+        _organization: command.organizationId,
+        _template: message._templateId,
+      });
+    }
+  }
+
+  private updateSocketCount(subscriber: SubscriberEntity, markAs: MarkMessagesAsEnum) {
+    const eventMessage =
+      markAs === MarkMessagesAsEnum.READ || markAs === MarkMessagesAsEnum.UNREAD
+        ? WebSocketEventEnum.UNREAD
+        : WebSocketEventEnum.UNSEEN;
+
+    this.webSocketsQueueService.add({
+      name: 'sendMessage',
+      data: {
+        event: eventMessage,
+        userId: subscriber._id,
+        _environmentId: subscriber._environmentId,
+      },
+      groupId: subscriber._organizationId,
+    });
+  }
+  @CachedEntity({
+    builder: (command: { subscriberId: string; _environmentId: string }) =>
+      buildSubscriberKey({
+        _environmentId: command._environmentId,
+        subscriberId: command.subscriberId,
+      }),
+  })
+  private async fetchSubscriber({
+    subscriberId,
+    _environmentId,
+  }: {
+    subscriberId: string;
+    _environmentId: string;
+  }): Promise<SubscriberEntity | null> {
+    return await this.subscriberRepository.findBySubscriberId(_environmentId, subscriberId);
+  }
+}

--- a/apps/api/src/app/widgets/widgets.controller.ts
+++ b/apps/api/src/app/widgets/widgets.controller.ts
@@ -65,6 +65,9 @@ import { ApiCommonResponses, ApiNoContentResponse } from '../shared/framework/re
 import { RemoveMessagesBulkCommand } from './usecases/remove-messages-bulk/remove-messages-bulk.command';
 import { RemoveMessagesBulk } from './usecases/remove-messages-bulk/remove-messages-bulk.usecase';
 import { RemoveMessagesBulkRequestDto } from './dtos/remove-messages-bulk-request.dto';
+import { MessageMarkAsRequestDto } from './dtos/mark-as-request.dto';
+import { MarkMessageAsByMark } from './usecases/mark-message-as-by-mark/mark-message-as-by-mark.usecase';
+import { MarkMessageAsByMarkCommand } from './usecases/mark-message-as-by-mark/mark-message-as-by-mark.command';
 
 @ApiCommonResponses()
 @Controller('/widgets')
@@ -75,6 +78,7 @@ export class WidgetsController {
     private getNotificationsFeedUsecase: GetNotificationsFeed,
     private getFeedCountUsecase: GetFeedCount,
     private markMessageAsUsecase: MarkMessageAs,
+    private markMessageAsByMarkUsecase: MarkMessageAsByMark,
     private removeMessageUsecase: RemoveMessage,
     private removeAllMessagesUsecase: RemoveAllMessages,
     private removeMessagesBulkUsecase: RemoveMessagesBulk,
@@ -212,7 +216,10 @@ export class WidgetsController {
   }
 
   @ApiOperation({
-    summary: 'Mark a subscriber feed message or messages as seen or as read',
+    summary: 'Mark a subscriber feed messages as seen or as read',
+    description: `Introducing '/messages/mark-as endpoint for consistent read and seen message handling,
+     deprecating old legacy endpoint.`,
+    deprecated: true,
   })
   @UseGuards(AuthGuard('subscriberJwt'))
   @Post('/messages/markAs')
@@ -232,6 +239,30 @@ export class WidgetsController {
     });
 
     return await this.markMessageAsUsecase.execute(command);
+  }
+
+  @ApiOperation({
+    summary: 'Mark a subscriber messages as seen, read, unseen or unread',
+  })
+  @UseGuards(AuthGuard('subscriberJwt'))
+  @Post('/messages/mark-as')
+  async markMessagesAs(
+    @SubscriberSession() subscriberSession: SubscriberEntity,
+    @Body() body: MessageMarkAsRequestDto
+  ): Promise<MessageEntity[]> {
+    const messageIds = this.toArray(body.messageId);
+    if (!messageIds || messageIds.length === 0) throw new BadRequestException('messageId is required');
+
+    return await this.markMessageAsByMarkUsecase.execute(
+      MarkMessageAsByMarkCommand.create({
+        organizationId: subscriberSession._organizationId,
+        subscriberId: subscriberSession.subscriberId,
+        environmentId: subscriberSession._environmentId,
+        messageIds,
+        markAs: body.markAs,
+        __source: 'notification_center',
+      })
+    );
   }
 
   @ApiOperation({

--- a/libs/dal/src/repositories/message/message.repository.ts
+++ b/libs/dal/src/repositories/message/message.repository.ts
@@ -277,6 +277,35 @@ export class MessageRepository extends BaseRepository<MessageDBModel, MessageEnt
     );
   }
 
+  async changeMessagesStatus({
+    environmentId,
+    subscriberId,
+    messageIds,
+    markAs,
+  }: {
+    environmentId: string;
+    subscriberId: string;
+    messageIds: string[];
+    markAs: MarkMessagesAsEnum;
+  }) {
+    const updatePayload = this.getReadSeenUpdatePayload(markAs);
+
+    await this.update(
+      {
+        _environmentId: environmentId,
+        _subscriberId: subscriberId,
+        _id: {
+          $in: messageIds.map((id) => {
+            return new Types.ObjectId(id);
+          }),
+        },
+      },
+      {
+        $set: updatePayload,
+      }
+    );
+  }
+
   async changeStatus(
     environmentId: string,
     subscriberId: string,


### PR DESCRIPTION
### What change does this PR introduce?

We have a few API endpoints to mark a(ll) message read and seen

1. https://docs.novu.co/api-reference/subscribers/marks-all-the-subscriber-messages-as-read-unread-seen-or-unseen-optionally-you-can-pass-feed-id-or-array-to-mark-messages-of-a-particular-feed
2. https://docs.novu.co/api-reference/subscribers/mark-a-subscriber-feed-message-as-seen

### Why was this change needed?

There are inconsistencies in how API works. The first API marks all seen messages as true if it is marked read as true but the second API does not.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
