### PR TITLE
feat(web,api): user profile page form

### DIFF
--- a/apps/api/src/app/user/dtos/update-profile-request.dto.ts
+++ b/apps/api/src/app/user/dtos/update-profile-request.dto.ts
@@ -8,5 +8,5 @@ export class UpdateProfileRequestDto {
   lastName: string;
 
   @ApiProperty()
-  imageUrl: string;
+  profilePicture?: string;
 }

--- a/apps/api/src/app/user/e2e/update-name-and-profile-picture.e2e.ts
+++ b/apps/api/src/app/user/e2e/update-name-and-profile-picture.e2e.ts
@@ -1,13 +1,8 @@
-import { EnvironmentRepository, OrganizationRepository, UserEntity, UserRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
 describe('Update user name and profile picture - /users/profile (PUT)', async () => {
   let session: UserSession;
-
-  const environmentRepository = new EnvironmentRepository();
-  const organizationRepository = new OrganizationRepository();
-  const userRepository = new UserRepository();
 
   before(async () => {
     session = new UserSession();
@@ -15,31 +10,34 @@ describe('Update user name and profile picture - /users/profile (PUT)', async ()
   });
 
   it('should update the user name and profile picture', async () => {
-    const { statusCode } = await session.testAgent.put('/v1/users/profile').send({
+    const profilePicture = 'https://example.com/profile-picture.jpg';
+    const {
+      body: { data },
+      statusCode,
+    } = await session.testAgent.put('/v1/users/profile').send({
       firstName: 'John',
       lastName: 'Doe',
-      imageUrl: 'https://example.com/profile-picture.jpg',
+      profilePicture: profilePicture,
     });
 
-    expect(statusCode).to.equal(204);
-
-    const user = (await userRepository.findOne({ _id: session.user._id })) as UserEntity;
-    expect(user.firstName).to.equal('John');
-    expect(user.lastName).to.equal('Doe');
-    expect(user.profilePicture).to.equal('https://example.com/profile-picture.jpg');
+    expect(statusCode).to.equal(200);
+    expect(data.firstName).to.equal('John');
+    expect(data.lastName).to.equal('Doe');
+    expect(data.profilePicture).to.equal(profilePicture);
   });
 
   it('should update the user name', async () => {
-    const { statusCode } = await session.testAgent.put('/v1/users/profile').send({
+    const {
+      body: { data },
+      statusCode,
+    } = await session.testAgent.put('/v1/users/profile').send({
       firstName: 'John',
       lastName: 'Doe',
     });
 
-    expect(statusCode).to.equal(204);
-
-    const user = (await userRepository.findOne({ _id: session.user._id })) as UserEntity;
-    expect(user.firstName).to.equal('John');
-    expect(user.lastName).to.equal('Doe');
+    expect(statusCode).to.equal(200);
+    expect(data.firstName).to.equal('John');
+    expect(data.lastName).to.equal('Doe');
   });
 
   it('should throw when invalid first name or last name provided', async () => {
@@ -58,19 +56,5 @@ describe('Update user name and profile picture - /users/profile (PUT)', async ()
 
     expect(body2.statusCode).to.equal(400);
     expect(body2.message).to.equal('First name and last name are required');
-  });
-
-  it('should remove the profile picture when imageUrl is not provided', async () => {
-    const { statusCode } = await session.testAgent.put('/v1/users/profile').send({
-      firstName: 'John',
-      lastName: 'Doe',
-    });
-
-    expect(statusCode).to.equal(204);
-
-    const user = (await userRepository.findOne({ _id: session.user._id })) as UserEntity;
-    expect(user.firstName).to.equal('John');
-    expect(user.lastName).to.equal('Doe');
-    expect(user.profilePicture).to.not.exist;
   });
 });

--- a/apps/api/src/app/user/usecases/update-name-and-profile-picture/update-name-and-profile-picture.command.ts
+++ b/apps/api/src/app/user/usecases/update-name-and-profile-picture/update-name-and-profile-picture.command.ts
@@ -1,10 +1,17 @@
 import { IsDefined, IsOptional, IsString, IsUrl } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+import { IsImageUrl } from '../../../shared/validators/image.validator';
 
 export class UpdateNameAndProfilePictureCommand extends EnvironmentWithUserCommand {
-  @IsUrl({ require_tld: false })
+  @IsUrl({
+    require_protocol: true,
+    protocols: ['https'],
+  })
+  @IsImageUrl({
+    message: 'Profile picture must be a valid image URL with one of the following extensions: jpg, jpeg, png, gif, svg',
+  })
   @IsOptional()
-  imageUrl: string;
+  profilePicture?: string;
 
   @IsDefined()
   @IsString()

--- a/apps/api/src/app/user/user.controller.ts
+++ b/apps/api/src/app/user/user.controller.ts
@@ -115,18 +115,17 @@ export class UsersController {
     summary: 'Update user name and profile picture',
   })
   @ExternalApiAccessible()
-  @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiNoContentResponse({
-    description: 'Profile updated successfully.',
-  })
-  async updateProfile(@UserSession() user: IJwtPayload, @Body() body: UpdateProfileRequestDto) {
+  async updateProfile(
+    @UserSession() user: IJwtPayload,
+    @Body() body: UpdateProfileRequestDto
+  ): Promise<UserResponseDto> {
     return await this.updateNameAndProfilePictureUsecase.execute(
       UpdateNameAndProfilePictureCommand.create({
         userId: user._id,
         environmentId: user.environmentId,
         firstName: body.firstName,
         lastName: body.lastName,
-        imageUrl: body.imageUrl,
+        profilePicture: body.profilePicture,
         organizationId: user.organizationId,
       })
     );

--- a/apps/web/src/api/hooks/index.ts
+++ b/apps/web/src/api/hooks/index.ts
@@ -9,3 +9,4 @@ export * from './usePreviewSms';
 export * from './usePreviewPush';
 export * from './usePreviewChat';
 export * from './usePreviewInApp';
+export * from './useUpdateUserProfile';

--- a/apps/web/src/api/hooks/useUpdateUserProfile.ts
+++ b/apps/web/src/api/hooks/useUpdateUserProfile.ts
@@ -1,0 +1,35 @@
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+import type { IResponseError, IUserEntity } from '@novu/shared';
+
+import { updateUserProfile } from '../user';
+
+interface IUpdateUserProfileVariables {
+  firstName: string;
+  lastName: string;
+  profilePicture?: string | null;
+}
+
+export const useUpdateUserProfile = (
+  options: UseMutationOptions<IUserEntity, IResponseError, IUpdateUserProfileVariables> = {}
+) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: updateUserProfileMutation, ...rest } = useMutation<
+    IUserEntity,
+    IResponseError,
+    IUpdateUserProfileVariables
+  >(updateUserProfile, {
+    ...options,
+    onSuccess: async (data, variables, context) => {
+      options.onSuccess?.(data, variables, context);
+      if (data) {
+        queryClient.setQueryData(['/v1/users/me'], data);
+      }
+    },
+  });
+
+  return {
+    updateUserProfile: updateUserProfileMutation,
+    ...rest,
+  };
+};

--- a/apps/web/src/api/user.ts
+++ b/apps/web/src/api/user.ts
@@ -1,3 +1,5 @@
+import { IUserEntity } from '@novu/shared';
+
 import { api } from './api.client';
 
 export async function getUser() {
@@ -10,4 +12,16 @@ export async function updateUserOnBoarding(showOnBoarding: boolean) {
 
 export async function updateUserOnBoardingTour(showOnBoardingTour: number) {
   return api.put('/v1/users/onboarding-tour', { showOnBoardingTour });
+}
+
+export async function updateUserProfile({
+  firstName,
+  lastName,
+  profilePicture,
+}: {
+  firstName: string;
+  lastName: string;
+  profilePicture?: string | null;
+}): Promise<IUserEntity> {
+  return api.put('/v1/users/profile', { firstName, lastName, profilePicture });
 }

--- a/apps/web/src/components/shared/ProfileImage.tsx
+++ b/apps/web/src/components/shared/ProfileImage.tsx
@@ -9,7 +9,7 @@ interface ProfileImageProps {
   /**
    * **NOTE**: Value should be URL string
    */
-  value: string;
+  value?: string | null;
 
   /**
    * **NOTE**: convert the File value to string URL to display the image

--- a/apps/web/src/pages/settings/user-profile-page/UserProfileForm.tsx
+++ b/apps/web/src/pages/settings/user-profile-page/UserProfileForm.tsx
@@ -1,0 +1,105 @@
+import { FC } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import * as capitalize from 'lodash.capitalize';
+import { Button, errorMessage, Input, successMessage } from '@novu/design-system';
+import type { IUserEntity } from '@novu/shared';
+
+import { css } from '../../../styled-system/css';
+import { ProfileImage } from '../../../components/shared';
+import { useUpdateUserProfile } from '../../../api/hooks';
+
+interface IUserProfileForm {
+  firstName: string;
+  lastName: string;
+}
+
+interface IUserProfileFormProps {
+  currentUser?: IUserEntity | null;
+}
+
+const formInputStyles = css({
+  minWidth: '18.75rem',
+  '& label': { marginTop: '0 !important' },
+  '& .mantine-TextInput-error': { position: 'absolute', marginTop: '0.5rem' },
+  '& input, .mantine-TextInput-wrapper': { marginBottom: '0 !important' },
+});
+
+const FIRST_NAME_LABEL = 'First name';
+const LAST_NAME_LABEL = 'Last name';
+const MIN_LENGTH_RULE = { value: 2, message: 'Should be longer than 2 characters' };
+
+const makeFormData = (data?: IUserEntity | null): IUserProfileForm => ({
+  firstName: capitalize(data?.firstName ?? ''),
+  lastName: capitalize(data?.lastName ?? ''),
+});
+
+export const UserProfileForm: FC<IUserProfileFormProps> = ({ currentUser }) => {
+  const {
+    register,
+    reset,
+    handleSubmit,
+    formState: { isDirty, errors },
+  } = useForm<IUserProfileForm>({
+    mode: 'onSubmit',
+    defaultValues: makeFormData(currentUser),
+  });
+
+  const { updateUserProfile, isLoading: isUpdatingUserProfile } = useUpdateUserProfile({
+    onSuccess: (newUserData) => {
+      successMessage('Profile updated successfully');
+      reset(makeFormData(newUserData));
+    },
+    onError: (e) => {
+      errorMessage('Failed to update profile: ' + e.message);
+    },
+  });
+
+  const onUpdateUserProfileHandler: SubmitHandler<IUserProfileForm> = ({ firstName, lastName }) => {
+    updateUserProfile({ firstName, lastName });
+  };
+
+  const onUpdateUserProfileImageHandler = async (_: File[]) => {
+    // TODO: Implement image upload
+  };
+
+  return (
+    <form
+      noValidate
+      onSubmit={handleSubmit(onUpdateUserProfileHandler)}
+      className={css({ display: 'flex', alignItems: 'flex-end', gap: '150', marginBottom: '2.5rem' })}
+    >
+      <ProfileImage
+        name="Profile picture"
+        onChange={onUpdateUserProfileImageHandler}
+        value={currentUser?.profilePicture}
+      />
+      <Input
+        className={formInputStyles}
+        {...register('firstName', {
+          required: `${FIRST_NAME_LABEL} is required`,
+          minLength: MIN_LENGTH_RULE,
+        })}
+        error={errors.firstName?.message}
+        label={FIRST_NAME_LABEL}
+      />
+      <Input
+        className={formInputStyles}
+        {...register('lastName', {
+          required: `${LAST_NAME_LABEL} is required`,
+          minLength: MIN_LENGTH_RULE,
+        })}
+        error={errors.lastName?.message}
+        label={LAST_NAME_LABEL}
+      />
+      <Button
+        size="lg"
+        type="submit"
+        className={css({ alignSelf: 'flex-end' })}
+        disabled={!isDirty || isUpdatingUserProfile}
+        loading={isUpdatingUserProfile}
+      >
+        Update
+      </Button>
+    </form>
+  );
+};

--- a/apps/web/src/pages/settings/user-profile-page/UserProfilePage.tsx
+++ b/apps/web/src/pages/settings/user-profile-page/UserProfilePage.tsx
@@ -7,6 +7,7 @@ import { styled } from '../../../styled-system/jsx';
 import { title } from '../../../styled-system/recipes';
 import { InputPlain } from '../components';
 import { SettingsPageContainer } from '../SettingsPageContainer';
+import { UserProfileForm } from './UserProfileForm';
 
 const Title = styled('h2', title);
 
@@ -17,6 +18,7 @@ export const UserProfilePage: FC = () => {
 
   return (
     <SettingsPageContainer title="User profile">
+      <UserProfileForm currentUser={currentUser} />
       <Title mb="100" variant="section">
         Profile security
       </Title>


### PR DESCRIPTION
### What change does this PR introduce?

Information Architecture:
- User Profile Page form
- Changed the API endpoint to update user profile data `PUT /users/profile`
- The image uploading will be implemented in separate PR

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

https://github.com/novuhq/novu/assets/2607232/754fc609-8a02-4458-b197-8b6689bddfd0

https://github.com/novuhq/novu/assets/2607232/dc5c4918-64b5-4a82-a2dc-9c4fefb1b47b






