### PR TITLE
Add exponential backoff with jitter for the In-App Notification Center to re-establish WebSocket connections

### DIFF
--- a/packages/notification-center/src/hooks/useInitializeSocket.ts
+++ b/packages/notification-center/src/hooks/useInitializeSocket.ts
@@ -9,6 +9,9 @@ type IUseInitializeSocket = (args: { socketUrl: string }) => {
   disconnectSocket: () => void;
 };
 
+const RECONNECTION_DELAY_MAX = 60000 * 5; // 5 minutes
+const RANDOMIZATION_FACTOR = 1;
+
 export const useInitializeSocket: IUseInitializeSocket = ({ socketUrl }) => {
   const socketRef = useRef<Socket | null>(null);
 
@@ -30,7 +33,8 @@ export const useInitializeSocket: IUseInitializeSocket = ({ socketUrl }) => {
 
       if (token) {
         socketRef.current = io(socketUrl, {
-          reconnectionDelayMax: 10000,
+          reconnectionDelayMax: RECONNECTION_DELAY_MAX,
+          randomizationFactor: RANDOMIZATION_FACTOR,
           transports: ['websocket'],
           auth: {
             token: `${token}`,


### PR DESCRIPTION
### What change does this PR introduce?

During our most recent incident we observed that the In-app notification center was constantly tring to reconnect to the websocket service and creating a thundering herd on our websocket system.
https://github.com/novuhq/novu/blob/4b9b81870a9a7b0aba9c0eb6fed547a48d46333b/packages/application-generic/src/resilience/delay.ts#L8

### Why was this change needed?

This will prevent our system from being overloaded if a network failure or a upgrade happens.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
