### PR TITLE
fix(api-service): Keep HTTP step response fields when hydrating steps for conditions fixes NV-8604

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.spec.ts
@@ -1,5 +1,6 @@
 import { NotificationStepEntity, NotificationTemplateEntity } from '@novu/dal';
-import { providerSchemas } from '@novu/framework';
+import { Client, providerSchemas } from '@novu/framework';
+import { Event, PostActionEnum, Workflow } from '@novu/framework/internal';
 import {
   CHAT_CONTENT_OVERRIDE_PROVIDER_IDS,
   ChatProviderIdEnum,
@@ -133,5 +134,110 @@ describe('ConstructFrameworkWorkflow content-override channel steps', () => {
 
     expect(options.controlSchema.properties?.body, 'the step\u2019s own controls must survive').to.exist;
     expect(providerOverrides?.additionalProperties?.additionalProperties).to.equal(true);
+  });
+});
+
+/**
+ * Worker-executed steps are hydrated from the job state on the bridge, and the framework validates
+ * that state against the step's output schema with AJV set to strip additional properties. Without
+ * an explicit schema the whole HTTP response body was removed, so conditions on its fields never
+ * matched and the next step was always skipped (NV-8604).
+ */
+describe('ConstructFrameworkWorkflow worker-executed step hydration', () => {
+  const HTTP_STEP_ID = 'http-request-step';
+  const IN_APP_STEP_ID = 'in-app-step';
+  const WORKFLOW_ID = 'http-conditions-workflow';
+
+  const hydrationDbWorkflow = {
+    _id: 'workflow-id',
+    _environmentId: 'env-id',
+    _organizationId: 'org-id',
+    name: 'HTTP request conditions',
+    origin: ResourceOriginEnum.NOVU_CLOUD,
+    triggers: [{ identifier: WORKFLOW_ID }],
+    steps: [
+      {
+        stepId: HTTP_STEP_ID,
+        template: {
+          type: StepTypeEnum.HTTP_REQUEST,
+          controls: {
+            schema: {
+              type: 'object',
+              properties: { url: { type: 'string' }, method: { type: 'string' } },
+              additionalProperties: false,
+            },
+          },
+        },
+      },
+      {
+        stepId: IN_APP_STEP_ID,
+        template: {
+          type: StepTypeEnum.IN_APP,
+          controls: {
+            schema: {
+              type: 'object',
+              properties: { body: { type: 'string' }, skip: { type: 'object', additionalProperties: true } },
+              additionalProperties: false,
+            },
+          },
+        },
+      },
+    ],
+  } as unknown as NotificationTemplateEntity;
+
+  function buildHydrationWorkflow(): Workflow {
+    const hydrationUsecase = Object.create(ConstructFrameworkWorkflow.prototype) as {
+      logger: { setContext: () => void; warn: () => void; error: () => void };
+      inAppOutputRendererUseCase: { execute: () => Promise<Record<string, unknown>> };
+      constructFrameworkWorkflow: (args: { dbWorkflow: NotificationTemplateEntity }) => Workflow;
+    };
+
+    hydrationUsecase.logger = { setContext: () => {}, warn: () => {}, error: () => {} };
+    hydrationUsecase.inAppOutputRendererUseCase = { execute: async () => ({ body: 'Enrolled' }) };
+
+    return hydrationUsecase.constructFrameworkWorkflow({ dbWorkflow: hydrationDbWorkflow });
+  }
+
+  function buildEvent(enrolmentCount: number): Event {
+    return {
+      action: PostActionEnum.EXECUTE,
+      workflowId: WORKFLOW_ID,
+      stepId: IN_APP_STEP_ID,
+      subscriber: {},
+      payload: {},
+      controls: {
+        body: 'Enrolled',
+        skip: { and: [{ '==': [{ var: `steps.${HTTP_STEP_ID}.enrolmentCount` }, 1] }] },
+      },
+      state: [
+        {
+          stepId: HTTP_STEP_ID,
+          outputs: { id: '123', message: { text: 'pawan' }, enrolmentCount },
+          state: { status: 'completed', error: false },
+        },
+      ],
+      context: {},
+      env: { name: 'Test', type: 'dev' },
+    } as unknown as Event;
+  }
+
+  async function executeInAppStep(enrolmentCount: number) {
+    const client = new Client({ secretKey: 'construct-framework-workflow-secret' });
+    await client.addWorkflows([buildHydrationWorkflow()]);
+
+    return client.executeWorkflow(buildEvent(enrolmentCount));
+  }
+
+  it('runs the next step when a condition matches a field of the hydrated HTTP response', async () => {
+    const result = await executeInAppStep(1);
+
+    expect(result.options?.skip).to.equal(false);
+    expect(result.outputs.body).to.equal('Enrolled');
+  });
+
+  it('skips the next step when the hydrated HTTP response does not satisfy the condition', async () => {
+    const result = await executeInAppStep(2);
+
+    expect(result.options?.skip).to.equal(true);
   });
 });

--- a/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
@@ -27,6 +27,7 @@ import {
   ActionStep,
   ChannelStep,
   ChatOutputUnvalidated,
+  CustomStep,
   PostActionEnum,
   Schema,
   Step,
@@ -411,20 +412,13 @@ export class ConstructFrameworkWorkflow {
        * the workflow graph correctly. The resolve function is a passthrough because execution already happened.
        */
       case StepTypeEnum.HTTP_REQUEST:
-        return step.custom(
-          stepId,
-          async (controlValues) => {
-            return controlValues;
-          },
-          this.constructActionStepOptions(staticStep, skip)
-        );
       case StepTypeEnum.CUSTOM:
         return step.custom(
           stepId,
           async (controlValues) => {
             return controlValues;
           },
-          this.constructActionStepOptions(staticStep, skip)
+          this.constructCustomStepOptions(staticStep, skip)
         );
       default:
         throw new InternalServerErrorException(`Step type ${stepType} is not supported`);
@@ -538,6 +532,24 @@ export class ConstructFrameworkWorkflow {
       disableOutputSanitization: true,
       providers,
     } as Required<Parameters<ChannelStep>[2]>;
+  }
+
+  /**
+   * Worker-executed steps (HTTP request, custom) are hydrated from the job state when a later step
+   * calls the bridge, and the framework validates that state against the step's output schema with
+   * AJV configured to remove additional properties. Without an explicit schema the framework falls
+   * back to a closed empty schema, which strips the whole response body and leaves conditions such
+   * as `steps.http-request-step.enrolmentCount equals 1` evaluating against nothing (NV-8604).
+   */
+  @Instrument()
+  private constructCustomStepOptions(
+    staticStep: NotificationStepEntity,
+    skip: SkipFunction
+  ): NonNullable<Parameters<CustomStep>[2]> {
+    return {
+      ...this.constructActionStepOptions(staticStep, skip),
+      outputSchema: PERMISSIVE_EMPTY_SCHEMA as unknown as Schema,
+    };
   }
 
   @Instrument()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Fixes [NV-8604](https://linear.app/novu/issue/NV-8604). Step conditions such as `steps.http-request-step.enrolmentCount equals 1` never matched, even when the HTTP response contained `enrolmentCount: 1`, so the following in-app step was always skipped.

HTTP request steps are executed by the worker, which stores the response body on the job. When a later step calls the Novu-managed bridge, `ConstructFrameworkWorkflow` re-registers every prior step so the framework can rebuild the workflow graph, and HTTP request (and custom) steps are registered through `step.custom`. The framework validates the hydrated job state of those prior steps against the step's output schema, and `step.custom` falls back to `emptySchema` (`additionalProperties: false`) when no `outputSchema` is given. Because the framework's AJV instance runs with `removeAdditional: 'failing'`, the entire response body was stripped to `{}` before it reached `fullPayloadForRender.steps`, which is what step conditions are evaluated against.

Those steps are now registered with a permissive output schema, so the hydrated response survives validation. Liquid variables (`{{steps.http-request-step.enrolmentCount}}`) were unaffected because they are rendered from the raw bridge state, which is why only conditions looked broken.

```mermaid
sequenceDiagram
    participant W as Worker
    participant B as Bridge (ConstructFrameworkWorkflow)
    participant F as Framework client
    W->>B: EXECUTE in-app step, state[http-request-step] = response body
    B->>F: register http step via step.custom(..., outputSchema)
    F->>F: validate hydrated state against output schema
    Note over F: before: closed empty schema strips body to {}
    Note over F: after: permissive schema keeps enrolmentCount
    F->>B: skip(controlValues) evaluates steps.http-request-step.enrolmentCount
```

### Screenshots

Verified end to end against the locally running API, worker and dashboard with a workflow whose in-app step is conditioned on two fields of the HTTP response (`steps.http-request-step.url` and `steps.http-request-step.json.enrolmentCount`).

Before the fix — the HTTP response satisfied the condition, yet the in-app step reported "Bridge execution skipped":

![Activity feed run before the fix: in-app step skipped despite a matching HTTP response](https://cursor.com/artifacts/c/art-5bf8bff5-280b-45af-80d7-dcd4b28ea298)

After the fix — same workflow and matching response, the in-app step reports "Step conditions matched" and "Message sent":

![Activity feed run after the fix: in-app step conditions matched and message sent](https://cursor.com/artifacts/c/art-41e42697-3923-4bbc-ab3c-ad75aa7f394b)

Conditions are still honoured in the negative case: with `enrolmentCount: 2` the same in-app step is skipped:

![Activity feed run after the fix: in-app step skipped when the response does not satisfy the condition](https://cursor.com/artifacts/c/art-dd0b8232-b44f-4d5c-ba29-12fe38326542)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- `StepTypeEnum.CUSTOM` shares the fix since it hits the same `step.custom` registration path.
- Two regression tests in `construct-framework-workflow.spec.ts` execute a real framework `Client` over a workflow built by the use case: one asserts the next step runs when the hydrated response matches the condition (fails without this change), the other asserts it is still skipped when it does not.
- Side effect worth knowing: for HTTP request steps the bridge preview response now returns the resolved request (url, method, body) instead of `{}`, which is what `PreviewUsecase.buildNovuSignatureSample` already expected. The dashboard only reads `novuSignature` from that response, so nothing else changes there.
- `apps/api` unit suite: 1259 passing, 13 failing — all pre-existing failures unrelated to this change (agent runtime API keys, MCP redirect URLs that need `API_ROOT_URL`, and `preferences.channels.tool` validation).

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8604](https://linear.app/novu/issue/NV-8604/http-step-fields-in-conditions-are-broken)

<div><a href="https://cursor.com/agents/bc-90cc4b35-3a99-427b-bca8-60a9c62f0b27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90cc4b35-3a99-427b-bca8-60a9c62f0b27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves worker-executed HTTP and custom step response fields while reconstructing workflows, allowing later conditions to evaluate hydrated outputs correctly.
- Registers HTTP request and custom steps with a permissive object output schema.
- Adds framework-client regression coverage for matching and non-matching HTTP response conditions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts | HTTP request and custom steps now use a permissive output schema so object-valued hydrated outputs survive framework validation. |
| apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.spec.ts | Adds integration-style regression tests proving matching hydrated fields run the next step while non-matching fields still skip it. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Worker
    participant API as ConstructFrameworkWorkflow
    participant Framework
    Worker->>API: Execute later step with prior HTTP output in state
    API->>Framework: Register prior step with permissive output schema
    Framework->>Framework: Validate and preserve hydrated response fields
    Framework->>Framework: Evaluate later-step condition against response
    Framework-->>API: Run or skip step based on condition
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;next&#39; into fix/http-step-c..."](https://github.com/novuhq/novu/commit/01c9b9ff2448485604c924767f168b1a41710cf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53961055)</sub>

<!-- /greptile_comment -->