### PR TITLE
fix(dashboard): restore ConnectSubscriberProvider on agent Overview tab fixes NV-8603

### DIFF
--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -366,7 +366,9 @@ export function AgentDetailsPage() {
               </TabsList>
 
               <TabsContent value="overview" className="outline-none">
-                <AgentOverviewTab agent={agent} />
+                <ConnectSubscriberProvider>
+                  <AgentOverviewTab agent={agent} />
+                </ConnectSubscriberProvider>
               </TabsContent>
               <TabsContent value="integrations" className="outline-none">
                 {currentTab === 'integrations' ? (


### PR DESCRIPTION
## Summary

- Wrap the agent **Overview** tab in `ConnectSubscriberProvider`, matching the Channels tab pattern.
- Fixes WhatsApp Embedded Signup (and Slack / Teams / Sendblue connect/test panels) missing on Overview when guides gate on `useConnectSubscriber().isReady`.
- Keeps Chat tab unwrapped so its own `NovuProvider` does not nest under the connect provider (same constraint as #12338).

### Why

After [#12338](https://github.com/novuhq/novu/pull/12338), `ConnectSubscriberProvider` only wrapped Channels. Overview still renders the same channel setup guides, so `isReady` stayed `false` and the Facebook / connect UI silently failed to mount (manual-credentials link still showed).

```mermaid
flowchart LR
  subgraph before [Before]
    O1[Overview] -.->|no provider| G1[Setup guides]
    C1[Channels] --> P1[ConnectSubscriberProvider] --> G2[Setup guides]
    Chat1[Chat] --> N1[own NovuProvider]
  end
  subgraph after [After]
    O2[Overview] --> P2[ConnectSubscriberProvider] --> G3[Setup guides]
    C2[Channels] --> P3[ConnectSubscriberProvider] --> G4[Setup guides]
    Chat2[Chat] --> N2[own NovuProvider]
  end
```

## Test plan

- [ ] Agent Overview with a fresh WhatsApp integration: **Log in with Facebook** appears
- [ ] Same agent on Channels tab: still works
- [ ] Slack (and Teams/Sendblue if present) connect/test UI on Overview when expected
- [ ] Agent Chat tab still works
- [ ] Header Inbox on agent details still works (not under connect provider)

fixes [NV-8603](https://linear.app/novu/issue/NV-8603/agent-overview-setup-guides-missing-connectsubscriberprovider-whatsapp)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores the subscriber connection context for channel setup guides rendered on the agent Overview tab while preserving separate provider boundaries for the Chat tab and header.
- Wraps `AgentOverviewTab` in `ConnectSubscriberProvider`.
- Matches the existing Integrations/Channels tab composition.
- Leaves the Chat tab’s independently identified `NovuProvider` outside this provider.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the provider scoped to the Overview tab and no identified provider-overlap or lifecycle regression.

The added provider supplies the context required by Overview setup guides, while inactive tab content unmounting keeps it isolated from the Chat tab’s separate subscriber provider.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/pages/agent-details.tsx | Adds the missing connect-subscriber context around the Overview tab without nesting the independently configured Chat provider or wrapping the page header. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Tabs[Agent details tabs] --> Overview[Overview]
  Overview --> Connect[ConnectSubscriberProvider]
  Connect --> Guides[Agent setup guides]
  Tabs --> Integrations[Integrations]
  Integrations --> ExistingConnect[ConnectSubscriberProvider]
  Tabs --> Chat[Chat]
  Chat --> ChatProvider[Independent NovuProvider]
```

<sub>Reviews (1): Last reviewed commit: ["Wrap AgentOverviewTab with ConnectSubscr..."](https://github.com/novuhq/novu/commit/541de8bfb3438543381e2c5775cf4ecc6a341f00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53929642)</sub>

**Context used:**

- Knowledge Base — [Dashboard App (apps/dashboard)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dashboard-app.md)

<!-- /greptile_comment -->