### PR TITLE
test(api): Filter on integrationId before assertion

### DIFF
--- a/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
@@ -55,7 +55,9 @@ describe('Update Integration - /integrations/:integrationId (PUT)', function () 
     // update integration
     await session.testAgent.put(`/v1/integrations/${integrationId}`).send(payload);
 
-    const integration = (await session.testAgent.get(`/v1/integrations`)).body.data[0];
+    const integration = (await session.testAgent.get(`/v1/integrations`)).body.data.find(
+      (fetchedIntegration) => fetchedIntegration._id === integrationId
+    );
 
     expect(integration.credentials.apiKey).to.equal(payload.credentials.apiKey);
     expect(integration.credentials.secretKey).to.equal(payload.credentials.secretKey);


### PR DESCRIPTION
### What changed? Why was the change needed?
Removal of indexes in https://github.com/novuhq/novu/commit/979f79c42045101488ca6cebe2faeb8e06320cf4 resulted in this test exhibiting flakey behaviour. The update integration test filter has been updated to specify the relevant `integrationId` to create a more robust assertion.

### Screenshots
_Previously failing test is passing in Local:_
<img width="852" alt="image" src="https://github.com/novuhq/novu/assets/32132657/5fb0e06b-6832-46a6-891f-f5b308485e75">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
