### PR TITLE
fix: handle resend error case

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -453,7 +453,7 @@ export class SendMessageEmail extends SendMessageBase {
         message,
         'error',
         'mail_unexpected_error',
-        'Error while sending email with provider',
+        error.message || error.name || 'Error while sending email with provider',
         command,
         LogCodeEnum.MAIL_PROVIDER_DELIVERY_ERROR,
         error
@@ -468,7 +468,7 @@ export class SendMessageEmail extends SendMessageBase {
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-          raw: JSON.stringify(error),
+          raw: JSON.stringify(error) === '{}' ? JSON.stringify({ message: error.message }) : JSON.stringify(error),
         })
       );
 

--- a/providers/resend/src/lib/resend.provider.ts
+++ b/providers/resend/src/lib/resend.provider.ts
@@ -43,6 +43,10 @@ export class ResendEmailProvider implements IEmailProvider {
       bcc: options.bcc,
     });
 
+    if (response.error) {
+      throw new Error(response.error.message);
+    }
+
     return {
       id: response.data?.id,
       date: new Date().toISOString(),


### PR DESCRIPTION
### What change does this PR introduce?
1. handled resend error case
2. updated email message usecase raw field for error case
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
1. [Discord](https://discord.com/channels/895029566685462578/1224393606950031560)
2. [Slack](https://novu.slack.com/archives/C04STJLFJ65/p1711442745444539?thread_ts=1711376460.553099&cid=C04STJLFJ65)
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

Below is the error and success response format from Resend 👇🏻

![Screenshot 2024-04-02 at 5 59 16 PM](https://github.com/novuhq/novu/assets/39362422/0e8bf3e5-0292-4949-8383-243c091bc1d2)


<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
