### PR TITLE
build(design-system): Add scripts for storybook build using nx

### DIFF
--- a/libs/design-system/package.json
+++ b/libs/design-system/package.json
@@ -16,7 +16,9 @@
     "dist/types"
   ],
   "scripts": {
-    "prepare": "panda codegen --clean",
+    "prepare": "pnpm prepare:panda && pnpm prepare:audit",
+    "prepare:panda": "panda codegen --clean",
+    "prepare:audit": "pnpm audit-components",
     "start": "npm run build:watch",
     "prebuild": "rimraf dist",
     "lint": "eslint --ext .ts,.tsx src",
@@ -28,7 +30,7 @@
     "build:esm:watch": "cross-env node_modules/.bin/tsc -p tsconfig.esm.json -w --preserveWatchOutput",
     "build:types": "tsc --declaration --emitDeclarationOnly --declarationMap --declarationDir dist/types -p tsconfig.json",
     "storybook": "pnpm panda --watch & storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "pnpm panda && storybook build",
     "cypress:install": "cypress install",
     "cypress:open": "cross-env NODE_ENV=test cypress open",
     "cypress:run": "cross-env NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=test cypress run --component",
@@ -95,5 +97,14 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
+  },
+  "nx": {
+    "targets": {
+      "build-storybook": {
+        "dependsOn": ["^build"],
+        "outputs": ["{projectRoot}/storybook-static"],
+        "inputs": ["{projectRoot}/.storybook", "{projectRoot}/src"]
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build:web": "nx build @novu/web",
     "build:widget": "nx build @novu/widget",
     "build:embed": "nx build @novu/embed",
-    "build:storybook": "nx run @novu/web:build-storybook",
+    "build:storybook": "nx run @novu/design-system:build-storybook",
     "test:providers": "cross-env pnpm --filter './providers/**' test",
     "release:patch": "lerna version patch --no-push",
     "release:minor": "lerna version minor --no-push",


### PR DESCRIPTION
### What change does this PR introduce?
* Add preparation scripts for component audit
* Add nx dependency array for storybook build
* Update root storybook build to targe design-system
* Add novu logo to Storybook

### Why was this change needed?
* We need to deploy Storybook to reconcile design system changes

### Other information (Screenshots)
<img width="1728" alt="image" src="https://github.com/novuhq/novu/assets/32132657/3a06d2a0-920b-4698-a9fc-2070cfb3a75c">
