### PR TITLE
fix(worker): Skip template rendering for Echo Workflow steps

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
@@ -89,12 +89,14 @@ export class SendMessageChat extends SendMessageBase {
     let content = '';
 
     try {
-      content = await this.compileTemplate.execute(
-        CompileTemplateCommand.create({
-          template: step.template.content as string,
-          data: this.getCompilePayload(command.compileContext),
-        })
-      );
+      if (!command.chimeraData) {
+        content = await this.compileTemplate.execute(
+          CompileTemplateCommand.create({
+            template: step.template.content as string,
+            data: this.getCompilePayload(command.compileContext),
+          })
+        );
+      }
     } catch (e) {
       await this.sendErrorHandlebars(command.job, e.message);
 

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
@@ -107,25 +107,27 @@ export class SendMessageInApp extends SendMessageBase {
     }
 
     try {
-      const compiled = await this.compileInAppTemplate.execute(
-        CompileInAppTemplateCommand.create({
-          organizationId: command.organizationId,
-          environmentId: command.environmentId,
-          payload: this.getCompilePayload(command.compileContext),
-          content: step.template.content as string,
-          cta: step.template.cta,
-          userId: command.userId,
-        }),
-        this.initiateTranslations.bind(this)
-      );
-      content = compiled.content;
+      if (!command.chimeraData) {
+        const compiled = await this.compileInAppTemplate.execute(
+          CompileInAppTemplateCommand.create({
+            organizationId: command.organizationId,
+            environmentId: command.environmentId,
+            payload: this.getCompilePayload(command.compileContext),
+            content: step.template.content as string,
+            cta: step.template.cta,
+            userId: command.userId,
+          }),
+          this.initiateTranslations.bind(this)
+        );
+        content = compiled.content;
 
-      if (step.template.cta?.data?.url) {
-        step.template.cta.data.url = compiled.url;
-      }
+        if (step.template.cta?.data?.url) {
+          step.template.cta.data.url = compiled.url;
+        }
 
-      if (step.template.cta?.action?.buttons) {
-        step.template.cta.action.buttons = compiled.ctaButtons;
+        if (step.template.cta?.action?.buttons) {
+          step.template.cta.action.buttons = compiled.ctaButtons;
+        }
       }
     } catch (e) {
       await this.sendErrorHandlebars(command.job, e.message);

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
@@ -91,19 +91,21 @@ export class SendMessagePush extends SendMessageBase {
     let title = '';
 
     try {
-      content = await this.compileTemplate.execute(
-        CompileTemplateCommand.create({
-          template: step.template?.content as string,
-          data,
-        })
-      );
+      if (!command.chimeraData) {
+        content = await this.compileTemplate.execute(
+          CompileTemplateCommand.create({
+            template: step.template?.content as string,
+            data,
+          })
+        );
 
-      title = await this.compileTemplate.execute(
-        CompileTemplateCommand.create({
-          template: step.template?.title as string,
-          data,
-        })
-      );
+        title = await this.compileTemplate.execute(
+          CompileTemplateCommand.create({
+            template: step.template?.title as string,
+            data,
+          })
+        );
+      }
     } catch (e) {
       await this.sendErrorHandlebars(command.job, e.message);
 

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
@@ -89,12 +89,14 @@ export class SendMessageSms extends SendMessageBase {
     let content: string | null = '';
 
     try {
-      content = await this.compileTemplate.execute(
-        CompileTemplateCommand.create({
-          template: step.template.content as string,
-          data: this.getCompilePayload(command.compileContext),
-        })
-      );
+      if (!command.chimeraData) {
+        content = await this.compileTemplate.execute(
+          CompileTemplateCommand.create({
+            template: step.template.content as string,
+            data: this.getCompilePayload(command.compileContext),
+          })
+        );
+      }
     } catch (e) {
       await this.sendErrorHandlebars(command.job, e.message);
 


### PR DESCRIPTION
### What change does this PR introduce?
* Skip template rendering for Push, SMS, In-App, and Chat channels when chimera content is present

### Why was this change needed?
Push, SMS, and Chat channels re-map some payload attributes (e.g. for SMS, `content` becomes `body`). This causes the template rendering to be passed a falsy object, and subsequently, template rendering fails with the following error seen in the Activity Log (see other info).

The Email channel already has this conditional skip (https://github.com/novuhq/novu/blob/next/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts#L205) and therefore is working correctly. The remaining channels are updated to skip rendering.

Due to the In-App channel not having any payload remapping, this channel was not impacted, but has been updated also for consistency.

### Other information (Screenshots)
_Push_
<img width="834" alt="image" src="https://github.com/novuhq/novu/assets/32132657/86390636-e73e-41f5-84cc-c2eb9bafd215">

_SMS_
<img width="835" alt="image" src="https://github.com/novuhq/novu/assets/32132657/f2386193-ebc1-44b1-a3ad-05f9ba52f01b">

_Chat_
<img width="831" alt="image" src="https://github.com/novuhq/novu/assets/32132657/0c9e7c80-4038-416a-bc42-53938ca28017">
N/A