### PR TITLE
fix(framework): support zod v4 schemas in json schema transformation

### DIFF
--- a/packages/framework/src/validators/validator.test.ts
+++ b/packages/framework/src/validators/validator.test.ts
@@ -581,5 +581,20 @@ describe('validators', () => {
         required: ['name', 'age'],
       });
     });
+
+    it('should transform a Zod v4 schema with a transform to its input-side JSON schema', async () => {
+      const schema = zV4.object({ name: zV4.string().transform((value) => value.length) }) as unknown as ZodSchema;
+
+      const result = await transformSchema(schema);
+
+      expect(result).toEqual({
+        $schema: 'https://json-schema.org/draft-07/schema',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        required: ['name'],
+      });
+    });
   });
 });

--- a/packages/framework/src/validators/validator.test.ts
+++ b/packages/framework/src/validators/validator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
+import { z as zV4 } from 'zod/v4';
 import { JsonSchema, Schema, ZodSchema } from '../types/schema.types';
 import { transformSchema, validateData } from './base.validator';
 
@@ -348,6 +349,19 @@ describe('validators', () => {
         errors: [{ message: 'Invalid input', path: '/name' }],
       });
     });
+
+    it('should validate data against a real Zod v4 schema', async () => {
+      const schema = zV4.object({ name: zV4.string() }) as unknown as ZodSchema;
+
+      const validResult = await validateData(schema, { name: 'John' });
+      expect(validResult).toEqual({ success: true, data: { name: 'John' } });
+
+      const invalidResult = await validateData(schema, { name: 123 });
+      expect(invalidResult).toEqual({
+        success: false,
+        errors: [{ message: 'Invalid input: expected string, received number', path: '/name' }],
+      });
+    });
   });
 
   describe('transformSchema', () => {
@@ -550,6 +564,22 @@ describe('validators', () => {
 
       // @ts-expect-error - we are testing the type guard
       await expect(transformSchema(schema)).rejects.toThrow('Invalid schema');
+    });
+
+    it('should transform a Zod v4 schema, which zod-to-json-schema cannot handle', async () => {
+      const schema = zV4.object({ name: zV4.string(), age: zV4.number() }) as unknown as ZodSchema;
+
+      const result = await transformSchema(schema);
+
+      expect(result).toEqual({
+        $schema: 'https://json-schema.org/draft-07/schema',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+        required: ['name', 'age'],
+      });
     });
   });
 });

--- a/packages/framework/src/validators/zod.validator.ts
+++ b/packages/framework/src/validators/zod.validator.ts
@@ -54,6 +54,16 @@ export class ZodValidator implements Validator<ZodSchema> {
   }
 
   async transformToJsonSchema(schema: ZodSchema): Promise<JsonSchema> {
+    if ('_zod' in schema) {
+      // Zod v4 schemas store their internals under `_zod` and are not supported
+      // by zod-to-json-schema, which walks v3 internals only.
+      const { toJSONSchema } = await import('zod/v4/core');
+
+      return toJSONSchema(schema as unknown as Parameters<typeof toJSONSchema>[0], {
+        target: 'draft-7',
+      }) as JsonSchema;
+    }
+
     const { zodToJsonSchema } = await import('zod-to-json-schema');
 
     // TODO: zod-to-json-schema is not using JSONSchema7

--- a/packages/framework/src/validators/zod.validator.ts
+++ b/packages/framework/src/validators/zod.validator.ts
@@ -59,8 +59,13 @@ export class ZodValidator implements Validator<ZodSchema> {
       // by zod-to-json-schema, which walks v3 internals only.
       const { toJSONSchema } = await import('zod/v4/core');
 
+      // `io: 'input'` converts the input side of the schema so that schemas
+      // with transforms/pipes describe what clients send (and don't throw,
+      // as transforms cannot be represented in JSON Schema on the output
+      // side) — the same side zod-to-json-schema converts for v3.
       return toJSONSchema(schema as unknown as Parameters<typeof toJSONSchema>[0], {
         target: 'draft-7',
+        io: 'input',
       }) as JsonSchema;
     }
 


### PR DESCRIPTION
## What changed? Why was the change needed?

Follow-up to #11891, closing the remaining runtime gap from #9416.

`transformToJsonSchema` always runs schemas through `zod-to-json-schema`, which only knows how to walk zod v3 internals (`_def.typeName`). Zod v4 schemas keep their def under `_zod`, so during workflow discovery a v4 schema comes out as a broken/empty JSON schema even though validation itself now works.

The fix detects v4 via the `'_zod' in schema` check and uses zod's own `toJSONSchema` from `zod/v4/core` (targeting draft-7 to match what `zod-to-json-schema` emits), keeping the existing `zod-to-json-schema` path untouched for v3. No dependency changes — the locked zod 3.25.x already ships the `zod/v4` subpaths, which also lets the tests exercise a real v4 schema.

Two notes for reviewers: the v4 output has no `additionalProperties: false` and uses the https form of the draft-07 `$schema` URL, which is zod's own serialization; and I deliberately didn't touch the `ZodSchema` type exports since #11527 covers that territory — this PR is only about the runtime transform.

Tested with `pnpm test` in packages/framework (vitest --typecheck): the new transform test fails on current `next` (zod-to-json-schema can't walk the v4 def) and passes with the fix; the real-v4 validate test and all existing validator cases pass.

## Screenshots

n/a

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Zod v4 support to JSON-schema transformation in the framework validators.

- Routes Zod v4 schemas through `zod/v4/core` JSON-schema conversion.
- Keeps the existing `zod-to-json-schema` path for Zod v3 schemas.
- Uses input-side conversion so transformed v4 schemas describe client input.
- Adds tests for real Zod v4 validation and transformation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the zod-validator contract by inspecting the environment snapshot that records Node and pnpm versions, working directory, and the exact focused command.
- Ran the focused Vitest test set for the zod validator and confirmed the run completed with exit code 0 and all tests passing (32/32), with the full output available in the focused test artifact.
- Reviewed the focused test log to note the engine warning and verify that no type errors were reported, matching the 32/32 passing tests.

<a href="https://app.greptile.com/trex/runs/14223332/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/validators/zod.validator.ts | Adds a Zod v4 JSON-schema transformation path while preserving the Zod v3 path. |
| packages/framework/src/validators/validator.test.ts | Adds tests for Zod v4 validation, JSON-schema transformation, and transformed input schemas. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(framework): convert the input side o..."](https://github.com/novuhq/novu/commit/181e11269a60d5accf183200bf7ef55e7a4ce67b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43775636)</sub>

<!-- /greptile_comment -->