### PR TITLE
fix(api): allow localhost and 127.0.0.1 to be interchangeable in development CORS checks (#12038)

### DIFF
--- a/apps/api/src/config/cors.config.ts
+++ b/apps/api/src/config/cors.config.ts
@@ -31,6 +31,16 @@ export const corsOptionsDelegate: Parameters<INestApplication['enableCors']>[0] 
 
     if (ALLOWED_ORIGINS_REGEX.test(requestOrigin)) {
       corsOptions.origin.push(requestOrigin);
+    } else if (isDevelopmentEnvironment()) {
+      const alternateOrigin = requestOrigin.includes('localhost')
+        ? requestOrigin.replace('localhost', '127.0.0.1')
+        : requestOrigin.includes('127.0.0.1')
+          ? requestOrigin.replace('127.0.0.1', 'localhost')
+          : '';
+
+      if (alternateOrigin && ALLOWED_ORIGINS_REGEX.test(alternateOrigin)) {
+        corsOptions.origin.push(requestOrigin);
+      }
     }
     if (process.env.WIDGET_BASE_URL) {
       corsOptions.origin.push(process.env.WIDGET_BASE_URL);


### PR DESCRIPTION
## Description
Fixes #12038.

BetterAuth routes require strictly validated origins for credential-based requests (they cannot use wildcard `*`). In local development, the `FRONT_BASE_URL` might be bound to `http://127.0.0.1:4201`, but developers often access the dashboard via `http://localhost:4201`. This mismatch causes frustrating preflight CORS failures that disrupt the local authentication flow.

This PR introduces an environment-aware fallback during CORS evaluation. If the environment is development (`isDevelopmentEnvironment()`), the CORS config will seamlessly swap `localhost` and `127.0.0.1` and evaluate both against the allowed regex.

## Changes Made
- Modified `apps/api/src/config/cors.config.ts`.
- In `isDevelopmentEnvironment()`, implemented an alternate origin string swap (`localhost` ↔ `127.0.0.1`).
- If the primary request origin fails but the alternate string passes the `ALLOWED_ORIGINS_REGEX`, the original request origin is safely whitelisted.

## Testing
- [x] Checked `isDevelopmentEnvironment()` bounds to ensure this logic **never** executes in `production` or `staging`.
- [x] Tested with `FRONT_BASE_URL=http://127.0.0.1:4201` and an Origin header of `http://localhost:4201` -> **Passed**.
- [x] Tested with `FRONT_BASE_URL=http://localhost:4201` and an Origin header of `http://127.0.0.1:4201` -> **Passed**.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds development-only CORS fallback handling that treats `localhost` and `127.0.0.1` as interchangeable for explicitly validated BetterAuth origins.
- Tries the configured origin expression against a swapped loopback-host representation when the original Origin does not match.
- Preserves the original request Origin in the credentialed CORS allowlist when the alternate representation matches.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking recommendation to make the loopback substitution hostname-aware.

The intended local BetterAuth flow is enabled, but whole-string substring replacement unnecessarily broadens a security-sensitive origin transformation under permissive configurations.

**Files Needing Attention:** apps/api/src/config/cors.config.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/config/cors.config.ts | Adds loopback-origin fallback validation, but performs the swap as a whole-string substring replacement rather than an exact hostname transformation. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312346%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12346&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fapi%2Fsrc%2Fconfig%2Fcors.config.ts%3A34-39%0A**Make%20loopback%20replacement%20hostname-aware**%0A%0AIf%20a%20local%20environment%20uses%20a%20portless%20or%20otherwise%20permissive%20%60FRONT_BASE_URL%60%20pattern%2C%20replacing%20substrings%20in%20the%20complete%20raw%20Origin%20can%20treat%20a%20non-loopback%20hostname%20containing%20%60localhost%60%20or%20%60127.0.0.1%60%20as%20its%20loopback%20counterpart%20and%20echo%20that%20origin%20into%20the%20credentialed%20CORS%20allowlist.%20Parse%20the%20Origin%20and%20apply%20interchangeability%20only%20when%20its%20hostname%20exactly%20equals%20one%20of%20those%20two%20values.%0A%0A**How%20this%20was%20verified%3A**%20The%20raw%20Origin%20is%20transformed%20with%20whole-string%20%60includes%60%2F%60replace%60%2C%20then%20the%20original%20value%20is%20admitted%20when%20the%20transformed%20value%20matches%20the%20configured%20regex.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12346&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/api/src/config/cors.config.ts:34-39
**Make loopback replacement hostname-aware**

If a local environment uses a portless or otherwise permissive `FRONT_BASE_URL` pattern, replacing substrings in the complete raw Origin can treat a non-loopback hostname containing `localhost` or `127.0.0.1` as its loopback counterpart and echo that origin into the credentialed CORS allowlist. Parse the Origin and apply interchangeability only when its hostname exactly equals one of those two values.

**How this was verified:** The raw Origin is transformed with whole-string `includes`/`replace`, then the original value is admitted when the transformed value matches the configured regex.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): allow localhost/127.0.0.1 orig..."](https://github.com/novuhq/novu/commit/2f97cba201b218d1c7b2e967931c9a137bc8caf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53705529)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->