### PR TITLE
feat: decluttering sentry errors

### DIFF
--- a/apps/web/src/initializeApp.ts
+++ b/apps/web/src/initializeApp.ts
@@ -26,7 +26,14 @@ export const initializeApp = () => {
         }),
       ],
       environment: ENV,
-
+      ignoreErrors: [
+        'Network Error',
+        'network error (Error)',
+        'ResizeObserver loop limit exceeded',
+        'ResizeObserver loop completed with undelivered notifications',
+        'Non-Error exception captured',
+        'Non-Error promise rejection captured',
+      ],
       /*
        * This sets the sample rate to be 10%. You may want this to be 100% while
        * in development and sample at a lower rate in production


### PR DESCRIPTION
### What change does this PR introduce?
We've noticed that some Sentry errors are not application related, and are thrown by @sentry/react, which results in that we are seeing them in the Sentry dashboard, for example [the error](https://novu-r9.sentry.io/issues/3842125709/?project=6250907&query=is%3Aunresolved&referrer=issue-stream&stream_index=1) ResizeObserver loop completed with undelivered notifications.

We would like to configure the common ignore rules in our web application.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
