### PR TITLE
fix(notification-center,widget): infinite scroll issue

### DIFF
--- a/apps/widget/cypress/e2e/notifications-list.spec.ts
+++ b/apps/widget/cypress/e2e/notifications-list.spec.ts
@@ -171,11 +171,12 @@ describe('Notifications List', function () {
     cy.getByTestId('unseen-count-label').should('contain', '99+');
   });
 
-  it('pagination check', async function () {
+  it('pagination check', function () {
     cy.wait('@getNotificationsFirstPage');
     cy.task('createNotifications', {
       organizationId: this.session.organization._id,
       enumerate: true,
+      ordered: true,
       identifier: this.session.templates[0].triggers[0].identifier,
       token: this.session.token,
       subscriberId: this.session.subscriber.subscriberId,
@@ -206,5 +207,5 @@ describe('Notifications List', function () {
 });
 
 function scrollToBottom() {
-  cy.getByTestId('notifications-scroll-area').get('.infinite-scroll-component').scrollTo('bottom');
+  cy.getByTestId('notifications-scroll-area').scrollTo('bottom', { ensureScrollable: true });
 }

--- a/apps/widget/cypress/plugins/index.ts
+++ b/apps/widget/cypress/plugins/index.ts
@@ -33,6 +33,7 @@ module.exports = (on, config) => {
       count = 1,
       organizationId,
       enumerate = false,
+      ordered = false,
     }) {
       const triggerIdentifier = identifier;
       const service = new NotificationsService(token);
@@ -44,6 +45,9 @@ module.exports = (on, config) => {
         await service.triggerEvent(triggerIdentifier, subscriberId, {
           firstName: `John${num}`,
         });
+        if (ordered) {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
       }
 
       if (organizationId) {

--- a/packages/notification-center/src/components/notification-center/components/NotificationsList.tsx
+++ b/packages/notification-center/src/components/notification-center/components/NotificationsList.tsx
@@ -47,4 +47,5 @@ export function NotificationsList({
 
 const notificationsListCss = css`
   height: 400px;
+  overflow-y: auto;
 `;


### PR DESCRIPTION
### What change does this PR introduce?

Fixes the issue introduced in: #5019, with not scrollable parent component.
Fixes the Widget test for the infinite scroll which was always passing, and makes sure that the scroll event is triggered on the scrollable element.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)


https://github.com/novuhq/novu/assets/2607232/9bd2fd91-e95a-4a8b-8da0-6e7fac39462d



https://github.com/novuhq/novu/assets/2607232/be3ec601-f2d7-4baf-b900-ec4e074e19af


