### PR TITLE
feat(ci): Docker build cache

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -1,0 +1,11 @@
+name: Cache
+description: GitHub Action to expose GitHub runtime to the workflow
+runs:
+  using: composite
+  steps:
+    - name: Expose GitHub Runtime
+      uses: crazy-max/ghaction-github-runtime@v3
+    - name: Env
+      shell: bash
+      run: |
+        env|sort

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -90,8 +90,8 @@ runs:
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
         DOCKER_BUILD_ARGUMENTS: >
-          --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-          --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
           --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
       run: |

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -71,7 +71,7 @@ runs:
       shell: bash
       env:
         GH_ACTOR: ${{ github.actor }}
-        GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+        GH_PASSWORD: ${{ inputs.github_token }}
       run: |
         echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
 

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -71,7 +71,7 @@ runs:
       shell: bash
       env:
         GH_ACTOR: ${{ github.actor }}
-        GH_PASSWORD: ${{ inputs.github_token }}
+        GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
       run: |
         echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
 

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -90,9 +90,10 @@ runs:
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
         DOCKER_BUILD_ARGUMENTS: >
-          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+          --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
+          --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
       run: |
         set -x
         cd apps/api && pnpm run docker:build

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -95,7 +95,7 @@ runs:
         DOCKER_BUILD_ARGUMENTS: >
           --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.environment }}
           --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.environment }},mode=max
-          --platform=linux/amd64,linux/arm64 --provenance=false
+          --platform=linux/amd64 --provenance=false
           --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
       run: |
         set -x

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -93,7 +93,7 @@ runs:
           --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
           --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
-          --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+          --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
       run: |
         set -x
         cd apps/api && pnpm run docker:build

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -90,10 +90,10 @@ runs:
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
         DOCKER_BUILD_ARGUMENTS: >
-          --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-          --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+          --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
-          --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+          --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
       run: |
         set -x
         cd apps/api && pnpm run docker:build

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -90,10 +90,10 @@ runs:
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
         DOCKER_BUILD_ARGUMENTS: >
-          --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-          --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+          --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
-          --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
+          --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
       run: |
         set -x
         cd apps/api && pnpm run docker:build

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -39,6 +39,7 @@ runs:
 
     # TODO Removed when migrated to action matrix for each build type
     - uses: ./.github/actions/free-space
+    - uses: ./.github/actions/cache
 
     - uses: crazy-max/ghaction-setup-docker@v2
       with:
@@ -58,7 +59,13 @@ runs:
     - name: Set Up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        driver-opts: 'image=moby/buildkit:v0.12.4'
+        driver-opts: 'image=moby/buildkit:v0.13.1'
+
+    - name: Prepare
+      shell: bash
+      run: |
+        service=${{ matrix.name }}
+        echo "SERVICE_NAME=$(basename "${service//-/-}")" >> $GITHUB_ENV
 
     - name: Login To Registry
       shell: bash
@@ -82,6 +89,10 @@ runs:
         IMAGE_TAG: ${{ github.sha }}
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
+        DOCKER_BUILD_ARGUMENTS: >
+          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --platform=linux/amd64,linux/arm64 --provenance=false
       run: |
         set -x
         cd apps/api && pnpm run docker:build

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -20,6 +20,9 @@ inputs:
   docker_name:
     description: 'Name for docker image'
     required: true
+  environment:
+    required: false
+    type: string
 
   bullmq_secret:
     description: 'Bullmq secret api token'
@@ -90,8 +93,8 @@ runs:
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
         DOCKER_BUILD_ARGUMENTS: >
-          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.environment }}
+          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.environment }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
           --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
       run: |

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -90,8 +90,8 @@ runs:
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
         DOCKER_BUILD_ARGUMENTS: >
-          --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-          --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
           --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
       run: |

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -93,7 +93,7 @@ runs:
           --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
           --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
-          --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+          --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
       run: |
         set -x
         cd apps/worker && pnpm run docker:build

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -71,7 +71,7 @@ runs:
       shell: bash
       env:
         GH_ACTOR: ${{ github.actor }}
-        GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+        GH_PASSWORD: ${{ inputs.github_token }}
       run: |
         echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
 

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -71,7 +71,7 @@ runs:
       shell: bash
       env:
         GH_ACTOR: ${{ github.actor }}
-        GH_PASSWORD: ${{ inputs.github_token }}
+        GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
       run: |
         echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
 

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -95,7 +95,7 @@ runs:
         DOCKER_BUILD_ARGUMENTS: >
           --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.environment }}
           --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.environment }},mode=max
-          --platform=linux/amd64,linux/arm64 --provenance=false
+          --platform=linux/amd64 --provenance=false
           --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
       run: |
         set -x

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -20,6 +20,9 @@ inputs:
   docker_name:
     description: 'Name for docker image'
     required: true
+  environment:
+    required: false
+    type: string
 
   bullmq_secret:
     description: 'Bullmq secret api token'
@@ -90,8 +93,8 @@ runs:
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
         DOCKER_BUILD_ARGUMENTS: >
-          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.environment }}
+          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.environment }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
           --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
       run: |

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -90,10 +90,10 @@ runs:
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
         DOCKER_BUILD_ARGUMENTS: >
-          --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-          --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+          --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
-          --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+          --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
       run: |
         set -x
         cd apps/worker && pnpm run docker:build

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -93,7 +93,7 @@ runs:
           --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
           --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
-          --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+          --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
       run: |
         set -x
         cd apps/worker && pnpm run docker:build

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -39,6 +39,7 @@ runs:
 
     # TODO Removed when migrated to action matrix for each build type
     - uses: ./.github/actions/free-space
+    - uses: ./.github/actions/cache
 
     - uses: crazy-max/ghaction-setup-docker@v2
       with:
@@ -58,7 +59,13 @@ runs:
     - name: Set Up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        driver-opts: 'image=moby/buildkit:v0.12.4'
+        driver-opts: 'image=moby/buildkit:v0.13.1'
+
+    - name: Prepare
+      shell: bash
+      run: |
+        service=${{ matrix.name }}
+        echo "SERVICE_NAME=$(basename "${service//-/-}")" >> $GITHUB_ENV
 
     - name: Login To Registry
       shell: bash
@@ -82,6 +89,10 @@ runs:
         IMAGE_TAG: ${{ github.sha }}
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
+        DOCKER_BUILD_ARGUMENTS: >
+          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --platform=linux/amd64,linux/arm64 --provenance=false
       run: |
         set -x
         cd apps/worker && pnpm run docker:build

--- a/.github/actions/docker/build-worker/action.yml
+++ b/.github/actions/docker/build-worker/action.yml
@@ -90,9 +90,10 @@ runs:
         GH_ACTOR: ${{ github.actor }}
         GH_PASSWORD: ${{ inputs.github_token }}
         DOCKER_BUILD_ARGUMENTS: >
-          --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-          --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+          --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+          --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
           --platform=linux/amd64,linux/arm64 --provenance=false
+          --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
       run: |
         set -x
         cd apps/worker && pnpm run docker:build

--- a/.github/workflows/dev-deploy-api.yml
+++ b/.github/workflows/dev-deploy-api.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           tag: dev
           push: 'true'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_PACKAGES }}
           docker_name: ${{ matrix.name }}
           bullmq_secret: ${{ secrets.BULL_MQ_PRO_NPM_TOKEN }}
 

--- a/.github/workflows/dev-deploy-api.yml
+++ b/.github/workflows/dev-deploy-api.yml
@@ -60,6 +60,7 @@ jobs:
           github_token: ${{ secrets.GH_PACKAGES }}
           docker_name: ${{ matrix.name }}
           bullmq_secret: ${{ secrets.BULL_MQ_PRO_NPM_TOKEN }}
+          environment: dev
 
       - name: Checkout cloud infra
         if: ${{ contains (matrix.name,'-ee') }}

--- a/.github/workflows/dev-deploy-inbound-mail.yml
+++ b/.github/workflows/dev-deploy-inbound-mail.yml
@@ -67,6 +67,12 @@ jobs:
         with:
           driver-opts: 'image=moby/buildkit:v0.13.1'
 
+      - name: Prepare
+        shell: bash
+        run: |
+          service=${{ matrix.name }}
+          echo "SERVICE_NAME=$(basename "${service//-/-}")" >> $GITHUB_ENV
+
       - name: Set Bull MQ Env variable for EE
         shell: bash
         run: |
@@ -81,9 +87,14 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+          DOCKER_BUILD_ARGUMENTS: >
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-dev
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-dev,mode=max
+            --platform=linux/amd64 --provenance=false
+            --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load --platform=linux/amd64,linux/arm64 --provenance=false
+          cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load $DOCKER_BUILD_ARGUMENTS
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
 

--- a/.github/workflows/dev-deploy-inbound-mail.yml
+++ b/.github/workflows/dev-deploy-inbound-mail.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
 
       - name: Set Bull MQ Env variable for EE
         shell: bash

--- a/.github/workflows/dev-deploy-worker.yml
+++ b/.github/workflows/dev-deploy-worker.yml
@@ -63,6 +63,7 @@ jobs:
           github_token: ${{ secrets.GH_PACKAGES }}
           docker_name: ${{ matrix.name }}
           bullmq_secret: ${{ secrets.BULL_MQ_PRO_NPM_TOKEN }}
+          environment: dev
 
   deploy_dev_workers:
     needs: build_dev_worker

--- a/.github/workflows/dev-deploy-ws.yml
+++ b/.github/workflows/dev-deploy-ws.yml
@@ -127,7 +127,7 @@ jobs:
           DOCKER_BUILD_ARGUMENTS: >
             --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-dev
             --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-dev,mode=max
-            --platform=linux/amd64,linux/arm64 --provenance=false
+            --platform=linux/amd64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin 

--- a/.github/workflows/dev-deploy-ws.yml
+++ b/.github/workflows/dev-deploy-ws.yml
@@ -65,6 +65,12 @@ jobs:
         with:
           driver-opts: 'image=moby/buildkit:v0.13.1'
 
+      - name: Prepare
+        shell: bash
+        run: |
+          service=${{ matrix.name }}
+          echo "SERVICE_NAME=$(basename "${service//-/-}")" >> $GITHUB_ENV
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -118,9 +124,14 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+          DOCKER_BUILD_ARGUMENTS: >
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-dev
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-dev,mode=max
+            --platform=linux/amd64,linux/arm64 --provenance=false
+            --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin 
-          BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG --platform=linux/amd64,linux/arm64 --provenance=false --load --secret id=BULL_MQ_PRO_NPM_TOKEN -f apps/ws/Dockerfile . 
+          BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG --load --secret id=BULL_MQ_PRO_NPM_TOKEN -f apps/ws/Dockerfile . $DOCKER_BUILD_ARGUMENTS
           docker run --network=host --name api -dit --env NODE_ENV=test ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
           docker run --network=host appropriate/curl --retry 10 --retry-delay 5 --retry-connrefused http://127.0.0.1:1340/v1/health-check | grep 'ok'
           docker tag ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:dev

--- a/.github/workflows/dev-deploy-ws.yml
+++ b/.github/workflows/dev-deploy-ws.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -87,10 +87,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/api && pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/api - -t novu-api --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -87,8 +87,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-prod
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-prod,mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -87,8 +87,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -64,7 +64,13 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
+
+      - name: Prepare
+        shell: bash
+        run: |
+          service=${{ matrix.name }}
+          echo "SERVICE_NAME=$(basename "${service//-/-}")" >> $GITHUB_ENV
 
       - name: Set Bull MQ Env variable for EE
         if: contains(matrix.name, 'ee')
@@ -80,9 +86,13 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+          DOCKER_BUILD_ARGUMENTS: >
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --platform=linux/amd64,linux/arm64 --provenance=false
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd apps/api && pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/api - -t novu-api --load --platform=linux/amd64,linux/arm64 --provenance=false
+          cd apps/api && pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/api - -t novu-api --load $DOCKER_BUILD_ARGUMENTS
           docker tag novu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker tag novu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker tag novu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -90,7 +90,7 @@ jobs:
             --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
             --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/api && pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/api - -t novu-api --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -87,9 +87,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
+            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/api && pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/api - -t novu-api --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -87,10 +87,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/api && pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/api - -t novu-api --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -77,10 +77,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -77,8 +77,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -77,10 +77,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.13.1'
+          driver-opts: 'image=moby/buildkit:v0.12.4'
 
       - name: Prepare
         shell: bash
@@ -77,9 +77,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
+            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
 
       - name: Prepare
         shell: bash

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -77,8 +77,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-prod
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-prod,mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -80,7 +80,7 @@ jobs:
             --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
             --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -54,7 +54,13 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
+
+      - name: Prepare
+        shell: bash
+        run: |
+          service=${{ matrix.name }}
+          echo "SERVICE_NAME=$(basename "${service//-/-}")" >> $GITHUB_ENV
 
       - name: Set Bull MQ Env variable for EE
         if: contains(matrix.name, 'ee')
@@ -70,9 +76,13 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+          DOCKER_BUILD_ARGUMENTS: >
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --platform=linux/amd64,linux/arm64 --provenance=false
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load --platform=linux/amd64,linux/arm64 --provenance=false
+          cd apps/inbound-mail && pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/inbound-mail - -t novu-inbound-mail --load $DOCKER_BUILD_ARGUMENTS
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker tag novu-inbound-mail ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
 
       - name: Prepare
         shell: bash

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -87,8 +87,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-prod
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-prod,mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -87,10 +87,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/worker && pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -64,7 +64,13 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
+
+      - name: Prepare
+        shell: bash
+        run: |
+          service=${{ matrix.name }}
+          echo "SERVICE_NAME=$(basename "${service//-/-}")" >> $GITHUB_ENV
 
       - name: Set Bull MQ Env variable for EE
         if: contains(matrix.name, 'ee')
@@ -80,9 +86,13 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+          DOCKER_BUILD_ARGUMENTS: >
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --platform=linux/amd64,linux/arm64 --provenance=false
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
-          cd apps/worker && pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load --platform=linux/amd64,linux/arm64 --provenance=false
+          cd apps/worker && pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load $DOCKER_BUILD_ARGUMENTS
           docker tag novu-worker ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:latest
           docker tag novu-worker ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod
           docker tag novu-worker ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -87,8 +87,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.13.1'
+          driver-opts: 'image=moby/buildkit:v0.12.4'
 
       - name: Prepare
         shell: bash
@@ -87,9 +87,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
+            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd apps/worker && pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
 
       - name: Prepare
         shell: bash

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -81,10 +81,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin 
           BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG --load -f apps/ws/Dockerfile . $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -84,7 +84,7 @@ jobs:
             --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
             --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin 
           BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG --load -f apps/ws/Dockerfile . $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -64,7 +64,13 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
+
+      - name: Prepare
+        shell: bash
+        run: |
+          service=${{ matrix.name }}
+          echo "SERVICE_NAME=$(basename "${service//-/-}")" >> $GITHUB_ENV
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
@@ -74,9 +80,13 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+          DOCKER_BUILD_ARGUMENTS: >
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --platform=linux/amd64,linux/arm64 --provenance=false
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin 
-          BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG --load --platform=linux/amd64,linux/arm64 --provenance=false -f apps/ws/Dockerfile .
+          BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG --load -f apps/ws/Dockerfile . $DOCKER_BUILD_ARGUMENTS
           docker run --network=host --name api -dit --env NODE_ENV=test ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
           docker run --network=host appropriate/curl --retry 10 --retry-delay 5 --retry-connrefused http://127.0.0.1:1340/v1/health-check | grep 'ok'
           docker tag ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:prod

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -81,8 +81,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -81,10 +81,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin 
           BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG --load -f apps/ws/Dockerfile . $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -81,8 +81,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-prod
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-prod,mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.13.1'
+          driver-opts: 'image=moby/buildkit:v0.12.4'
 
       - name: Prepare
         shell: bash
@@ -81,9 +81,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
+            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin 
           BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN -t ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG --load -f apps/ws/Dockerfile . $DOCKER_BUILD_ARGUMENTS

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -110,8 +110,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
@@ -135,8 +135,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -110,10 +110,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build
@@ -135,10 +135,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
 
       - name: Build, tag, and push image to ghcr.io
         id: build-image

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -112,7 +112,7 @@ jobs:
           DOCKER_BUILD_ARGUMENTS: >
             --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.env_tag }}
             --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.env_tag }},mode=max
-            --platform=linux/amd64,linux/arm64 --provenance=false
+            --platform=linux/amd64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -66,6 +66,12 @@ jobs:
           submodules: ${{ contains (matrix.name,'-ee') }}
           token: ${{ secrets.SUBMODULES_TOKEN }}
 
+      - name: Prepare
+        shell: bash
+        run: |
+          service=${{ matrix.name }}
+          echo "SERVICE_NAME=$(basename "${service//-/-}")" >> $GITHUB_ENV
+
       - uses: ./.github/actions/setup-project
         with:
           slim: 'true'
@@ -89,7 +95,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.12.4'
+          driver-opts: 'image=moby/buildkit:v0.13.1'
 
       - name: Build, tag, and push image to ghcr.io
         id: build-image
@@ -103,6 +109,10 @@ jobs:
           PROJECT_PATH: ${{ inputs.project_path }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+          DOCKER_BUILD_ARGUMENTS: >
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --platform=linux/amd64,linux/arm64 --provenance=false
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build
@@ -123,6 +133,10 @@ jobs:
           PROJECT_PATH: ${{ inputs.project_path }}
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
+          DOCKER_BUILD_ARGUMENTS: >
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --platform=linux/amd64,linux/arm64 --provenance=false
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -113,7 +113,7 @@ jobs:
             --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
             --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build
@@ -138,7 +138,7 @@ jobs:
             --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
             --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver-opts: 'image=moby/buildkit:v0.13.1'
+          driver-opts: 'image=moby/buildkit:v0.12.4'
 
       - name: Build, tag, and push image to ghcr.io
         id: build-image
@@ -110,9 +110,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
+            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build
@@ -134,9 +135,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
+            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -110,8 +110,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.env_tag }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.env_tag }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |
@@ -135,8 +135,8 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.env_tag }}
+            --cache-to type=registry,ref=ghcr.io/novuhq/cache:build-cache-${{ env.SERVICE_NAME }}-${{ inputs.env_tag }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
             --output=type=image,name=ghcr.io/novuhq/${{ matrix.name }},push-by-digest=true,name-canonical=true
         run: |

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -110,10 +110,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build
@@ -135,10 +135,10 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
           GH_PASSWORD: ${{ secrets.GH_PACKAGES }}
           DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }}
-            --cache-to type=registry,ref=ghcr.io/novuhq/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
+            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }}
+            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/novu/cache:build-cache-${{ env.SERVICE_NAME }},mode=max
             --platform=linux/amd64,linux/arm64 --provenance=false
-            --output=type=image,name=ghcr.io/novuhq/${{ inputs.docker_name }},push-by-digest=true,name-canonical=true
+            --output=type=image,name=ghcr.io/ras-devops/${{ env.DOCKER_NAME }},push-by-digest=true,name-canonical=true
         run: |
           echo $GH_PASSWORD | docker login ghcr.io -u $GH_ACTOR --password-stdin
           cd $PROJECT_PATH && npm run docker:build

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\"",
     "precommit": "lint-staged",
-    "docker:build": "pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --load --platform=linux/amd64,linux/arm64 --provenance=false -t novu-api --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/api -",
+    "docker:build": "pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --load -t novu-api --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/api - $DOCKER_BUILD_ARGUMENTS",
     "docker:build:depot": "pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | depot build --build-arg PACKAGE_PATH=apps/api - -t novu-api --load",
     "start": "pnpm start:dev",
     "start:dev": "cross-env TZ=UTC nest start --watch",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "prebuild": "rimraf build",
     "build": "pnpm panda && cross-env NODE_OPTIONS=--max_old_space_size=4096 GENERATE_SOURCEMAP=false react-app-rewired --max_old_space_size=4096 build",
     "precommit": "lint-staged",
-    "docker:build": "docker buildx build --load --platform=linux/amd64,linux/arm64 --provenance=false -f ./Dockerfile -t novu-web ./../..",
+    "docker:build": "docker buildx build --load -f ./Dockerfile -t novu-web ./../.. $DOCKER_BUILD_ARGUMENTS",
     "docker:build:depot": "depot build -f ./Dockerfile -t novu-web ./../.. --load",
     "envsetup:docker": "chmod +x ./env.sh && ./env.sh && mv ./env-config.js ./build/env-config.js",
     "envsetup": "chmod +x ./env.sh && ./env.sh && mv env-config.js ./public/env-config.js",

--- a/apps/webhook/package.json
+++ b/apps/webhook/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
-    "docker:build": "pnpm --silent --workspace-root pnpm-context -- apps/webhook/Dockerfile | docker buildx build --load --platform=linux/amd64,linux/arm64 --provenance=false --build-arg PACKAGE_PATH=apps/webhook - -t novu-webhook",
+    "docker:build": "pnpm --silent --workspace-root pnpm-context -- apps/webhook/Dockerfile | docker buildx build --load --build-arg PACKAGE_PATH=apps/webhook - -t novu-webhook $DOCKER_BUILD_ARGUMENTS",
     "docker:build:depot": "pnpm --silent --workspace-root pnpm-context -- apps/webhook/Dockerfile | depot build --build-arg PACKAGE_PATH=apps/webhook - -t novu-webhook --load",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "npm run start:dev",

--- a/apps/widget/package.json
+++ b/apps/widget/package.json
@@ -11,7 +11,7 @@
     "envsetup:docker": "chmod +x ./env.sh && ./env.sh && mv ./env-config.js ./build/env-config.js",
     "start:static:build": "pnpm envsetup:docker && http-server build -p 4500 --proxy http://127.0.0.1:4500?",
     "start:docker": "pnpm build && pnpm start:static:build",
-    "docker:build": "docker buildx build -f ./Dockerfile --load --platform=linux/amd64,linux/arm64 --provenance=false -t novu-widget ./../..",
+    "docker:build": "docker buildx build -f ./Dockerfile --load -t novu-widget ./../.. $DOCKER_BUILD_ARGUMENTS",
     "docker:build:depot": "depot build -f ./Dockerfile -t novu-widget ./../.. --load",
     "prebuild": "rimraf build",
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=4096 react-app-rewired --max_old_space_size=4096 build",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -10,7 +10,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\"",
     "precommit": "lint-staged",
-    "docker:build": "pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load --platform=linux/amd64,linux/arm64 --provenance=false",
+    "docker:build": "pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load $DOCKER_BUILD_ARGUMENTS",
     "docker:build:depot": "pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | depot build --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load",
     "start": "pnpm start:dev",
     "start:dev": "cross-env TZ=UTC nest start --watch",

--- a/libs/embed/package.json
+++ b/libs/embed/package.json
@@ -30,7 +30,7 @@
     "start:dev": "concurrently \"pnpm start\"",
     "start:docker": "pnpm build && http-server -p 4701 dist",
     "start:test:web": "http-server -p 4701 -o test",
-    "docker:build": "docker buildx build --load --platform=linux/amd64,linux/arm64 --provenance=false -f ./Dockerfile -t novu-embed ./../..",
+    "docker:build": "docker buildx build --load -f ./Dockerfile -t novu-embed ./../.. $DOCKER_BUILD_ARGUMENTS",
     "docker:build:depot": "depot build -f ./Dockerfile -t novu-embed ./../.. --load",
     "test": "echo \"Error: no test specified\"",
     "test:watch": "jest --coverage --watch",


### PR DESCRIPTION
We want to update the runners to have cache for docker, pnpm, etc to decrease the build time.
To bypass the Github cache restriction in 10Gb we decide to use the GitHub package registry as a cache. After the first run the new package with the name "cache" will be created for storing the cache images separated by tags. More information about this type of cache you can see [here](https://docs.docker.com/build/cache/backends/registry/)

WEBHOOK service
**Without the cache:**
https://github.com/novuhq/novu/actions/runs/8738434410
**With the cache:**
https://github.com/novuhq/novu/actions/runs/8739026750

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
**Without the cache:**
![Screenshot from 2024-04-18 17-41-06](https://github.com/novuhq/novu/assets/141645418/5a7cb70b-64aa-4783-a5da-2bf3c09544a1)

**With the cache:**
![Screenshot from 2024-04-18 17-40-47](https://github.com/novuhq/novu/assets/141645418/b1539360-2622-47ec-b4e5-8d0aa14a285f)

**Cache package:**
![image](https://github.com/novuhq/novu/assets/141645418/766f4e32-dc63-48fd-bc63-1b8c56a8f518)
