### PR TITLE
fix: Use origin instead of host

### DIFF
--- a/apps/api/src/config/cors.spec.ts
+++ b/apps/api/src/config/cors.spec.ts
@@ -71,7 +71,7 @@ describe('CORS Configuration', () => {
             {
               url: '/v1/test',
               headers: {
-                host: 'https://test--' + process.env.PR_PREVIEW_ROOT_URL,
+                origin: 'https://test--' + process.env.PR_PREVIEW_ROOT_URL,
               },
             },
             callbackSpy

--- a/apps/api/src/config/cors.ts
+++ b/apps/api/src/config/cors.ts
@@ -10,7 +10,7 @@ export const corsOptionsDelegate: Parameters<INestApplication['enableCors']>[0] 
     methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
   };
 
-  const host = (req.headers as any)?.host || '';
+  const origin = (req.headers as any)?.origin || '';
 
   if (['test', 'local'].includes(process.env.NODE_ENV) || isWidgetRoute(req.url) || isBlueprintRoute(req.url)) {
     corsOptions.origin = '*';
@@ -23,12 +23,12 @@ export const corsOptionsDelegate: Parameters<INestApplication['enableCors']>[0] 
     const shouldDisableCorsForPreviewUrls =
       process.env.PR_PREVIEW_ROOT_URL &&
       process.env.NODE_ENV === 'dev' &&
-      host.includes(process.env.PR_PREVIEW_ROOT_URL);
+      origin.includes(process.env.PR_PREVIEW_ROOT_URL);
 
     Logger.verbose(`Should allow deploy preview? ${shouldDisableCorsForPreviewUrls ? 'Yes' : 'No'}.`, {
       curEnv: process.env.NODE_ENV,
       previewUrlRoot: process.env.PR_PREVIEW_ROOT_URL,
-      host,
+      origin,
     });
 
     if (shouldDisableCorsForPreviewUrls) {


### PR DESCRIPTION
### What changed? Why was the change needed?

- Use `origin` instead of `host` while determining CORS

### Context

Taken from [NewRelic](https://one.eu.newrelic.com/nr1-core/logger/logs-summary/MzgxMjQwOHxBUE18QVBQTElDQVRJT058NDk3NjQzODIy?account=3812408&duration=604800000&state=4aa1cd09-11ed-2121-01ee-7ea96322f3e7)
```
req.headers.host:dev.api.novu.co
...
req.headers.origin:https://dev.web.novu.co
```