### PR TITLE
feat(dal): add deleted index and type safety index

### DIFF
--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -1,9 +1,10 @@
 import * as mongoose from 'mongoose';
-import { Schema } from 'mongoose';
+import { IndexOptions, Schema } from 'mongoose';
 import * as mongooseDelete from 'mongoose-delete';
 
 import { schemaOptions } from '../schema-default.options';
-import { SubscriberDBModel } from './subscriber.entity';
+import { SubscriberDBModel, SubscriberEntity } from './subscriber.entity';
+import { IndexDefinition } from '../../shared/types';
 
 const subscriberSchema = new Schema<SubscriberDBModel>(
   {
@@ -163,10 +164,12 @@ subscriberSchema.index({
  *    subscriberId: /on-boarding-subscriber/i,
  *  });
  */
-subscriberSchema.index(
+
+index(
   {
     subscriberId: 1,
     _environmentId: 1,
+    deleted: 1,
     _id: 1,
   },
   { unique: true }
@@ -178,3 +181,7 @@ subscriberSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, over
 export const Subscriber =
   (mongoose.models.Subscriber as mongoose.Model<SubscriberDBModel>) ||
   mongoose.model<SubscriberDBModel>('Subscriber', subscriberSchema);
+
+function index(fields: IndexDefinition<SubscriberEntity>, options?: IndexOptions) {
+  subscriberSchema.index(fields, options);
+}

--- a/libs/dal/src/shared/types/index.ts
+++ b/libs/dal/src/shared/types/index.ts
@@ -1,0 +1,1 @@
+export * from './index.type';

--- a/libs/dal/src/shared/types/index.type.ts
+++ b/libs/dal/src/shared/types/index.type.ts
@@ -1,0 +1,3 @@
+import { IndexDirection } from 'mongoose';
+
+export type IndexDefinition<Entity> = Partial<Record<keyof Entity, IndexDirection>>;


### PR DESCRIPTION
### What change does this PR introduce?

We want to optimize the call checking for non deleted subscribers.
This change is recommended by Mongodb Atlas.
As an alternative, the query may need to be changed.

### Why was this change needed?

This will increase the query speed of calls looking for non deleted subscribers and will increase the trigger speed.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
