### PR TITLE
feat(worker): debounce subscriber online state reporting in socket worker fixes NV-8028

### DIFF
--- a/enterprise/workers/socket/src/durable-objects/websocket-room.ts
+++ b/enterprise/workers/socket/src/durable-objects/websocket-room.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from 'cloudflare:workers';
-import type { IConnectionMetadata, IEnv } from '../types';
+import type { IConnectionMetadata, IEnv, IOnlineReportRecord } from '../types';
 
 /**
  * WebSocket Room Durable Object with Hibernation Support
@@ -7,6 +7,22 @@ import type { IConnectionMetadata, IEnv } from '../types';
  */
 export class WebSocketRoom extends DurableObject<IEnv> {
   private static readonly MAX_CONNECTIONS = 100;
+
+  /**
+   * How long to wait after the last connection closes before reporting the
+   * subscriber as offline. Quick reconnects (page navigations, reloads) within
+   * this window cancel out the offline+online API call pair entirely.
+   */
+  private static readonly OFFLINE_DEBOUNCE_MS = 60_000;
+
+  /**
+   * How long a successful online report is trusted before being re-asserted.
+   * Bounds divergence caused by external writers (legacy ws service), failed
+   * API calls, or out-of-band DB changes, while keeping API traffic low.
+   */
+  private static readonly ONLINE_REASSERT_TTL_MS = 6 * 60 * 60 * 1000;
+
+  private static readonly ONLINE_REPORT_KEY = 'onlineReport';
 
   /**
    * Constructor - called when DO is instantiated or wakes from hibernation
@@ -71,7 +87,7 @@ export class WebSocketRoom extends DurableObject<IEnv> {
 
     // Use waitUntil to allow hibernation without waiting for API call
     this.ctx.waitUntil(
-      this.notifySubscriberOnlineState(userId, environmentId, true, undefined, jwtToken).catch((error) =>
+      this.reportOnlineIfNeeded(currentConnections, userId, environmentId, jwtToken).catch((error) =>
         console.error('Failed to notify subscriber online state:', error)
       )
     );
@@ -99,13 +115,44 @@ export class WebSocketRoom extends DurableObject<IEnv> {
   async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
     ws.close(code, reason);
 
-    const metadata = this.getConnectionMetadata(ws);
+    // The closing socket is still included in getWebSockets() at this point
+    const remainingConnections = this.ctx.getWebSockets().length - 1;
 
-    if (metadata) {
-      this.handleSubscriberDisconnection(metadata);
+    if (remainingConnections <= 0) {
+      await this.scheduleOfflineReport();
+    }
+  }
+
+  /**
+   * Debounced offline reporting: fires OFFLINE_DEBOUNCE_MS after the last
+   * connection closes. If the subscriber reconnected in the meantime, this is
+   * a no-op and no offline/online API call pair is sent at all.
+   */
+  async alarm(): Promise<void> {
+    if (this.ctx.getWebSockets().length > 0) {
+      return;
     }
 
-    // No need to delete from connectionTokens - using serializeAttachment instead
+    const report = await this.ctx.storage.get<IOnlineReportRecord>(WebSocketRoom.ONLINE_REPORT_KEY);
+
+    if (!report?.jwtToken) {
+      console.warn('No online report record available, skipping offline notification');
+
+      return;
+    }
+
+    const succeeded = await this.notifySubscriberOnlineState(
+      report.userId,
+      report.environmentId,
+      false,
+      undefined,
+      report.jwtToken
+    );
+
+    if (!succeeded) {
+      // Throwing makes the Cloudflare runtime retry the alarm with backoff
+      throw new Error('Failed to report subscriber offline state, alarm will be retried');
+    }
   }
 
   /**
@@ -183,6 +230,55 @@ export class WebSocketRoom extends DurableObject<IEnv> {
   }
 
   /**
+   * Report the subscriber as online unless it is redundant. The online state
+   * is considered already reported when the room had live connections before
+   * this one, or when an offline alarm is still pending (the offline report
+   * was never sent). A successful report older than ONLINE_REASSERT_TTL_MS is
+   * re-asserted regardless, to self-heal external state divergence.
+   */
+  private async reportOnlineIfNeeded(
+    connectionsBeforeAccept: number,
+    userId: string,
+    environmentId: string,
+    jwtToken: string
+  ): Promise<void> {
+    const [pendingAlarm, report] = await Promise.all([
+      this.ctx.storage.getAlarm(),
+      this.ctx.storage.get<IOnlineReportRecord>(WebSocketRoom.ONLINE_REPORT_KEY),
+    ]);
+
+    const isFreshlyReported =
+      report !== undefined && Date.now() - report.reportedAt < WebSocketRoom.ONLINE_REASSERT_TTL_MS;
+    const isAlreadyOnline = connectionsBeforeAccept > 0 || pendingAlarm !== null;
+
+    if (isAlreadyOnline && isFreshlyReported) {
+      return;
+    }
+
+    const succeeded = await this.notifySubscriberOnlineState(userId, environmentId, true, undefined, jwtToken);
+
+    if (succeeded) {
+      const record: IOnlineReportRecord = { reportedAt: Date.now(), jwtToken, userId, environmentId };
+      await this.ctx.storage.put(WebSocketRoom.ONLINE_REPORT_KEY, record);
+    }
+  }
+
+  /**
+   * Schedule the debounced offline report. An already pending alarm is left
+   * untouched (resetting or deleting alarms costs extra storage writes and the
+   * alarm handler no-ops when connections exist anyway).
+   */
+  private async scheduleOfflineReport(): Promise<void> {
+    const pendingAlarm = await this.ctx.storage.getAlarm();
+
+    if (pendingAlarm !== null) {
+      return;
+    }
+
+    await this.ctx.storage.setAlarm(Date.now() + WebSocketRoom.OFFLINE_DEBOUNCE_MS);
+  }
+
+  /**
    * Notify the API about subscriber online state changes
    */
   private async notifySubscriberOnlineState(
@@ -191,19 +287,19 @@ export class WebSocketRoom extends DurableObject<IEnv> {
     isOnline: boolean,
     organizationId?: string,
     jwtToken?: string
-  ): Promise<void> {
+  ): Promise<boolean> {
     const apiUrl = this.env.API_URL;
 
     if (!apiUrl) {
       console.warn('API_URL not configured, skipping online state notification');
 
-      return;
+      return false;
     }
 
     if (!jwtToken) {
       console.warn('JWT token not available, skipping online state notification');
 
-      return;
+      return false;
     }
 
     try {
@@ -225,8 +321,12 @@ export class WebSocketRoom extends DurableObject<IEnv> {
       if (!response.ok) {
         console.error(`Failed to notify API about subscriber online state: ${response.status} ${response.statusText}`);
       }
+
+      return response.ok;
     } catch (error) {
       console.error(`Error notifying API about subscriber online state:`, error);
+
+      return false;
     }
   }
 
@@ -262,25 +362,6 @@ export class WebSocketRoom extends DurableObject<IEnv> {
       jwtToken: attachment.jwtToken,
       contextKeys: attachment.contextKeys,
     };
-  }
-
-  private handleSubscriberDisconnection(metadata: IConnectionMetadata): void {
-    const activeConnections = this.getActiveConnectionsForUser(metadata.userId);
-
-    const remainingConnections = activeConnections - 1;
-
-    if (remainingConnections <= 0) {
-      // Use waitUntil to allow hibernation without waiting for API call
-      this.ctx.waitUntil(
-        this.notifySubscriberOnlineState(
-          metadata.userId,
-          metadata.environmentId,
-          false,
-          undefined,
-          metadata.jwtToken
-        ).catch((error) => console.error('Failed to notify subscriber offline state:', error))
-      );
-    }
   }
 
   private extractContextKeysFromHeader(request: Request): string[] {

--- a/enterprise/workers/socket/src/types/index.ts
+++ b/enterprise/workers/socket/src/types/index.ts
@@ -14,6 +14,13 @@ export interface IConnectionMetadata {
   contextKeys: string[];
 }
 
+export interface IOnlineReportRecord {
+  reportedAt: number;
+  jwtToken: string;
+  userId: string;
+  environmentId: string;
+}
+
 export interface IWebSocketRoom {
   sendToUser(userId: string, event: string, data: unknown, contextKeys: string[]): Promise<void>;
   getActiveConnectionsForUser(userId: string): number;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Reduce /v1/internal/subscriber-online-state API throughput

## What

`POST /v1/internal/subscriber-online-state` is the #2 transaction on the API (~23M calls/day, ~267 rps) against only ~5M inbox sessions/day — ~4.5 calls per session, dominated by reconnect/navigation flapping. The Cloudflare socket worker's `WebSocketRoom` Durable Object fires an online POST on every connect (even with other live connections) and an immediate offline POST on every last-disconnect, so each page navigation produces an offline+online pair.

This change makes the DO report only real state transitions, using a storage-light design that minimizes Durable Object billing (row writes, alarms):

- **Online suppression**: the online POST is skipped when the room already had live connections, or when an offline alarm is still pending (meaning offline was never reported, so Mongo still says online). Both checks are reads, not writes.
- **Debounced offline**: instead of POSTing offline immediately, the DO sets a 60s alarm (only if none is pending — alarms are never reset or deleted, avoiding extra storage writes). If the subscriber reconnected by the time it fires, the alarm no-ops, collapsing the offline+online pair to zero API calls.
- **Self-healing TTL**: a successful online report older than 6h is re-asserted, bounding divergence from the still-live legacy `apps/ws` dual-writer, swallowed failures, or out-of-band DB edits. A single storage row `{reportedAt, jwtToken, userId, environmentId}` is written only on successful online POSTs.
- **Offline retry**: a failed offline POST throws from `alarm()`, so the Cloudflare runtime retries with backoff; the still-pending alarm keeps suppression consistent during retries.

Correctness note: the only consumer of `isOnline`/`lastOnlineAt` is the workflow conditions filter, which evaluates `isOnline || lastOnlineAt within X` at minute granularity — while online, `lastOnlineAt` is never read, so suppressing redundant online POSTs loses nothing, and the 60s offline delay is immaterial.

```mermaid
sequenceDiagram
    participant Client
    participant DO as WebSocketRoom DO
    participant API as Novu API

    Client->>DO: connect (first)
    DO->>API: POST online
    DO->>DO: store {reportedAt, jwt} on 200
    Client->>DO: connect (second tab)
    Note over DO: live sockets > 0, fresh report -> skip
    Client->>DO: disconnect (last)
    DO->>DO: setAlarm(+60s), no POST
    Client->>DO: reconnect (page navigation)
    Note over DO: alarm pending -> skip online POST
    DO->>DO: alarm fires, sockets > 0 -> no-op
    Client->>DO: disconnect (for real)
    DO->>DO: setAlarm(+60s)
    DO->>API: alarm fires, sockets == 0 -> POST offline
```

## Expected impact

- N parallel tabs: N online calls → 1.
- Page navigation/reload (reconnect < 60s): 2 calls → 0.
- Long sessions: 1 call, plus at most one re-assert per 6h.
- Projected ~70% reduction of the 23M calls/day and the corresponding MongoDB subscriber writes, at an estimated net Cloudflare cost of ~$120–160/month (setAlarm row writes, alarm invocations) — far below the API/Mongo savings.

## Verification

Manually verified end-to-end against the real Durable Object runtime: `wrangler dev` → request-counting proxy → local API, driving WebSocket connect/disconnect sequences with a Node `ws` client and checking the Mongo subscriber document:

1. First connect → exactly 1 online POST (200), Mongo `isOnline: true`.
2. Second parallel connection → 0 POSTs.
3. Close all + reconnect within 60s → 0 POSTs (pending alarm suppresses; alarm later no-ops were confirmed via the no-reset firing time).
4. Full disconnect → exactly 1 offline POST 60s later, Mongo `isOnline: false` with fresh `lastOnlineAt`.
5. TTL re-assert (with TTL temporarily lowered to 15s, then restored) → stale record forced an online POST despite the pending-alarm suppression.

A sequence that previously produced 5 API calls produced 2. Full annotated log: [online_state_verification_annotated.log](https://cursor.com/artifacts/c/art-ecaa99c8-5be5-42c2-a439-eca6c94c1a4b)

`tsc --noEmit` passes on the worker package.

## Notes

- `enterprise/workers/socket` is tracked directly in this repo (not the `.source` submodule), so no matching `packages-enterprise` PR is needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a9daa71-5af5-4ea3-95ec-43e10be3f9c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a9daa71-5af5-4ea3-95ec-43e10be3f9c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The WebSocketRoom Durable Object now reports subscriber online/offline state using a debounced alarm model instead of immediate per-disconnection notifications. On connection, the code suppresses redundant online reports if the room already has live connections or a pending offline alarm. On last disconnect, it schedules a 60-second debounced alarm; if a reconnect occurs before it fires, the alarm no-ops, collapsing offline+online pairs. Online-report metadata is stored in durable storage with a self-healing TTL that re-asserts successful reports older than 6 hours. This reduces redundant API calls by ~70% (estimated 16M calls/day reduction from ~23M total).

## Affected areas

**enterprise/workers/socket** – The WebSocketRoom Durable Object now uses an alarm-driven debounced offline-reporting mechanism with online-suppression logic and durable storage for online-report metadata. A new `IOnlineReportRecord` interface was added to define the shape of stored online reports. The API contract for `notifySubscriberOnlineState()` changed to return `Promise<boolean>` instead of `Promise<void>` to signal success/failure.

## Key technical decisions

- **API contract change**: `notifySubscriberOnlineState()` now returns `Promise<boolean>`, indicating success/failure rather than void.
- **Debounced offline reporting**: 60-second alarm-based debouncing collapses rapid disconnect/reconnect pairs.
- **Online suppression**: Reads-only checks prevent redundant online reports based on existing connections and pending offline alarms.
- **Self-healing TTL**: Stored online reports include timestamp and JWT; reports older than 6 hours are re-asserted.
- **Offline retry resilience**: Failed offline POSTs throw from `alarm()`, allowing Cloudflare to retry with backoff while suppression remains active.

## Testing

No test additions were mentioned in the provided changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the immediate per-disconnect API calls that report subscriber online state with a debounced alarm approach in the `WebSocketRoom` Durable Object, aiming to cut ~23 M daily calls to `/v1/internal/subscriber-online-state` by suppressing redundant online POSTs and collapsing rapid reconnect cycles into zero calls.

- **Online suppression**: a new `reportOnlineIfNeeded` method skips the online POST when live connections already exist or an offline alarm is pending, and stores `{reportedAt, jwtToken, userId, environmentId}` on each successful assertion; the record is re-asserted after 6 h to self-heal external state divergence.
- **Debounced offline**: `webSocketClose` sets a 60 s alarm instead of POSTing immediately; `alarm()` no-ops if connections are restored before it fires, and throws on API failure so Cloudflare retries with backoff.
- **Types**: a new `IOnlineReportRecord` interface formalises the single storage record.

<h3>Confidence Score: 3/5</h3>

The debouncing logic is sound for the happy path, but the single-record alarm design may report the wrong subscriber offline in any multi-user DO scenario, and the stored JWT can expire for long single-tab sessions causing the offline alarm to retry indefinitely.

Two distinct correctness issues exist. The ONLINE_REPORT_KEY record holds exactly one userId/jwtToken, yet the class exposes tag-filtered multi-user APIs. The original code used the disconnecting socket's own metadata, so it was always per-user correct; the new alarm handler reads a single stored record, meaning in any multi-user room the wrong subscriber gets reported offline. Additionally, for a subscriber maintaining one open connection longer than the JWT lifetime with no second connection to trigger the 6 h re-assertion, the stored JWT expires and the alarm enters a Cloudflare-managed retry loop with no termination condition, keeping the DO alive and the subscriber permanently marked online.

enterprise/workers/socket/src/durable-objects/websocket-room.ts — specifically the alarm() handler and the reportOnlineIfNeeded suppression logic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| enterprise/workers/socket/src/durable-objects/websocket-room.ts | Rewrites subscriber online-state reporting from immediate API calls to debounced alarms; introduces a single per-DO storage record for userId/jwtToken that may report the wrong user offline in multi-user DO scenarios, and may fail indefinitely for long-lived sessions with expired JWTs. |
| enterprise/workers/socket/src/types/index.ts | Adds the new IOnlineReportRecord interface with reportedAt, jwtToken, userId, and environmentId fields; straightforward and correct. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant DO as WebSocketRoom DO
    participant S as DO Storage
    participant API as Novu API

    C->>DO: fetch (connect, 1st socket)
    DO->>S: getAlarm() + get(onlineReport)
    S-->>DO: "alarm=null, report=undefined"
    DO->>API: POST online
    API-->>DO: 200 OK
    DO->>S: put(onlineReport)

    C->>DO: fetch (connect, 2nd tab)
    Note over DO: isAlreadyOnline=true and isFreshlyReported=true, skip

    C->>DO: webSocketClose (last socket)
    DO->>S: setAlarm(now + 60s)

    alt Reconnects within 60s
        C->>DO: fetch (reconnect)
        Note over DO: pendingAlarm != null, skip online POST
        DO->>DO: "alarm fires, sockets > 0, no-op"
    else No reconnect
        DO->>DO: alarm fires, no live sockets
        DO->>API: POST offline
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aenterprise%2Fworkers%2Fsocket%2Fsrc%2Fdurable-objects%2Fwebsocket-room.ts%3A131-156%0A**Single-record%20design%20breaks%20if%20DO%20hosts%20multiple%20users**%0A%0AThe%20class%20retains%20tag-based%2C%20per-user%20APIs%20%28%60getWebSockets%28'user%3AX'%29%60%2C%20%60sendToUser%60%2C%20%60getActiveConnectionsForUser%60%29%20that%20exist%20precisely%20because%20one%20DO%20instance%20can%20serve%20multiple%20subscribers.%20The%20original%20%60handleSubscriberDisconnection%60%20used%20%60metadata.userId%60%2F%60metadata.jwtToken%60%20from%20the%20disconnecting%20socket%2C%20so%20it%20correctly%20reported%20*that%20user's*%20offline%20state.%20The%20new%20%60alarm%28%29%60%20instead%20reads%20a%20single%20%60ONLINE_REPORT_KEY%60%20record%20%E2%80%94%20last%20overwritten%20by%20whoever%20triggered%20the%20most%20recent%20successful%20online%20POST%20%E2%80%94%20so%20it%20will%20report%20the%20*wrong*%20user%20as%20offline%20whenever%20two%20users%20share%20the%20same%20DO%20instance.%20If%20the%20DO%20is%20guaranteed%20to%20be%20per-subscriber%20%28one%20user%20per%20room%29%2C%20this%20is%20fine%2C%20but%20the%20code%20does%20not%20enforce%20that%20invariant%20and%20the%20existing%20multi-user%20APIs%20suggest%20it%20is%20not%20enforced%20externally%20either.%0A%0A%23%23%23%20Issue%202%20of%203%0Aenterprise%2Fworkers%2Fsocket%2Fsrc%2Fdurable-objects%2Fwebsocket-room.ts%3A136-155%0A**Stale%20JWT%20causes%20unbounded%20alarm%20retries%20for%20long-lived%20connections**%0A%0A%60ONLINE_REPORT_KEY.jwtToken%60%20is%20refreshed%20only%20when%20%60reportOnlineIfNeeded%60%20actually%20calls%20the%20API%2C%20which%20is%20skipped%20while%20%60isAlreadyOnline%20%26%26%20isFreshlyReported%60%20is%20true%20%E2%80%94%20i.e.%20as%20long%20as%20existing%20connections%20are%20present%20and%20the%20last%20report%20is%20under%206%20h%20old.%20For%20a%20subscriber%20with%20a%20single%20long-lived%20connection%20%28no%20second%20tab%20opening%20to%20trigger%20re-assertion%29%2C%20the%20stored%20JWT%20is%20only%20as%20fresh%20as%20the%20initial%20connect.%20If%20the%20JWT%20lifetime%20is%20shorter%20than%20the%20session%20length%2C%20the%20alarm%20fires%20with%20an%20expired%20token%2C%20receives%20a%20401%2C%20throws%2C%20and%20Cloudflare%20retries%20indefinitely%20%E2%80%94%20keeping%20the%20DO%20awake%20and%20generating%20alarm%20invocations%20%E2%80%94%20while%20the%20subscriber%20remains%20permanently%20marked%20%22online%22%20in%20the%20database.%20Updating%20%60ONLINE_REPORT_KEY%60%20with%20the%20closing%20socket's%20JWT%20in%20%60webSocketClose%60%20%28before%20scheduling%20the%20alarm%29%20would%20at%20least%20ensure%20the%20freshest%20available%20token%20is%20used%2C%20though%20the%20deeper%20fix%20is%20an%20internal%2Fservice-account%20credential%20for%20alarm-time%20offline%20POSTs.%0A%0A%23%23%23%20Issue%203%20of%203%0Aenterprise%2Fworkers%2Fsocket%2Fsrc%2Fdurable-objects%2Fwebsocket-room.ts%3A244-256%0A**%60isFreshlyReported%60%20alone%20is%20not%20sufficient%20to%20trust%20the%20DB%20state**%0A%0A%60isFreshlyReported%60%20is%20%60true%60%20as%20long%20as%20%60reportedAt%60%20is%20within%20the%20last%206%20h.%20However%2C%20after%20a%20successful%20offline%20alarm%20fires%20%28subscriber%20reported%20offline%2C%20%60ONLINE_REPORT_KEY%60%20is%20NOT%20deleted%29%2C%20the%20record%20remains%20in%20storage.%20If%20the%20subscriber%20reconnects%20within%206%20h%2C%20%60isFreshlyReported%60%20will%20still%20be%20%60true%60%20but%20the%20DB%20says%20*offline*.%20Here%20%60isAlreadyOnline%20%3D%20false%60%20%28no%20connections%2C%20no%20pending%20alarm%29%2C%20so%20%60false%20%26%26%20true%60%20evaluates%20to%20%60false%60%20and%20the%20online%20call%20proceeds%20%E2%80%94%20correct.%20However%2C%20if%20the%20alarm%20failed%20on%20the%20last%20attempt%20%28threw%29%2C%20%60getAlarm%28%29%60%20returns%20the%20next%20retry%20timestamp%2C%20so%20%60pendingAlarm%20!%3D%3D%20null%60%20and%20%60isAlreadyOnline%20%3D%20true%60.%20Combined%20with%20%60isFreshlyReported%20%3D%20true%60%2C%20the%20reconnecting%20subscriber's%20online%20POST%20is%20suppressed%20even%20though%20the%20DB%20may%20have%20been%20set%20to%20offline%20on%20a%20previous%20successful%20retry.%20A%20clarifying%20comment%20or%20state%20flag%20would%20confirm%20this%20edge%20case%20is%20intentionally%20tolerated.%0A%0A&pr=11539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
enterprise/workers/socket/src/durable-objects/websocket-room.ts:131-156
**Single-record design breaks if DO hosts multiple users**

The class retains tag-based, per-user APIs (`getWebSockets('user:X')`, `sendToUser`, `getActiveConnectionsForUser`) that exist precisely because one DO instance can serve multiple subscribers. The original `handleSubscriberDisconnection` used `metadata.userId`/`metadata.jwtToken` from the disconnecting socket, so it correctly reported *that user's* offline state. The new `alarm()` instead reads a single `ONLINE_REPORT_KEY` record — last overwritten by whoever triggered the most recent successful online POST — so it will report the *wrong* user as offline whenever two users share the same DO instance. If the DO is guaranteed to be per-subscriber (one user per room), this is fine, but the code does not enforce that invariant and the existing multi-user APIs suggest it is not enforced externally either.

### Issue 2 of 3
enterprise/workers/socket/src/durable-objects/websocket-room.ts:136-155
**Stale JWT causes unbounded alarm retries for long-lived connections**

`ONLINE_REPORT_KEY.jwtToken` is refreshed only when `reportOnlineIfNeeded` actually calls the API, which is skipped while `isAlreadyOnline && isFreshlyReported` is true — i.e. as long as existing connections are present and the last report is under 6 h old. For a subscriber with a single long-lived connection (no second tab opening to trigger re-assertion), the stored JWT is only as fresh as the initial connect. If the JWT lifetime is shorter than the session length, the alarm fires with an expired token, receives a 401, throws, and Cloudflare retries indefinitely — keeping the DO awake and generating alarm invocations — while the subscriber remains permanently marked "online" in the database. Updating `ONLINE_REPORT_KEY` with the closing socket's JWT in `webSocketClose` (before scheduling the alarm) would at least ensure the freshest available token is used, though the deeper fix is an internal/service-account credential for alarm-time offline POSTs.

### Issue 3 of 3
enterprise/workers/socket/src/durable-objects/websocket-room.ts:244-256
**`isFreshlyReported` alone is not sufficient to trust the DB state**

`isFreshlyReported` is `true` as long as `reportedAt` is within the last 6 h. However, after a successful offline alarm fires (subscriber reported offline, `ONLINE_REPORT_KEY` is NOT deleted), the record remains in storage. If the subscriber reconnects within 6 h, `isFreshlyReported` will still be `true` but the DB says *offline*. Here `isAlreadyOnline = false` (no connections, no pending alarm), so `false && true` evaluates to `false` and the online call proceeds — correct. However, if the alarm failed on the last attempt (threw), `getAlarm()` returns the next retry timestamp, so `pendingAlarm !== null` and `isAlreadyOnline = true`. Combined with `isFreshlyReported = true`, the reconnecting subscriber's online POST is suppressed even though the DB may have been set to offline on a previous successful retry. A clarifying comment or state flag would confirm this edge case is intentionally tolerated.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): reduce subscriber-online-s..."](https://github.com/novuhq/novu/commit/7745b3237c15d270447c6fefe68a75bf8cdec749) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37246977)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->