### PR TITLE
fix: set novu providers as primary for new orgs

### DIFF
--- a/apps/api/src/app/organization/e2e/create-organization.e2e.ts
+++ b/apps/api/src/app/organization/e2e/create-organization.e2e.ts
@@ -104,7 +104,7 @@ describe('Create Organization - /organizations (POST)', async () => {
       expect(user?.jobTitle).to.eq(testOrganization.jobTitle);
     });
 
-    it('should create organization with built in Novu integrations', async () => {
+    it('should create organization with built in Novu integrations and set them as primary', async () => {
       const testOrganization: ICreateOrganizationDto = {
         name: 'Org Name',
       };
@@ -120,14 +120,30 @@ describe('Create Organization - /organizations (POST)', async () => {
       const novuSmsIntegration = integrations.filter(
         (i) => i.active && i.name === 'Novu SMS' && i.providerId === SmsProviderIdEnum.Novu
       );
+      const novuEmailIntegrationProduction = novuEmailIntegration.filter(
+        (el) => el._environmentId === productionEnv?._id
+      );
+      const novuEmailIntegrationDevelopment = novuEmailIntegration.filter(
+        (el) => el._environmentId === developmentEnv?._id
+      );
+      const novuSmsIntegrationProduction = novuSmsIntegration.filter((el) => el._environmentId === productionEnv?._id);
+      const novuSmsIntegrationDevelopment = novuSmsIntegration.filter(
+        (el) => el._environmentId === developmentEnv?._id
+      );
 
       expect(integrations.length).to.eq(4);
       expect(novuEmailIntegration?.length).to.eq(2);
       expect(novuSmsIntegration?.length).to.eq(2);
-      expect(novuEmailIntegration.filter((el) => el._environmentId === productionEnv?._id).length).to.eq(1);
-      expect(novuSmsIntegration.filter((el) => el._environmentId === productionEnv?._id).length).to.eq(1);
-      expect(novuEmailIntegration.filter((el) => el._environmentId === developmentEnv?._id).length).to.eq(1);
-      expect(novuSmsIntegration.filter((el) => el._environmentId === developmentEnv?._id).length).to.eq(1);
+
+      expect(novuEmailIntegrationProduction.length).to.eq(1);
+      expect(novuSmsIntegrationProduction.length).to.eq(1);
+      expect(novuEmailIntegrationDevelopment.length).to.eq(1);
+      expect(novuSmsIntegrationDevelopment.length).to.eq(1);
+
+      expect(novuEmailIntegrationProduction[0].primary).to.eq(true);
+      expect(novuSmsIntegrationProduction[0].primary).to.eq(true);
+      expect(novuEmailIntegrationDevelopment[0].primary).to.eq(true);
+      expect(novuSmsIntegrationDevelopment[0].primary).to.eq(true);
     });
 
     it('when Novu Email credentials are not set it should not create Novu Email integration', async () => {


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
FIX: when creating a new org, Novu Email and SMS providers are not marked as primary on all environments.

Once a user creates a new organization, everything should work out of the box
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
