### PR TITLE
fix: used mantine color scheme hook to handle color scheme

### DIFF
--- a/apps/web/src/pages/templates/WorkflowListPage.tsx
+++ b/apps/web/src/pages/templates/WorkflowListPage.tsx
@@ -52,7 +52,7 @@ const columns: IExtendedColumn<INotificationTemplateExtended>[] = [
       <Group spacing={8}>
         <Group spacing={4}>
           <When truthy={original.chimera}>
-            <Tooltip label="Workflow is handled by Chimera" position="top">
+            <Tooltip label="Workflow is handled by Echo" position="top">
               <div>
                 <Bolt color="#4c6dd4" width="24px" height="24px" />
               </div>

--- a/apps/web/src/pages/templates/components/WorkflowSidebar.tsx
+++ b/apps/web/src/pages/templates/components/WorkflowSidebar.tsx
@@ -2,16 +2,17 @@ import { ReactNode } from 'react';
 import { Title } from '@mantine/core';
 import { useNavigate } from 'react-router-dom';
 import { colors, Sidebar } from '@novu/design-system';
+import { useMantineColorScheme } from '@mantine/core';
 
 import { useBasePath } from '../hooks/useBasePath';
-import { useLocalThemePreference } from '@novu/shared-web';
 
 export const WorkflowSidebar = ({ children, title }: { children: ReactNode; title: string }) => {
   const navigate = useNavigate();
   const path = useBasePath();
-  const { themeStatus } = useLocalThemePreference();
 
-  const isDark = themeStatus === 'dark';
+  const { colorScheme } = useMantineColorScheme();
+
+  const isDark = colorScheme === 'dark';
 
   return (
     <Sidebar


### PR DESCRIPTION
### What change does this PR introduce?
1. replace useLocalThemePreference hook with useMantineColorScheme 
2. replace chimera with echo in tooltip
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

To fix this issue 

https://github.com/novuhq/novu/assets/39362422/14affa15-a3f9-4059-93ba-e94587ec75a0

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

After fix:- 

https://github.com/novuhq/novu/assets/39362422/4cfe298e-e873-410a-aea8-182bd085958a

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
