### PR TITLE
feat(providers): add Aliyun (Alibaba Cloud) SMS provider

### DIFF
--- a/apps/dashboard/public/images/providers/light/square/aliyun.svg
+++ b/apps/dashboard/public/images/providers/light/square/aliyun.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 60 60" fill="none">
+  <rect width="60" height="60" rx="12" fill="#FF6A00"/>
+  <text x="30" y="38" font-family="Arial, Helvetica, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF" text-anchor="middle">AL</text>
+</svg>

--- a/libs/application-generic/src/factories/sms/handlers/aliyun.handler.ts
+++ b/libs/application-generic/src/factories/sms/handlers/aliyun.handler.ts
@@ -1,0 +1,17 @@
+import { AliyunSmsProvider } from '@novu/providers';
+import { ChannelTypeEnum, ICredentials, SmsProviderIdEnum } from '@novu/shared';
+import { BaseSmsHandler } from './base.handler';
+
+export class AliyunSmsHandler extends BaseSmsHandler {
+  constructor() {
+    super(SmsProviderIdEnum.Aliyun, ChannelTypeEnum.SMS);
+  }
+
+  buildProvider(credentials: ICredentials) {
+    this.provider = new AliyunSmsProvider({
+      accessKeyId: credentials.apiKey,
+      accessKeySecret: credentials.secretKey,
+      from: credentials.from,
+    });
+  }
+}

--- a/libs/application-generic/src/factories/sms/handlers/aliyun.handler.ts
+++ b/libs/application-generic/src/factories/sms/handlers/aliyun.handler.ts
@@ -12,6 +12,7 @@ export class AliyunSmsHandler extends BaseSmsHandler {
       accessKeyId: credentials.apiKey,
       accessKeySecret: credentials.secretKey,
       from: credentials.from,
+      templateId: credentials.templateId,
     });
   }
 }

--- a/libs/application-generic/src/factories/sms/handlers/index.ts
+++ b/libs/application-generic/src/factories/sms/handlers/index.ts
@@ -1,5 +1,6 @@
 export * from './africas-talking.handler';
 export * from './afro-sms.handler';
+export * from './aliyun.handler';
 export * from './azure-sms.handler';
 export * from './bandwidth.handler';
 export * from './brevo-sms.handler';

--- a/libs/application-generic/src/factories/sms/sms.factory.ts
+++ b/libs/application-generic/src/factories/sms/sms.factory.ts
@@ -2,6 +2,7 @@ import { IntegrationEntity } from '@novu/dal';
 import {
   AfricasTalkingSmsHandler,
   AfroSmsHandler,
+  AliyunSmsHandler,
   AzureSmsHandler,
   BandwidthHandler,
   BrevoSmsHandler,
@@ -44,6 +45,7 @@ import { ISmsFactory, ISmsHandler } from './interfaces';
 
 export class SmsFactory implements ISmsFactory {
   handlers: ISmsHandler[] = [
+    new AliyunSmsHandler(),
     new SnsHandler(),
     new TelnyxHandler(),
     new TwilioHandler(),

--- a/packages/framework/src/schemas/providers/sms/index.ts
+++ b/packages/framework/src/schemas/providers/sms/index.ts
@@ -43,4 +43,5 @@ export const smsProviderSchemas = {
   sinch: genericProviderSchemas,
   'isendpro-sms': genericProviderSchemas,
   'ruach-sms': genericProviderSchemas,
+  aliyun: genericProviderSchemas,
 } as const satisfies Record<SmsProviderIdEnum, { output: JsonSchema }>;

--- a/packages/framework/src/shared.ts
+++ b/packages/framework/src/shared.ts
@@ -164,6 +164,7 @@ export enum SmsProviderIdEnum {
   Sinch = 'sinch',
   ISendProSms = 'isendpro-sms',
   RuachSms = 'ruach-sms',
+  Aliyun = 'aliyun',
 }
 
 export enum ChatProviderIdEnum {

--- a/packages/providers/src/lib/sms/aliyun/aliyun.provider.spec.ts
+++ b/packages/providers/src/lib/sms/aliyun/aliyun.provider.spec.ts
@@ -82,6 +82,38 @@ test('should let _passthrough override the resolved params', async () => {
   expect(url).toContain('PhoneNumbers=%2B8613900139000');
 });
 
+test('should JSON-serialize a structured TemplateParam override', async () => {
+  const provider = new AliyunSmsProvider({
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+    from: 'AliyunTest',
+  });
+
+  const fetchMock = vi.fn().mockResolvedValue(okResponse());
+  global.fetch = fetchMock;
+
+  await provider.sendMessage(
+    {
+      content: 'ignored',
+      from: 'AliyunTest',
+      to: '+8613800138000',
+    },
+    {
+      _passthrough: {
+        body: {
+          TemplateCode: 'SMS_123456789',
+          TemplateParam: { code: '1234' },
+        },
+      },
+    }
+  );
+
+  const [url] = fetchMock.mock.calls[0];
+  // `{ code: '1234' }` must be serialized to the JSON string Aliyun expects, not `[object Object]`.
+  expect(url).toContain(`TemplateParam=${encodeURIComponent('{"code":"1234"}')}`);
+  expect(url).not.toContain('object%20Object');
+});
+
 test('should throw when Aliyun returns a non-OK code', async () => {
   const provider = new AliyunSmsProvider({
     accessKeyId: 'test-access-key-id',

--- a/packages/providers/src/lib/sms/aliyun/aliyun.provider.spec.ts
+++ b/packages/providers/src/lib/sms/aliyun/aliyun.provider.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { AliyunSmsProvider } from './aliyun.provider';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const okResponse = () => ({
+  json: () => Promise.resolve({ Code: 'OK', Message: 'OK', RequestId: 'req-1', BizId: 'mock-biz-id' }),
+});
+
+test('should trigger Aliyun SMS correctly', async () => {
+  const provider = new AliyunSmsProvider({
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+    from: 'AliyunTest',
+  });
+
+  const fetchMock = vi.fn().mockResolvedValue(okResponse());
+  global.fetch = fetchMock;
+
+  const result = await provider.sendMessage(
+    {
+      content: '{"code":"1234"}',
+      from: 'AliyunTest',
+      to: '+8613800138000',
+    },
+    {
+      _passthrough: {
+        body: {
+          TemplateCode: 'SMS_123456789',
+        },
+      },
+    }
+  );
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchMock.mock.calls[0];
+  expect(url).toContain('https://dysmsapi.aliyuncs.com/?');
+  expect(init.method).toBe('GET');
+  // system + business params are present in the signed query string
+  expect(url).toContain('Action=SendSms');
+  expect(url).toContain('Version=2017-05-25');
+  expect(url).toContain('Signature=');
+  expect(url).toContain('AccessKeyId=test-access-key-id');
+  expect(url).toContain('SignName=AliyunTest');
+  expect(url).toContain('TemplateCode=SMS_123456789');
+  // phone number is percent-encoded ('+' -> %2B)
+  expect(url).toContain('PhoneNumbers=%2B8613800138000');
+  expect(result.id).toBe('mock-biz-id');
+});
+
+test('should let _passthrough override the resolved params', async () => {
+  const provider = new AliyunSmsProvider({
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+    from: 'AliyunTest',
+  });
+
+  const fetchMock = vi.fn().mockResolvedValue(okResponse());
+  global.fetch = fetchMock;
+
+  await provider.sendMessage(
+    {
+      content: '{"code":"1234"}',
+      from: 'AliyunTest',
+      to: '+8613800138000',
+    },
+    {
+      _passthrough: {
+        body: {
+          PhoneNumbers: '+8613900139000',
+          TemplateCode: 'SMS_123456789',
+        },
+      },
+    }
+  );
+
+  const [url] = fetchMock.mock.calls[0];
+  expect(url).toContain('PhoneNumbers=%2B8613900139000');
+});
+
+test('should throw when Aliyun returns a non-OK code', async () => {
+  const provider = new AliyunSmsProvider({
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+    from: 'AliyunTest',
+  });
+
+  global.fetch = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve({ Code: 'isv.MOBILE_NUMBER_ILLEGAL', Message: 'invalid number' }),
+  });
+
+  await expect(
+    provider.sendMessage({
+      content: '{"code":"1234"}',
+      from: 'AliyunTest',
+      to: 'not-a-number',
+    })
+  ).rejects.toThrow('isv.MOBILE_NUMBER_ILLEGAL');
+});

--- a/packages/providers/src/lib/sms/aliyun/aliyun.provider.spec.ts
+++ b/packages/providers/src/lib/sms/aliyun/aliyun.provider.spec.ts
@@ -119,6 +119,7 @@ test('should throw when Aliyun returns a non-OK code', async () => {
     accessKeyId: 'test-access-key-id',
     accessKeySecret: 'test-access-key-secret',
     from: 'AliyunTest',
+    templateId: 'SMS_123456789',
   });
 
   global.fetch = vi.fn().mockResolvedValue({
@@ -141,6 +142,7 @@ test('should throw when the response has no BizId even if it looks successful', 
     accessKeyId: 'test-access-key-id',
     accessKeySecret: 'test-access-key-secret',
     from: 'AliyunTest',
+    templateId: 'SMS_123456789',
   });
 
   // HTTP error whose body carries no `Code` — previously slipped through and
@@ -158,4 +160,70 @@ test('should throw when the response has no BizId even if it looks successful', 
       to: '+8613800138000',
     })
   ).rejects.toThrow('Aliyun SMS request failed');
+});
+
+test('should use the templateId credential as the default TemplateCode', async () => {
+  const provider = new AliyunSmsProvider({
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+    from: 'AliyunTest',
+    templateId: 'SMS_CREDENTIAL_DEFAULT',
+  });
+
+  const fetchMock = vi.fn().mockResolvedValue(okResponse());
+  global.fetch = fetchMock;
+
+  await provider.sendMessage({
+    content: '{"code":"1234"}',
+    from: 'AliyunTest',
+    to: '+8613800138000',
+  });
+
+  const [url] = fetchMock.mock.calls[0];
+  expect(url).toContain('TemplateCode=SMS_CREDENTIAL_DEFAULT');
+});
+
+test('should let _passthrough.TemplateCode override the credential default', async () => {
+  const provider = new AliyunSmsProvider({
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+    from: 'AliyunTest',
+    templateId: 'SMS_CREDENTIAL_DEFAULT',
+  });
+
+  const fetchMock = vi.fn().mockResolvedValue(okResponse());
+  global.fetch = fetchMock;
+
+  await provider.sendMessage(
+    {
+      content: '{"code":"1234"}',
+      from: 'AliyunTest',
+      to: '+8613800138000',
+    },
+    { _passthrough: { body: { TemplateCode: 'SMS_PER_MESSAGE' } } }
+  );
+
+  const [url] = fetchMock.mock.calls[0];
+  expect(url).toContain('TemplateCode=SMS_PER_MESSAGE');
+  expect(url).not.toContain('SMS_CREDENTIAL_DEFAULT');
+});
+
+test('should fail fast when no TemplateCode is available from credential or passthrough', async () => {
+  const provider = new AliyunSmsProvider({
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+    from: 'AliyunTest',
+  });
+
+  const fetchMock = vi.fn().mockResolvedValue(okResponse());
+  global.fetch = fetchMock;
+
+  await expect(
+    provider.sendMessage({
+      content: '{"code":"1234"}',
+      from: 'AliyunTest',
+      to: '+8613800138000',
+    })
+  ).rejects.toThrow('Aliyun requires a TemplateCode');
+  expect(fetchMock).not.toHaveBeenCalled();
 });

--- a/packages/providers/src/lib/sms/aliyun/aliyun.provider.spec.ts
+++ b/packages/providers/src/lib/sms/aliyun/aliyun.provider.spec.ts
@@ -6,6 +6,8 @@ afterEach(() => {
 });
 
 const okResponse = () => ({
+  ok: true,
+  status: 200,
   json: () => Promise.resolve({ Code: 'OK', Message: 'OK', RequestId: 'req-1', BizId: 'mock-biz-id' }),
 });
 
@@ -88,6 +90,8 @@ test('should throw when Aliyun returns a non-OK code', async () => {
   });
 
   global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 400,
     json: () => Promise.resolve({ Code: 'isv.MOBILE_NUMBER_ILLEGAL', Message: 'invalid number' }),
   });
 
@@ -98,4 +102,28 @@ test('should throw when Aliyun returns a non-OK code', async () => {
       to: 'not-a-number',
     })
   ).rejects.toThrow('isv.MOBILE_NUMBER_ILLEGAL');
+});
+
+test('should throw when the response has no BizId even if it looks successful', async () => {
+  const provider = new AliyunSmsProvider({
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+    from: 'AliyunTest',
+  });
+
+  // HTTP error whose body carries no `Code` — previously slipped through and
+  // resolved as a success with `id: undefined`.
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: () => Promise.resolve({ Message: 'Internal error' }),
+  });
+
+  await expect(
+    provider.sendMessage({
+      content: '{"code":"1234"}',
+      from: 'AliyunTest',
+      to: '+8613800138000',
+    })
+  ).rejects.toThrow('Aliyun SMS request failed');
 });

--- a/packages/providers/src/lib/sms/aliyun/aliyun.provider.ts
+++ b/packages/providers/src/lib/sms/aliyun/aliyun.provider.ts
@@ -50,7 +50,7 @@ export class AliyunSmsProvider extends BaseProvider implements ISmsProvider {
       templateParam: options.content,
     });
 
-    const params: Record<string, string> = {
+    const params: Record<string, unknown> = {
       AccessKeyId: this.config.accessKeyId || '',
       Action: 'SendSms',
       Format: 'JSON',
@@ -65,7 +65,14 @@ export class AliyunSmsProvider extends BaseProvider implements ISmsProvider {
 
     const canonicalizedQuery = Object.keys(params)
       .sort()
-      .map((key) => `${this.percentEncode(key)}=${this.percentEncode(params[key])}`)
+      .map((key) => {
+        const value = params[key];
+        // Aliyun expects every parameter as a string, and `TemplateParam` in particular as a JSON
+        // string. A structured `_passthrough.body.TemplateParam` (e.g. `{ code: '1234' }`) would
+        // otherwise stringify to `[object Object]` and be rejected, so serialise non-strings.
+        const normalized = typeof value === 'string' ? value : JSON.stringify(value);
+        return `${this.percentEncode(key)}=${this.percentEncode(normalized)}`;
+      })
       .join('&');
 
     const stringToSign = `GET&${this.percentEncode('/')}&${this.percentEncode(canonicalizedQuery)}`;

--- a/packages/providers/src/lib/sms/aliyun/aliyun.provider.ts
+++ b/packages/providers/src/lib/sms/aliyun/aliyun.provider.ts
@@ -1,0 +1,108 @@
+import { createHmac, randomUUID } from 'crypto';
+import { SmsProviderIdEnum } from '@novu/shared';
+import { ChannelTypeEnum, ISendMessageSuccessResponse, ISmsOptions, ISmsProvider } from '@novu/stateless';
+import { BaseProvider, CasingEnum } from '../../../base.provider';
+import { WithPassthrough } from '../../../utils/types';
+
+interface IAliyunResponse {
+  Code?: string;
+  Message?: string;
+  RequestId?: string;
+  BizId?: string;
+}
+
+/**
+ * Aliyun (Alibaba Cloud) SMS provider.
+ *
+ * Uses the Dysmsapi `SendSms` RPC action (API version 2017-05-25). Requests are
+ * authenticated with the standard Aliyun RPC signature (HMAC-SHA1 over the sorted,
+ * percent-encoded query string), so no external SDK dependency is required.
+ *
+ * Aliyun SMS is strictly template-based: a registered `TemplateCode` and a JSON
+ * `TemplateParam` are required. `TemplateCode` (and any `TemplateParam` override)
+ * can be supplied per-message through the bridge `_passthrough.body`, while the
+ * message `content` is used as the default `TemplateParam`.
+ */
+export class AliyunSmsProvider extends BaseProvider implements ISmsProvider {
+  public static readonly BASE_URL = 'https://dysmsapi.aliyuncs.com/';
+  channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
+  protected casing = CasingEnum.PASCAL_CASE;
+  id = SmsProviderIdEnum.Aliyun;
+
+  constructor(
+    private config: {
+      accessKeyId?: string;
+      accessKeySecret?: string;
+      from?: string;
+      regionId?: string;
+    }
+  ) {
+    super();
+  }
+
+  async sendMessage(
+    options: ISmsOptions,
+    bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
+  ): Promise<ISendMessageSuccessResponse> {
+    const data = this.transform<Record<string, string>>(bridgeProviderData, {
+      phoneNumbers: options.to,
+      signName: options.from || this.config.from,
+      templateParam: options.content,
+    });
+
+    const params: Record<string, string> = {
+      AccessKeyId: this.config.accessKeyId || '',
+      Action: 'SendSms',
+      Format: 'JSON',
+      RegionId: this.config.regionId || 'cn-hangzhou',
+      SignatureMethod: 'HMAC-SHA1',
+      SignatureNonce: randomUUID(),
+      SignatureVersion: '1.0',
+      Timestamp: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+      Version: '2017-05-25',
+      ...data.body,
+    };
+
+    const canonicalizedQuery = Object.keys(params)
+      .sort()
+      .map((key) => `${this.percentEncode(key)}=${this.percentEncode(params[key])}`)
+      .join('&');
+
+    const stringToSign = `GET&${this.percentEncode('/')}&${this.percentEncode(canonicalizedQuery)}`;
+    const signature = createHmac('sha1', `${this.config.accessKeySecret ?? ''}&`)
+      .update(stringToSign)
+      .digest('base64');
+
+    const url = `${AliyunSmsProvider.BASE_URL}?Signature=${this.percentEncode(signature)}&${canonicalizedQuery}`;
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...data.headers,
+      },
+    });
+
+    const body = (await response.json()) as IAliyunResponse;
+
+    if (body.Code && body.Code !== 'OK') {
+      throw new Error(`Aliyun SMS request failed (${body.Code}): ${body.Message}`);
+    }
+
+    return {
+      id: body.BizId,
+      date: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Percent-encode a value per Aliyun's RPC signing rules (RFC 3986 with the
+   * `+`, `*` and `~` adjustments), matching how the canonical query string is signed.
+   */
+  private percentEncode(value: string): string {
+    return encodeURIComponent(value)
+      .replace(/\+/g, '%20')
+      .replace(/\*/g, '%2A')
+      .replace(/%7E/g, '~');
+  }
+}

--- a/packages/providers/src/lib/sms/aliyun/aliyun.provider.ts
+++ b/packages/providers/src/lib/sms/aliyun/aliyun.provider.ts
@@ -35,6 +35,7 @@ export class AliyunSmsProvider extends BaseProvider implements ISmsProvider {
       accessKeySecret?: string;
       from?: string;
       regionId?: string;
+      templateId?: string;
     }
   ) {
     super();
@@ -47,8 +48,18 @@ export class AliyunSmsProvider extends BaseProvider implements ISmsProvider {
     const data = this.transform<Record<string, string>>(bridgeProviderData, {
       phoneNumbers: options.to,
       signName: options.from || this.config.from,
+      templateCode: this.config.templateId,
       templateParam: options.content,
     });
+
+    // Aliyun requires a registered `TemplateCode`. It defaults to the integration credential, but a
+    // workflow may omit the credential and pass it per-message via `_passthrough.body.TemplateCode`.
+    // Fail fast with a clear message rather than letting Aliyun reject the send cryptically.
+    if (!data.body.TemplateCode) {
+      throw new Error(
+        'Aliyun requires a TemplateCode. Set it as the "Template Code" integration credential or supply it per-message via _passthrough.body.TemplateCode.'
+      );
+    }
 
     const params: Record<string, unknown> = {
       AccessKeyId: this.config.accessKeyId || '',

--- a/packages/providers/src/lib/sms/aliyun/aliyun.provider.ts
+++ b/packages/providers/src/lib/sms/aliyun/aliyun.provider.ts
@@ -85,8 +85,8 @@ export class AliyunSmsProvider extends BaseProvider implements ISmsProvider {
 
     const body = (await response.json()) as IAliyunResponse;
 
-    if (body.Code && body.Code !== 'OK') {
-      throw new Error(`Aliyun SMS request failed (${body.Code}): ${body.Message}`);
+    if (!response.ok || body.Code !== 'OK' || !body.BizId) {
+      throw new Error(`Aliyun SMS request failed (${body.Code ?? response.status}): ${body.Message ?? 'unknown error'}`);
     }
 
     return {

--- a/packages/providers/src/lib/sms/index.ts
+++ b/packages/providers/src/lib/sms/index.ts
@@ -1,5 +1,6 @@
 export * from './africas-talking/africas-talking.provider';
 export * from './afro-sms/afro-sms.provider';
+export * from './aliyun/aliyun.provider';
 export * from './azure-sms/azure-sms.provider';
 export * from './bandwidth/bandwidth.provider';
 export * from './brevo-sms/brevo-sms.provider';

--- a/packages/shared/src/consts/providers/channels/sms.ts
+++ b/packages/shared/src/consts/providers/channels/sms.ts
@@ -3,6 +3,7 @@ import { UTM_CAMPAIGN_QUERY_PARAM } from '../../../ui';
 import {
   africasTalkingConfig,
   afroSmsConfig,
+  aliyunConfig,
   azureSmsConfig,
   bandwidthConfig,
   brevoSmsConfig,
@@ -43,6 +44,14 @@ import {
 import { IProviderConfig } from '../provider.interface';
 
 export const smsProviders: IProviderConfig[] = [
+  {
+    id: SmsProviderIdEnum.Aliyun,
+    displayName: 'Aliyun SMS',
+    channel: ChannelTypeEnum.SMS,
+    credentials: aliyunConfig,
+    docReference: 'https://www.alibabacloud.com/help/en/sms/',
+    logoFileName: { light: 'aliyun.svg', dark: 'aliyun.svg' },
+  },
   {
     id: SmsProviderIdEnum.Novu,
     displayName: 'Novu SMS',

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -380,6 +380,27 @@ export const termiiConfig: IConfigCredential[] = [
   ...smsConfigBase,
 ];
 
+export const aliyunConfig: IConfigCredential[] = [
+  {
+    key: CredentialsKeyEnum.ApiKey,
+    displayName: 'Access Key ID',
+    type: 'string',
+    required: true,
+  },
+  {
+    key: CredentialsKeyEnum.SecretKey,
+    displayName: 'Access Key Secret',
+    type: 'string',
+    required: true,
+  },
+  {
+    key: CredentialsKeyEnum.From,
+    displayName: 'Signature Name (SignName)',
+    type: 'string',
+    required: true,
+  },
+];
+
 export const burstSmsConfig: IConfigCredential[] = [
   {
     key: CredentialsKeyEnum.ApiKey,

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -399,6 +399,13 @@ export const aliyunConfig: IConfigCredential[] = [
     type: 'string',
     required: true,
   },
+  {
+    key: CredentialsKeyEnum.TemplateId,
+    displayName: 'Template Code',
+    description: 'Default Aliyun TemplateCode. Optional — can be overridden per-message via _passthrough.body.TemplateCode.',
+    type: 'string',
+    required: false,
+  },
 ];
 
 export const burstSmsConfig: IConfigCredential[] = [

--- a/packages/shared/src/entities/integration/credential.interface.ts
+++ b/packages/shared/src/entities/integration/credential.interface.ts
@@ -144,4 +144,9 @@ export interface ICredentials {
    * when the verification side (e.g. AWS KMS) holds the key as binary material.
    */
   hmacSecretKeyEncoding?: 'text' | 'base64' | 'hex';
+  /**
+   * Aliyun SMS: default registered `TemplateCode`. Optional — a workflow may instead supply the
+   * template per-message via `_passthrough.body.TemplateCode`, which overrides this value.
+   */
+  templateId?: string;
 }

--- a/packages/shared/src/types/providers.ts
+++ b/packages/shared/src/types/providers.ts
@@ -70,6 +70,8 @@ export enum CredentialsKeyEnum {
   RoutingMode = 'routingMode',
   /** Email webhook: how the HMAC secret key value is interpreted when signing webhook calls. */
   HmacSecretKeyEncoding = 'hmacSecretKeyEncoding',
+  /** Aliyun SMS: default registered TemplateCode, overridable per-message via `_passthrough.body.TemplateCode`. */
+  TemplateId = 'templateId',
 }
 
 export type ConfigurationKey = keyof IConfigurations;

--- a/packages/shared/src/types/providers.ts
+++ b/packages/shared/src/types/providers.ts
@@ -142,6 +142,7 @@ export enum SmsProviderIdEnum {
   ISendProSms = 'isendpro-sms',
   CmTelecom = 'cm-telecom',
   RuachSms = 'ruach-sms',
+  Aliyun = 'aliyun',
 }
 
 export enum ChatProviderIdEnum {


### PR DESCRIPTION
> **Draft note:** opened as a draft because novu caps non-write-access contributors at 1 open PR and #12223 (Text.lk) currently holds that slot. This is complete and CI-ready; I'll mark it ready-for-review once #12223 lands (or sooner if a maintainer wants to take it first). Feedback on the modeling question below is very welcome in the meantime.

### What changed? Why was the change needed?

Adds **Aliyun (Alibaba Cloud)** as a native SMS provider, implemented per the official add-a-provider guide. Closes #4173.

Aliyun's Dysmsapi `SendSms` is a template-based, signed RPC API. This wires it in end-to-end:
- `packages/providers/src/lib/sms/aliyun` — provider + spec (hand-rolled Dysmsapi RPC with HMAC-SHA1 request signing, no `@alicloud/*` SDK dependency)
- `@novu/shared` — provider enum, credentials, metadata
- `@novu/framework` — provider enum + schema
- app-generic SMS handler + factory registration
- dashboard provider logo

Credentials map as: `apiKey` = AccessKey ID, `secretKey` = AccessKey Secret, `from` = Sign Name.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- **Signing** is verified against Aliyun's official documented example (computed signature matches their reference); no third-party SDK is pulled in.
- **Error handling**: rejects on non-OK HTTP status, a non-`OK` `Code`, or a missing `BizId`, so a failed send is never recorded as `MESSAGE_SENT`.
- **Open modeling question**: Aliyun is template-based (`TemplateCode` + `TemplateParam`, not free-text). Currently these flow through the bridge `_passthrough.body` with message content as the default `TemplateParam`. Would welcome your steer on the preferred way to surface template code/params in the Novu SMS model.
- **Logo**: `aliyun.svg` is a placeholder — can swap for the official brand asset.
- Unit tests in `aliyun.provider.spec.ts`.

</details>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Aliyun as an end-to-end SMS provider, including shared credentials and metadata, framework registration, worker handler wiring, signed Dysmsapi requests, tests, and a dashboard logo.
- Implements HMAC-SHA1 signing and Aliyun response validation.
- Adds an optional default Template Code credential with per-message passthrough overrides.
- Serializes structured template parameters as Aliyun-compatible JSON.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because dashboard and legacy sends still reject the newly added default Template Code credential.

abdulwaarith0 stated that the credential fallback was implemented, but the concrete residual case is a send with `templateId` and no passthrough: the fallback remains under `templateCode`, while validation checks `TemplateCode`, so the request fails before reaching Aliyun.

**Files Needing Attention:** packages/providers/src/lib/sms/aliyun/aliyun.provider.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/providers/src/lib/sms/aliyun/aliyun.provider.ts | Implements request transformation, signing, serialization, and response handling, but the credential-only TemplateCode fallback uses a key that does not satisfy its PascalCase validation. |
| packages/providers/src/lib/sms/aliyun/aliyun.provider.spec.ts | Covers successful sends, error responses, passthrough overrides, structured template parameters, and the intended credential fallback. |
| libs/application-generic/src/factories/sms/handlers/aliyun.handler.ts | Correctly maps Aliyun access credentials, sign name, and template identifier into the provider configuration. |
| packages/shared/src/consts/providers/credentials/provider-credentials.ts | Adds the Aliyun credential form, including the optional default Template Code requested by the prior review. |
| packages/shared/src/consts/providers/channels/sms.ts | Registers Aliyun metadata, credentials, documentation, and dashboard logo for the SMS provider catalog. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant W as Workflow worker
  participant H as AliyunSmsHandler
  participant P as AliyunSmsProvider
  participant A as Aliyun Dysmsapi
  W->>H: SMS options + integration credentials
  H->>P: config including templateId
  W->>P: sendMessage(options, passthrough)
  P->>P: Resolve and validate TemplateCode
  P->>P: Canonicalize parameters and sign request
  P->>A: GET SendSms
  A-->>P: Code, Message, BizId
  P-->>W: Message ID or error
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312224%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12224&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fproviders%2Fsrc%2Flib%2Fsms%2Faliyun%2Faliyun.provider.ts%3A51%0A**Template%20credential%20uses%20wrong%20casing**%0A%0AWhen%20an%20integration%20has%20%60templateId%60%20configured%20but%20no%20per-message%20passthrough%2C%20the%20credential%20is%20merged%20under%20%60templateCode%60%20while%20validation%20checks%20%60TemplateCode%60%2C%20causing%20the%20send%20to%20throw%20before%20calling%20Aliyun.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20TemplateCode%3A%20this.config.templateId%2C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/providers/src/lib/sms/aliyun/aliyun.provider.ts:51
**Template credential uses wrong casing**

When an integration has `templateId` configured but no per-message passthrough, the credential is merged under `templateCode` while validation checks `TemplateCode`, causing the send to throw before calling Aliyun.

```suggestion
      TemplateCode: this.config.templateId,
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["feat(providers): add optional Aliyun Tem..."](https://github.com/novuhq/novu/commit/20e96f9a7cd4398cce3bb46454c32ea88f905ebd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50097684)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->