### PR TITLE
fix(worker): Provide correct execution context to Echo endpoints

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/digest/digest.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/digest/digest.usecase.ts
@@ -71,11 +71,13 @@ export class Digest extends SendMessageType {
       })
     );
 
+    const jobsToUpdate = [...nextJobs.map((job) => job._id), command.job._id];
+
     await this.jobRepository.update(
       {
         _environmentId: command.environmentId,
         _id: {
-          $in: nextJobs.map((job) => job._id),
+          $in: jobsToUpdate,
         },
       },
       {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -88,13 +88,16 @@ export class SendMessage {
 
     const stepType = command.step?.template?.type;
 
-    const chimeraResponse = await this.chimeraConnector.execute<
-      SendMessageCommand & { variables: IFilterVariables },
-      ExecuteOutput<IChimeraChannelResponse> | null
-    >({
-      ...command,
-      variables: shouldRun.variables,
-    });
+    let chimeraResponse: ExecuteOutput<IChimeraChannelResponse> | null = null;
+    if (!['digest', 'delay'].includes(stepType as any)) {
+      chimeraResponse = await this.chimeraConnector.execute<
+        SendMessageCommand & { variables: IFilterVariables },
+        ExecuteOutput<IChimeraChannelResponse> | null
+      >({
+        ...command,
+        variables: shouldRun.variables,
+      });
+    }
 
     if (!command.payload?.$on_boarding_trigger) {
       const usedFilters = shouldRun?.conditions.reduce(ConditionsFilter.sumFilters, {

--- a/packages/application-generic/src/usecases/add-job/add-delay-job.usecase.ts
+++ b/packages/application-generic/src/usecases/add-job/add-delay-job.usecase.ts
@@ -2,6 +2,7 @@ import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 
 import { JobRepository, JobStatusEnum } from '@novu/dal';
 import {
+  DelayTypeEnum,
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
   StepTypeEnum,
@@ -46,7 +47,13 @@ export class AddDelayJob {
         stepMetadata: data.step.metadata,
         payload: data.payload,
         overrides: data.overrides,
-        chimeraResponse: command.chimeraResponse?.outputs,
+        // TODO: Remove fallback after other delay types are implemented.
+        chimeraResponse: command.chimeraResponse?.outputs
+          ? {
+              type: DelayTypeEnum.REGULAR,
+              ...command.chimeraResponse?.outputs,
+            }
+          : undefined,
       });
 
       await this.jobRepository.updateStatus(

--- a/packages/application-generic/src/usecases/add-job/merge-or-create-digest.usecase.ts
+++ b/packages/application-generic/src/usecases/add-job/merge-or-create-digest.usecase.ts
@@ -50,7 +50,8 @@ export class MergeOrCreateDigest {
   ): Promise<MergeOrCreateDigestResultType> {
     const { job } = command;
 
-    const digestMeta = job.digest as IDigestBaseMetadata | undefined;
+    const digestMeta =
+      command.chimeraData ?? (job.digest as IDigestBaseMetadata | undefined);
     const digestKey = command.chimeraData?.digestKey ?? digestMeta?.digestKey;
     const digestValue = getNestedValue(job.payload, digestKey);
 
@@ -73,7 +74,10 @@ export class MergeOrCreateDigest {
       case DigestCreationResultEnum.SKIPPED:
         return await this.processSkippedDigest(job, command.filtered);
       case DigestCreationResultEnum.CREATED:
-        return await this.processCreatedDigest(digestMeta, job);
+        return await this.processCreatedDigest(
+          digestMeta as IDigestBaseMetadata,
+          job
+        );
       default:
         throw new ApiException('Something went wrong with digest creation');
     }


### PR DESCRIPTION
### What changed? Why was the change needed?
* Echo endpoints were not received the correct `data` and `inputs` context, resulting in the endpoints throwing a BadRequestError. This change ensures the correct context is provided to those endpoints for the `delay` and `digest` steps.

### Screenshots
See https://github.com/novuhq/packages-enterprise/pull/126

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
[<!-- A link to a dependent pull request  -->]
https://github.com/novuhq/packages-enterprise/pull/126

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
