### PR TITLE
Nv 3567 subscribers are duplicated during the burst of events

### DIFF
--- a/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.spec.ts
+++ b/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.spec.ts
@@ -1,0 +1,121 @@
+import { TopicSubscribersRepository, SubscriberRepository } from '@novu/dal';
+import { SubscribersService, UserSession } from '@novu/testing';
+
+import { removeDuplicatedSubscribers } from './remove-duplicated-subscribers.migration';
+import { expect } from 'chai';
+
+describe('Migration: Remove Duplicated Subscribers', () => {
+  let session: UserSession;
+  let subscriberService: SubscribersService;
+  const subscriberRepository = new SubscriberRepository();
+  const topicSubscribersRepository = new TopicSubscribersRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+  });
+
+  it('should remove duplicated subscribers', async () => {
+    const duplicatedSubscriberId = '123';
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_subscriber',
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'mid_subscriber',
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'last_subscriber',
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+
+    const duplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+
+    expect(duplicates.length).to.equal(3);
+
+    await removeDuplicatedSubscribers();
+
+    const remainingDuplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+
+    expect(remainingDuplicates.length).to.equal(1);
+    expect(remainingDuplicates[0].firstName).to.equal('last_subscriber');
+  });
+
+  it('should always keep one subscriber per environment', async () => {
+    const duplicatedSubscriberId = '123';
+    const firstEnvironmentId = session.environment._id;
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'env_1',
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'env_1',
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+
+    const secondEnvironmentId = session.organization._id;
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'env_2',
+      _environmentId: secondEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'env_2',
+      _environmentId: secondEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+
+    const duplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(duplicates.length).to.equal(2);
+
+    const duplicates2 = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(duplicates2.length).to.equal(2);
+
+    await removeDuplicatedSubscribers();
+
+    const remainingDuplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(remainingDuplicates.length).to.equal(1);
+    expect(remainingDuplicates[0].firstName).to.equal('env_1');
+
+    const remainingDuplicates2 = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: secondEnvironmentId,
+    });
+    expect(remainingDuplicates2.length).to.equal(1);
+    expect(remainingDuplicates2[0].firstName).to.equal('env_2');
+  });
+});

--- a/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.spec.ts
+++ b/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.spec.ts
@@ -3,6 +3,7 @@ import { SubscribersService, UserSession } from '@novu/testing';
 
 import { removeDuplicatedSubscribers } from './remove-duplicated-subscribers.migration';
 import { expect } from 'chai';
+import { ChatProviderIdEnum, IChannelSettings, ISubscriber } from '@novu/shared';
 
 describe('Migration: Remove Duplicated Subscribers', () => {
   let session: UserSession;
@@ -226,6 +227,208 @@ describe('Migration: Remove Duplicated Subscribers', () => {
     expect(remainingDuplicates[0].locale).to.equal('locale_5');
     expect(remainingDuplicates[0].data?.key).to.be.undefined;
     expect(remainingDuplicates[0].data?.newStuff).to.equal('value_4');
+  });
+
+  it('should merge 2 channel integration', async () => {
+    const duplicatedSubscriberId = '123';
+    const firstEnvironmentId = session.environment._id;
+
+    const subscriber1: ISubscriber = {
+      email: 'email_1',
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_1',
+      lastName: 'last_name_1',
+      channels: [{ _integrationId: '1', providerId: ChatProviderIdEnum.Slack, credentials: { webhookUrl: 'url_1' } }],
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+      deleted: false,
+      createdAt: '2021-01-01T00:00:00.000Z',
+      updatedAt: '2021-01-01T00:00:00.000Z',
+    };
+    const firstCreatedSubscriber = await subscriberRepository.create(subscriber1);
+
+    const subscriber2: ISubscriber = {
+      email: 'email_1',
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_1',
+      lastName: 'last_name_1',
+      channels: [
+        {
+          _integrationId: '2',
+          providerId: ChatProviderIdEnum.Discord,
+          credentials: { deviceTokens: ['token_123', 'token_123'] },
+        },
+      ],
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+      deleted: false,
+      createdAt: '2021-01-01T00:00:00.000Z',
+      updatedAt: '2021-01-01T00:00:00.000Z',
+    };
+    await subscriberRepository.create(subscriber2);
+
+    await removeDuplicatedSubscribers();
+
+    const remainingDuplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(remainingDuplicates.length).to.equal(1);
+    expect(remainingDuplicates[0]._id).to.equal(firstCreatedSubscriber._id);
+    expect(remainingDuplicates[0]._organizationId).to.equal(firstCreatedSubscriber._organizationId);
+    expect(remainingDuplicates[0]._environmentId).to.equal(firstCreatedSubscriber._environmentId);
+    expect(remainingDuplicates[0].email).to.equal('email_1');
+    expect(remainingDuplicates[0].firstName).to.equal('first_name_1');
+    expect(remainingDuplicates[0].lastName).to.equal('last_name_1');
+    expect(remainingDuplicates[0].createdAt).to.equal('2021-01-01T00:00:00.000Z');
+
+    const firstChannel: IChannelSettings | undefined = remainingDuplicates[0].channels?.find(
+      (channel) => channel._integrationId === '1'
+    );
+    expect(firstChannel?._integrationId).to.equal('1');
+    expect(firstChannel?.providerId).to.equal(ChatProviderIdEnum.Slack);
+    expect(firstChannel?.credentials.webhookUrl).to.equal('url_1');
+
+    const secondChannel: IChannelSettings | undefined = remainingDuplicates[0].channels?.find(
+      (channel) => channel._integrationId === '2'
+    );
+    expect(secondChannel?._integrationId).to.equal('2');
+    expect(secondChannel?.providerId).to.equal(ChatProviderIdEnum.Discord);
+    expect(secondChannel?.credentials.deviceTokens).to.deep.equal(['token_123']);
+  });
+
+  it('should merge 2 channel same integration', async () => {
+    const duplicatedSubscriberId = '123';
+    const firstEnvironmentId = session.environment._id;
+
+    const subscriber1: ISubscriber = {
+      email: 'email_1',
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_1',
+      lastName: 'last_name_1',
+      channels: [
+        {
+          _integrationId: '1',
+          providerId: ChatProviderIdEnum.Discord,
+          credentials: { deviceTokens: ['token_1', 'token_2'] },
+        },
+      ],
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+      deleted: false,
+      createdAt: '2021-01-01T00:00:00.000Z',
+      updatedAt: '2021-01-01T00:00:00.000Z',
+    };
+    const firstCreatedSubscriber = await subscriberRepository.create(subscriber1);
+
+    const subscriber2: ISubscriber = {
+      email: 'email_1',
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_1',
+      lastName: 'last_name_1',
+      channels: [
+        {
+          _integrationId: '1',
+          providerId: ChatProviderIdEnum.Discord,
+          credentials: { deviceTokens: ['token_2', 'token_3', 'token_3'] },
+        },
+      ],
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+      deleted: false,
+      createdAt: '2021-01-01T00:00:00.000Z',
+      updatedAt: '2021-01-01T00:00:00.000Z',
+    };
+    await subscriberRepository.create(subscriber2);
+
+    await removeDuplicatedSubscribers();
+
+    const remainingDuplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(remainingDuplicates.length).to.equal(1);
+    expect(remainingDuplicates[0]._id).to.equal(firstCreatedSubscriber._id);
+    expect(remainingDuplicates[0]._organizationId).to.equal(firstCreatedSubscriber._organizationId);
+    expect(remainingDuplicates[0]._environmentId).to.equal(firstCreatedSubscriber._environmentId);
+    expect(remainingDuplicates[0].email).to.equal('email_1');
+    expect(remainingDuplicates[0].firstName).to.equal('first_name_1');
+    expect(remainingDuplicates[0].lastName).to.equal('last_name_1');
+    expect(remainingDuplicates[0].createdAt).to.equal('2021-01-01T00:00:00.000Z');
+
+    const firstChannel: IChannelSettings | undefined = remainingDuplicates[0].channels?.find(
+      (channel) => channel._integrationId === '1'
+    );
+    expect(firstChannel?._integrationId).to.equal('1');
+    expect(firstChannel?.providerId).to.equal(ChatProviderIdEnum.Discord);
+    expect(firstChannel?.credentials.deviceTokens).to.deep.equal(['token_1', 'token_2', 'token_3']);
+  });
+
+  it('should merge 2 channel same integration', async () => {
+    const duplicatedSubscriberId = '123';
+    const firstEnvironmentId = session.environment._id;
+
+    const subscriber1: ISubscriber = {
+      email: 'email_1',
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_1',
+      lastName: 'last_name_1',
+      channels: [
+        {
+          _integrationId: '1',
+          providerId: ChatProviderIdEnum.Slack,
+          credentials: { webhookUrl: 'old_url_1' },
+        },
+      ],
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+      deleted: false,
+      createdAt: '2021-01-01T00:00:00.000Z',
+      updatedAt: '2021-01-01T00:00:00.000Z',
+    };
+    const firstCreatedSubscriber = await subscriberRepository.create(subscriber1);
+
+    const subscriber2: ISubscriber = {
+      email: 'email_1',
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_1',
+      lastName: 'last_name_1',
+      channels: [
+        {
+          _integrationId: '1',
+          providerId: ChatProviderIdEnum.Slack,
+          credentials: { webhookUrl: 'new_url_1' },
+        },
+      ],
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+      deleted: false,
+      createdAt: '2021-01-01T00:00:00.000Z',
+      updatedAt: '2021-01-01T00:00:00.000Z',
+    };
+    await subscriberRepository.create(subscriber2);
+
+    await removeDuplicatedSubscribers();
+
+    const remainingDuplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(remainingDuplicates.length).to.equal(1);
+    expect(remainingDuplicates[0]._id).to.equal(firstCreatedSubscriber._id);
+    expect(remainingDuplicates[0]._organizationId).to.equal(firstCreatedSubscriber._organizationId);
+    expect(remainingDuplicates[0]._environmentId).to.equal(firstCreatedSubscriber._environmentId);
+    expect(remainingDuplicates[0].email).to.equal('email_1');
+    expect(remainingDuplicates[0].firstName).to.equal('first_name_1');
+    expect(remainingDuplicates[0].lastName).to.equal('last_name_1');
+    expect(remainingDuplicates[0].createdAt).to.equal('2021-01-01T00:00:00.000Z');
+
+    const firstChannel: IChannelSettings | undefined = remainingDuplicates[0].channels?.find(
+      (channel) => channel._integrationId === '1'
+    );
+    expect(firstChannel?._integrationId).to.equal('1');
+    expect(firstChannel?.providerId).to.equal(ChatProviderIdEnum.Slack);
+    expect(firstChannel?.credentials.webhookUrl).to.be.equal('new_url_1');
   });
 
   it('should keep the first created subscriber after merge', async () => {

--- a/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.spec.ts
+++ b/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.spec.ts
@@ -1,4 +1,4 @@
-import { TopicSubscribersRepository, SubscriberRepository } from '@novu/dal';
+import { SubscriberRepository } from '@novu/dal';
 import { SubscribersService, UserSession } from '@novu/testing';
 
 import { removeDuplicatedSubscribers } from './remove-duplicated-subscribers.migration';
@@ -8,7 +8,6 @@ describe('Migration: Remove Duplicated Subscribers', () => {
   let session: UserSession;
   let subscriberService: SubscribersService;
   const subscriberRepository = new SubscriberRepository();
-  const topicSubscribersRepository = new TopicSubscribersRepository();
 
   beforeEach(async () => {
     session = new UserSession();
@@ -117,5 +116,149 @@ describe('Migration: Remove Duplicated Subscribers', () => {
     });
     expect(remainingDuplicates2.length).to.equal(1);
     expect(remainingDuplicates2[0].firstName).to.equal('env_2');
+  });
+
+  it('should merge the metadata across duplicated subscribers', async () => {
+    const duplicatedSubscriberId = '123';
+    const firstEnvironmentId = session.environment._id;
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name',
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      lastName: 'last_name',
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+
+    const duplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(duplicates.length).to.equal(2);
+
+    await removeDuplicatedSubscribers();
+
+    const remainingDuplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(remainingDuplicates.length).to.equal(1);
+    expect(remainingDuplicates[0].firstName).to.equal('first_name');
+    expect(remainingDuplicates[0].lastName).to.equal('last_name');
+  });
+
+  it('should merge the metadata across duplicated subscribers by latest created subscriber', async () => {
+    const duplicatedSubscriberId = '123';
+    const firstEnvironmentId = session.environment._id;
+
+    const firstCreatedSubscriber = await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_1',
+      lastName: 'last_name_1',
+      email: 'email_1',
+      phone: 'phone_1',
+      avatar: 'avatar_1',
+      locale: 'locale_1',
+      data: { key: 'value_1' },
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_2',
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      email: 'email_3',
+      phone: 'phone_3',
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      avatar: 'avatar_4',
+      data: { newStuff: 'value_4' },
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_5',
+      locale: 'locale_5',
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+
+    const duplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(duplicates.length).to.equal(5);
+
+    await removeDuplicatedSubscribers();
+
+    const remainingDuplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(remainingDuplicates.length).to.equal(1);
+    expect(remainingDuplicates[0]._id).to.equal(firstCreatedSubscriber._id);
+    expect(remainingDuplicates[0]._organizationId).to.equal(firstCreatedSubscriber._organizationId);
+    expect(remainingDuplicates[0]._environmentId).to.equal(firstCreatedSubscriber._environmentId);
+    expect(remainingDuplicates[0].__v).to.equal(firstCreatedSubscriber.__v);
+
+    expect(remainingDuplicates[0].firstName).to.equal('first_name_5');
+    expect(remainingDuplicates[0].lastName).to.equal('last_name_1');
+    expect(remainingDuplicates[0].email).to.equal('email_3');
+    expect(remainingDuplicates[0].phone).to.equal('phone_3');
+    expect(remainingDuplicates[0].avatar).to.equal('avatar_4');
+    expect(remainingDuplicates[0].locale).to.equal('locale_5');
+    expect(remainingDuplicates[0].data?.key).to.be.undefined;
+    expect(remainingDuplicates[0].data?.newStuff).to.equal('value_4');
+  });
+
+  it('should keep the first created subscriber after merge', async () => {
+    const duplicatedSubscriberId = '123';
+    const firstEnvironmentId = session.environment._id;
+
+    const firstCreatedSubscriber = await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name',
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+    await subscriberRepository.create({
+      subscriberId: duplicatedSubscriberId,
+      firstName: 'first_name_2',
+      _environmentId: firstEnvironmentId,
+      _organizationId: session.organization._id,
+    });
+
+    const duplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+    expect(duplicates.length).to.equal(2);
+
+    await removeDuplicatedSubscribers();
+
+    const remainingDuplicates = await subscriberRepository.find({
+      subscriberId: duplicatedSubscriberId,
+      _environmentId: session.environment._id,
+    });
+
+    expect(remainingDuplicates.length).to.equal(1);
+    expect(remainingDuplicates[0]._id).to.equal(firstCreatedSubscriber._id);
   });
 });

--- a/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.ts
+++ b/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.ts
@@ -1,0 +1,71 @@
+import '../../../src/config';
+import { AppModule } from '../../../src/app.module';
+
+import { NestFactory } from '@nestjs/core';
+
+import { SubscriberRepository } from '@novu/dal';
+
+export async function removeDuplicatedSubscribers() {
+  // eslint-disable-next-line no-console
+  console.log('start migration - remove duplicated subscribers');
+
+  const app = await NestFactory.create(AppModule, {
+    logger: false,
+  });
+
+  const batchSize = 1000;
+  const subscriberRepository = app.get(SubscriberRepository);
+
+  const pipeline = [
+    // Group by subscriberId and _environmentId
+    {
+      $group: {
+        _id: { subscriberId: '$subscriberId', environmentId: '$_environmentId' },
+        count: { $sum: 1 },
+        docs: { $push: '$_id' }, // Store document IDs for removal
+      },
+    },
+    // Filter groups having more than one document (duplicates)
+    {
+      $match: {
+        count: { $gt: 1 },
+      },
+    },
+  ];
+
+  const cursor = await subscriberRepository._model.aggregate(pipeline, {
+    batchSize: batchSize,
+    readPreference: 'secondaryPreferred',
+    allowDiskUse: true,
+  });
+
+  for (const group of cursor) {
+    const docsToRemove = group.docs.slice(0, -1); // Keep the last created document, remove others
+    const { subscriberId, environmentId } = group._id;
+
+    console.log(
+      'deleting',
+      docsToRemove.length,
+      'duplicates for subscriberId:',
+      subscriberId,
+      'environmentId:',
+      environmentId
+    );
+
+    try {
+      const result = await subscriberRepository.deleteMany({
+        _id: { $in: docsToRemove },
+        subscriberId: subscriberId,
+        _environmentId: environmentId,
+      });
+      console.log('Documents deleted:', result.modifiedCount);
+    } catch (err) {
+      console.error('Error deleting documents:', err);
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('end migration- remove duplicated subscribers');
+
+  app.close();
+}

--- a/apps/ws/src/shared/subscriber-online/subscriber-online.service.ts
+++ b/apps/ws/src/shared/subscriber-online/subscriber-online.service.ts
@@ -30,7 +30,7 @@ export class SubscriberOnlineService {
 
   private async updateOnlineStatus(subscriber: ISubscriberJwt, updatePayload: IUpdateSubscriberPayload) {
     await this.subscriberRepository.update(
-      { _id: subscriber._id, _organizationId: subscriber.organizationId },
+      { _id: subscriber._id, _environmentId: subscriber.environmentId },
       {
         $set: updatePayload,
       }

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -10,12 +10,10 @@ const subscriberSchema = new Schema<SubscriberDBModel>(
     _organizationId: {
       type: Schema.Types.ObjectId,
       ref: 'Organization',
-      index: true,
     },
     _environmentId: {
       type: Schema.Types.ObjectId,
       ref: 'Environment',
-      index: true,
     },
     firstName: Schema.Types.String,
     lastName: Schema.Types.String,

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -173,7 +173,7 @@ subscriberSchema.index({
  * subscriberId_2022:environmentId_123:_id_1234
  * We expect an exception to be thrown when attempting to create two subscribers with the same subscriberId (e.g., 2022) within the same environment.
  *
- * We can not add `deleted` field to the index the client wont be able to delete twice subsbriber with the same subscriberId.
+ * We can not add `deleted` field to the index the client wont be able to delete twice subscriber with the same subscriberId.
  */
 index(
   {

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -172,12 +172,13 @@ subscriberSchema.index({
  * subscriberId_2022:environmentId_123:_id_123
  * subscriberId_2022:environmentId_123:_id_1234
  * We expect an exception to be thrown when attempting to create two subscribers with the same subscriberId (e.g., 2022) within the same environment.
+ *
+ * We can not add `deleted` field to the index the client wont be able to delete twice subsbriber with the same subscriberId.
  */
 index(
   {
     subscriberId: 1,
     _environmentId: 1,
-    deleted: 1,
   },
   { unique: true }
 );

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -163,11 +163,14 @@ subscriberSchema.index({
  *    subscriberId: /on-boarding-subscriber/i,
  *  });
  */
-subscriberSchema.index({
-  subscriberId: 1,
-  _environmentId: 1,
-  _id: 1,
-});
+subscriberSchema.index(
+  {
+    subscriberId: 1,
+    _environmentId: 1,
+    _id: 1,
+  },
+  { unique: true }
+);
 
 subscriberSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, overrideMethods: 'all' });
 

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -1,9 +1,10 @@
 import * as mongoose from 'mongoose';
-import { Schema } from 'mongoose';
+import { IndexOptions, Schema } from 'mongoose';
 import * as mongooseDelete from 'mongoose-delete';
 
 import { schemaOptions } from '../schema-default.options';
-import { SubscriberDBModel } from './subscriber.entity';
+import { SubscriberDBModel, SubscriberEntity } from './subscriber.entity';
+import { IndexDefinition } from '../../shared/types';
 
 const subscriberSchema = new Schema<SubscriberDBModel>(
   {
@@ -163,10 +164,12 @@ subscriberSchema.index({
  *    subscriberId: /on-boarding-subscriber/i,
  *  });
  */
-subscriberSchema.index(
+
+index(
   {
     subscriberId: 1,
     _environmentId: 1,
+    deleted: 1,
     _id: 1,
   },
   { unique: true }
@@ -178,3 +181,7 @@ subscriberSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, over
 export const Subscriber =
   (mongoose.models.Subscriber as mongoose.Model<SubscriberDBModel>) ||
   mongoose.model<SubscriberDBModel>('Subscriber', subscriberSchema);
+
+function index(fields: IndexDefinition<SubscriberEntity>, options?: IndexOptions) {
+  subscriberSchema.index(fields, options);
+}

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -165,12 +165,19 @@ subscriberSchema.index({
  *  });
  */
 
+/*
+ * This index needs to be unique and exclude "_id" to prevent duplicate subscribers during concurrent creation attempts.
+ * This situation could occur if two attempts are made to create a subscriber with the same subscriberId (e.g., 2022) simultaneously.
+ * We want to ensure that the _id field is not included in the index to avoid scenarios where MongoDB's unique validation fails to prevent duplicates, such as:
+ * subscriberId_2022:environmentId_123:_id_123
+ * subscriberId_2022:environmentId_123:_id_1234
+ * We expect an exception to be thrown when attempting to create two subscribers with the same subscriberId (e.g., 2022) within the same environment.
+ */
 index(
   {
     subscriberId: 1,
     _environmentId: 1,
     deleted: 1,
-    _id: 1,
   },
   { unique: true }
 );

--- a/libs/dal/src/shared/types/index.ts
+++ b/libs/dal/src/shared/types/index.ts
@@ -1,0 +1,1 @@
+export * from './index.type';

--- a/libs/dal/src/shared/types/index.type.ts
+++ b/libs/dal/src/shared/types/index.type.ts
@@ -1,0 +1,3 @@
+import { IndexDirection } from 'mongoose';
+
+export type IndexDefinition<Entity> = Partial<Record<keyof Entity, IndexDirection>>;

--- a/libs/dal/src/types/error.enum.ts
+++ b/libs/dal/src/types/error.enum.ts
@@ -1,0 +1,3 @@
+export enum ErrorCodesEnum {
+  DUPLICATE_KEY = '11000',
+}

--- a/libs/dal/src/types/index.ts
+++ b/libs/dal/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './enforce';
 export * from './helpers';
 export * from './results';
+export * from './error.enum';


### PR DESCRIPTION
### What change does this PR introduce?

During the burst of trigger events the processed subscribers might get duplicated in the database. This could happen due to the race conditions in the worker's concurrent processing.

### Why was this change needed?

Duplicated subscribers mean that the wrong document might be picked from the database and for example some fields might be missing (email), resulting in messages not being delivered.

### Other information (Screenshots)

We have to introduce the unique index on the subscriberId and environmentId combo to prevent and fix this problem.
