### PR TITLE
fix(framework): Zod 4 types and step-resolver TS2589 fixes NV-8022

### DIFF
--- a/packages/framework/src/resources/step-resolver/step.test-d.ts
+++ b/packages/framework/src/resources/step-resolver/step.test-d.ts
@@ -1,0 +1,24 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { step } from './step';
+
+describe('step-resolver', () => {
+  it('should compile handlers that use ctx without TS2589', () => {
+    step.email('my-step', async (_controls, { payload }) => ({
+      subject: String(Object.keys(payload).length),
+      body: 'y',
+    }));
+
+    step.email('my-step', async (_controls, ctx) => ({
+      subject: String(Object.keys(ctx.payload).length),
+      body: 'y',
+    }));
+  });
+
+  it('should type payload as Record<string, unknown> by default', () => {
+    step.email('my-step', async (_controls, { payload }) => {
+      expectTypeOf(payload).toEqualTypeOf<Record<string, unknown>>();
+
+      return { subject: 'x', body: 'y' };
+    });
+  });
+});

--- a/packages/framework/src/resources/step-resolver/step.ts
+++ b/packages/framework/src/resources/step-resolver/step.ts
@@ -39,6 +39,15 @@ type ResolveControls<T extends Schema | undefined> = T extends Schema ? FromSche
 
 type ResolveEnv<T extends Schema | undefined> = T extends Schema ? FromSchema<T> : Record<string, string>;
 
+/** Loose provider map for step factory signatures — avoids deep providerSchemas instantiation at call sites. */
+type StepResolverProvidersLoose = Record<
+  string,
+  (
+    step: { controls: Record<string, unknown>; outputs: Record<string, unknown> },
+    ctx: StepResolverContext
+  ) => Awaitable<WithPassthrough<Record<string, unknown>>>
+>;
+
 type StepResolverProviders<
   T_StepType extends keyof typeof providerSchemas,
   T_Controls,
@@ -66,20 +75,27 @@ type BaseStepResolverOptions<
   ) => Awaitable<boolean>;
 };
 
-type ChannelStepResolverOptions<
-  T_StepType extends keyof typeof providerSchemas,
+type BaseStepFactoryOptions<
   TControlSchema extends Schema | undefined,
   TPayloadSchema extends Schema | undefined,
-  T_Output extends Record<string, unknown>,
   TEnvSchema extends Schema | undefined = undefined,
-> = BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema> & {
-  providers?: StepResolverProviders<
-    T_StepType,
-    ResolveControls<TControlSchema>,
-    T_Output,
-    ResolveControls<TPayloadSchema>,
-    ResolveEnv<TEnvSchema>
-  >;
+> = {
+  controlSchema?: TControlSchema;
+  payloadSchema?: TPayloadSchema;
+  envSchema?: TEnvSchema;
+  skip?: (
+    controls: ResolveControls<TControlSchema>,
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
+  ) => Awaitable<boolean>;
+};
+
+/** Options accepted by channel step factory functions — schemas are inferred from here, not the resolve callback. */
+type ChannelStepFactoryOptions<
+  TControlSchema extends Schema | undefined,
+  TPayloadSchema extends Schema | undefined,
+  TEnvSchema extends Schema | undefined = undefined,
+> = BaseStepFactoryOptions<TControlSchema, TPayloadSchema, TEnvSchema> & {
+  providers?: StepResolverProvidersLoose;
   disableOutputSanitization?: boolean;
 };
 
@@ -275,11 +291,8 @@ function email<
   TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
-  resolve: (
-    controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
-  ) => Promise<EmailOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'email', TControlSchema, TPayloadSchema, EmailOutputUnvalidated, TEnvSchema>
+  resolve: (controls: ResolveControls<TControlSchema>, ctx: StepResolverContext) => Promise<EmailOutputUnvalidated>,
+  options?: ChannelStepFactoryOptions<TControlSchema, TPayloadSchema, TEnvSchema>
 ): EmailStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'email',
@@ -300,11 +313,8 @@ function sms<
   TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
-  resolve: (
-    controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
-  ) => Promise<SmsOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'sms', TControlSchema, TPayloadSchema, SmsOutputUnvalidated, TEnvSchema>
+  resolve: (controls: ResolveControls<TControlSchema>, ctx: StepResolverContext) => Promise<SmsOutputUnvalidated>,
+  options?: ChannelStepFactoryOptions<TControlSchema, TPayloadSchema, TEnvSchema>
 ): SmsStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'sms',
@@ -325,11 +335,8 @@ function chat<
   TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
-  resolve: (
-    controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
-  ) => Promise<ChatOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'chat', TControlSchema, TPayloadSchema, ChatOutputUnvalidated, TEnvSchema>
+  resolve: (controls: ResolveControls<TControlSchema>, ctx: StepResolverContext) => Promise<ChatOutputUnvalidated>,
+  options?: ChannelStepFactoryOptions<TControlSchema, TPayloadSchema, TEnvSchema>
 ): ChatStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'chat',
@@ -350,11 +357,8 @@ function push<
   TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
-  resolve: (
-    controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
-  ) => Promise<PushOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'push', TControlSchema, TPayloadSchema, PushOutputUnvalidated, TEnvSchema>
+  resolve: (controls: ResolveControls<TControlSchema>, ctx: StepResolverContext) => Promise<PushOutputUnvalidated>,
+  options?: ChannelStepFactoryOptions<TControlSchema, TPayloadSchema, TEnvSchema>
 ): PushStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'push',
@@ -375,11 +379,8 @@ function inApp<
   TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
-  resolve: (
-    controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
-  ) => Promise<InAppOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'in_app', TControlSchema, TPayloadSchema, InAppOutputUnvalidated, TEnvSchema>
+  resolve: (controls: ResolveControls<TControlSchema>, ctx: StepResolverContext) => Promise<InAppOutputUnvalidated>,
+  options?: ChannelStepFactoryOptions<TControlSchema, TPayloadSchema, TEnvSchema>
 ): InAppStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'in_app',
@@ -400,11 +401,8 @@ function delay<
   TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
-  resolve: (
-    controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
-  ) => Promise<DelayOutputUnvalidated>,
-  options?: BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema>
+  resolve: (controls: ResolveControls<TControlSchema>, ctx: StepResolverContext) => Promise<DelayOutputUnvalidated>,
+  options?: BaseStepFactoryOptions<TControlSchema, TPayloadSchema, TEnvSchema>
 ): DelayStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'delay',
@@ -423,11 +421,8 @@ function digest<
   TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
-  resolve: (
-    controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
-  ) => Promise<DigestOutputUnvalidated>,
-  options?: BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema>
+  resolve: (controls: ResolveControls<TControlSchema>, ctx: StepResolverContext) => Promise<DigestOutputUnvalidated>,
+  options?: BaseStepFactoryOptions<TControlSchema, TPayloadSchema, TEnvSchema>
 ): DigestStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'digest',
@@ -446,11 +441,8 @@ function throttle<
   TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
-  resolve: (
-    controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
-  ) => Promise<ThrottleOutputUnvalidated>,
-  options?: BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema>
+  resolve: (controls: ResolveControls<TControlSchema>, ctx: StepResolverContext) => Promise<ThrottleOutputUnvalidated>,
+  options?: BaseStepFactoryOptions<TControlSchema, TPayloadSchema, TEnvSchema>
 ): ThrottleStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'throttle',

--- a/packages/framework/src/types/schema.types/zod.schema.types.ts
+++ b/packages/framework/src/types/schema.types/zod.schema.types.ts
@@ -1,10 +1,3 @@
-import type zod from 'zod';
-
-/**
- * A ZodSchema used to validate a JSON object.
- */
-export type ZodSchema = zod.ZodType<Record<string, unknown>, zod.ZodTypeDef, Record<string, unknown>>;
-
 /**
  * A minimal ZodSchema type.
  *
@@ -14,6 +7,16 @@ export type ZodSchema = zod.ZodType<Record<string, unknown>, zod.ZodTypeDef, Rec
  */
 export type ZodSchemaMinimal = {
   readonly safeParseAsync: unknown;
+};
+
+/**
+ * A ZodSchema used to validate a JSON object.
+ *
+ * Structurally typed for Zod 3 and 4 compatibility — avoids ZodTypeDef removed in Zod 4.
+ */
+export type ZodSchema = ZodSchemaMinimal & {
+  readonly _output: Record<string, unknown>;
+  readonly _input: Record<string, unknown>;
 };
 
 /**

--- a/packages/framework/src/validators/zod.validator.ts
+++ b/packages/framework/src/validators/zod.validator.ts
@@ -10,6 +10,15 @@ import type {
 import type { ValidateResult, Validator } from '../types/validator.types';
 import { checkDependencies } from '../utils/import.utils';
 
+type ZodParseIssue = { path: (string | number)[]; message: string };
+
+type ZodParseResult = { success: true; data: unknown } | { success: false; error: { errors: ZodParseIssue[] } };
+
+/** Runtime Zod schema shape used inside the validator — not exported. */
+type ZodSchemaRuntime = ZodSchemaMinimal & {
+  safeParseAsync: (data: unknown) => Promise<ZodParseResult>;
+};
+
 export class ZodValidator implements Validator<ZodSchema> {
   readonly requiredImports: readonly ImportRequirement[] = [
     {
@@ -39,24 +48,24 @@ export class ZodValidator implements Validator<ZodSchema> {
     T_Unvalidated = FromSchemaUnvalidated<T_Schema>,
     T_Validated = FromSchema<T_Schema>,
   >(data: T_Unvalidated, schema: T_Schema): Promise<ValidateResult<T_Validated>> {
-    const result = await schema.safeParseAsync(data);
+    const result = await (schema as ZodSchemaRuntime).safeParseAsync(data);
     if (result.success) {
       return { success: true, data: result.data as T_Validated };
-    } else {
-      return {
-        success: false,
-        errors: result.error.errors.map((err) => ({
-          path: `/${err.path.join('/')}`,
-          message: err.message,
-        })),
-      };
     }
+
+    return {
+      success: false,
+      errors: result.error.errors.map((err) => ({
+        path: `/${err.path.join('/')}`,
+        message: err.message,
+      })),
+    };
   }
 
   async transformToJsonSchema(schema: ZodSchema): Promise<JsonSchema> {
     const { zodToJsonSchema } = await import('zod-to-json-schema');
 
     // TODO: zod-to-json-schema is not using JSONSchema7
-    return zodToJsonSchema(schema) as JsonSchema;
+    return zodToJsonSchema(schema as Parameters<typeof zodToJsonSchema>[0]) as JsonSchema;
   }
 }


### PR DESCRIPTION
## Summary

- **Zod 4 compatibility:** Replace `ZodSchema` definition that referenced Zod 3-only `ZodTypeDef` with a structural type compatible with Zod 3 and 4. Update `ZodValidator` to use an internal runtime schema shape.
- **TS2589 fix:** Simplify `step-resolver` factory callback signatures so handlers using `ctx` no longer trigger "Type instantiation is excessively deep". Factory options use loose provider types; exported resolver types keep full precision.
- **Regression coverage:** Add `step.test-d.ts` type tests for the customer-reported handler pattern.

## Why

Customer reported two issues with `@novu/framework` 2.11.x:
1. Published `.d.ts` breaks in Zod 4 workspaces (same class of issue as #8896 for `@novu/api`)
2. `step.email(..., async (controls, { payload }) => ...)` fails `tsc` with TS2589

Runtime behavior was fine; only TypeScript consumers running `tsc` in CI were affected.

## Test plan

- [x] `pnpm --filter @novu/framework build` — passes, attw reports no export issues
- [x] `pnpm --filter @novu/framework test -- src/resources/step-resolver/step.test-d.ts` — type tests pass
- [x] Manual repro with Zod 4 + customer handler snippet — `tsc` passes
- [ ] Publish `@novu/framework` and verify customer can remove their typed cast workaround


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Fixed two TypeScript compatibility issues in `@novu/framework`: (1) Replaced the exported `ZodSchema` type definition to be compatible with both Zod 3 and Zod 4 by removing a Zod 3-specific type dependency; (2) Simplified step-resolver factory callback signatures to avoid "Type instantiation is excessively deep" (TS2589) errors when handlers use the `ctx` parameter, introducing looser provider types at call sites while keeping exported resolver types fully typed.

## Affected areas

**framework**: Updated `ZodValidator` to use internal runtime type helpers; refactored step factory functions (`email`, `sms`, `chat`, `push`, `inApp`, `delay`, `digest`, `throttle`) to use simplified `StepResolverContext` in callbacks and new loose factory options types; replaced the published `ZodSchema` type with a structural definition for Zod version compatibility.

## Key technical decisions

- Introduced `StepResolverProvidersLoose` to avoid excessive generic instantiation at factory call sites while maintaining full precision in exported resolver types.
- Replaced the imported Zod type-dependent `ZodSchema` definition with a purely structural type using phantom `_output` and `_input` fields, enabling Zod 3/4 compatibility without version-specific imports.
- Internal `ZodValidator` refactoring uses untyped helper types (`ZodSchemaRuntime`) for the `safeParseAsync` method to isolate type complexity from the public API.

## Testing

Added new type tests in `step.test-d.ts` to verify that handler patterns using `ctx` compile without TS2589. Existing build and type-export checks pass; manual verification with Zod 4 and the reported customer handler pattern confirms the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->