### PR TITLE
fix(@novu/node): Fix parameter parsing

### DIFF
--- a/packages/node/src/lib/novu.spec.ts
+++ b/packages/node/src/lib/novu.spec.ts
@@ -26,6 +26,10 @@ describe('test initialization of novu node package', () => {
   test('should use the NOVU_API_KEY when defined', async () => {
     expect(new Novu().apiKey).toBe('cafebabe');
   });
+
+  test('should use the NOVU_API_KEY when defined', async () => {
+    expect(new Novu('whatever').apiKey).toBe('whatever');
+  });
 });
 
 describe('test use of novu node package', () => {

--- a/packages/node/src/lib/novu.ts
+++ b/packages/node/src/lib/novu.ts
@@ -53,9 +53,13 @@ export class Novu extends EventEmitter {
       apiKey = args[0];
       config = args[1];
     } else if (arguments.length === 1) {
-      const { apiKey: key, ...rest } = args[0];
-      apiKey = key;
-      config = rest;
+      if (typeof args[0] === 'object') {
+        const { apiKey: key, ...rest } = args[0];
+        apiKey = key;
+        config = rest;
+      } else {
+        apiKey = args[0];
+      }
     } else {
       apiKey = getEnvVariable('NOVU_API_KEY');
     }


### PR DESCRIPTION
### What changed? Why was the change needed?
Fix Novu SDK when the API key is passed as a string.

