### PR TITLE
fix: Ensure panda works with nested output directory

### DIFF
--- a/apps/web/panda.config.ts
+++ b/apps/web/panda.config.ts
@@ -38,6 +38,9 @@ export default defineConfig({
   // The output directory for your css system
   outdir: './src/styled-system',
 
+  // Recommended by panda maintainer due to potential bug with nesting styled-system in src
+  importMap: 'styled-system',
+  
   // Enables JSX util generation!
   jsxFramework: 'react',
 });


### PR DESCRIPTION
### What change does this PR introduce?

- Add a new property to the panda config

### Why was this change needed?

- I was having issues with panda generating styles for `cva` (atomic recipes)
- A maintainer of Panda suggested that our nested output (`./src/styled-system`) was the reason, and thus suggested this as a fix ([Discord thread](https://discord.com/channels/1118988919804010566/1227407665672749088))
