### PR TITLE
.github: change github runners for e2e web/widget to blacksmith

### DIFF
--- a/.github/workflows/reusable-web-e2e.yml
+++ b/.github/workflows/reusable-web-e2e.yml
@@ -24,9 +24,11 @@ jobs:
       # leaving the Dashboard hanging ...
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, blacksmith-4vcpu-ubuntu-2204]
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 80
 
     permissions:
@@ -151,7 +153,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, blacksmith-4vcpu-ubuntu-2204]
     timeout-minutes: 80
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/reusable-widget-e2e.yml
+++ b/.github/workflows/reusable-widget-e2e.yml
@@ -16,7 +16,10 @@ jobs:
   # This workflow contains a single job called "build"
   e2e_widget:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, blacksmith-4vcpu-ubuntu-2204]
     timeout-minutes: 80
     permissions:
       contents: read


### PR DESCRIPTION
This change is a proof of concept to show if blacksmith runners can be faster for some of the longest running pipelines in novu's CI.

This is as per a conversation with Dima over email!