### PR TITLE
fix(web): make InApp code editor fit the height of its parent container

### DIFF
--- a/apps/web/src/pages/templates/components/in-app-editor/InAppEditorBlock.tsx
+++ b/apps/web/src/pages/templates/components/in-app-editor/InAppEditorBlock.tsx
@@ -132,7 +132,7 @@ function ContentContainerController() {
       data-test-id="in-app-content-form-item"
       control={control}
       render={({ field }) => {
-        return <CustomCodeEditor height="100px" onChange={field.onChange} value={field.value} />;
+        return <CustomCodeEditor height="100%" onChange={field.onChange} value={field.value} />;
       }}
     />
   );


### PR DESCRIPTION
### What change does this PR introduce?

The code editor was using a fixed height of 100px. Making it scroll even when there is available space.
This changes makes it take full height of its parent

### Other information (Screenshots)
Before:
![Screenshot from 2024-04-06 02-58-01](https://github.com/FlacorLopes/novu/assets/1523957/1fe19193-ec1e-4b76-8cd5-c8de9f08b9b0)

After:
![Screenshot from 2024-04-06 02-59-13](https://github.com/FlacorLopes/novu/assets/1523957/847a2634-14d9-4890-875d-20df89198632)
