### PR TITLE
ci: Use * instead of ['*']

### DIFF
--- a/apps/api/src/config/cors.spec.ts
+++ b/apps/api/src/config/cors.spec.ts
@@ -79,10 +79,7 @@ describe('CORS Configuration', () => {
 
           expect(callbackSpy.calledOnce).to.be.ok;
           expect(callbackSpy.firstCall.firstArg).to.be.null;
-          expect(callbackSpy.firstCall.lastArg.origin.length).to.equal(3);
-          expect(callbackSpy.firstCall.lastArg.origin[0]).to.equal('https://test.com');
-          expect(callbackSpy.firstCall.lastArg.origin[1]).to.equal('https://widget.com');
-          expect(callbackSpy.firstCall.lastArg.origin[2]).to.equal('*');
+          expect(callbackSpy.firstCall.lastArg.origin).to.equal('*');
         });
       }
     });


### PR DESCRIPTION
### What changed? Why was the change needed?

Unfortunately, this is still not working. While the origin code change seems to have been right anyway (yay!), it's still failing between the OPTIONS and POST requests...

Here are [the logs](https://one.eu.newrelic.com/nr1-core/logger/logs-summary/MzgxMjQwOHxBUE18QVBQTElDQVRJT058NDk3NjQzODIy?account=3812408&duration=1800000&state=95cf8453-0b31-ed61-b956-7c9a9f505491) for me logging into dev successfully (via `dev.web.novu.co`). You’ll notice that two requests have req.url: /v1/auth/login . However, when I [search by that](https://one.eu.newrelic.com/nr1-core/logger/logs-summary/MzgxMjQwOHxBUE18QVBQTElDQVRJT058NDk3NjQzODIy?account=3812408&begin=1713385225484&end=1713385345484&state=80d50e9b-44b6-f894-c625-cc241aa72ca8) immediately after trying to login via the deploy-preview, I don’t see a log like that.

I see [these logs](https://one.eu.newrelic.com/nr1-core/logger/logs-summary/MzgxMjQwOHxBUE18QVBQTElDQVRJT058NDk3NjQzODIy?account=3812408&duration=1800000&state=875bbb93-b282-e982-a567-a0b38479b185) that indicate that we are now doing the matching correctly during the OPTIONS request, but something is still going wrong after. I believe it's not responding correctly since I don't see Access-Control-Allow-Origin: * . Looking through the code, the only difference is setting origin: '*' vs pushing '*' onto the origins array... so trying that!
