### PR TITLE
feat(auth-v2): Add externalId to user and organizations

### DIFF
--- a/libs/dal/src/repositories/organization/organization.entity.ts
+++ b/libs/dal/src/repositories/organization/organization.entity.ts
@@ -30,6 +30,8 @@ export class OrganizationEntity implements IOrganizationEntity {
   createdAt: string;
 
   updatedAt: string;
+
+  externalId?: string;
 }
 
 export type OrganizationDBModel = OrganizationEntity;

--- a/libs/dal/src/repositories/organization/organization.schema.ts
+++ b/libs/dal/src/repositories/organization/organization.schema.ts
@@ -60,6 +60,7 @@ const organizationSchema = new Schema<OrganizationDBModel>(
         default: false,
       },
     },
+    externalId: Schema.Types.String,
   },
   schemaOptions
 );

--- a/libs/dal/src/repositories/user/user.entity.ts
+++ b/libs/dal/src/repositories/user/user.entity.ts
@@ -53,6 +53,8 @@ export class UserEntity implements IUserEntity {
   servicesHashes?: { intercom?: string };
 
   jobTitle?: JobTitleEnum;
+
+  externalId?: string;
 }
 
 export type UserDBModel = UserEntity;

--- a/libs/dal/src/repositories/user/user.schema.ts
+++ b/libs/dal/src/repositories/user/user.schema.ts
@@ -41,6 +41,7 @@ const userSchema = new Schema<UserDBModel>(
       intercom: Schema.Types.String,
     },
     jobTitle: Schema.Types.String,
+    externalId: Schema.Types.String,
   },
   schemaOptions
 );

--- a/libs/shared/src/entities/organization/organization.interface.ts
+++ b/libs/shared/src/entities/organization/organization.interface.ts
@@ -18,4 +18,5 @@ export interface IOrganizationEntity {
   productUseCases?: ProductUseCases;
   createdAt: string;
   updatedAt: string;
+  externalId?: string;
 }

--- a/libs/shared/src/entities/user/user.interface.ts
+++ b/libs/shared/src/entities/user/user.interface.ts
@@ -14,4 +14,5 @@ export interface IUserEntity {
   showOnBoardingTour?: number;
   servicesHashes?: IServicesHashes;
   jobTitle?: JobTitleEnum;
+  externalId?: string;
 }


### PR DESCRIPTION
### What change does this PR introduce?

Introduce `externalId` field to user and organization collections. 

### Why was this change needed?

Store the unique id of the external user management provider.