### PR TITLE
fix(worker): Move missing SMS content check inside echo conditional

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
@@ -96,15 +96,15 @@ export class SendMessageSms extends SendMessageBase {
             data: this.getCompilePayload(command.compileContext),
           })
         );
+
+        if (!content) {
+          throw new PlatformException(`Unexpected error: SMS content is missing`);
+        }
       }
     } catch (e) {
       await this.sendErrorHandlebars(command.job, e.message);
 
       return;
-    }
-
-    if (!content) {
-      throw new PlatformException(`Unexpected error: SMS content is missing`);
     }
 
     const phone = command.payload.phone || subscriber.phone;


### PR DESCRIPTION
### What change does this PR introduce?
* Move missing SMS content check inside echo conditional

### Why was this change needed?
SMS channel requires content to be present for successful delivery. This change moves the content check inside the echo conditional branch

### Other information (Screenshots)
N/A