### PR TITLE
fix: Ensure health check return the correct status

### DIFF
--- a/apps/api/src/app/health/health.controller.ts
+++ b/apps/api/src/app/health/health.controller.ts
@@ -1,6 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
-import { HealthCheck, HealthCheckResult, HealthCheckService, HealthIndicatorFunction } from '@nestjs/terminus';
+import {
+  HealthCheck,
+  HealthCheckResult,
+  HealthCheckService,
+  HealthIndicatorFunction,
+  HealthCheckError,
+} from '@nestjs/terminus';
 import {
   CacheServiceHealthIndicator,
   DalServiceHealthIndicator,
@@ -25,14 +31,12 @@ export class HealthController {
     const checks: HealthIndicatorFunction[] = [
       async () => this.dalHealthIndicator.isHealthy(),
       async () => this.workflowQueueHealthIndicator.isHealthy(),
-      async () => {
-        return {
-          apiVersion: {
-            version,
-            status: 'up',
-          },
-        };
-      },
+      async () => ({
+        apiVersion: {
+          version,
+          status: 'up',
+        },
+      }),
     ];
 
     if (process.env.ELASTICACHE_CLUSTER_SERVICE_HOST) {

--- a/apps/webhook/src/health/health.controller.ts
+++ b/apps/webhook/src/health/health.controller.ts
@@ -12,14 +12,12 @@ export class HealthController {
   @HealthCheck()
   async healthCheck(): Promise<HealthCheckResult> {
     const result = await this.healthCheckService.check([
-      async () => {
-        return {
-          apiVersion: {
-            version,
-            status: 'up',
-          },
-        };
-      },
+      async () => ({
+        apiVersion: {
+          version,
+          status: 'up',
+        },
+      }),
       () => this.dalHealthIndicator.isHealthy(),
     ]);
 

--- a/apps/worker/src/app/health/health.controller.ts
+++ b/apps/worker/src/app/health/health.controller.ts
@@ -21,14 +21,12 @@ export class HealthController {
     return this.healthCheckService.check([
       async () => this.dalHealthIndicator.isHealthy(),
       ...this.healthIndicators.map((indicator) => async () => indicator.isHealthy()),
-      async () => {
-        return {
-          apiVersion: {
-            version,
-            status: 'up',
-          },
-        };
-      },
+      async () => ({
+        apiVersion: {
+          version,
+          status: 'up',
+        },
+      }),
     ]);
   }
 }

--- a/apps/ws/src/health/health.controller.ts
+++ b/apps/ws/src/health/health.controller.ts
@@ -23,14 +23,12 @@ export class HealthController {
       ...indicatorHealthCheckFunctions,
       async () => this.dalHealthIndicator.isHealthy(),
       async () => this.wsServerHealthIndicator.isHealthy(),
-      async () => {
-        return {
-          apiVersion: {
-            version,
-            status: 'up',
-          },
-        };
-      },
+      async () => ({
+        apiVersion: {
+          version,
+          status: 'up',
+        },
+      }),
     ]);
 
     return result;

--- a/apps/ws/src/socket/services/ws-server-health-indicator.service.ts
+++ b/apps/ws/src/socket/services/ws-server-health-indicator.service.ts
@@ -1,4 +1,4 @@
-import { HealthIndicator, HealthIndicatorResult } from '@nestjs/terminus';
+import { HealthCheckError, HealthIndicator, HealthIndicatorResult } from '@nestjs/terminus';
 import { Injectable } from '@nestjs/common';
 
 import { IHealthIndicator } from '@novu/application-generic';
@@ -7,16 +7,21 @@ import { WSGateway } from '../ws.gateway';
 
 @Injectable()
 export class WSServerHealthIndicator extends HealthIndicator implements IHealthIndicator {
-  private INDICATOR_KEY = 'ws-server';
+  private static KEY = 'ws-server';
 
   constructor(private wsGateway: WSGateway) {
     super();
   }
 
   async isHealthy(): Promise<HealthIndicatorResult> {
-    const status = !!this.wsGateway.server;
+    const isHealthy = !!this.wsGateway.server;
+    const result = this.getStatus(WSServerHealthIndicator.KEY, isHealthy);
 
-    return this.getStatus(this.INDICATOR_KEY, status);
+    if (isHealthy) {
+      return result;
+    }
+
+    throw new HealthCheckError('WS server health check failed', result);
   }
 
   isActive(): Promise<HealthIndicatorResult> {

--- a/packages/application-generic/src/health/cache.health-indicator.ts
+++ b/packages/application-generic/src/health/cache.health-indicator.ts
@@ -3,34 +3,25 @@ import {
   HealthIndicator,
   HealthIndicatorResult,
 } from '@nestjs/terminus';
-import { Injectable, Logger } from '@nestjs/common';
-
+import { Injectable } from '@nestjs/common';
 import { CacheService } from '../services/cache';
-
-const LOG_CONTEXT = 'CacheServiceHealthIndicator';
 
 @Injectable()
 export class CacheServiceHealthIndicator extends HealthIndicator {
-  private INDICATOR_KEY = 'cacheService';
+  private static KEY = 'cacheService';
 
   constructor(private cacheService: CacheService) {
     super();
   }
 
   async isHealthy(): Promise<HealthIndicatorResult> {
-    const isReady = this.cacheService.cacheEnabled();
+    const isHealthy = this.cacheService.cacheEnabled();
+    const result = this.getStatus(CacheServiceHealthIndicator.KEY, isHealthy);
 
-    if (isReady) {
-      Logger.verbose('CacheService is ready', LOG_CONTEXT);
-
-      return this.getStatus(this.INDICATOR_KEY, true);
+    if (isHealthy) {
+      return result;
     }
 
-    Logger.verbose('CacheServiceHealthIndicator is not ready', LOG_CONTEXT);
-
-    throw new HealthCheckError(
-      'Cache Health',
-      this.getStatus(this.INDICATOR_KEY, false)
-    );
+    throw new HealthCheckError('Cache health check failed', result);
   }
 }

--- a/packages/application-generic/src/health/dal.health-indicator.ts
+++ b/packages/application-generic/src/health/dal.health-indicator.ts
@@ -1,4 +1,8 @@
-import { HealthIndicator, HealthIndicatorResult } from '@nestjs/terminus';
+import {
+  HealthCheckError,
+  HealthIndicator,
+  HealthIndicatorResult,
+} from '@nestjs/terminus';
 import { Injectable } from '@nestjs/common';
 import { DalService } from '@novu/dal';
 import { IHealthIndicator } from './health-indicator.interface';
@@ -8,16 +12,21 @@ export class DalServiceHealthIndicator
   extends HealthIndicator
   implements IHealthIndicator
 {
-  private INDICATOR_KEY = 'db';
+  private static KEY = 'db';
 
   constructor(private dalService: DalService) {
     super();
   }
 
   async isHealthy(): Promise<HealthIndicatorResult> {
-    const status = this.dalService.connection.readyState === 1;
+    const isHealthy = this.dalService.connection.readyState === 1;
+    const result = this.getStatus(DalServiceHealthIndicator.KEY, isHealthy);
 
-    return this.getStatus(this.INDICATOR_KEY, status);
+    if (isHealthy) {
+      return result;
+    }
+
+    throw new HealthCheckError('DAL health check failed', result);
   }
 
   isActive(): Promise<HealthIndicatorResult> {


### PR DESCRIPTION
### What change does this PR introduce?

This PR throws the Terminus error when the indicator is unhealthy and applies minor code refactorings to most health indicators. Throwing the right error results in the correct status page result (see screenshots). 

### Why was this change needed?

Currently, the DAL and Cache health checks won't cause the overall health status of the app to return an error, as Terminus requires us to throw a HealthCheck error from the indicator when its status is unhealthy.

For more information, refer to https://docs.nestjs.com/recipes/terminus#custom-health-indicator

### Screenshots

![Screenshot 2024-04-10 at 12 36 42](https://github.com/novuhq/novu/assets/1352422/b740a190-db44-47a2-a27c-67969401554f)
![Screenshot 2024-04-10 at 12 01 56](https://github.com/novuhq/novu/assets/1352422/ec57a854-4afd-4643-95a5-203cf77ec73a)

