### PR TITLE
feat(api-service,js): deliver Agent Chat card parts and sendAction for button clicks fixes NV-8600

### DIFF
--- a/apps/api/src/app/agents/agent-chat/activity-to-events.spec.ts
+++ b/apps/api/src/app/agents/agent-chat/activity-to-events.spec.ts
@@ -117,6 +117,37 @@ describe('activity-to-events run lifecycle', () => {
     ]);
   });
 
+  it('maps stored Card trees to protocol card content', () => {
+    const card = {
+      type: 'card',
+      title: 'Support Agent',
+      children: [{ type: 'text', content: 'How can I help?' }],
+    };
+    const envelopes = mapNewestFirstEventActivities(
+      [
+        activity({
+          type: ConversationActivityTypeEnum.MESSAGE,
+          identifier: 'msg_card0000001',
+          platformMessageId: 'act_card0000001',
+          sequence: 1,
+          content: 'How can I help?',
+          richContent: { card },
+        }),
+      ],
+      context
+    );
+
+    expect(envelopes.map((envelope) => envelope.event)).to.deep.equal([
+      {
+        type: 'message',
+        role: 'assistant',
+        messageId: 'act_card0000001',
+        content: { card },
+        files: undefined,
+      },
+    ]);
+  });
+
   it('uses immutable activity ids for approval request messages', () => {
     const envelopes = mapNewestFirstEventActivities(
       [

--- a/apps/api/src/app/agents/agent-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/agent-chat/activity-to-events.ts
@@ -3,6 +3,7 @@ import {
   type AgentEvent,
   type AgentEventEnvelope,
   type AgentFileRef,
+  type AgentMessageContent,
   isDeltaEvent,
 } from '@novu/agent-event-protocol';
 import {
@@ -35,6 +36,23 @@ function filesFromRichContent(richContent?: Record<string, unknown>) {
   return files as AgentFileRef[];
 }
 
+function isCardTree(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && (value as { type?: unknown }).type === 'card';
+}
+
+/** Prefer the stored Card tree. Fall back to markdown when no Card is present. */
+export function messageContentFromStored(params: {
+  content?: string;
+  richContent?: Record<string, unknown>;
+}): AgentMessageContent {
+  const card = params.richContent?.card;
+  if (isCardTree(card)) {
+    return { card };
+  }
+
+  return { markdown: params.content ?? '' };
+}
+
 const MESSAGE_ROLE_BY_SENDER = {
   [ConversationActivitySenderTypeEnum.AGENT]: 'assistant',
   [ConversationActivitySenderTypeEnum.SUBSCRIBER]: 'user',
@@ -53,7 +71,7 @@ function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | 
         role,
         // Browser-visible id is platformMessageId (aligned with live WS envelopes).
         messageId: activity.platformMessageId ?? activity.identifier,
-        content: { markdown: activity.content },
+        content: messageContentFromStored({ content: activity.content, richContent: activity.richContent }),
         files: filesFromRichContent(activity.richContent),
       };
     }
@@ -142,7 +160,7 @@ function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | 
       return {
         type: 'channel.edit',
         messageId: activity.platformMessageId ?? activity.identifier,
-        content: { markdown: activity.content },
+        content: messageContentFromStored({ content: activity.content, richContent: activity.richContent }),
       };
 
     case ConversationActivityTypeEnum.DELETE:

--- a/apps/api/src/app/agents/agent-chat/agent-chat-event.factory.ts
+++ b/apps/api/src/app/agents/agent-chat/agent-chat-event.factory.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { AGENT_EVENT_PROTOCOL_VERSION, type AgentEvent, type AgentEventEnvelope } from '@novu/agent-event-protocol';
+import {
+  AGENT_EVENT_PROTOCOL_VERSION,
+  type AgentEvent,
+  type AgentEventEnvelope,
+  type AgentMessageContent,
+} from '@novu/agent-event-protocol';
 import { shortId } from '@novu/application-generic';
 
 type AgentChatFactoryBaseInput = {
@@ -14,12 +19,12 @@ type AgentChatFactoryBaseInput = {
 
 export type AgentChatFactoryMessageInput = AgentChatFactoryBaseInput & {
   platformMessageId: string;
-  content: { markdown: string };
+  content: AgentMessageContent;
 };
 
 export type AgentChatFactoryEditInput = AgentChatFactoryBaseInput & {
   platformMessageId: string;
-  content: { markdown: string };
+  content: AgentMessageContent;
 };
 
 export type AgentChatFactoryDeleteInput = AgentChatFactoryBaseInput & {

--- a/apps/api/src/app/agents/agent-chat/agent-chat-platform-delivery.service.ts
+++ b/apps/api/src/app/agents/agent-chat/agent-chat-platform-delivery.service.ts
@@ -8,15 +8,14 @@ import {
   type AgentChatEditMessageParams,
   type AgentChatStartTypingParams,
   conversationIdFromThreadId,
-  extractCardPlainText,
 } from '@novu/chat-adapter-agent-chat';
 import { type ConversationEntity, ConversationParticipantTypeEnum, SubscriberRepository } from '@novu/dal';
 import { WebSocketEventEnum } from '@novu/shared';
-import type { CardElement } from 'chat';
 import type { ResolvedAgentConfig } from '../channels/agent-config-resolver.service';
 import { AgentConversationService } from '../conversation-runtime/conversation/agent-conversation.service';
 import { ConversationEventSequenceService } from '../conversation-runtime/conversation/conversation-event-sequence.service';
 import { OutboundDeliveryInfo } from '../conversation-runtime/egress/outbound-delivery-info.service';
+import { messageContentFromStored } from './activity-to-events';
 import { AgentChatEventFactory } from './agent-chat-event.factory';
 
 export type AgentChatPlatformDeliveryContext = {
@@ -61,13 +60,12 @@ export class AgentChatPlatformDeliveryService {
       this.deliveryInfo.report({ messageId: platformMessageId, sequence });
 
       if (conversation && sequence !== undefined) {
-        const markdown = this.markdownForLiveEnvelope(content, richContent);
         const envelope = this.eventFactory.createMessageEnvelope({
           conversationId: conversation._id,
           conversationIdentifier: conversation.identifier,
           agentId: context.config.agentIdentifier,
           platformMessageId,
-          content: { markdown },
+          content: messageContentFromStored({ content, richContent }),
           sequence,
         });
         await this.emitBestEffort(context, conversation, envelope);
@@ -89,13 +87,12 @@ export class AgentChatPlatformDeliveryService {
       this.deliveryInfo.report({ sequence });
 
       if (conversation && sequence !== undefined) {
-        const markdown = this.markdownForLiveEnvelope(content, richContent);
         const envelope = this.eventFactory.createEditEnvelope({
           conversationId: conversation._id,
           conversationIdentifier: conversation.identifier,
           agentId: context.config.agentIdentifier,
           platformMessageId: messageId,
-          content: { markdown },
+          content: messageContentFromStored({ content, richContent }),
           sequence,
         });
         await this.emitBestEffort(context, conversation, envelope);
@@ -213,20 +210,6 @@ export class AgentChatPlatformDeliveryService {
       organizationId: context.config.organizationId,
       conversationId: conversation._id,
     });
-  }
-
-  private markdownForLiveEnvelope(content: string, richContent?: Record<string, unknown>): string {
-    const trimmed = content?.trim() ?? '';
-    if (trimmed && trimmed !== '[Card]') {
-      return trimmed;
-    }
-
-    const card = richContent?.card;
-    if (card && typeof card === 'object') {
-      return extractCardPlainText(card as CardElement);
-    }
-
-    return trimmed || '[Card]';
   }
 
   private async emitBestEffort(

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-panel.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-panel.tsx
@@ -87,9 +87,10 @@ function AgentChatSurface({
   const [draft, setDraft] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { messages, pendingActions, sendMessage, respondToAction, error, isRunning, isLoading, typing } = useAgentChat({
-    agentId,
-  });
+  const { messages, pendingActions, sendMessage, sendAction, respondToAction, error, isRunning, isLoading, typing } =
+    useAgentChat({
+      agentId,
+    });
 
   const composerDisabled = isRunning || isLoading;
   const canSend = !composerDisabled && Boolean(draft.trim());
@@ -146,6 +147,8 @@ function AgentChatSurface({
                 key={message.id}
                 message={message}
                 showAvatar={message.role !== 'user' && messages[index - 1]?.role !== message.role}
+                cardActionsDisabled={composerDisabled}
+                onCardAction={(action) => void sendAction(action)}
               />
             ))}
             {showTypingRow ? <ChatTypingRow status={typing?.status} /> : null}

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
@@ -27,6 +27,9 @@ function stripPoweredByWatermark(text: string): string {
 type AgentMessagePart = AgentMessage['parts'][number];
 type ToolPart = Extract<AgentMessagePart, { type: 'tool' }>;
 type TextPart = Extract<AgentMessagePart, { type: 'text' }>;
+type CardPart = Extract<AgentMessagePart, { type: 'card' }>;
+
+export type CardActionHandler = (args: { actionId: string; sourceMessageId: string; value?: string }) => void;
 
 function formatMessageTime(createdAt: string): string | null {
   const date = new Date(createdAt);
@@ -81,12 +84,23 @@ export function ChatEmptyState({ onPickStarter }: { onPickStarter: (text: string
   );
 }
 
-export function ChatMessageRow({ message, showAvatar }: { message: AgentMessage; showAvatar: boolean }) {
+export function ChatMessageRow({
+  message,
+  showAvatar,
+  onCardAction,
+  cardActionsDisabled,
+}: {
+  message: AgentMessage;
+  showAvatar: boolean;
+  onCardAction?: CardActionHandler;
+  cardActionsDisabled?: boolean;
+}) {
   const isUser = message.role === 'user';
   const textParts = message.parts.filter((part): part is TextPart => part.type === 'text');
   const text = stripPoweredByWatermark(textParts.map((part) => part.text).join(''));
   const isStreaming = textParts.some((part) => part.state === 'streaming');
   const tools = message.parts.filter((part): part is ToolPart => part.type === 'tool');
+  const cards = message.parts.filter((part): part is CardPart => part.type === 'card');
   const time = formatMessageTime(message.createdAt);
   const failed = message.status === 'failed';
 
@@ -118,7 +132,7 @@ export function ChatMessageRow({ message, showAvatar }: { message: AgentMessage;
     );
   }
 
-  const hasContent = Boolean(text) || tools.length > 0;
+  const hasContent = Boolean(text) || tools.length > 0 || cards.length > 0;
   if (!hasContent) return null;
 
   return (
@@ -133,6 +147,14 @@ export function ChatMessageRow({ message, showAvatar }: { message: AgentMessage;
             ) : null}
           </div>
         ) : null}
+        {cards.map((part, index) => (
+          <ChatCardPart
+            key={`${message.id}-card-${index}`}
+            card={part.card}
+            disabled={cardActionsDisabled}
+            onAction={onCardAction ? (action) => onCardAction({ ...action, sourceMessageId: message.id }) : undefined}
+          />
+        ))}
         {tools.length > 0 ? (
           <div className="flex flex-wrap gap-1.5">
             {tools.map((tool) => (
@@ -146,6 +168,188 @@ export function ChatMessageRow({ message, showAvatar }: { message: AgentMessage;
           {time}
         </span>
       ) : null}
+    </div>
+  );
+}
+
+type CardButtonView = { id: string; label: string; value?: string; style?: string };
+
+type CardChildView =
+  | { type: 'text'; content: string }
+  | { type: 'divider' }
+  | { type: 'image'; url: string; alt: string }
+  | { type: 'link'; url: string; label: string }
+  | { type: 'actions'; buttons: CardButtonView[] };
+
+type CardView = {
+  title?: string;
+  subtitle?: string;
+  imageUrl?: string;
+  children: CardChildView[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function cardButtonsFromNode(node: unknown): CardButtonView[] {
+  if (!isRecord(node)) {
+    return [];
+  }
+
+  if (node.type === 'button') {
+    const id = readString(node.id);
+    const label = readString(node.label);
+    if (!id || !label) {
+      return [];
+    }
+
+    return [{ id, label, value: readString(node.value), style: readString(node.style) }];
+  }
+
+  if (node.type === 'actions' && Array.isArray(node.children)) {
+    return node.children.flatMap((child) => cardButtonsFromNode(child));
+  }
+
+  return [];
+}
+
+function cardChildFromNode(node: unknown): CardChildView | null {
+  if (!isRecord(node)) {
+    return null;
+  }
+
+  if (node.type === 'text') {
+    const content = readString(node.content);
+
+    return content ? { type: 'text', content } : null;
+  }
+
+  if (node.type === 'divider') {
+    return { type: 'divider' };
+  }
+
+  if (node.type === 'image') {
+    const url = toSafeExternalUrl(readString(node.url));
+
+    return url ? { type: 'image', url, alt: readString(node.alt) ?? '' } : null;
+  }
+
+  if (node.type === 'link') {
+    const url = toSafeExternalUrl(readString(node.url));
+    const label = readString(node.label);
+
+    return url && label ? { type: 'link', url, label } : null;
+  }
+
+  const buttons = cardButtonsFromNode(node);
+
+  return buttons.length > 0 ? { type: 'actions', buttons } : null;
+}
+
+function cardViewFromRecord(card: Record<string, unknown>): CardView {
+  const children = Array.isArray(card.children) ? card.children : [];
+
+  return {
+    title: readString(card.title),
+    subtitle: readString(card.subtitle),
+    imageUrl: toSafeExternalUrl(readString(card.imageUrl)),
+    children: children.flatMap((child) => {
+      const view = cardChildFromNode(child);
+
+      return view ? [view] : [];
+    }),
+  };
+}
+
+function cardButtonAppearance(style?: string): {
+  variant: 'error' | 'primary' | 'secondary';
+  mode: 'filled' | 'outline';
+} {
+  if (style === 'danger') {
+    return { variant: 'error', mode: 'outline' };
+  }
+
+  if (style === 'primary') {
+    return { variant: 'primary', mode: 'filled' };
+  }
+
+  return { variant: 'secondary', mode: 'outline' };
+}
+
+function ChatCardPart({
+  card,
+  disabled,
+  onAction,
+}: {
+  card: Record<string, unknown>;
+  disabled?: boolean;
+  onAction?: (args: { actionId: string; value?: string }) => void;
+}) {
+  const view = cardViewFromRecord(card);
+
+  return (
+    <div className="border-stroke-soft bg-bg-white shadow-regular-xs flex w-full flex-col gap-2.5 rounded-2xl rounded-tl-md border px-3.5 py-2.5">
+      {view.imageUrl ? (
+        <img src={view.imageUrl} alt={view.title ?? ''} className="max-h-40 w-full rounded-lg object-cover" />
+      ) : null}
+      {view.title ? <p className="text-label-sm text-text-strong font-medium">{view.title}</p> : null}
+      {view.subtitle ? <p className="text-label-xs text-text-soft">{view.subtitle}</p> : null}
+      {view.children.map((child, index) => {
+        switch (child.type) {
+          case 'text':
+            return (
+              <MarkdownText key={index} className="text-paragraph-sm leading-5">
+                {child.content}
+              </MarkdownText>
+            );
+          case 'divider':
+            return <hr key={index} className="border-stroke-soft" />;
+          case 'image':
+            return (
+              <img key={index} src={child.url} alt={child.alt} className="max-h-40 w-full rounded-lg object-cover" />
+            );
+          case 'link':
+            return (
+              <a
+                key={index}
+                href={child.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-label-xs text-primary-base inline-flex items-center gap-1 font-medium"
+              >
+                {child.label}
+                <RiExternalLinkLine className="size-3" aria-hidden />
+              </a>
+            );
+          case 'actions':
+            return (
+              <div key={index} className="flex flex-wrap gap-1.5">
+                {child.buttons.map((button) => {
+                  const appearance = cardButtonAppearance(button.style);
+
+                  return (
+                    <Button
+                      key={button.id}
+                      type="button"
+                      size="2xs"
+                      variant={appearance.variant}
+                      mode={appearance.mode}
+                      disabled={disabled || !onAction}
+                      onClick={() => onAction?.({ actionId: button.id, value: button.value })}
+                    >
+                      {button.label}
+                    </Button>
+                  );
+                })}
+              </div>
+            );
+        }
+      })}
     </div>
   );
 }

--- a/docs/agents/channels/agent-chat/quickstart.mdx
+++ b/docs/agents/channels/agent-chat/quickstart.mdx
@@ -226,7 +226,7 @@ Start with `type === 'text'`. Then handle the other part types as you need them.
 | `tool` | Tool call and result. |
 | `approval` | Gated tool. Use `pendingActions` and `respondToAction`. |
 | `mcp-connection` | MCP connect card. Open `authorizeUrl`. |
-| `card` | Structured card payload. |
+| `card` | Structured Card tree. Draw `part.card`. Button clicks call `sendAction`. See [Cards](#cards). |
 | `file` | File attachment metadata. |
 | `source` | Citation (`url` or `document`). |
 
@@ -264,6 +264,104 @@ const { messages } = useAgentChat({ agentId: 'YOUR_AGENT_IDENTIFIER' });
 </CodeGroup>
 
 Full field tables: [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat).
+
+## Cards
+
+A Card is a structured reply. It can include a title, text, images, links, and buttons.
+
+When the agent sends a Card, the message includes a part with `type: 'card'`. The data is on `part.card`.
+
+Agents create Cards with JSX or `Card({…})`. That authoring API is shared with Slack and the other ACI channels: [Interactive cards](/agents/custom-code-agent/building-blocks/reply#interactive-cards). You can also post the JSON with [Send an agent reply](/api-reference/agents/send-an-agent-reply).
+
+The SDK does not type `part.card`. Read the fields that you support. Skip child types that you do not use.
+
+An Order card arrives as this object on `part.card`:
+
+```json
+{
+  "type": "card",
+  "title": "Order #1234",
+  "children": [
+    { "type": "text", "content": "Your order is ready for pickup." },
+    {
+      "type": "actions",
+      "children": [
+        { "type": "button", "id": "ack", "label": "Acknowledge" },
+        { "type": "button", "id": "escalate", "label": "Escalate", "style": "danger" }
+      ]
+    }
+  ]
+}
+```
+
+| Field | What it is |
+| --- | --- |
+| `title` | Optional heading. |
+| `subtitle` | Optional secondary heading. |
+| `imageUrl` | Optional header image. |
+| `children` | Ordered nodes. See the table below. |
+
+| `child.type` | Fields |
+| --- | --- |
+| `text` | `content` |
+| `divider` | None |
+| `image` | `url`, `alt` |
+| `link` | `url`, `label` |
+| `actions` | `children` of `button` |
+| `button` | `id`, `label`, optional `value` and `style` |
+
+Draw `title` and the `children` that you support. If the subscriber clicks a button, call `sendAction`. The agent receives the click in `onAction`.
+
+```tsx
+const { messages, sendAction } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{messages.map((message) =>
+  message.parts.map((part, i) => {
+    if (part.type !== 'card') {
+      return null;
+    }
+
+    const title = typeof part.card.title === 'string' ? part.card.title : null;
+    const children = Array.isArray(part.card.children) ? part.card.children : [];
+
+    return (
+      <article key={i}>
+        {title ? <h3>{title}</h3> : null}
+        {children.map((child, j) => {
+          if (child?.type === 'text') {
+            return <p key={j}>{child.content}</p>;
+          }
+
+          if (child?.type !== 'actions') {
+            return null;
+          }
+
+          return child.children?.map((button) => (
+            <button
+              key={button.id}
+              type="button"
+              onClick={() =>
+                void sendAction({
+                  actionId: button.id,
+                  value: button.value,
+                  sourceMessageId: message.id,
+                })
+              }
+            >
+              {button.label}
+            </button>
+          ));
+        })}
+      </article>
+    );
+  })
+)}
+```
+
+Do not send the button label with `sendMessage`. That call creates a new chat message.
+Do not call `respondToAction`. That function is for tool approval only.
 
 ## Thinking and running
 

--- a/docs/agents/custom-code-agent/building-blocks/reply.mdx
+++ b/docs/agents/custom-code-agent/building-blocks/reply.mdx
@@ -164,10 +164,10 @@ await ctx.reply(
 );
 ```
 
-When a user clicks a button or selects a dropdown value, `onAction` fires with `action.id` and `action.value`. See [Handlers and context](/agents/custom-code-agent/building-blocks/handle-events#onaction).
-
   </Tab>
 </Tabs>
+
+When a user clicks a button or selects a dropdown value, `onAction` fires with `action.id` and `action.value`. See [Handlers and context](/agents/custom-code-agent/building-blocks/handle-events#onaction). On [Agent Chat](/agents/channels/agent-chat/quickstart#cards), the same tree arrives as a `card` part. The web UI draws it and calls `sendAction`.
 
 ### Available card components
 
@@ -198,5 +198,8 @@ The following table lists the card components you can use in replies:
   </Card>
   <Card icon="code" href="/api-reference/agents/send-an-agent-reply" title="Send an agent reply API">
     Send replies from your backend without a bridge handler.
+  </Card>
+  <Card icon="message-circle" href="/agents/channels/agent-chat/quickstart#cards" title="Agent Chat cards">
+    Draw `part.type === 'card'` in your product UI and call `sendAction`.
   </Card>
 </Columns>

--- a/docs/platform/sdks/react/hooks/use-agent-chat.mdx
+++ b/docs/platform/sdks/react/hooks/use-agent-chat.mdx
@@ -31,7 +31,7 @@ Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Produc
 | `messages` | `AgentMessage[]` | Folded timeline for the current conversation. |
 | `pendingActions` | `AgentPendingAction[]` | Tool approvals and MCP connect items that are still pending. Derived from `messages`. |
 | `conversationId` | `string \| undefined` | Server conversation id after create or resume. Undefined until the first successful send on a new chat. |
-| `error` | `NovuError \| AgentChatPlanLimitError` | Last error from load, send, or `respondToAction`. |
+| `error` | `NovuError \| AgentChatPlanLimitError` | Last error from load, send, `respondToAction`, or `sendAction`. |
 | `isLoading` | `boolean` | True until the first history fetch completes. False when there is no `conversationId` prop. |
 | `isFetching` | `boolean` | True while a history request is in flight. |
 | `isRunning` | `boolean` | True while the agent turn is in progress. |
@@ -42,6 +42,7 @@ Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Produc
 | `fetchMore` | `() => Promise<{ data?: { messages: AgentMessage[]; hasMore: boolean }; error?: NovuError }>` | Load an older history page. |
 | `sendMessage` | `(text: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| AgentChatPlanLimitError }>` | Send a user message. Creates a conversation when `conversationId` is omitted. |
 | `respondToAction` | `(args: { actionId: string; decision: 'approved' \| 'denied' }) => Promise<{ data?: RespondToActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Approve or deny a pending `tool-approval`. Pass `action.id` from `pendingActions`. |
+| `sendAction` | `(args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{ data?: SendActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Click a Card button. Pass `id` / `value` from the button and `message.id` as `sourceMessageId`. Do not use this for tool approval. Render walk: [Cards](/agents/channels/agent-chat/quickstart#cards). |
 
 ## Message type
 
@@ -62,7 +63,7 @@ Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Produc
 | `tool` | Tool call and result. |
 | `approval` | Gated tool waiting on the subscriber. Use `pendingActions` + `respondToAction`. |
 | `mcp-connection` | MCP server connect card. Open `authorizeUrl` in the browser. |
-| `card` | Structured card payload (`card` object). |
+| `card` | Structured Card tree (`card` object). Draw it in your UI. Button clicks call `sendAction`. Agents send Cards with [Interactive cards](/agents/custom-code-agent/building-blocks/reply#interactive-cards). Client walk: [Cards](/agents/channels/agent-chat/quickstart#cards). |
 | `file` | File attachment metadata. |
 | `source` | Citation (`url` or `document`). |
 
@@ -87,4 +88,4 @@ Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Produc
 
 ## JavaScript SDK
 
-The same client lives on `novu.agentChat` in [`@novu/js`](/platform/sdks/javascript#agent-chat): `sendMessage`, `loadConversation`, `fetchMore`, `respondToAction`, `subscribe`, `unsubscribe`.
+The same client lives on `novu.agentChat` in [`@novu/js`](/platform/sdks/javascript#agent-chat): `sendMessage`, `loadConversation`, `fetchMore`, `respondToAction`, `sendAction`, `subscribe`, `unsubscribe`.

--- a/packages/js/scripts/size-limit.mjs
+++ b/packages/js/scripts/size-limit.mjs
@@ -15,8 +15,8 @@ const modules = [
   {
     name: 'UMD minified',
     filePath: umdPath,
-    // Raised for headless agentChat on Novu (NV-8445). Split to ./agent-chat later if needed.
-    limitInBytes: 224_000,
+    // Raised for headless agentChat on Novu. Split to ./agent-chat later if needed.
+    limitInBytes: 225_000,
   },
   {
     name: 'UMD gzip',

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -10,6 +10,7 @@ describe('AgentChat', () => {
   let emitter: NovuEventEmitter;
   let sendMessage: jest.Mock;
   let respondToAction: jest.Mock;
+  let sendAction: jest.Mock;
   let getEvents: jest.Mock;
   let connect: jest.Mock;
   let agentChat: AgentChat;
@@ -18,9 +19,10 @@ describe('AgentChat', () => {
     emitter = new NovuEventEmitter();
     sendMessage = jest.fn();
     respondToAction = jest.fn();
+    sendAction = jest.fn();
     getEvents = jest.fn();
     connect = jest.fn().mockResolvedValue({ data: undefined });
-    const agentChatService = { sendMessage, respondToAction, getEvents } as unknown as AgentChatService;
+    const agentChatService = { sendMessage, respondToAction, sendAction, getEvents } as unknown as AgentChatService;
     agentChat = new AgentChat({
       inboxServiceInstance,
       eventEmitterInstance: emitter,
@@ -1556,6 +1558,44 @@ describe('AgentChat', () => {
 
     expect(result.error).toBeDefined();
     expect(respondToAction).not.toHaveBeenCalled();
+  });
+
+  it('sendAction POSTs actionId, value, and sourceMessageId', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
+    sendAction.mockResolvedValue({ identifier: 'conv_abcdefghijkl' });
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hi', key: 'local_card' });
+    const result = await agentChat.sendAction({
+      agentId: 'agent_1',
+      key: 'local_card',
+      actionId: 'topic-billing',
+      sourceMessageId: 'act_card0000001',
+      value: 'billing',
+    });
+
+    expect(result).toEqual({ data: { conversationId: 'conv_abcdefghijkl' } });
+    expect(sendAction).toHaveBeenCalledWith({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+      actionId: 'topic-billing',
+      sourceMessageId: 'act_card0000001',
+      value: 'billing',
+    });
+  });
+
+  it('sendAction returns error without POST when sourceMessageId is empty', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hi', key: 'local_card_empty' });
+    const result = await agentChat.sendAction({
+      agentId: 'agent_1',
+      key: 'local_card_empty',
+      actionId: 'topic-billing',
+      sourceMessageId: '   ',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(sendAction).not.toHaveBeenCalled();
   });
 
   function recordChanges(key: string) {

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -14,6 +14,8 @@ import type {
   LoadConversationResult,
   RespondToActionArgs,
   RespondToActionResult,
+  SendActionArgs,
+  SendActionResult,
   SendMessageArgs,
   SendMessageResult,
 } from './types';
@@ -128,53 +130,61 @@ export class AgentChat extends BaseModule {
   }
 
   async respondToAction(args: RespondToActionArgs): Result<RespondToActionResult, NovuError | AgentChatPlanLimitError> {
-    return this.callWithSession<RespondToActionResult, NovuError | AgentChatPlanLimitError>(async () => {
-      const entry = this.#resolveFetchEntry(args);
-      if (!entry?.conversationId) {
-        return {
-          error: new NovuError(
-            'Cannot respond to action without a conversation id',
-            new Error('missing conversation id')
-          ),
-        };
-      }
+    return this.#withConversationAction(
+      args,
+      'Cannot respond to action without a conversation id',
+      'Failed to respond to action',
+      async (entry, conversationId) => {
+        const pending = derivePendingActions(entry.messages).find((action) => action.id === args.actionId);
+        if (!pending || pending.type !== 'tool-approval') {
+          return { error: new NovuError('Pending action not found', new Error('pending action not found')) };
+        }
 
-      const pending = derivePendingActions(entry.messages).find((action) => action.id === args.actionId);
-      if (!pending || pending.type !== 'tool-approval') {
-        return { error: new NovuError('Pending action not found', new Error('pending action not found')) };
-      }
+        const actionId = args.decision === 'approved' ? pending.approveActionId : pending.denyActionId;
+        if (!actionId) {
+          return {
+            error: new NovuError(
+              'Pending approval is missing action id',
+              new Error('pending approval missing action id')
+            ),
+          };
+        }
 
-      const actionId = args.decision === 'approved' ? pending.approveActionId : pending.denyActionId;
-      if (!actionId) {
-        return {
-          error: new NovuError(
-            'Pending approval is missing action id',
-            new Error('pending approval missing action id')
-          ),
-        };
-      }
-
-      try {
-        const data = await this.#agentChatService.respondToAction({
+        return this.#agentChatService.respondToAction({
           agentId: args.agentId,
-          conversationId: entry.conversationId,
+          conversationId,
           actionId,
           agentHash: args.agentHash,
         });
+      }
+    );
+  }
 
-        return {
-          data: {
-            conversationId: data.identifier,
-          },
-        };
-      } catch (error) {
-        if (error instanceof AgentChatPlanLimitError) {
-          return { error };
+  async sendAction(args: SendActionArgs): Result<SendActionResult, NovuError | AgentChatPlanLimitError> {
+    return this.#withConversationAction(
+      args,
+      'Cannot send action without a conversation id',
+      'Failed to send action',
+      async (_entry, conversationId) => {
+        const actionId = args.actionId.trim();
+        const sourceMessageId = args.sourceMessageId.trim();
+        if (!actionId) {
+          return { error: new NovuError('actionId is required', new Error('missing action id')) };
+        }
+        if (!sourceMessageId) {
+          return { error: new NovuError('sourceMessageId is required', new Error('missing source message id')) };
         }
 
-        return { error: new NovuError('Failed to respond to action', error) };
+        return this.#agentChatService.sendAction({
+          agentId: args.agentId,
+          conversationId,
+          actionId,
+          sourceMessageId,
+          value: args.value,
+          agentHash: args.agentHash,
+        });
       }
-    });
+    );
   }
 
   /**
@@ -289,6 +299,42 @@ export class AgentChat extends BaseModule {
           return { error: new NovuError('Failed to send agent chat message', error) };
         }
       });
+    });
+  }
+
+  /**
+   * Shared session + conversation + plan-limit wrapper for `respondToAction` and `sendAction`.
+   * The two public methods stay separate: they take different ids and extra fields.
+   */
+  async #withConversationAction(
+    args: { agentId: string; conversationId?: string; key?: string },
+    missingConversationMessage: string,
+    failureMessage: string,
+    run: (entry: ConversationEntry, conversationId: string) => Promise<{ identifier: string } | { error: NovuError }>
+  ): Result<{ conversationId: string }, NovuError | AgentChatPlanLimitError> {
+    return this.callWithSession<{ conversationId: string }, NovuError | AgentChatPlanLimitError>(async () => {
+      const entry = this.#resolveFetchEntry(args);
+      const conversationId = entry?.conversationId;
+      if (!entry || !conversationId) {
+        return {
+          error: new NovuError(missingConversationMessage, new Error('missing conversation id')),
+        };
+      }
+
+      try {
+        const result = await run(entry, conversationId);
+        if ('error' in result) {
+          return { error: result.error };
+        }
+
+        return { data: { conversationId: result.identifier } };
+      } catch (error) {
+        if (error instanceof AgentChatPlanLimitError) {
+          return { error };
+        }
+
+        return { error: new NovuError(failureMessage, error) };
+      }
     });
   }
 

--- a/packages/js/src/agent-chat/apply-envelope.test.ts
+++ b/packages/js/src/agent-chat/apply-envelope.test.ts
@@ -1,4 +1,9 @@
-import { AGENT_EVENT_PROTOCOL_VERSION, type AgentEvent, type AgentEventEnvelope } from '@novu/agent-event-protocol';
+import {
+  AGENT_EVENT_PROTOCOL_VERSION,
+  type AgentEvent,
+  type AgentEventEnvelope,
+  type AgentMessageContent,
+} from '@novu/agent-event-protocol';
 import { type AgentMessage, createInitialAgentConversationState } from './agent-message.types';
 import { appendUserMessage, applyEnvelope, applyEnvelopes } from './apply-envelope';
 
@@ -377,5 +382,39 @@ describe('applyEnvelope', () => {
     );
 
     expect(next.typing).toBeUndefined();
+  });
+
+  it('folds card content into a card part', () => {
+    const card = {
+      type: 'card',
+      title: 'Support Agent',
+      children: [{ type: 'text', content: 'How can I help?' }],
+    };
+    const next = applyEnvelope(
+      createInitialAgentConversationState(),
+      envelope(1, {
+        type: 'message',
+        role: 'assistant',
+        messageId: 'm-card',
+        content: { card },
+      })
+    );
+
+    expect(assistantMessages(next.messages)[0]?.parts).toEqual([{ type: 'card', card }]);
+  });
+
+  it('folds exclusive durable content as markdown or card, not both', () => {
+    const card = { type: 'card', title: 'Support' };
+    const next = applyEnvelope(
+      createInitialAgentConversationState(),
+      envelope(1, {
+        type: 'message',
+        role: 'assistant',
+        messageId: 'm-both',
+        content: { markdown: 'Hello', card } as AgentMessageContent,
+      })
+    );
+
+    expect(assistantMessages(next.messages)[0]?.parts).toEqual([{ type: 'text', text: 'Hello', state: 'done' }]);
   });
 });

--- a/packages/js/src/agent-chat/apply-envelope.ts
+++ b/packages/js/src/agent-chat/apply-envelope.ts
@@ -351,9 +351,7 @@ function applyDurableMessageParts(
     } else {
       next = [...next, { type: 'text', text: content.markdown, state: 'done' }];
     }
-  }
-
-  if ('card' in content) {
+  } else {
     next = [...next, { type: 'card', card: content.card }];
   }
 

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -18,6 +18,8 @@ export type {
   LoadConversationResult,
   RespondToActionArgs,
   RespondToActionResult,
+  SendActionArgs,
+  SendActionResult,
   SendMessageArgs,
   SendMessageResult,
 } from './types';

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -83,6 +83,22 @@ export type RespondToActionResult = {
   conversationId: string;
 };
 
+export type SendActionArgs = AgentHashFields & {
+  agentId: string;
+  /** `id` of the clicked Card button. */
+  actionId: string;
+  /** Platform message id of the message that carries the Card. */
+  sourceMessageId: string;
+  /** `value` of the clicked Card button, if set. */
+  value?: string;
+  conversationId?: string;
+  key?: string;
+};
+
+export type SendActionResult = {
+  conversationId: string;
+};
+
 /** What caused a fold. A live fold carries the envelope that caused it. Internal to the store seam. */
 export type AgentChatChangeSource =
   | { kind: 'live'; envelope: AgentEventEnvelope }

--- a/packages/js/src/api/agent-chat-service.test.ts
+++ b/packages/js/src/api/agent-chat-service.test.ts
@@ -166,6 +166,42 @@ describe('AgentChatService', () => {
     );
   });
 
+  it('POSTs a Card button action with sourceMessageId and value', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { identifier: 'conv_abcdefghijkl' } }),
+    } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const httpClient = new HttpClient({ apiUrl: 'https://test.novu.co' });
+    httpClient.setAuthorizationToken('test-token');
+    const service = new AgentChatService({ httpClient });
+
+    const result = await service.sendAction({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+      actionId: 'topic-billing',
+      sourceMessageId: 'act_card0000001',
+      value: 'billing',
+    });
+
+    expect(result).toEqual({ identifier: 'conv_abcdefghijkl' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://test.novu.co/v1/agent-chat/conversations',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          agentId: 'agent_1',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          actionId: 'topic-billing',
+          sourceMessageId: 'act_card0000001',
+          value: 'billing',
+        }),
+      })
+    );
+  });
+
   it('GETs older conversation events with before cursor', async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/packages/js/src/api/agent-chat-service.ts
+++ b/packages/js/src/api/agent-chat-service.ts
@@ -48,6 +48,17 @@ export type AgentChatRespondToActionArgs = AgentHashFields & {
   actionId: string;
 };
 
+export type AgentChatSendActionArgs = AgentHashFields & {
+  agentId: string;
+  conversationId: string;
+  /** `id` of the clicked Card button. */
+  actionId: string;
+  /** Platform message id of the message that carries the Card. */
+  sourceMessageId: string;
+  /** `value` of the clicked Card button, if set. */
+  value?: string;
+};
+
 export type AgentChatRespondToActionResponse = {
   identifier: string;
 };
@@ -73,6 +84,17 @@ export class AgentChatService {
       agentId: args.agentId,
       conversationIdentifier: args.conversationId,
       actionId: args.actionId,
+      ...(args.agentHash ? { agentHash: args.agentHash } : {}),
+    });
+  }
+
+  async sendAction(args: AgentChatSendActionArgs): Promise<AgentChatRespondToActionResponse> {
+    return this.#postAccept({
+      agentId: args.agentId,
+      conversationIdentifier: args.conversationId,
+      actionId: args.actionId,
+      sourceMessageId: args.sourceMessageId,
+      ...(args.value !== undefined ? { value: args.value } : {}),
       ...(args.agentHash ? { agentHash: args.agentHash } : {}),
     });
   }

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -16,6 +16,8 @@ export type {
   LoadConversationResult,
   RespondToActionArgs,
   RespondToActionResult,
+  SendActionArgs,
+  SendActionResult,
   SendMessageArgs,
   SendMessageResult,
 } from './agent-chat';

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -9,6 +9,7 @@ import type {
   LoadConversationResult,
   NovuError,
   RespondToActionResult,
+  SendActionResult,
   SendMessageResult,
 } from '@novu/js';
 import { derivePendingActions } from '@novu/js';
@@ -72,6 +73,10 @@ export type UseAgentChatResult = {
   }>;
   respondToAction: (args: { actionId: string; decision: 'approved' | 'denied' }) => Promise<{
     data?: RespondToActionResult;
+    error?: NovuError | AgentChatPlanLimitError;
+  }>;
+  sendAction: (args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{
+    data?: SendActionResult;
     error?: NovuError | AgentChatPlanLimitError;
   }>;
 };
@@ -376,11 +381,36 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     [novu, agentId, agentHash, sessionKeyRef, conversationIdRef, propsRef]
   );
 
+  const sendAction = useCallback(
+    async (args: { actionId: string; sourceMessageId: string; value?: string }) => {
+      setError(undefined);
+
+      const response = await novu.agentChat.sendAction({
+        agentId,
+        agentHash,
+        key: sessionKeyRef.current,
+        conversationId: conversationIdRef.current,
+        actionId: args.actionId,
+        sourceMessageId: args.sourceMessageId,
+        value: args.value,
+      });
+
+      if (response.error) {
+        setError(response.error);
+        propsRef.current.onError?.(response.error);
+      }
+
+      return response;
+    },
+    [novu, agentId, agentHash, sessionKeyRef, conversationIdRef, propsRef]
+  );
+
   return {
     messages,
     pendingActions,
     sendMessage,
     respondToAction,
+    sendAction,
     conversationId,
     error,
     isLoading,

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -91,6 +91,7 @@ export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
     fetchMore: () => Promise.resolve({ data: undefined, error: undefined }),
     sendMessage: () => Promise.resolve({ data: undefined, error: undefined }),
     respondToAction: () => Promise.resolve({ data: undefined, error: undefined }),
+    sendAction: () => Promise.resolve({ data: undefined, error: undefined }),
   };
 }
 


### PR DESCRIPTION
## Summary

- Live WS and history now emit `{ card }` when `richContent.card` is a stored Card tree, so `useAgentChat` gets `part.type === 'card'` instead of flattened markdown.
- Add `sendAction({ actionId, value, sourceMessageId })` on `novu.agentChat` and `useAgentChat`. Button clicks go to the agent's `onAction`. `respondToAction` stays tool-approval only.
- Dashboard Agent Chat tester draws Card primitives (title, text, image, divider, link, buttons) and wires clicks to `sendAction`. Docs cover the client walk and authoring backlink.

```mermaid
sequenceDiagram
  participant Agent
  participant API
  participant Client as useAgentChat
  Agent->>API: reply with Card
  API->>Client: live WS / history content { card }
  Client->>Client: fold part.type card
  Client->>API: sendAction(actionId, value, sourceMessageId)
  API->>Agent: onAction
```

## Test plan

- [ ] History: activity with `richContent.card` maps to envelope `content.card` (`activity-to-events.spec.ts`)
- [ ] Client: durable `{ card }` folds to `{ type: 'card', card }`; exclusive markdown/card content does not emit both
- [ ] `sendAction` POSTs `actionId`, `value`, and `sourceMessageId`
- [ ] Dashboard tester: topic-picker Card shows buttons; click hits `onAction`
- [ ] Do not use `sendMessage` or `respondToAction` for Card buttons

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves structured Cards across Agent Chat live/history delivery, adds generic Card-action sending to the JavaScript and React clients, and renders Card content in the dashboard tester.
- Emits `{ card }` rather than flattened markdown for stored Card trees.
- Adds `sendAction` across the transport, client, React hook, exports, tests, and documentation.
- Adds dashboard rendering for Card text, media, links, and actions.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the dashboard Card renderer preserves the existing link-button actions used by Agent Chat replies.

Structured Card delivery and generic action dispatch are aligned across the API and clients, but the dashboard parser silently removes valid link-button CTAs from Cards produced by existing server paths.

**Files Needing Attention:** apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/agent-chat/activity-to-events.ts | Preserves valid stored Card trees in message and edit history envelopes while retaining markdown fallback. |
| apps/api/src/app/agents/agent-chat/agent-chat-platform-delivery.service.ts | Aligns live Agent Chat delivery with history by emitting structured Card content. |
| packages/js/src/agent-chat/apply-envelope.ts | Folds exclusive durable Card content into Card parts without an established blocking reconciliation defect. |
| packages/js/src/agent-chat/agent-chat.ts | Adds validated generic Card-action dispatch while retaining the separate tool-approval action path. |
| packages/js/src/api/agent-chat-service.ts | Sends the generic action fields expected by the existing Agent Chat ingress endpoint. |
| packages/react/src/hooks/useAgentChat.ts | Exposes the JavaScript client's sendAction operation through the React hook. |
| apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx | Adds structured Card rendering but drops valid link-button action children emitted by existing API producers. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Agent
  participant API
  participant Client as JS/React Agent Chat
  participant Dashboard
  Agent->>API: Reply with Card tree
  API->>Client: Live/history envelope with content.card
  Client->>Client: Fold into card part
  Client->>Dashboard: Render Card primitives
  Dashboard->>Client: sendAction(actionId, value, sourceMessageId)
  Client->>API: POST generic action
  API->>Agent: Invoke onAction
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312353%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12353&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fagents%2Fagent-chat-panel%2Fagent-chat-parts.tsx%3A204%0A**Link-button%20actions%20are%20discarded**%0A%0AWhen%20an%20Agent%20Chat%20Card%20contains%20an%20existing%20%60link-button%60%20action%2C%20this%20parser%20recognizes%20only%20%60button%60%20nodes%20and%20discards%20the%20action%2C%20causing%20setup%2C%20upgrade%2C%20connection%2C%20and%20similar%20Cards%20to%20render%20without%20their%20call-to-action%20links.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12353&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx:204
**Link-button actions are discarded**

When an Agent Chat Card contains an existing `link-button` action, this parser recognizes only `button` nodes and discards the action, causing setup, upgrade, connection, and similar Cards to render without their call-to-action links.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api-service,js): deliver Agent Chat..."](https://github.com/novuhq/novu/commit/b43a6cb5795c3fd97769db390f937948f79c2409) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53926401)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)
- Knowledge Base — [Dashboard App (apps/dashboard)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dashboard-app.md)
</details>

<!-- /greptile_comment -->