### PR TITLE
feat(providers): add Text.lk SMS provider

### DIFF
--- a/apps/dashboard/public/images/providers/light/square/textlk.svg
+++ b/apps/dashboard/public/images/providers/light/square/textlk.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="none" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#F7941D" />
+  <path fill="#fff" d="M8.4 11.2h6.5v2.1h-2.1v7.5h-2.3v-7.5H8.4v-2.1Z" />
+  <path fill="#fff" d="M16.1 11.2h2.3v7.4h4v2.2h-6.3v-9.6Z" />
+  <circle cx="23.2" cy="19.6" r="1.3" fill="#fff" />
+</svg>

--- a/libs/application-generic/src/factories/sms/handlers/index.ts
+++ b/libs/application-generic/src/factories/sms/handlers/index.ts
@@ -34,5 +34,6 @@ export * from './sms77.handler';
 export * from './sns.handler';
 export * from './telnyx.handler';
 export * from './termii.handler';
+export * from './textlk.handler';
 export * from './twilio.handler';
 export * from './unifonic.handler';

--- a/libs/application-generic/src/factories/sms/handlers/textlk.handler.ts
+++ b/libs/application-generic/src/factories/sms/handlers/textlk.handler.ts
@@ -1,0 +1,16 @@
+import { TextLkSmsProvider } from '@novu/providers';
+import { ChannelTypeEnum, ICredentials, SmsProviderIdEnum } from '@novu/shared';
+import { BaseSmsHandler } from './base.handler';
+
+export class TextLkSmsHandler extends BaseSmsHandler {
+  constructor() {
+    super(SmsProviderIdEnum.TextLk, ChannelTypeEnum.SMS);
+  }
+
+  buildProvider(credentials: ICredentials) {
+    this.provider = new TextLkSmsProvider({
+      apiKey: credentials.apiKey,
+      from: credentials.from,
+    });
+  }
+}

--- a/libs/application-generic/src/factories/sms/sms.factory.ts
+++ b/libs/application-generic/src/factories/sms/sms.factory.ts
@@ -36,6 +36,7 @@ import {
   SnsHandler,
   TelnyxHandler,
   TermiiSmsHandler,
+  TextLkSmsHandler,
   TwilioHandler,
   UnifonicHandler,
 } from './handlers';
@@ -49,6 +50,7 @@ export class SmsFactory implements ISmsFactory {
     new TwilioHandler(),
     new Sms77Handler(),
     new TermiiSmsHandler(),
+    new TextLkSmsHandler(),
     new PlivoHandler(),
     new ClickatellHandler(),
     new GupshupSmsHandler(),

--- a/packages/framework/src/schemas/providers/sms/index.ts
+++ b/packages/framework/src/schemas/providers/sms/index.ts
@@ -36,6 +36,7 @@ export const smsProviderSchemas = {
   sns: genericProviderSchemas,
   telnyx: genericProviderSchemas,
   termii: genericProviderSchemas,
+  textlk: genericProviderSchemas,
   twilio: twilioProviderSchemas,
   'afro-message': genericProviderSchemas,
   unifonic: genericProviderSchemas,

--- a/packages/framework/src/shared.ts
+++ b/packages/framework/src/shared.ts
@@ -144,6 +144,7 @@ export enum SmsProviderIdEnum {
   Kannel = 'kannel',
   Maqsam = 'maqsam',
   Termii = 'termii',
+  TextLk = 'textlk',
   AfricasTalking = 'africas-talking',
   Novu = 'novu-sms',
   Sendchamp = 'sendchamp',

--- a/packages/providers/src/lib/sms/index.ts
+++ b/packages/providers/src/lib/sms/index.ts
@@ -36,5 +36,6 @@ export * from './sns/sns.provider';
 export * from './telnyx/telnyx.interface';
 export * from './telnyx/telnyx.provider';
 export * from './termii/termii.provider';
+export * from './textlk/textlk.provider';
 export * from './twilio/twilio.provider';
 export * from './unifonic/unifonic.provider';

--- a/packages/providers/src/lib/sms/textlk/textlk.provider.spec.ts
+++ b/packages/providers/src/lib/sms/textlk/textlk.provider.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { TextLkSmsProvider } from './textlk.provider';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('should trigger Text.lk library correctly', async () => {
+  const provider = new TextLkSmsProvider({
+    apiKey: 'test-api-key',
+    from: 'TextLkTest',
+  });
+
+  const fetchMock = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve({ status: 'success', data: { uid: 'mock-uid-123' } }),
+  });
+  global.fetch = fetchMock;
+
+  const result = await provider.sendMessage({
+    content: 'Your otp code is 32901',
+    from: 'TextLkTest',
+    to: '+94771234567',
+  });
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    'https://app.text.lk/api/v3/sms/send',
+    expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer test-api-key',
+      }),
+      body: '{"recipient":"+94771234567","sender_id":"TextLkTest","type":"plain","message":"Your otp code is 32901"}',
+    })
+  );
+  expect(result.id).toBe('mock-uid-123');
+});
+
+test('should trigger Text.lk library correctly with _passthrough', async () => {
+  const provider = new TextLkSmsProvider({
+    apiKey: 'test-api-key',
+    from: 'TextLkTest',
+  });
+
+  const fetchMock = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve({ status: 'success', data: { uid: 'mock-uid-456' } }),
+  });
+  global.fetch = fetchMock;
+
+  await provider.sendMessage(
+    {
+      content: 'Your otp code is 32901',
+      from: 'TextLkTest',
+      to: '+94771234567',
+    },
+    {
+      _passthrough: {
+        body: {
+          recipient: '+94770000000',
+        },
+      },
+    }
+  );
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    'https://app.text.lk/api/v3/sms/send',
+    expect.objectContaining({
+      body: '{"recipient":"+94770000000","sender_id":"TextLkTest","type":"plain","message":"Your otp code is 32901"}',
+    })
+  );
+});

--- a/packages/providers/src/lib/sms/textlk/textlk.provider.spec.ts
+++ b/packages/providers/src/lib/sms/textlk/textlk.provider.spec.ts
@@ -12,6 +12,8 @@ test('should trigger Text.lk library correctly', async () => {
   });
 
   const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
     json: () => Promise.resolve({ status: 'success', data: { uid: 'mock-uid-123' } }),
   });
   global.fetch = fetchMock;
@@ -42,6 +44,8 @@ test('should trigger Text.lk library correctly with _passthrough', async () => {
   });
 
   const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
     json: () => Promise.resolve({ status: 'success', data: { uid: 'mock-uid-456' } }),
   });
   global.fetch = fetchMock;
@@ -67,4 +71,25 @@ test('should trigger Text.lk library correctly with _passthrough', async () => {
       body: '{"recipient":"+94770000000","sender_id":"TextLkTest","type":"plain","message":"Your otp code is 32901"}',
     })
   );
+});
+
+test('should reject when Text.lk returns an error response', async () => {
+  const provider = new TextLkSmsProvider({
+    apiKey: 'test-api-key',
+    from: 'TextLkTest',
+  });
+
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 422,
+    json: () => Promise.resolve({ status: 'error', message: 'Insufficient balance' }),
+  });
+
+  await expect(
+    provider.sendMessage({
+      content: 'Your otp code is 32901',
+      from: 'TextLkTest',
+      to: '+94771234567',
+    })
+  ).rejects.toThrow('Text.lk SMS error: Insufficient balance');
 });

--- a/packages/providers/src/lib/sms/textlk/textlk.provider.ts
+++ b/packages/providers/src/lib/sms/textlk/textlk.provider.ts
@@ -1,0 +1,60 @@
+import { SmsProviderIdEnum } from '@novu/shared';
+import { ChannelTypeEnum, ISendMessageSuccessResponse, ISmsOptions, ISmsProvider } from '@novu/stateless';
+import { BaseProvider, CasingEnum } from '../../../base.provider';
+import { WithPassthrough } from '../../../utils/types';
+
+interface ITextLkResponse {
+  status?: string;
+  message?: string;
+  data?: {
+    uid?: string;
+    status?: string;
+    cost?: string;
+  };
+}
+
+export class TextLkSmsProvider extends BaseProvider implements ISmsProvider {
+  public static readonly BASE_URL = 'https://app.text.lk/api/v3/sms/send';
+  channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
+  protected casing = CasingEnum.SNAKE_CASE;
+  id = SmsProviderIdEnum.TextLk;
+
+  constructor(
+    private config: {
+      apiKey?: string;
+      from?: string;
+    }
+  ) {
+    super();
+  }
+
+  async sendMessage(
+    options: ISmsOptions,
+    bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
+  ): Promise<ISendMessageSuccessResponse> {
+    const data = this.transform(bridgeProviderData, {
+      recipient: options.to,
+      sender_id: options.from || this.config.from,
+      type: 'plain',
+      message: options.content,
+    });
+
+    const response = await fetch(TextLkSmsProvider.BASE_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.config.apiKey}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        ...data.headers,
+      },
+      body: JSON.stringify(data.body),
+    });
+
+    const body = (await response.json()) as ITextLkResponse;
+
+    return {
+      id: body.data?.uid,
+      date: new Date().toISOString(),
+    };
+  }
+}

--- a/packages/providers/src/lib/sms/textlk/textlk.provider.ts
+++ b/packages/providers/src/lib/sms/textlk/textlk.provider.ts
@@ -52,8 +52,12 @@ export class TextLkSmsProvider extends BaseProvider implements ISmsProvider {
 
     const body = (await response.json()) as ITextLkResponse;
 
+    if (!response.ok || body.status !== 'success' || !body.data?.uid) {
+      throw new Error(`Text.lk SMS error: ${body.message || `request failed with status ${response.status}`}`);
+    }
+
     return {
-      id: body.data?.uid,
+      id: body.data.uid,
       date: new Date().toISOString(),
     };
   }

--- a/packages/shared/src/consts/providers/channels/sms.ts
+++ b/packages/shared/src/consts/providers/channels/sms.ts
@@ -37,6 +37,7 @@ import {
   snsConfig,
   telnyxConfig,
   termiiConfig,
+  textLkConfig,
   twilioConfig,
   unifonicConfig,
 } from '../credentials';
@@ -197,6 +198,14 @@ export const smsProviders: IProviderConfig[] = [
     credentials: smsCentralConfig,
     docReference: 'https://www.smscentral.com.au/sms-api/',
     logoFileName: { light: 'sms-central.png', dark: 'sms-central.png' },
+  },
+  {
+    id: SmsProviderIdEnum.TextLk,
+    displayName: 'Text.lk',
+    channel: ChannelTypeEnum.SMS,
+    credentials: textLkConfig,
+    docReference: 'https://docs.text.lk/',
+    logoFileName: { light: 'textlk.svg', dark: 'textlk.svg' },
   },
   {
     id: SmsProviderIdEnum.Termii,

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -373,6 +373,16 @@ export const termiiConfig: IConfigCredential[] = [
   ...smsConfigBase,
 ];
 
+export const textLkConfig: IConfigCredential[] = [
+  {
+    key: CredentialsKeyEnum.ApiKey,
+    displayName: 'API Key',
+    type: 'string',
+    required: true,
+  },
+  ...smsConfigBase,
+];
+
 export const burstSmsConfig: IConfigCredential[] = [
   {
     key: CredentialsKeyEnum.ApiKey,

--- a/packages/shared/src/types/providers.ts
+++ b/packages/shared/src/types/providers.ts
@@ -116,6 +116,7 @@ export enum SmsProviderIdEnum {
   Kannel = 'kannel',
   Maqsam = 'maqsam',
   Termii = 'termii',
+  TextLk = 'textlk',
   AfricasTalking = 'africas-talking',
   Novu = 'novu-sms',
   Sendchamp = 'sendchamp',


### PR DESCRIPTION
feat(providers): add Text.lk SMS provider

Adds Text.lk as a native SMS provider, following the add-a-provider guide. Closes #9725 (Linear NV-7005).

Text.lk has a simple HTTP SMS API. This wires it in end to end:
- `packages/providers/src/lib/sms/textlk` (provider + spec)
- `@novu/shared`: provider enum, credentials, metadata
- `@novu/framework`: provider enum + schema
- generic SMS handler + factory registration
- dashboard logo

Credentials are an API token + sender ID, mapped to the standard `ISmsProvider` interface. Tests are in `textlk.provider.spec.ts`.

The `textlk.svg` logo is a placeholder, happy to swap it for the official asset. Also happy to adjust credential naming to match your conventions.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Text.lk as an end-to-end SMS provider.

- Implements the Text.lk HTTP provider with passthrough support and response validation.
- Registers its credentials, identifiers, framework schema, application handler, factory entry, and dashboard asset.
- Adds provider tests for successful sends, passthrough overrides, and vendor errors.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported error-response path now throws before returning success, and the worker records provider rejection as a failed send.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/providers/src/lib/sms/textlk/textlk.provider.ts | Implements Text.lk request construction and now rejects HTTP errors, vendor errors, and responses lacking a provider identifier. |
| packages/providers/src/lib/sms/textlk/textlk.provider.spec.ts | Covers successful delivery, passthrough body overrides, and rejection of a representative error response. |
| libs/application-generic/src/factories/sms/handlers/textlk.handler.ts | Maps stored API-key and sender credentials into the Text.lk provider. |
| libs/application-generic/src/factories/sms/sms.factory.ts | Registers the Text.lk handler in SMS provider dispatch. |
| packages/shared/src/consts/providers/channels/sms.ts | Exposes Text.lk integration metadata, credentials, documentation, and logo configuration. |
| packages/framework/src/schemas/providers/sms/index.ts | Registers Text.lk with the framework’s generic SMS provider schema. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Worker
  participant Factory as SmsFactory
  participant Handler as TextLkSmsHandler
  participant Provider as TextLkSmsProvider
  participant TextLk as Text.lk API
  Worker->>Factory: Resolve textlk integration
  Factory->>Handler: Select registered handler
  Handler->>Provider: Build with API key and sender ID
  Worker->>Provider: sendMessage(options, passthrough)
  Provider->>TextLk: POST /api/v3/sms/send
  alt Successful response with data.uid
    TextLk-->>Provider: "status=success, uid"
    Provider-->>Worker: Message identifier
  else HTTP/vendor error or missing uid
    TextLk-->>Provider: Error response
    Provider-->>Worker: Throw provider error
  end
```

<sub>Reviews (2): Last reviewed commit: ["fix(providers): reject Text.lk error res..."](https://github.com/novuhq/novu/commit/ef3748906b7136ee0b5817e7f4b336ef7acc683d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50063924)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Providers package](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/providers-package.md)
- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)
- Knowledge Base — [@novu/framework (packages/framework)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/framework-package.md)
- Knowledge Base — [Dashboard App (apps/dashboard)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dashboard-app.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)
</details>

<!-- /greptile_comment -->
