### PR TITLE
feat(api): Allow img tags in the In-App & Email Editor 

### DIFF
--- a/apps/api/src/app/message-template/shared/sanitizer.service.spec.ts
+++ b/apps/api/src/app/message-template/shared/sanitizer.service.spec.ts
@@ -70,6 +70,6 @@ describe('HTML Sanitizer', function () {
       },
     ]);
 
-    expect(result[0].content).to.equal('<img src="https://example.com/image.jpg" alt="Example Image">');
+    expect(result[0].content).to.equal('<img src="https://example.com/image.jpg" alt="Example Image" />');
   });
 });

--- a/apps/api/src/app/message-template/shared/sanitizer.service.spec.ts
+++ b/apps/api/src/app/message-template/shared/sanitizer.service.spec.ts
@@ -60,4 +60,16 @@ describe('HTML Sanitizer', function () {
 
     expect(result[0].content).to.equal('<p style="color:red;">Red Text</p>');
   });
+
+  it('should NOT sanitize img tags', function () {
+    const result = sanitizeMessageContent([
+      {
+        type: EmailBlockTypeEnum.TEXT,
+        content: '<img src="https://example.com/image.jpg" alt="Example Image">',
+        url: '',
+      },
+    ]);
+
+    expect(result[0].content).to.equal('<img src="https://example.com/image.jpg" alt="Example Image">');
+  });
 });

--- a/apps/api/src/app/message-template/shared/sanitizer.service.ts
+++ b/apps/api/src/app/message-template/shared/sanitizer.service.ts
@@ -16,7 +16,7 @@ const sanitizeOptions: sanitize.IOptions = {
     /**
      * Additional attributes to allow on all tags.
      */
-    '*': ['style'],
+    '*': ['style', 'img'],
   },
   /**
    * Required to disable console warnings when allowing style tags.

--- a/apps/api/src/app/message-template/shared/sanitizer.service.ts
+++ b/apps/api/src/app/message-template/shared/sanitizer.service.ts
@@ -10,13 +10,14 @@ const sanitizeOptions: sanitize.IOptions = {
   /**
    * Additional tags to allow.
    */
-  allowedTags: sanitize.defaults.allowedTags.concat(['style']),
+  allowedTags: sanitize.defaults.allowedTags.concat(['style', 'img']),
   allowedAttributes: {
     ...sanitize.defaults.allowedAttributes,
     /**
      * Additional attributes to allow on all tags.
      */
-    '*': ['style', 'img'],
+    '*': ['style'],
+    img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
   },
   /**
    * Required to disable console warnings when allowing style tags.


### PR DESCRIPTION
### What change does this PR introduce?

Novu used an npm packaged called [sanitize-html](https://www.npmjs.com/package/sanitize-html), [the default allowed tags](https://www.npmjs.com/package/sanitize-html#default-options), doesnt include img tags, this PR aims to include it as it was done for the style tag in this https://github.com/novuhq/novu/pull/4841.

### Why was this change needed?

Closes #5310 

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
