### PR TITLE
fix(web): Tweak scrollbar placement in sidebar

### DIFF
--- a/apps/web/src/components/layout/components/SideNav.tsx
+++ b/apps/web/src/components/layout/components/SideNav.tsx
@@ -171,19 +171,19 @@ export function SideNav({}: Props) {
         borderRight: 'none',
         width: '300px',
         minHeight: '100vh',
-        padding: '16px 24px',
+        padding: '16px 0',
         paddingBottom: '0px',
         '@media (max-width: 768px)': {
           width: '100%',
         },
       }}
     >
-      <Navbar.Section mb={24}>
+      <Navbar.Section sx={{ marginBottom: '24px', padding: '0 24px' }}>
         <Link to="/">
           <NovuLogo />
         </Link>
       </Navbar.Section>
-      <Navbar.Section sx={{ overflowY: 'auto', flex: 1 }}>
+      <Navbar.Section sx={{ overflowY: 'auto', flex: 1, padding: '0 24px' }}>
         <Popover
           classNames={classes}
           withArrow


### PR DESCRIPTION
### What change does this PR introduce?

Tweak scrollbar placement to stick to the right side of the sidebar.

### Why was this change needed?
In smaller screens or resolutions and especially in other OS (not in OSX) it looks like this:
<img width="1438" alt="Screenshot 2024-03-20 at 15 39 06" src="https://github.com/novuhq/novu/assets/1352422/2b411027-3c1b-4877-9a3a-6bc35502cdf0">

### Other information (Screenshots)

https://github.com/novuhq/novu/assets/1352422/5619bfcc-19a3-4e1c-8171-3615774b17fa



