### PR TITLE
feat(dashboard,api-service): enable image asset upload in maily email editor fixes NV-8315

### DIFF
--- a/apps/api/src/app/storage/e2e/get-signed-url.e2e.ts
+++ b/apps/api/src/app/storage/e2e/get-signed-url.e2e.ts
@@ -18,4 +18,30 @@ describe('Get Signed Url - /storage/upload-url (GET) #novu-v0', () => {
     expect(data.signedUrl).to.contain('.jpg');
     expect(data.signedUrl).to.contain(`${session.organization._id}/${session.environment._id}`);
   });
+
+  it('should return a signed URL under the email-assets prefix for the EMAIL_ASSET type', async () => {
+    const {
+      body: { data },
+    } = await session.testAgent.get('/v1/storage/upload-url?extension=png&type=EMAIL_ASSET');
+
+    expect(data.path).to.contain('.png');
+    expect(data.signedUrl).to.contain(`${session.organization._id}/${session.environment._id}/email-assets/`);
+  });
+
+  it('should accept gif and webp extensions', async () => {
+    for (const extension of ['gif', 'webp']) {
+      const {
+        body: { data },
+      } = await session.testAgent.get(`/v1/storage/upload-url?extension=${extension}&type=EMAIL_ASSET`);
+
+      expect(data.path).to.contain(`.${extension}`);
+      expect(data.signedUrl).to.contain(`.${extension}`);
+    }
+  });
+
+  it('should reject an svg extension', async () => {
+    const { status } = await session.testAgent.get('/v1/storage/upload-url?extension=svg&type=EMAIL_ASSET');
+
+    expect(status).to.equal(422);
+  });
 });

--- a/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.command.ts
+++ b/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.command.ts
@@ -1,11 +1,11 @@
-import { UploadTypesEnum } from '@novu/shared';
+import { FileExtensionEnum, UploadTypesEnum } from '@novu/shared';
 import { IsDefined, IsEnum, IsIn, IsString } from 'class-validator';
 
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class GetSignedUrlCommand extends EnvironmentWithUserCommand {
   @IsString()
-  @IsIn(['jpg', 'png', 'jpeg'])
+  @IsIn(Object.values(FileExtensionEnum))
   extension: string;
 
   @IsDefined()

--- a/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.usecase.ts
+++ b/apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.usecase.ts
@@ -15,6 +15,8 @@ export class GetSignedUrl {
     switch (command.type) {
       case UploadTypesEnum.USER_PROFILE:
         return `users/${command.userId}/profile-pictures/${randomId}.${command.extension}`;
+      case UploadTypesEnum.EMAIL_ASSET:
+        return `${command.organizationId}/${command.environmentId}/email-assets/${randomId}.${command.extension}`;
       case UploadTypesEnum.BRANDING:
       default:
         return `${command.organizationId}/${command.environmentId}/${randomId}.${command.extension}`;

--- a/apps/dashboard/src/api/storage.ts
+++ b/apps/dashboard/src/api/storage.ts
@@ -1,0 +1,20 @@
+import type { FileExtensionEnum, IEnvironment, UploadTypesEnum } from '@novu/shared';
+import { get } from './api.client';
+
+export type UploadUrlResponse = {
+  signedUrl: string;
+  path: string;
+  additionalHeaders?: Record<string, string>;
+};
+
+export async function getSignedUploadUrl({
+  environment,
+  extension,
+  type,
+}: {
+  environment: IEnvironment;
+  extension: FileExtensionEnum;
+  type: UploadTypesEnum;
+}): Promise<{ data: UploadUrlResponse }> {
+  return get(`/storage/upload-url?extension=${extension}&type=${type}`, { environment });
+}

--- a/apps/dashboard/src/components/maily/maily-config.tsx
+++ b/apps/dashboard/src/components/maily/maily-config.tsx
@@ -24,6 +24,7 @@ import {
   getVariableSuggestions,
   HTMLCodeBlockExtension,
   ImageExtension,
+  ImageUploadExtension,
   InlineImageExtension,
   LinkExtension,
   ButtonAttributes as MailyButtonAttributes,
@@ -55,6 +56,7 @@ import { createHtmlCodeBlock } from '@/components/maily/blocks/html';
 import { ForView } from '@/components/maily/views/for-view';
 import { HTMLCodeBlockView } from '@/components/maily/views/html-view';
 import { useDataRef } from '@/hooks/use-data-ref';
+import { EMAIL_ASSET_MIME_TYPES, useEmailAssetUpload } from '@/hooks/use-email-asset-upload';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { LocalizationResourceEnum, TranslationKey } from '@/types/translations';
 import { IsAllowedVariable, LiquidVariable, ParsedVariables } from '@/utils/parseStepVariables';
@@ -343,6 +345,9 @@ export const useCreateExtensions = ({
    */
   const propsRef = useDataRef(props);
 
+  const { isEnabled: isEmailAssetUploadEnabled, uploadAsset } = useEmailAssetUpload();
+  const uploadAssetRef = useDataRef(uploadAsset);
+
   const translationExtension = useCreateTranslationExtension({
     isTranslationEnabled: isTranslationEnabled ?? false,
     translationKeys: props.translationKeys,
@@ -456,6 +461,15 @@ export const useCreateExtensions = ({
 
     if (isTranslationEnabled) {
       extensions.push(translationExtension);
+    }
+
+    if (isEmailAssetUploadEnabled) {
+      extensions.push(
+        ImageUploadExtension.configure({
+          onImageUpload: (file: Blob) => uploadAssetRef.current(file),
+          allowedMimeTypes: EMAIL_ASSET_MIME_TYPES,
+        })
+      );
     }
 
     extensions.push(
@@ -595,5 +609,5 @@ export const useCreateExtensions = ({
     );
 
     return extensions;
-  }, [propsRef, translationExtension, isTranslationEnabled]);
+  }, [propsRef, translationExtension, isTranslationEnabled, isEmailAssetUploadEnabled, uploadAssetRef]);
 };

--- a/apps/dashboard/src/hooks/use-email-asset-upload.ts
+++ b/apps/dashboard/src/hooks/use-email-asset-upload.ts
@@ -1,0 +1,75 @@
+import {
+  FeatureFlagsKeysEnum,
+  MIME_TYPE_TO_FILE_EXTENSION,
+  MimeTypesEnum,
+  UploadTypesEnum,
+} from '@novu/shared';
+import { useCallback } from 'react';
+import { getSignedUploadUrl } from '@/api/storage';
+import { showErrorToast } from '@/components/primitives/sonner-helpers';
+import { useEnvironment } from '@/context/environment/hooks';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
+
+export const MAX_EMAIL_ASSET_SIZE_BYTES = 2 * 1024 * 1024;
+
+// SVG is intentionally excluded: most email clients don't render it and it can carry scripts.
+export const EMAIL_ASSET_MIME_TYPES: MimeTypesEnum[] = [
+  MimeTypesEnum.JPEG,
+  MimeTypesEnum.PNG,
+  MimeTypesEnum.GIF,
+  MimeTypesEnum.WEBP,
+];
+
+export function useEmailAssetUpload() {
+  const { currentEnvironment } = useEnvironment();
+  const isFlagEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_EMAIL_ASSET_UPLOAD_ENABLED);
+
+  const uploadAsset = useCallback(
+    async (file: Blob): Promise<string> => {
+      if (!currentEnvironment) {
+        throw new Error('No environment selected');
+      }
+
+      const mimeType = file.type as MimeTypesEnum;
+
+      if (!EMAIL_ASSET_MIME_TYPES.includes(mimeType)) {
+        showErrorToast('Only JPEG, PNG, GIF and WebP images can be uploaded');
+        throw new Error(`Unsupported image type: ${file.type}`);
+      }
+
+      if (file.size > MAX_EMAIL_ASSET_SIZE_BYTES) {
+        showErrorToast('Images must be smaller than 2 MB');
+        throw new Error('Image exceeds the 2 MB size limit');
+      }
+
+      try {
+        const { data } = await getSignedUploadUrl({
+          environment: currentEnvironment,
+          extension: MIME_TYPE_TO_FILE_EXTENSION[mimeType],
+          type: UploadTypesEnum.EMAIL_ASSET,
+        });
+
+        const uploadResponse = await fetch(data.signedUrl, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': mimeType,
+            ...data.additionalHeaders,
+          },
+          body: file,
+        });
+
+        if (!uploadResponse.ok) {
+          throw new Error(`Image upload failed with status ${uploadResponse.status}`);
+        }
+
+        return data.path;
+      } catch (error) {
+        showErrorToast('Failed to upload the image, please try again');
+        throw error;
+      }
+    },
+    [currentEnvironment]
+  );
+
+  return { isEnabled: isFlagEnabled, uploadAsset };
+}

--- a/libs/maily-core/src/editor/components/bubble-menu-button.tsx
+++ b/libs/maily-core/src/editor/components/bubble-menu-button.tsx
@@ -14,7 +14,7 @@ export function BubbleMenuButton(item: BubbleMenuItem) {
       data-state={item?.isActive?.()}
       className={cn('!mly-size-7 mly-px-2.5 disabled:mly-cursor-not-allowed', item?.className)}
       type="button"
-      disabled={item.disbabled}
+      disabled={item.disabled}
     >
       {item.icon ? (
         <item.icon className={cn('mly-h-3 mly-w-3 mly-shrink-0 mly-stroke-[2.5]', item?.iconClassName)} />

--- a/libs/maily-core/src/editor/components/image-menu/image-bubble-menu.tsx
+++ b/libs/maily-core/src/editor/components/image-menu/image-bubble-menu.tsx
@@ -15,6 +15,7 @@ import { LinkInputPopover } from '../ui/link-input-popover';
 import { Select } from '../ui/select';
 import { TooltipProvider } from '../ui/tooltip';
 import { ImageSize } from './image-size';
+import { UploadImageAction } from './upload-image-action';
 import { useImageState } from './use-image-state';
 
 export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
@@ -110,10 +111,13 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
                   .run();
               }
             }}
-            tooltip="Source URL"
+            tooltip="Image Source"
             icon={ImageDown}
             editor={editor}
             isVariable={state.isSrcVariable}
+            {...(state.isImageActive
+              ? { renderAction: (close: () => void) => <UploadImageAction editor={editor} close={close} /> }
+              : {})}
           />
 
           {state.isImageActive && (

--- a/libs/maily-core/src/editor/components/image-menu/upload-image-action.tsx
+++ b/libs/maily-core/src/editor/components/image-menu/upload-image-action.tsx
@@ -1,0 +1,95 @@
+import { Editor } from '@tiptap/core';
+import { ImageUpIcon } from 'lucide-react';
+import { useRef } from 'react';
+import { useImageUploadOptions } from '@/editor/extensions/image-upload/image-upload';
+
+type UploadImageActionProps = {
+  editor: Editor;
+  /** Closes the containing popover once a file has been picked. */
+  close: () => void;
+};
+
+/**
+ * "Upload image" row rendered inside the image source popover. Picking a file
+ * uploads it via the configured onImageUpload callback and swaps the selected
+ * image node's src. Renders nothing when uploads are not configured.
+ */
+export function UploadImageAction(props: UploadImageActionProps) {
+  const { editor, close } = props;
+
+  const { onImageUpload, allowedMimeTypes = [] } = useImageUploadOptions(editor);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  if (!onImageUpload) {
+    return null;
+  }
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Clear the input so picking the same file again re-triggers onChange.
+    e.target.value = '';
+
+    if (!file || (allowedMimeTypes.length > 0 && !allowedMimeTypes.includes(file.type))) {
+      return;
+    }
+
+    // Capture the selected image node before the async upload — the selection may
+    // move while the file uploads, so we can't resolve the target afterwards.
+    const pos = editor.state.selection.from;
+    const prevSrc = editor.state.doc.nodeAt(pos)?.attrs?.src;
+
+    close();
+
+    try {
+      const uploadedSrc = await onImageUpload(file);
+
+      const nodeAtPos = editor.state.doc.nodeAt(pos);
+
+      if (nodeAtPos?.type.name === 'image') {
+        const { tr } = editor.state;
+        tr.setNodeMarkup(pos, undefined, { ...nodeAtPos.attrs, src: uploadedSrc, isSrcVariable: false });
+        editor.view.dispatch(tr);
+      } else {
+        // The document shifted during the upload; fall back to matching the node
+        // by the src it had when the file was picked.
+        const { tr } = editor.state;
+        let found = false;
+
+        editor.state.doc.descendants((node, nodePos) => {
+          if (!found && node.type.name === 'image' && node.attrs.src === prevSrc) {
+            tr.setNodeMarkup(nodePos, undefined, { ...node.attrs, src: uploadedSrc, isSrcVariable: false });
+            found = true;
+            return false;
+          }
+        });
+
+        if (found) {
+          editor.view.dispatch(tr);
+        }
+      }
+    } catch (error) {
+      console.error('Image replace failed', error);
+    }
+  };
+
+  return (
+    <div className="mly-mb-1.5">
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        className="mly-flex mly-h-8 mly-w-full mly-items-center mly-gap-2 mly-rounded-lg mly-border mly-border-gray-300 mly-bg-white mly-px-2 mly-text-sm mly-font-medium mly-text-midnight-gray mly-shadow-sm mly-transition-colors hover:mly-bg-gray-50"
+      >
+        <ImageUpIcon className="mly-h-3 mly-w-3 mly-shrink-0 mly-stroke-[2.5]" />
+        <span>Upload image</span>
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={allowedMimeTypes.length > 0 ? allowedMimeTypes.join(',') : 'image/*'}
+        onChange={handleFileChange}
+        className="mly-hidden"
+        multiple={false}
+      />
+    </div>
+  );
+}

--- a/libs/maily-core/src/editor/components/ui/link-input-popover.tsx
+++ b/libs/maily-core/src/editor/components/ui/link-input-popover.tsx
@@ -18,6 +18,12 @@ type LinkInputPopoverProps = {
   icon?: LucideIcon;
   tooltip?: string;
 
+  /**
+   * Optional row rendered above the URL input (e.g. an upload action).
+   * Receives a callback that closes the popover.
+   */
+  renderAction?: (close: () => void) => React.ReactNode;
+
   editor: Editor;
 };
 
@@ -27,6 +33,7 @@ export function LinkInputPopover(props: LinkInputPopoverProps) {
     onValueChange,
     tooltip,
     icon: Icon = Link,
+    renderAction,
     editor,
 
     isVariable,
@@ -90,6 +97,8 @@ export function LinkInputPopover(props: LinkInputPopoverProps) {
         sideOffset={8}
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
+        {renderAction?.(() => setIsOpen(false))}
+
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/libs/maily-core/src/editor/nodes/image/image-view.tsx
+++ b/libs/maily-core/src/editor/nodes/image/image-view.tsx
@@ -1,6 +1,6 @@
 import { type NodeViewProps, NodeViewWrapper } from '@tiptap/react';
-import { Ban, BracesIcon, GrabIcon, ImageOffIcon, Loader2 } from 'lucide-react';
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+import { Ban, BracesIcon, ImageOffIcon, ImageUpIcon, Loader2 } from 'lucide-react';
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useImageUploadOptions } from '@/editor/extensions/image-upload/image-upload';
 import { getAspectRatio, getNewHeight } from '@/editor/utils/aspect-ratio';
 import { cn } from '@/editor/utils/classname';
@@ -13,7 +13,7 @@ export const IMAGE_MAX_HEIGHT = 400;
 export type ImageStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
 export function ImageView(props: NodeViewProps) {
-  const { node, selected, editor } = props;
+  const { node, selected, editor, updateAttributes } = props;
 
   const [status, setStatus] = useState<ImageStatus>('idle');
   const [isPlaceholderImage, setIsPlaceholderImage] = useState(false);
@@ -133,12 +133,28 @@ export function ImageView(props: NodeViewProps) {
   const hasImageSrc = !!attrs.src;
   const isDroppable = !!onImageUpload && editor.isEditable && !hasImageSrc && !isSrcVariable && status === 'idle';
 
+  const acceptedTypesHint = useMemo(() => {
+    if (allowedMimeTypes.length === 0) {
+      return undefined;
+    }
+
+    const names = allowedMimeTypes.map((mime) => {
+      const subtype = mime.split('/')[1] ?? mime;
+      return subtype.replace('+xml', '').toUpperCase();
+    });
+
+    return names.length > 1 ? `${names.slice(0, -1).join(', ')} or ${names[names.length - 1]}` : names[0];
+  }, [allowedMimeTypes]);
+
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!isDroppable || !e.target.files || e.target.files.length === 0) {
       return;
     }
 
     const file = e.target.files[0];
+    // Clear the input so picking the same file again re-triggers onChange
+    // (e.g. retrying after a failed upload).
+    e.target.value = '';
     await handleImageUpload(file);
   };
 
@@ -151,15 +167,21 @@ export function ImageView(props: NodeViewProps) {
       try {
         setStatus('loading');
         const imageUrl = await onImageUpload(file);
-        editor.chain().updateImageAttributes({ src: imageUrl }).run();
+        // Use the node view's position-tracked updateAttributes instead of the
+        // selection-based updateImageAttributes command: by the time the upload
+        // resolves, the selection may have left this image node (file dialog focus
+        // loss, clicks), which would silently drop the src update.
+        updateAttributes({ src: imageUrl });
         setIsPlaceholderImage(false);
         setStatus('loaded');
       } catch (error) {
         console.error('Error uploading image:', error);
-        setStatus('error');
+        // Return to the droppable state so the drop zone reappears and the user
+        // can retry — the 'error' status renders nothing when the node has no src.
+        setStatus('idle');
       }
     },
-    [onImageUpload]
+    [onImageUpload, updateAttributes]
   );
 
   // load the image using new Image() to avoid layout shift
@@ -189,14 +211,13 @@ export function ImageView(props: NodeViewProps) {
       const aspectRatio = getAspectRatio(naturalWidth, naturalHeight);
       const calculatedHeight = Math.min(getNewHeight(wrapperWidth, aspectRatio), naturalHeight);
 
-      editor
-        .chain()
-        .updateImageAttributes({
-          width: Math.min(wrapperWidth, naturalWidth),
-          height: Math.min(calculatedHeight, naturalHeight),
-          aspectRatio,
-        })
-        .run();
+      // Position-tracked update — img.onload fires async, so the selection may no
+      // longer be on this node (see handleImageUpload above).
+      updateAttributes({
+        width: Math.min(wrapperWidth, naturalWidth),
+        height: Math.min(calculatedHeight, naturalHeight),
+        aspectRatio,
+      });
     };
     img.onerror = () => {
       setStatus('error');
@@ -295,7 +316,7 @@ export function ImageView(props: NodeViewProps) {
         : {})}
     >
       {!hasImageSrc && status === 'idle' && (
-        <ImageStatusLabel status="idle" minHeight={height} isDropZone={isDroppable} />
+        <ImageStatusLabel status="idle" minHeight={height} isDropZone={isDroppable} hint={acceptedTypesHint} />
       )}
 
       {!hasImageSrc && status === 'loading' && !isSrcVariable && (
@@ -371,16 +392,29 @@ type ImageStatusLabelProps = {
   status: ImageStatus | 'variable';
   minHeight?: number | string;
   isDropZone?: boolean;
+  /**
+   * Secondary line shown under the drop-zone prompt (e.g. accepted file types).
+   * When provided, the drop zone renders as a spacious stacked layout; without
+   * it, a compact single row is used (e.g. the logo slot).
+   */
+  hint?: string;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 export function ImageStatusLabel(props: ImageStatusLabelProps) {
-  const { status, minHeight, className, style, isDropZone, ...rest } = props;
+  const { status, minHeight, className, style, isDropZone, hint, ...rest } = props;
+
+  const isUploadZone = status === 'idle' && isDropZone;
+  const isStackedUploadZone = isUploadZone && !!hint;
 
   return (
     <div
       {...rest}
       className={cn(
-        'mly-flex mly-items-center mly-justify-center mly-gap-2 mly-rounded-lg mly-bg-soft-gray mly-px-4 mly-py-2 mly-text-sm mly-font-medium',
+        'mly-flex mly-items-center mly-justify-center mly-gap-2 mly-rounded-lg mly-text-sm mly-font-medium mly-leading-normal',
+        isUploadZone
+          ? 'mly-border mly-border-dashed mly-border-gray-300 mly-bg-gray-50 mly-text-gray-600 mly-transition-colors hover:mly-border-gray-400 hover:mly-bg-gray-100'
+          : 'mly-bg-soft-gray',
+        isStackedUploadZone ? 'mly-flex-col mly-gap-3 mly-px-6 mly-py-10' : 'mly-px-4 mly-py-2',
         {
           'mly-text-gray-500 hover:mly-bg-soft-gray/60': status === 'loading',
           'mly-text-red-500 hover:mly-bg-soft-gray/60': status === 'error',
@@ -403,12 +437,25 @@ export function ImageStatusLabel(props: ImageStatusLabelProps) {
         </>
       )}
 
-      {status === 'idle' && isDropZone && (
-        <>
-          <GrabIcon className="mly-size-4 mly-stroke-[2.5]" />
-          <span>Click or Drop image here</span>
-        </>
-      )}
+      {isUploadZone &&
+        (isStackedUploadZone ? (
+          <>
+            <div className="mly-flex mly-size-10 mly-items-center mly-justify-center mly-rounded-full mly-border mly-border-gray-200 mly-bg-white mly-shadow-sm">
+              <ImageUpIcon className="mly-size-[18px] mly-stroke-[1.75] mly-text-gray-500" />
+            </div>
+            <div className="mly-flex mly-flex-col mly-items-center mly-gap-0.5 mly-text-center">
+              <span className="mly-text-sm mly-font-medium mly-text-gray-700">
+                Click to upload <span className="mly-font-normal mly-text-gray-500">or drag and drop</span>
+              </span>
+              <span className="mly-text-xs mly-font-normal mly-text-gray-400">{hint}</span>
+            </div>
+          </>
+        ) : (
+          <>
+            <ImageUpIcon className="mly-size-4 mly-stroke-[2]" />
+            <span>Click or drop image here</span>
+          </>
+        ))}
 
       {status === 'loading' && (
         <>

--- a/libs/maily-core/src/editor/plugins/image-upload/image-upload-plugin.ts
+++ b/libs/maily-core/src/editor/plugins/image-upload/image-upload-plugin.ts
@@ -40,12 +40,12 @@ export function ImageUploadPlugin(options: ImageUploadPluginOptions) {
     const transaction = tr.insert(resolvedPos.pos, imageNode);
     view.dispatch(transaction);
 
+    // Find the placeholder image node
+    const predicate = (node: Node) => node.type.name === 'image' && node.attrs.src === placeholderSrc;
+
     onImageUpload?.(file)
       .then((uploadedSrc) => {
         const updateTr = view.state.tr;
-
-        // Find the placeholder image node
-        const predicate = (node: Node) => node.type.name === 'image' && node.attrs.src === placeholderSrc;
 
         view.state.doc.descendants((node, pos) => {
           if (predicate(node)) {
@@ -61,6 +61,19 @@ export function ImageUploadPlugin(options: ImageUploadPluginOptions) {
       })
       .catch((error) => {
         console.error('Image upload failed', error);
+
+        // Remove the placeholder node — its blob: URL is revoked below, so leaving
+        // it in place persists a permanently broken image.
+        const removeTr = view.state.tr;
+
+        view.state.doc.descendants((node, pos) => {
+          if (predicate(node)) {
+            removeTr.delete(pos, pos + node.nodeSize);
+            return false;
+          }
+        });
+
+        view.dispatch(removeTr);
       })
       .finally(() => {
         editor.extensionStorage.imageUpload.placeholderImages.delete(placeholderSrc);

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -140,6 +140,8 @@ export enum FeatureFlagsKeysEnum {
    * organization for the duration of the rotation, then disable.
    */
   IS_MULTIPLE_SECRET_KEYS_ALLOWED = 'IS_MULTIPLE_SECRET_KEYS_ALLOWED',
+  /** Enable image asset upload (drag/drop, paste, file picker) in the Maily email editor. Requires object storage to be configured on the API. Create the boolean in LaunchDarkly for cloud, or set `VITE_IS_EMAIL_ASSET_UPLOAD_ENABLED` when self-hosted. */
+  IS_EMAIL_ASSET_UPLOAD_ENABLED = 'IS_EMAIL_ASSET_UPLOAD_ENABLED',
 
   // String flags
   CF_SCHEDULER_MODE = 'CF_SCHEDULER_MODE', // Values: "off" | "shadow" | "live" | "complete"

--- a/packages/shared/src/types/files.ts
+++ b/packages/shared/src/types/files.ts
@@ -2,22 +2,30 @@ export enum FileExtensionEnum {
   JPEG = 'jpeg',
   PNG = 'png',
   JPG = 'jpg',
+  GIF = 'gif',
+  WEBP = 'webp',
 }
 
 export enum MimeTypesEnum {
   JPEG = 'image/jpeg',
   PNG = 'image/png',
   JPG = 'image/jpg',
+  GIF = 'image/gif',
+  WEBP = 'image/webp',
 }
 
 export const FILE_EXTENSION_TO_MIME_TYPE: Record<FileExtensionEnum, MimeTypesEnum> = {
   [FileExtensionEnum.JPEG]: MimeTypesEnum.JPEG,
   [FileExtensionEnum.PNG]: MimeTypesEnum.PNG,
   [FileExtensionEnum.JPG]: MimeTypesEnum.JPG,
+  [FileExtensionEnum.GIF]: MimeTypesEnum.GIF,
+  [FileExtensionEnum.WEBP]: MimeTypesEnum.WEBP,
 };
 
 export const MIME_TYPE_TO_FILE_EXTENSION: Record<MimeTypesEnum, FileExtensionEnum> = {
   [MimeTypesEnum.JPEG]: FileExtensionEnum.JPEG,
   [MimeTypesEnum.PNG]: FileExtensionEnum.PNG,
   [MimeTypesEnum.JPG]: FileExtensionEnum.JPG,
+  [MimeTypesEnum.GIF]: FileExtensionEnum.GIF,
+  [MimeTypesEnum.WEBP]: FileExtensionEnum.WEBP,
 };

--- a/packages/shared/src/types/storage.ts
+++ b/packages/shared/src/types/storage.ts
@@ -1,4 +1,5 @@
 export enum UploadTypesEnum {
   BRANDING = 'BRANDING',
   USER_PROFILE = 'USER_PROFILE',
+  EMAIL_ASSET = 'EMAIL_ASSET',
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

The Maily email editor only accepted image **URLs** — users had to host images elsewhere before using them in an email. This PR lets users upload images directly (drag/drop, paste, or file picker) to Novu-managed storage and renders the resulting public URL in the email.

Most of the machinery already existed but was never wired together:

- The Maily fork (`@novu/maily-core`) ships a complete `ImageUploadExtension` with drop/paste/picker UI in the image and logo node views — dormant because the dashboard never registered it.
- The API's presigned-URL endpoint `GET /v1/storage/upload-url` (multi-cloud `StorageService`: S3/GCS/Azure) had no client callers.

**Changes:**

- **Shared:** `gif`/`webp` added to `FileExtensionEnum`/`MimeTypesEnum` + maps; new `UploadTypesEnum.EMAIL_ASSET`; new `IS_EMAIL_ASSET_UPLOAD_ENABLED` feature flag key.
- **API:** extension validation now derives from `FileExtensionEnum` (SVG stays rejected — poor email-client support and a script-carrying format on a public origin); `EMAIL_ASSET` uploads are keyed under `{org}/{env}/email-assets/{randomId}.{ext}`.
- **Dashboard:** new `api/storage.ts` client + `useEmailAssetUpload` hook (mime-type allowlist, 2 MB client-side limit, presigned PUT with `Content-Type`/`additionalHeaders`, error toasts); `maily-config.tsx` registers `ImageUploadExtension` when the flag is on, using the existing data-ref pattern so the memoized extensions call the latest handler.

**Behavior:** flag off → editor is URL-only, exactly as today. Flag on → image block, logo block, and editor-wide drop/paste upload to storage. Inline images stay URL-only (their node view has no upload UI; deferred). Rendering needed no changes — the output renderer already emits `<img src>` verbatim.

### Screenshots

N/A — upload UI is pre-existing (dormant) Maily fork code; no visual changes while the flag is off.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- Storage e2e (`get-signed-url.e2e.ts`) extended and passing locally: `email-assets/` path shape, gif/webp accepted, svg rejected with 422.
- Size limit is client-side only: presigned PUTs can't enforce content-length (only POST policies can). Accepted for MVP — blast radius is the org's own storage path.
- Uploaded assets are env-scoped by key but referenced by absolute public URL, so a workflow promoted to prod keeps pointing at the origin env's asset. Accepted for MVP; matters only if per-env asset cleanup is ever built.
- No asset library/DB entity — upload-and-forget; orphaned files in the bucket are accepted. The `email-assets/` prefix keeps the door open for a future library.
- Before cloud rollout, the `IS_EMAIL_ASSET_UPLOAD_ENABLED` boolean needs creating in LaunchDarkly; self-hosted uses `VITE_IS_EMAIL_ASSET_UPLOAD_ENABLED`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds direct image asset uploads to the Maily email editor. The main changes are:

- Adds `EMAIL_ASSET` storage signing under the organization/environment `email-assets` prefix.
- Adds GIF and WebP file extension and MIME type support in shared storage types.
- Adds a dashboard upload hook that validates image MIME type and size before PUTing to the signed URL.
- Registers Maily image upload support behind the `IS_EMAIL_ASSET_UPLOAD_ENABLED` feature flag.
- Adds upload UI handling for image drop zones, paste/drop placeholders, and image source replacement.

<h3>Confidence Score: 5/5</h3>

This PR appears safe to merge with low risk.

The storage path and validation changes are covered by e2e tests. The dashboard upload path validates file type and size before uploading. The editor integration is feature-flagged and no blocking issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The initial storage-signed-url end-to-end run was attempted and a setup blocker was identified, as captured by storage-signed-url-01-before.log.
- A focused executable validation script named storage-signed-url-focused.ts was generated to isolate gif, webp, and svg cases for targeted verification.
- The focused script was run and produced runtime output with full status codes and messages for the gif/webp/svg cases, as captured by storage-signed-url-02-after.log.
- An evidence log summarizing the executed log and outcomes across gif, webp, svg, and email-assets key shapes was generated to facilitate quick inspection.

<a href="https://app.greptile.com/trex/runs/14804844/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/storage/usecases/get-signed-url/get-signed-url.usecase.ts | Adds EMAIL_ASSET key mapping under organization/environment email-assets prefix; no blocking issues found. |
| apps/dashboard/src/components/maily/maily-config.tsx | Registers ImageUploadExtension behind the feature flag with a ref-backed upload handler; no blocking issues found. |
| apps/dashboard/src/hooks/use-email-asset-upload.ts | Adds client-side MIME/size validation, presigned PUT upload, and toast error handling for email assets. |
| libs/maily-core/src/editor/nodes/image/image-view.tsx | Adds upload drop-zone UI and uses position-tracked node updates for async upload/load callbacks. |
| libs/maily-core/src/editor/plugins/image-upload/image-upload-plugin.ts | Cleans up failed drop/paste upload placeholders and revokes blob URLs after upload completion. |
| packages/shared/src/types/files.ts | Adds GIF/WebP extension and MIME type mappings used by storage signing and dashboard validation. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Maily as Maily editor
participant Dashboard as Dashboard upload hook
participant API as API storage endpoint
participant Storage as Object storage

User->>Maily: Drop/paste/pick image
Maily->>Dashboard: onImageUpload(file)
Dashboard->>Dashboard: Validate MIME type and 2 MB limit
Dashboard->>API: "GET /storage/upload-url?type=EMAIL_ASSET&extension=..."
API->>Storage: Create signed PUT URL for org/env/email-assets key
Storage-->>API: signedUrl, public path, headers
API-->>Dashboard: UploadUrlResponse
Dashboard->>Storage: PUT file with Content-Type/additional headers
Storage-->>Dashboard: Upload success
Dashboard-->>Maily: Public image URL/path
Maily->>Maily: Update image src
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Maily as Maily editor
participant Dashboard as Dashboard upload hook
participant API as API storage endpoint
participant Storage as Object storage

User->>Maily: Drop/paste/pick image
Maily->>Dashboard: onImageUpload(file)
Dashboard->>Dashboard: Validate MIME type and 2 MB limit
Dashboard->>API: "GET /storage/upload-url?type=EMAIL_ASSET&extension=..."
API->>Storage: Create signed PUT URL for org/env/email-assets key
Storage-->>API: signedUrl, public path, headers
API-->>Dashboard: UploadUrlResponse
Dashboard->>Storage: PUT file with Content-Type/additional headers
Storage-->>Dashboard: Upload success
Dashboard-->>Maily: Public image URL/path
Maily->>Maily: Update image src
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fixes"](https://github.com/novuhq/novu/commit/0a453b4d83996a94dd8b170ce7e9c98123222f68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44765309)</sub>

<!-- /greptile_comment -->