### PR TITLE
Editor autocomplete - does not open in a second use

### DIFF
--- a/apps/web/src/pages/templates/components/email-editor/TextRowContent.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/TextRowContent.tsx
@@ -71,7 +71,7 @@ export function TextRowContent({ blockIndex }: { blockIndex: number }) {
 
   const checkPreviousChar = (data: string, anchorPos: number) => {
     if (anchorPos > 1) {
-      const endContent = data.slice(anchorPos);
+      const endContent = data.slice(anchorPos - 2);
 
       const contentToUse = endContent ? endContent : data;
       const slicePositions = contentToUse.indexOf('{{') + 2;

--- a/apps/web/src/pages/templates/components/email-editor/TextRowContent.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/TextRowContent.tsx
@@ -74,7 +74,7 @@ export function TextRowContent({ blockIndex }: { blockIndex: number }) {
       const endContent = data.slice(anchorPos - 2);
 
       const contentToUse = endContent ? endContent : data;
-      const slicePositions = contentToUse.indexOf('{{') + 2;
+      const slicePositions = contentToUse.lastIndexOf('{') + 1;
 
       const currentChar = contentToUse.charAt(slicePositions - 1);
       const previousChar = contentToUse.charAt(slicePositions - 2);
@@ -114,7 +114,7 @@ export function TextRowContent({ blockIndex }: { blockIndex: number }) {
 
     const endContent = data.slice(anchorPosition);
 
-    const slicePositions = endContent.indexOf('{{') + 2;
+    const slicePositions = endContent.lastIndexOf('{{') + 2;
     const newEndContent = `${endContent.slice(0, slicePositions)}${value}${endContent.slice(slicePositions)}`;
 
     const newContent = `${data.slice(0, anchorPosition)}${newEndContent}`;


### PR DESCRIPTION
### What change does this PR introduce?
In the editor, after adding a {{..}} once. Writing only one { opens the autocomplete dropdown, when adding the second { (so its {{ ) the dropdown does not show again.

The slice was wrong, at the second input of {{ it took the whole content and so used the indexes of the first {{
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
