### PR TITLE
chore(infra): Remove CI steps for redundant general worker

### DIFF
--- a/.github/workflows/dev-deploy-worker.yml
+++ b/.github/workflows/dev-deploy-worker.yml
@@ -64,20 +64,8 @@ jobs:
           docker_name: ${{ matrix.name }}
           bullmq_secret: ${{ secrets.BULL_MQ_PRO_NPM_TOKEN }}
 
-  # Temporary for the migration phase
-  deploy_general_worker:
-    needs: build_dev_worker
-    uses: ./.github/workflows/reusable-app-service-deploy.yml
-    secrets: inherit
-    with:
-      environment: Development
-      service_name: worker
-      terraform_workspace: novu-dev
-      # This is a workaround to an issue with matrix outputs
-      docker_image: ghcr.io/novuhq/novu/worker-ee:${{ github.sha }}
-
   deploy_dev_workers:
-    needs: deploy_general_worker
+    needs: build_dev_worker
     uses: ./.github/workflows/reusable-workers-service-deploy.yml
     secrets: inherit
     with:

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -95,20 +95,8 @@ jobs:
           docker push ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
           echo "IMAGE=ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-  # Temporary for the migration phase
-  deploy_general_worker_eu:
-    needs: build_prod_image
-    uses: ./.github/workflows/reusable-app-service-deploy.yml
-    secrets: inherit
-    with:
-      environment: Production
-      service_name: worker
-      terraform_workspace: novu-prod-eu
-      # This is a workaround to an issue with matrix outputs
-      docker_image: ghcr.io/novuhq/novu/worker-ee:${{ github.sha }}
-
   deploy_prod_workers_eu:
-    needs: deploy_general_worker_eu
+    needs: build_prod_image
     uses: ./.github/workflows/reusable-workers-service-deploy.yml
     secrets: inherit
     with:
@@ -117,25 +105,8 @@ jobs:
       # This is a workaround to an issue with matrix outputs
       docker_image: ghcr.io/novuhq/novu/worker-ee:${{ github.sha }}
 
-
-  # Temporary for the migration phase
-  deploy_general_worker_us:
-    needs:
-      - deploy_prod_workers_eu
-      - build_prod_image
-    uses: ./.github/workflows/reusable-app-service-deploy.yml
-    secrets: inherit
-    with:
-      environment: Production
-      service_name: worker
-      terraform_workspace: novu-prod
-      # This is a workaround to an issue with matrix outputs
-      docker_image: ghcr.io/novuhq/novu/worker-ee:${{ github.sha }}
-
   deploy_prod_workers_us:
-    needs:
-      - deploy_general_worker_us
-      - build_prod_image
+    needs: build_prod_image
     uses: ./.github/workflows/reusable-workers-service-deploy.yml
     secrets: inherit
     with:


### PR DESCRIPTION
### What change does this PR introduce?
* Remove CI steps for deploying Dev+Prod-US+Prod-EU redundant general worker

### Why was this change needed?
* The general worker has been removed from the infrastructure as code

### Other information (Screenshots)
The Github workflow is currently failing due to missing TF outputs:
https://github.com/novuhq/novu/actions/runs/8530276325/job/23368621576#step:8:13
