### PR TITLE
refactor(api-service): centralize agent conversation activity access fixes NV-8576

### DIFF
--- a/apps/api/src/app/agents/agent-chat/agent-chat-platform-delivery.service.ts
+++ b/apps/api/src/app/agents/agent-chat/agent-chat-platform-delivery.service.ts
@@ -15,7 +15,6 @@ import { WebSocketEventEnum } from '@novu/shared';
 import type { CardElement } from 'chat';
 import type { ResolvedAgentConfig } from '../channels/agent-config-resolver.service';
 import { AgentConversationService } from '../conversation-runtime/conversation/agent-conversation.service';
-import { ConversationEventSequenceService } from '../conversation-runtime/conversation/conversation-event-sequence.service';
 import { OutboundDeliveryInfo } from '../conversation-runtime/egress/outbound-delivery-info.service';
 import { AgentChatEventFactory } from './agent-chat-event.factory';
 
@@ -36,7 +35,6 @@ export type AgentChatPlatformDeliveryContext = {
 export class AgentChatPlatformDeliveryService {
   constructor(
     private readonly conversationService: AgentConversationService,
-    private readonly eventSequenceService: ConversationEventSequenceService,
     private readonly subscriberRepository: SubscriberRepository,
     private readonly webSocketsQueueService: WebSocketsQueueService,
     private readonly eventFactory: AgentChatEventFactory,
@@ -208,7 +206,7 @@ export class AgentChatPlatformDeliveryService {
       return undefined;
     }
 
-    return this.eventSequenceService.mint({
+    return this.conversationService.mintEventSequence({
       environmentId: context.config.environmentId,
       organizationId: context.config.organizationId,
       conversationId: conversation._id,

--- a/apps/api/src/app/agents/agent-chat/usecases/list-agent-chat-conversation-events/list-agent-chat-conversation-events.usecase.ts
+++ b/apps/api/src/app/agents/agent-chat/usecases/list-agent-chat-conversation-events/list-agent-chat-conversation-events.usecase.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import { AgentRepository, ConversationParticipantTypeEnum, ConversationRepository } from '@novu/dal';
-import { ConversationActivityLedger } from '../../../conversation-runtime/conversation/conversation-activity-ledger';
+import { AgentConversationService } from '../../../conversation-runtime/conversation/agent-conversation.service';
 import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
 import { type EventMapContext, mapNewestFirstEventActivities } from '../../activity-to-events';
 import { withAgentChatContextFilter } from '../../agent-chat-context-query.util';
@@ -17,7 +17,7 @@ interface EventPageResult {
 export class ListAgentChatConversationEvents {
   constructor(
     private readonly conversationRepository: ConversationRepository,
-    private readonly activityLedger: ConversationActivityLedger,
+    private readonly conversationService: AgentConversationService,
     private readonly agentRepository: AgentRepository
   ) {}
 
@@ -71,7 +71,7 @@ export class ListAgentChatConversationEvents {
       agentIdentifier: agent.identifier,
     };
 
-    const page = await this.activityLedger.listForView({
+    const page = await this.conversationService.listForView({
       view: 'client_events',
       environmentId: command.environmentId,
       organizationId: command.organizationId,

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -202,13 +202,6 @@ import { USE_CASES } from './usecases';
     AgentConversationEnabledGuard,
     AgentChatEnabledGuard,
   ],
-  exports: [
-    ...USE_CASES,
-    ChatInstanceRegistry,
-    InboundDispatcher,
-    OutboundGateway,
-    ConfirmLinkedAuthCards,
-    ConversationActivityLedger,
-  ],
+  exports: [...USE_CASES, ChatInstanceRegistry, InboundDispatcher, OutboundGateway, ConfirmLinkedAuthCards],
 })
 export class AgentsModule {}

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.helpers.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.helpers.ts
@@ -1,0 +1,35 @@
+export const INBOUND_ATTACHMENT_ONLY_PREVIEW = '[Attachment]';
+export const DEFAULT_CONVERSATION_TITLE = 'Untitled conversation';
+
+/** Default number of recent activities loaded as conversation history for every runtime. */
+export const AGENT_HISTORY_LIMIT = 50;
+
+export function getConversationTitle(firstMessageText: string): string {
+  const trimmed = firstMessageText.trim();
+
+  if (trimmed.length === 0) {
+    return DEFAULT_CONVERSATION_TITLE;
+  }
+
+  return trimmed.slice(0, 200);
+}
+
+export function getInboundActivityPreview(
+  content: string | undefined,
+  options: { richContent?: Record<string, unknown>; hasPlatformAttachments?: boolean } = {}
+): string {
+  const trimmed = content?.trim() ?? '';
+
+  if (trimmed.length > 0) {
+    return trimmed;
+  }
+
+  const attachments = options.richContent?.attachments;
+  const hasStoredAttachments = Array.isArray(attachments) && attachments.length > 0;
+
+  if (hasStoredAttachments || options.hasPlatformAttachments) {
+    return INBOUND_ATTACHMENT_ONLY_PREVIEW;
+  }
+
+  return trimmed;
+}

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
@@ -13,7 +13,7 @@ import {
   getInboundActivityPreview,
   INBOUND_ATTACHMENT_ONLY_PREVIEW,
 } from './agent-conversation.service';
-import { ConversationEventSequenceService } from './conversation-event-sequence.service';
+import { ConversationActivityLedger } from './conversation-activity-ledger';
 
 describe('AgentConversationService', () => {
   function makeLogger() {
@@ -41,308 +41,53 @@ describe('AgentConversationService', () => {
     };
   }
 
-  function makeActivityRepository() {
+  function makeLedger(overrides: Partial<Record<keyof ConversationActivityLedger, sinon.SinonStub>> = {}) {
     return {
-      createAgentActivity: sinon.stub().resolves({ _id: 'activity-1', identifier: 'act_generated' }),
-      findOne: sinon.stub().resolves(null),
-    };
-  }
-
-  function basePersistParams() {
-    return {
-      conversationId: 'conv-1',
-      channel: {
-        platform: 'slack',
-        _integrationId: 'integration-a',
-        platformThreadId: 'thread-1',
-      },
-      platformMessageId: 'msg-1',
-      agentIdentifier: 'agent-a',
-      content: 'hello',
-      environmentId: 'env-1',
-      organizationId: 'org-1',
-    };
-  }
-
-  function makeEventSequenceService(mint = sinon.stub().resolves(undefined)) {
-    return { mint } as unknown as ConversationEventSequenceService;
+      persistAgentMessage: overrides.persistAgentMessage ?? sinon.stub().resolves({ activity: {}, created: true }),
+      persistWorkflowOriginHydration: overrides.persistWorkflowOriginHydration ?? sinon.stub().resolves(undefined),
+      isWorkflowOriginHydrated: overrides.isWorkflowOriginHydrated ?? sinon.stub().resolves(false),
+      persistMcpConnectionRequest: overrides.persistMcpConnectionRequest ?? sinon.stub().resolves({}),
+      persistMcpConnectionResult: overrides.persistMcpConnectionResult ?? sinon.stub().resolves({}),
+      persistToolResult: overrides.persistToolResult ?? sinon.stub().resolves(undefined),
+      persistInboundMessage: overrides.persistInboundMessage ?? sinon.stub().resolves({}),
+      listForView: overrides.listForView ?? sinon.stub().resolves({ data: [], hasMore: false }),
+      mint: overrides.mint ?? sinon.stub().resolves(1),
+    } as unknown as ConversationActivityLedger;
   }
 
   function makeService(
     conversationRepository: ConversationRepository,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    activityRepository: any = makeActivityRepository(),
-    eventSequenceService = makeEventSequenceService(),
-    agentChatLiveActivityPublisher = { emitPersistedClientEvent: sinon.stub().resolves(undefined) }
+    ledger: ConversationActivityLedger = makeLedger()
   ) {
-    return new AgentConversationService(
-      conversationRepository,
-      activityRepository as any,
-      eventSequenceService,
-      agentChatLiveActivityPublisher as any,
-      makeLogger() as any
-    );
+    return new AgentConversationService(conversationRepository, ledger, makeLogger() as any);
   }
 
-  describe('persistAgentMessage', () => {
-    it('uses the caller-supplied identifier when provided', async () => {
-      const activityRepository = makeActivityRepository();
-      const conversationRepository = {
-        touchActivity: sinon.stub().resolves(undefined),
-      } as unknown as ConversationRepository;
-      const service = makeService(conversationRepository, activityRepository);
-
-      const result = await service.persistAgentMessage({
-        ...basePersistParams(),
-        identifier: 'client-msg-123',
-      });
-
-      expect(result.created).to.equal(true);
-      expect(activityRepository.createAgentActivity.calledOnce).to.equal(true);
-      expect(activityRepository.createAgentActivity.firstCall.args[0].identifier).to.equal('client-msg-123');
-      expect(activityRepository.createAgentActivity.firstCall.args[0].type).to.equal(
-        ConversationActivityTypeEnum.MESSAGE
-      );
-    });
-
-    it('mints an act_ identifier when none is supplied', async () => {
-      const activityRepository = makeActivityRepository();
-      const conversationRepository = {
-        touchActivity: sinon.stub().resolves(undefined),
-      } as unknown as ConversationRepository;
-      const service = makeService(conversationRepository, activityRepository);
-
-      await service.persistAgentMessage(basePersistParams());
-
-      const identifier = activityRepository.createAgentActivity.firstCall.args[0].identifier;
-
-      expect(identifier).to.match(/^act_/);
-    });
-
-    it('logs and returns the existing activity on duplicate identifier races', async () => {
-      const duplicateError = Object.assign(new Error('duplicate key'), { code: 11000 });
-      const existingActivity = { _id: 'existing-1', identifier: 'client-msg-123' };
-      const activityRepository = {
-        createAgentActivity: sinon.stub().rejects(duplicateError),
-        findOne: sinon.stub().resolves(existingActivity),
-      };
-      const conversationRepository = {
-        touchActivity: sinon.stub().resolves(undefined),
-      } as unknown as ConversationRepository;
-      const logger = makeLogger();
-      const service = new AgentConversationService(
-        conversationRepository,
-        activityRepository as any,
-        makeEventSequenceService(),
-        { emitPersistedClientEvent: sinon.stub().resolves(undefined) } as any,
-        logger as any
-      );
-
-      const result = await service.persistAgentMessage({
-        ...basePersistParams(),
-        identifier: 'client-msg-123',
-      });
-
-      expect(result.activity).to.equal(existingActivity);
-      expect(result.created).to.equal(false);
-      expect(logger.warn.calledOnce).to.equal(true);
-    });
-  });
-
-  describe('persistWorkflowOriginHydration', () => {
-    function makeHydrationParams() {
-      return {
+  describe('delegation', () => {
+    it('delegates persistAgentMessage to the ledger', async () => {
+      const ledger = makeLedger();
+      const service = makeService({} as unknown as ConversationRepository, ledger);
+      const params = {
         conversationId: 'conv-1',
-        channel: {
-          platform: 'whatsapp',
-          _integrationId: 'integration-a',
-          platformThreadId: 'whatsapp:15551234567',
-        },
+        channel: { platform: 'slack', _integrationId: 'int-1', platformThreadId: 'thread-1' },
         agentIdentifier: 'agent-a',
+        content: 'hello',
         environmentId: 'env-1',
         organizationId: 'org-1',
-        platformMessageId: 'wamid.abc',
-        platformThreadId: 'whatsapp:15551234567',
-        messageContent: 'Your order shipped',
-        signalData: { workflowIdentifier: 'order-alerts' },
-      };
-    }
-
-    it('swallows duplicate-key errors from the signal write', async () => {
-      const duplicateError = Object.assign(new Error('duplicate key'), { code: 11000 });
-      const activityRepository = {
-        createAgentActivity: sinon
-          .stub()
-          .resolves({ _id: 'activity-1', identifier: 'workflow-dispatch-msg:wamid.abc' }),
-        createSignalActivity: sinon.stub().rejects(duplicateError),
-        findOne: sinon.stub().resolves(null),
-      };
-      const conversationRepository = {
-        touchActivity: sinon.stub().resolves(undefined),
-      } as unknown as ConversationRepository;
-      const logger = makeLogger();
-      const service = new AgentConversationService(
-        conversationRepository,
-        activityRepository as any,
-        makeEventSequenceService(),
-        { emit: sinon.stub().resolves(undefined) } as any,
-        logger as any
-      );
-
-      await service.persistWorkflowOriginHydration(makeHydrationParams());
-
-      expect(activityRepository.createSignalActivity.calledOnce).to.equal(true);
-      expect(logger.warn.calledOnce).to.equal(true);
-      expect(logger.warn.firstCall.args[1]).to.equal('Workflow origin already hydrated');
-    });
-
-    it('rethrows non-duplicate errors from the signal write', async () => {
-      const activityRepository = {
-        createAgentActivity: sinon
-          .stub()
-          .resolves({ _id: 'activity-1', identifier: 'workflow-dispatch-msg:wamid.abc' }),
-        createSignalActivity: sinon.stub().rejects(new Error('mongo timeout')),
-        findOne: sinon.stub().resolves(null),
-      };
-      const conversationRepository = {
-        touchActivity: sinon.stub().resolves(undefined),
-      } as unknown as ConversationRepository;
-      const service = makeService(conversationRepository, activityRepository);
-
-      try {
-        await service.persistWorkflowOriginHydration(makeHydrationParams());
-        expect.fail('expected persistWorkflowOriginHydration to throw');
-      } catch (err) {
-        expect((err as Error).message).to.equal('mongo timeout');
-      }
-    });
-  });
-
-  describe('isWorkflowOriginHydrated', () => {
-    it('matches the signal identifier written by persistWorkflowOriginHydration', async () => {
-      const activityRepository = { count: sinon.stub().resolves(1) };
-      const service = makeService({} as unknown as ConversationRepository, activityRepository);
-
-      const hydrated = await service.isWorkflowOriginHydrated('env-1', 'conv-1', 'wamid.abc');
-
-      expect(hydrated).to.equal(true);
-      expect(activityRepository.count.firstCall.args[0]).to.deep.equal({
-        _environmentId: 'env-1',
-        _conversationId: 'conv-1',
-        identifier: 'workflow-dispatch-origin:wamid.abc',
-      });
-    });
-
-    it('returns false when the signal is absent', async () => {
-      const activityRepository = { count: sinon.stub().resolves(0) };
-      const service = makeService({} as unknown as ConversationRepository, activityRepository);
-
-      expect(await service.isWorkflowOriginHydrated('env-1', 'conv-1', 'wamid.abc')).to.equal(false);
-    });
-  });
-
-  describe('MCP connection activities', () => {
-    it('persists request and result activities and publishes both to agent chat', async () => {
-      const activityRepository = makeActivityRepository();
-      activityRepository.createAgentActivity.callsFake(async (params: Record<string, unknown>) => ({
-        _id: `activity-${activityRepository.createAgentActivity.callCount}`,
-        ...params,
-      }));
-      const conversationRepository = {
-        touchActivity: sinon.stub().resolves(undefined),
-      } as unknown as ConversationRepository;
-      const publisher = { emitPersistedClientEvent: sinon.stub().resolves(undefined) };
-      const service = makeService(
-        conversationRepository,
-        activityRepository,
-        makeEventSequenceService(sinon.stub().onFirstCall().resolves(10).onSecondCall().resolves(11)),
-        publisher
-      );
-      const context = {
-        ...basePersistParams(),
-        channel: {
-          platform: 'agent_chat',
-          _integrationId: 'integration-a',
-          platformThreadId: 'thread-1',
-        },
       };
 
-      await service.persistMcpConnectionRequest({
-        ...context,
-        actionId: 'tool-use-1',
-        mcpId: 'stripe',
-        displayName: 'Stripe',
-        authorizeUrl: 'https://example.com/authorize',
-      });
-      await service.persistMcpConnectionResult({
-        ...context,
-        actionId: 'tool-use-1',
-        mcpId: 'stripe',
-        status: 'connected',
-      });
+      await service.persistAgentMessage(params);
 
-      expect(activityRepository.createAgentActivity.firstCall.args[0]).to.deep.include({
-        identifier: 'mcp-connection:tool-use-1:request',
-        type: ConversationActivityTypeEnum.MCP_CONNECTION_REQUEST,
-        sequence: 10,
-        richContent: {
-          mcpConnection: {
-            actionId: 'tool-use-1',
-            mcpId: 'stripe',
-            displayName: 'Stripe',
-            authorizeUrl: 'https://example.com/authorize',
-            authorizeUrlWithAutoApprove: undefined,
-          },
-        },
-      });
-      expect(activityRepository.createAgentActivity.secondCall.args[0]).to.deep.include({
-        identifier: 'mcp-connection:tool-use-1:result',
-        type: ConversationActivityTypeEnum.MCP_CONNECTION_RESULT,
-        sequence: 11,
-        richContent: {
-          mcpConnection: {
-            actionId: 'tool-use-1',
-            mcpId: 'stripe',
-            status: 'connected',
-            message: undefined,
-          },
-        },
-      });
-      expect(publisher.emitPersistedClientEvent.callCount).to.equal(2);
+      expect(ledger.persistAgentMessage.calledOnceWithExactly(params)).to.equal(true);
     });
-  });
 
-  describe('event sequencing', () => {
-    it('allocates a sequence for durable tool activities on any channel', async () => {
-      const conversationRepository = {} as unknown as ConversationRepository;
-      const activityRepository = {
-        createToolActivity: sinon.stub().resolves({ _id: 'tool-activity' }),
-      };
-      const mint = sinon.stub().resolves(4);
-      const service = makeService(conversationRepository, activityRepository, makeEventSequenceService(mint));
+    it('delegates mintEventSequence to the ledger', async () => {
+      const ledger = makeLedger();
+      const service = makeService({} as unknown as ConversationRepository, ledger);
+      const params = { environmentId: 'env-1', organizationId: 'org-1', conversationId: 'conv-1' };
 
-      await service.persistToolResult({
-        conversationId: 'conv-1',
-        channel: {
-          platform: 'slack',
-          _integrationId: 'integration-a',
-          platformThreadId: 'thread-1',
-        },
-        agentIdentifier: 'agent-a',
-        environmentId: 'env-1',
-        organizationId: 'org-1',
-        toolCallId: 'tool-call-1',
-        output: 'done',
-      });
+      await service.mintEventSequence(params);
 
-      expect(activityRepository.createToolActivity.firstCall.args[0].sequence).to.equal(4);
-      expect(
-        mint.calledOnceWithExactly({
-          environmentId: 'env-1',
-          organizationId: 'org-1',
-          conversationId: 'conv-1',
-        })
-      ).to.equal(true);
+      expect(ledger.mint.calledOnceWithExactly(params)).to.equal(true);
     });
   });
 
@@ -386,13 +131,7 @@ describe('AgentConversationService', () => {
       updateParticipants: sinon.stub(),
     } as unknown as ConversationRepository;
 
-    const service = new AgentConversationService(
-      conversationRepository,
-      {} as any,
-      makeEventSequenceService(),
-      { emitPersistedClientEvent: sinon.stub().resolves(undefined) } as any,
-      makeLogger() as any
-    );
+    const service = makeService(conversationRepository);
 
     await service.createOrGetConversation({
       ...baseCreateParams(),
@@ -418,13 +157,7 @@ describe('AgentConversationService', () => {
       updateParticipants: sinon.stub(),
     } as unknown as ConversationRepository;
 
-    const service = new AgentConversationService(
-      conversationRepository,
-      {} as any,
-      makeEventSequenceService(),
-      { emitPersistedClientEvent: sinon.stub().resolves(undefined) } as any,
-      makeLogger() as any
-    );
+    const service = makeService(conversationRepository);
 
     await service.createOrGetConversation({
       ...baseCreateParams(),
@@ -451,13 +184,7 @@ describe('AgentConversationService', () => {
       updateParticipants: sinon.stub(),
     } as unknown as ConversationRepository;
 
-    const service = new AgentConversationService(
-      conversationRepository,
-      {} as any,
-      makeEventSequenceService(),
-      { emitPersistedClientEvent: sinon.stub().resolves(undefined) } as any,
-      makeLogger() as any
-    );
+    const service = makeService(conversationRepository);
 
     let threw = false;
     try {
@@ -490,13 +217,7 @@ describe('AgentConversationService', () => {
       updateParticipants: sinon.stub(),
     } as unknown as ConversationRepository;
 
-    const service = new AgentConversationService(
-      conversationRepository,
-      {} as any,
-      makeEventSequenceService(),
-      { emitPersistedClientEvent: sinon.stub().resolves(undefined) } as any,
-      makeLogger() as any
-    );
+    const service = makeService(conversationRepository);
 
     let threw = false;
     try {
@@ -528,13 +249,7 @@ describe('AgentConversationService', () => {
       updateParticipants: sinon.stub(),
     } as unknown as ConversationRepository;
 
-    const service = new AgentConversationService(
-      conversationRepository,
-      {} as any,
-      makeEventSequenceService(),
-      { emitPersistedClientEvent: sinon.stub().resolves(undefined) } as any,
-      makeLogger() as any
-    );
+    const service = makeService(conversationRepository);
 
     await service.createOrGetConversation(baseCreateParams());
 
@@ -558,13 +273,7 @@ describe('AgentConversationService', () => {
       updateParticipants: sinon.stub(),
     } as unknown as ConversationRepository;
 
-    const service = new AgentConversationService(
-      conversationRepository,
-      {} as any,
-      makeEventSequenceService(),
-      { emitPersistedClientEvent: sinon.stub().resolves(undefined) } as any,
-      makeLogger() as any
-    );
+    const service = makeService(conversationRepository);
 
     await service.createOrGetConversation(baseCreateParams());
 
@@ -587,16 +296,43 @@ describe('AgentConversationService', () => {
       updateParticipants: sinon.stub(),
     } as unknown as ConversationRepository;
 
-    const service = new AgentConversationService(
-      conversationRepository,
-      {} as any,
-      makeEventSequenceService(),
-      { emitPersistedClientEvent: sinon.stub().resolves(undefined) } as any,
-      makeLogger() as any
-    );
+    const service = makeService(conversationRepository);
 
     await service.findByPlatformThread('e', 'o', 'agent-x', 'int-x', 'thread-z');
 
     expect(findByPlatformThread.calledOnceWithExactly('e', 'o', 'agent-x', 'int-x', 'thread-z')).to.equal(true);
+  });
+
+  it('orchestrates resolveConversation across repository and ledger', async () => {
+    const updateStatus = sinon.stub().resolves(undefined);
+    const markBillingResolved = sinon.stub().resolves(undefined);
+    const clearExternalSessionId = sinon.stub().resolves(undefined);
+    const persistResolveSignal = sinon.stub().resolves(undefined);
+    const conversationRepository = {
+      updateStatus,
+      markBillingResolved,
+      clearExternalSessionId,
+    } as unknown as ConversationRepository;
+    const ledger = makeLedger({ persistResolveSignal });
+    const service = makeService(conversationRepository, ledger);
+    const params = {
+      conversationId: 'conv-1',
+      channel: { platform: 'slack', _integrationId: 'int-1', platformThreadId: 'thread-1' },
+      agentIdentifier: 'agent-a',
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      summary: 'done',
+    };
+
+    await service.resolveConversation(params);
+
+    expect(updateStatus.calledOnce).to.equal(true);
+    expect(markBillingResolved.calledOnce).to.equal(true);
+    expect(clearExternalSessionId.calledOnce).to.equal(true);
+    expect(persistResolveSignal.calledOnce).to.equal(true);
+    expect(persistResolveSignal.firstCall.args[0]).to.include({
+      content: 'done',
+      summary: 'done',
+    });
   });
 });

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -1,63 +1,57 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { PinoLogger, shortId } from '@novu/application-generic';
 import {
+  ActivityView,
   ConversationActivityEntity,
-  ConversationActivityRepository,
-  ConversationActivitySenderTypeEnum,
-  ConversationActivityToolData,
-  ConversationActivityTypeEnum,
   ConversationChannel,
   ConversationEntity,
   ConversationParticipantTypeEnum,
   ConversationRepository,
   ConversationStatusEnum,
-  isDuplicateKeyError,
 } from '@novu/dal';
-import type { TriggerRecipientsPayload } from '@novu/shared';
-import { AgentChatLiveActivityPublisher } from '../../agent-chat/agent-chat-live-activity.publisher';
-import { mintApprovalActionIds } from '../../shared/tool-approval/mint-approval-action-ids';
-import { ConversationEventSequenceService } from './conversation-event-sequence.service';
+import { getConversationTitle } from './agent-conversation.helpers';
+import type {
+  ConversationActivityContext,
+  PersistAgentActivityParams,
+  PersistAgentMessageResult,
+  PersistInboundMessageParams,
+  PersistMcpConnectionRequestParams,
+  PersistMcpConnectionResultParams,
+  PersistToolApprovalDecisionParams,
+  PersistToolApprovalRequestParams,
+  PersistToolResultParams,
+  PersistTriggerSignalParams,
+  PersistWorkflowOriginHydrationParams,
+  ResolveConversationParams,
+  UpdateMetadataParams,
+} from './agent-conversation.types';
+import { ConversationActivityLedger } from './conversation-activity-ledger';
+import type { PersistRunLifecycleParams } from './run-lifecycle-activity';
 
-export const INBOUND_ATTACHMENT_ONLY_PREVIEW = '[Attachment]';
-export const DEFAULT_CONVERSATION_TITLE = 'Untitled conversation';
+export {
+  AGENT_HISTORY_LIMIT,
+  DEFAULT_CONVERSATION_TITLE,
+  getConversationTitle,
+  getInboundActivityPreview,
+  INBOUND_ATTACHMENT_ONLY_PREVIEW,
+} from './agent-conversation.helpers';
 
-/** Default number of recent activities loaded as conversation history for every runtime. */
-export const AGENT_HISTORY_LIMIT = 50;
-
-/** Stable per-origin identifier for the workflow-origin signal — see `persistWorkflowOriginHydration`. */
-function workflowOriginSignalIdentifier(platformMessageId: string): string {
-  return `workflow-dispatch-origin:${platformMessageId}`;
-}
-
-export function getConversationTitle(firstMessageText: string): string {
-  const trimmed = firstMessageText.trim();
-
-  if (trimmed.length === 0) {
-    return DEFAULT_CONVERSATION_TITLE;
-  }
-
-  return trimmed.slice(0, 200);
-}
-
-export function getInboundActivityPreview(
-  content: string | undefined,
-  options: { richContent?: Record<string, unknown>; hasPlatformAttachments?: boolean } = {}
-): string {
-  const trimmed = content?.trim() ?? '';
-
-  if (trimmed.length > 0) {
-    return trimmed;
-  }
-
-  const attachments = options.richContent?.attachments;
-  const hasStoredAttachments = Array.isArray(attachments) && attachments.length > 0;
-
-  if (hasStoredAttachments || options.hasPlatformAttachments) {
-    return INBOUND_ATTACHMENT_ONLY_PREVIEW;
-  }
-
-  return trimmed;
-}
+export type {
+  ConversationActivityContext,
+  MetadataOp,
+  PersistAgentActivityParams,
+  PersistAgentMessageResult,
+  PersistInboundMessageParams,
+  PersistMcpConnectionRequestParams,
+  PersistMcpConnectionResultParams,
+  PersistToolApprovalDecisionParams,
+  PersistToolApprovalRequestParams,
+  PersistToolResultParams,
+  PersistTriggerSignalParams,
+  PersistWorkflowOriginHydrationParams,
+  ResolveConversationParams,
+  UpdateMetadataParams,
+} from './agent-conversation.types';
 
 export interface CreateOrGetConversationParams {
   environmentId: string;
@@ -85,138 +79,17 @@ export interface CreateOrGetConversationParams {
   contextKeys?: string[];
 }
 
-export interface PersistInboundMessageParams {
-  conversationId: string;
-  platform: string;
-  integrationId: string;
-  platformThreadId: string;
-  senderType: ConversationActivitySenderTypeEnum;
-  senderId: string;
-  senderName?: string;
-  content: string;
-  richContent?: Record<string, unknown>;
-  hasPlatformAttachments?: boolean;
-  platformMessageId?: string;
-  /** Caller-supplied activity identifier; defaults to a server-minted act_* id */
-  identifier?: string;
-  /** Pre-allocated conversation event sequence; minted at persist time when absent */
-  sequence?: number;
-  environmentId: string;
-  organizationId: string;
-}
-
-export interface ConversationActivityContext {
-  conversationId: string;
-  channel: ConversationChannel;
-  agentIdentifier: string;
-  environmentId: string;
-  organizationId: string;
-}
-
-export interface PersistAgentMessageResult {
-  activity: ConversationActivityEntity;
-  /** `false` when the identifier already existed — the caller lost the persist race. */
-  created: boolean;
-}
-
-export interface PersistAgentActivityParams extends ConversationActivityContext {
-  platformMessageId?: string;
-  /** Overrides channel.platformThreadId when delivery returns a different thread ID */
-  platformThreadId?: string;
-  /** Caller-supplied activity identifier; defaults to a server-minted act_* id */
-  identifier?: string;
-  agentName?: string;
-  content: string;
-  richContent?: Record<string, unknown>;
-  /** Pre-allocated conversation event sequence; minted at persist time when absent */
-  sequence?: number;
-}
-
-export interface PersistToolApprovalRequestParams extends ConversationActivityContext {
-  approvalId: string;
-  toolCallId: string;
-  toolName: string;
-  input?: Record<string, unknown>;
-  /** Human-readable preview for the display timeline. */
-  preview?: string;
-  /** When omitted, self-hosted `tool-approval:*` ids are minted. */
-  approveActionId?: string;
-  denyActionId?: string;
-}
-
-export type MetadataOp =
-  | { action: 'set'; key: string; value: unknown }
-  | { action: 'delete'; key: string }
-  | { action: 'clear' };
-
-export interface UpdateMetadataParams extends ConversationActivityContext {
-  currentMetadata: Record<string, unknown>;
-  ops: MetadataOp[];
-}
-
-export interface ResolveConversationParams extends ConversationActivityContext {
-  summary?: string;
-}
-
-export interface PersistTriggerSignalParams extends ConversationActivityContext {
-  workflowId: string;
-  to: TriggerRecipientsPayload;
-  transactionId: string;
-}
-
-export interface PersistWorkflowOriginHydrationParams extends ConversationActivityContext {
-  platformMessageId: string;
-  platformThreadId: string;
-  messageContent: string;
-  signalData: Record<string, unknown>;
-}
-
-export interface PersistToolApprovalDecisionParams extends ConversationActivityContext {
-  approvalId: string;
-  approved: boolean;
-  toolName?: string;
-  actorType:
-    | ConversationActivitySenderTypeEnum.SUBSCRIBER
-    | ConversationActivitySenderTypeEnum.PLATFORM_USER
-    | ConversationActivitySenderTypeEnum.SYSTEM;
-  actorId: string;
-}
-
-export interface PersistToolResultParams extends ConversationActivityContext {
-  toolCallId: string;
-  toolName?: string;
-  /** The tool's output as returned by the model runtime (JSON-serializable). */
-  output: unknown;
-  /** Human-readable preview for the display timeline; defaults to a generic line. */
-  preview?: string;
-}
-
-export interface PersistMcpConnectionRequestParams extends ConversationActivityContext {
-  actionId: string;
-  mcpId: string;
-  displayName: string;
-  authorizeUrl: string;
-  authorizeUrlWithAutoApprove?: string;
-}
-
-export interface PersistMcpConnectionResultParams extends ConversationActivityContext {
-  actionId: string;
-  mcpId: string;
-  status: 'connected' | 'failed';
-  message?: string;
-}
-
 @Injectable()
 export class AgentConversationService {
   constructor(
     private readonly conversationRepository: ConversationRepository,
-    private readonly activityRepository: ConversationActivityRepository,
-    private readonly eventSequenceService: ConversationEventSequenceService,
-    private readonly agentChatLiveActivityPublisher: AgentChatLiveActivityPublisher,
+    private readonly ledger: ConversationActivityLedger,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
   }
+
+  // --- Thread ---
 
   getPrimaryChannel(conversation: ConversationEntity): ConversationChannel {
     const channel = conversation.channels?.[0];
@@ -302,113 +175,6 @@ export class AgentConversationService {
     return conversation;
   }
 
-  private async ensureParticipant(conversation: ConversationEntity, params: CreateOrGetConversationParams) {
-    const alreadyPresent = conversation.participants.some(
-      (p) => p.id === params.participantId && p.type === params.participantType
-    );
-    if (alreadyPresent) return;
-
-    const platformIdentity = `${params.platform}:${params.platformUserId}`;
-
-    if (params.participantType === ConversationParticipantTypeEnum.SUBSCRIBER) {
-      const platformUserIdx = conversation.participants.findIndex(
-        (p) => p.type === ConversationParticipantTypeEnum.PLATFORM_USER && p.id === platformIdentity
-      );
-
-      if (platformUserIdx !== -1) {
-        conversation.participants[platformUserIdx] = { type: params.participantType, id: params.participantId };
-
-        this.logger.debug(
-          `Upgraded participant ${platformIdentity} → subscriber ${params.participantId} in conversation ${conversation._id}`
-        );
-      } else {
-        conversation.participants.push({ type: params.participantType, id: params.participantId });
-      }
-    } else {
-      conversation.participants.push({ type: params.participantType, id: params.participantId });
-    }
-
-    await this.conversationRepository.updateParticipants(
-      params.environmentId,
-      params.organizationId,
-      conversation._id,
-      conversation.participants
-    );
-  }
-
-  async persistInboundMessage(params: PersistInboundMessageParams): Promise<ConversationActivityEntity> {
-    const content = params.content ?? '';
-    const preview = getInboundActivityPreview(content, {
-      richContent: params.richContent,
-      hasPlatformAttachments: params.hasPlatformAttachments,
-    });
-    const identifier = params.identifier ?? `act_${shortId(12)}`;
-    const sequence = await this.resolveEventSequence(
-      params.conversationId,
-      params.environmentId,
-      params.organizationId,
-      params.sequence
-    );
-
-    try {
-      const [activity] = await Promise.all([
-        this.activityRepository.createUserActivity({
-          identifier,
-          conversationId: params.conversationId,
-          platform: params.platform,
-          integrationId: params.integrationId,
-          platformThreadId: params.platformThreadId,
-          senderType: params.senderType,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          content,
-          richContent: params.richContent,
-          platformMessageId: params.platformMessageId,
-          sequence,
-          environmentId: params.environmentId,
-          organizationId: params.organizationId,
-        }),
-        this.conversationRepository.touchActivity(
-          params.environmentId,
-          params.organizationId,
-          params.conversationId,
-          preview
-        ),
-      ]);
-
-      return activity;
-    } catch (err) {
-      if (params.identifier && isDuplicateKeyError(err)) {
-        const existing = await this.activityRepository.findOne(
-          {
-            _environmentId: params.environmentId,
-            _conversationId: params.conversationId,
-            identifier: params.identifier,
-          },
-          '*'
-        );
-
-        if (existing) {
-          return existing;
-        }
-      }
-
-      throw err;
-    }
-  }
-
-  async findSourceActivity(
-    environmentId: string,
-    conversationId: string,
-    platformMessageId: string
-  ): Promise<ConversationActivityEntity | null> {
-    return this.activityRepository.findByPlatformMessageId(environmentId, conversationId, platformMessageId);
-  }
-
-  async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
-    return this.activityRepository.countAgentMessages(environmentId, conversationId);
-  }
-
   async getConversation(
     conversationId: string,
     environmentId: string,
@@ -489,205 +255,6 @@ export class AgentConversationService {
     );
   }
 
-  async findAgentMessageByIdentifier(
-    environmentId: string,
-    conversationId: string,
-    identifier: string
-  ): Promise<ConversationActivityEntity | null> {
-    return this.activityRepository.findOne(
-      {
-        _environmentId: environmentId,
-        _conversationId: conversationId,
-        identifier,
-        type: ConversationActivityTypeEnum.MESSAGE,
-      },
-      '*'
-    );
-  }
-
-  async persistAgentMessage(params: PersistAgentActivityParams): Promise<PersistAgentMessageResult> {
-    try {
-      const activity = await this.persistAgentActivity(params, ConversationActivityTypeEnum.MESSAGE, 'activity');
-
-      return { activity, created: true };
-    } catch (err) {
-      if (params.identifier && isDuplicateKeyError(err)) {
-        this.logger.warn(
-          { identifier: params.identifier, conversationId: params.conversationId },
-          'Agent message activity already recorded (duplicate identifier)'
-        );
-
-        const existing = await this.activityRepository.findOne(
-          {
-            _environmentId: params.environmentId,
-            _conversationId: params.conversationId,
-            identifier: params.identifier,
-          },
-          '*'
-        );
-
-        if (existing) {
-          return { activity: existing, created: false };
-        }
-      }
-
-      throw err;
-    }
-  }
-
-  /** Records the platform-native message id after a successful post on a persist-first delivery. */
-  async setAgentMessagePlatformMessageId(params: {
-    environmentId: string;
-    organizationId: string;
-    conversationId: string;
-    activityId: string;
-    platformMessageId: string;
-  }): Promise<void> {
-    await this.activityRepository.update(
-      {
-        _environmentId: params.environmentId,
-        _organizationId: params.organizationId,
-        _conversationId: params.conversationId,
-        _id: params.activityId,
-      },
-      { $set: { platformMessageId: params.platformMessageId } }
-    );
-  }
-
-  /** Compensating delete when the platform post fails, so a retry can re-claim the identifier. */
-  async deleteAgentMessage(params: {
-    environmentId: string;
-    organizationId: string;
-    conversationId: string;
-    activityId: string;
-  }): Promise<void> {
-    await this.activityRepository.findOneAndDelete({
-      _environmentId: params.environmentId,
-      _organizationId: params.organizationId,
-      _conversationId: params.conversationId,
-      _id: params.activityId,
-    });
-  }
-
-  async persistToolApprovalRequest(params: PersistToolApprovalRequestParams): Promise<ConversationActivityEntity> {
-    const toolName = params.toolName;
-    const sequence = await this.resolveEventSequence(
-      params.conversationId,
-      params.environmentId,
-      params.organizationId
-    );
-    const actionIds =
-      params.approveActionId && params.denyActionId
-        ? { approveActionId: params.approveActionId, denyActionId: params.denyActionId }
-        : mintApprovalActionIds({ approvalId: params.approvalId });
-
-    const activity = await this.activityRepository.createToolActivity({
-      identifier: `act_${shortId(12)}`,
-      conversationId: params.conversationId,
-      platform: params.channel.platform,
-      integrationId: params.channel._integrationId,
-      platformThreadId: params.channel.platformThreadId,
-      senderType: ConversationActivitySenderTypeEnum.AGENT,
-      senderId: params.agentIdentifier,
-      content: params.preview ?? `Approval required: ${toolName}`,
-      type: ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST,
-      toolData: {
-        approvalId: params.approvalId,
-        toolCallId: params.toolCallId,
-        toolName: params.toolName,
-        input: params.input,
-        approveActionId: actionIds.approveActionId,
-        denyActionId: actionIds.denyActionId,
-      },
-      sequence,
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-    });
-
-    await this.agentChatLiveActivityPublisher.emitPersistedClientEvent({
-      channel: params.channel,
-      conversationId: params.conversationId,
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-      agentIdentifier: params.agentIdentifier,
-      activity,
-    });
-
-    return activity;
-  }
-
-  /** Links a delivered approval card message to its ledger row (for platform edits). */
-  async linkToolApprovalRequestCard(params: {
-    environmentId: string;
-    organizationId: string;
-    conversationId: string;
-    activityId: string;
-    platformMessageId: string;
-  }): Promise<void> {
-    await this.activityRepository.update(
-      {
-        _environmentId: params.environmentId,
-        _organizationId: params.organizationId,
-        _conversationId: params.conversationId,
-        _id: params.activityId,
-        type: ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST,
-      },
-      { $set: { platformMessageId: params.platformMessageId } }
-    );
-  }
-
-  async persistAgentEdit(params: PersistAgentActivityParams): Promise<ConversationActivityEntity> {
-    return this.persistAgentActivity(params, ConversationActivityTypeEnum.EDIT, 'preview');
-  }
-
-  async persistAgentDelete(params: PersistAgentActivityParams): Promise<ConversationActivityEntity> {
-    return this.persistAgentActivity(params, ConversationActivityTypeEnum.DELETE, 'preview');
-  }
-
-  private async persistAgentActivity(
-    params: PersistAgentActivityParams & {
-      toolData?: ConversationActivityToolData;
-    },
-    type: ConversationActivityTypeEnum,
-    touch: 'activity' | 'preview'
-  ): Promise<ConversationActivityEntity> {
-    const threadId = params.platformThreadId ?? params.channel.platformThreadId;
-    const sequence = await this.resolveEventSequence(
-      params.conversationId,
-      params.environmentId,
-      params.organizationId,
-      params.sequence
-    );
-
-    const touchFn =
-      touch === 'activity'
-        ? this.conversationRepository.touchActivity.bind(this.conversationRepository)
-        : this.conversationRepository.touchPreview.bind(this.conversationRepository);
-
-    const [activity] = await Promise.all([
-      this.activityRepository.createAgentActivity({
-        identifier: params.identifier ?? `act_${shortId(12)}`,
-        conversationId: params.conversationId,
-        platform: params.channel.platform,
-        integrationId: params.channel._integrationId,
-        platformThreadId: threadId,
-        platformMessageId: params.platformMessageId,
-        agentId: params.agentIdentifier,
-        senderName: params.agentName,
-        content: params.content,
-        richContent: params.richContent,
-        toolData: params.toolData,
-        type,
-        sequence,
-        environmentId: params.environmentId,
-        organizationId: params.organizationId,
-      }),
-      touchFn(params.environmentId, params.organizationId, params.conversationId, params.content),
-    ]);
-
-    return activity;
-  }
-
   async updateMetadata(params: UpdateMetadataParams): Promise<void> {
     let merged: Record<string, unknown> = { ...(params.currentMetadata ?? {}) };
     const descriptions: string[] = [];
@@ -721,17 +288,10 @@ export class AgentConversationService {
         params.conversationId,
         merged
       ),
-      this.activityRepository.createSignalActivity({
-        identifier: `act_${shortId(12)}`,
-        conversationId: params.conversationId,
-        platform: params.channel.platform,
-        integrationId: params.channel._integrationId,
-        platformThreadId: params.channel.platformThreadId,
-        agentId: params.agentIdentifier,
+      this.ledger.persistMetadataSignal({
+        ...params,
         content: `Metadata updated: ${descriptions.join(', ')}`,
-        signalData: { type: 'metadata', payload: merged },
-        environmentId: params.environmentId,
-        organizationId: params.organizationId,
+        payload: merged,
       }),
     ]);
   }
@@ -753,268 +313,218 @@ export class AgentConversationService {
         new Date().toISOString()
       ),
       this.conversationRepository.clearExternalSessionId(params.environmentId, params.conversationId),
-      this.activityRepository.createSignalActivity({
-        identifier: `act_${shortId(12)}`,
-        conversationId: params.conversationId,
-        platform: params.channel.platform,
-        integrationId: params.channel._integrationId,
-        platformThreadId: params.channel.platformThreadId,
-        agentId: params.agentIdentifier,
+      this.ledger.persistResolveSignal({
+        ...params,
         content: params.summary ?? 'Conversation resolved',
-        signalData: { type: 'resolve', payload: params.summary ? { summary: params.summary } : undefined },
-        environmentId: params.environmentId,
-        organizationId: params.organizationId,
       }),
     ]);
   }
 
-  /**
-   * Persist a tool-approval decision as a signal activity so it becomes part of
-   * the durable transcript. Self-hosted (stateless) agents reconstruct the resume
-   * message list from history via `toModelMessages`, so the decision must live in
-   * the transcript — not only in the ephemeral approval card.
-   */
-  async persistToolApprovalDecision(params: PersistToolApprovalDecisionParams): Promise<ConversationActivityEntity> {
-    const toolName = params.toolName ?? 'tool call';
-    const sequence = await this.resolveEventSequence(
-      params.conversationId,
-      params.environmentId,
-      params.organizationId
-    );
+  // --- Messages ---
 
-    const activity = await this.activityRepository.createToolActivity({
-      identifier: `act_${shortId(12)}`,
-      conversationId: params.conversationId,
-      platform: params.channel.platform,
-      integrationId: params.channel._integrationId,
-      platformThreadId: params.channel.platformThreadId,
-      senderType: params.actorType,
-      senderId: params.actorId,
-      content: params.approved ? `Approved ${toolName}` : `Denied ${toolName}`,
-      type: ConversationActivityTypeEnum.TOOL_APPROVAL_DECISION,
-      toolData: { approvalId: params.approvalId, approved: params.approved, toolName: params.toolName },
-      sequence,
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-    });
-
-    await this.agentChatLiveActivityPublisher.emitPersistedClientEvent({
-      channel: params.channel,
-      conversationId: params.conversationId,
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-      agentIdentifier: params.agentIdentifier,
-      activity,
-    });
-
-    return activity;
+  async persistInboundMessage(params: PersistInboundMessageParams): Promise<ConversationActivityEntity> {
+    return this.ledger.persistInboundMessage(params);
   }
 
-  async persistToolResult(params: PersistToolResultParams): Promise<void> {
-    const sequence = await this.resolveEventSequence(
-      params.conversationId,
-      params.environmentId,
-      params.organizationId
-    );
-
-    const activity = await this.activityRepository.createToolActivity({
-      identifier: `act_${shortId(12)}`,
-      conversationId: params.conversationId,
-      platform: params.channel.platform,
-      integrationId: params.channel._integrationId,
-      platformThreadId: params.channel.platformThreadId,
-      senderType: ConversationActivitySenderTypeEnum.AGENT,
-      senderId: params.agentIdentifier,
-      content: params.preview ?? `Tool result: ${params.toolName ?? params.toolCallId}`,
-      type: ConversationActivityTypeEnum.TOOL_RESULT,
-      toolData: { toolCallId: params.toolCallId, toolName: params.toolName, output: params.output },
-      sequence,
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-    });
-
-    await this.agentChatLiveActivityPublisher.emitPersistedClientEvent({
-      channel: params.channel,
-      conversationId: params.conversationId,
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-      agentIdentifier: params.agentIdentifier,
-      activity,
-    });
+  async persistAgentMessage(params: PersistAgentActivityParams): Promise<PersistAgentMessageResult> {
+    return this.ledger.persistAgentMessage(params);
   }
 
-  async persistMcpConnectionRequest(params: PersistMcpConnectionRequestParams): Promise<ConversationActivityEntity> {
-    const activity = await this.persistAgentActivity(
-      {
-        ...params,
-        identifier: `mcp-connection:${params.actionId}:request`,
-        content: `Connect ${params.displayName}`,
-        richContent: {
-          mcpConnection: {
-            actionId: params.actionId,
-            mcpId: params.mcpId,
-            displayName: params.displayName,
-            authorizeUrl: params.authorizeUrl,
-            authorizeUrlWithAutoApprove: params.authorizeUrlWithAutoApprove,
-          },
-        },
-      },
-      ConversationActivityTypeEnum.MCP_CONNECTION_REQUEST,
-      'activity'
-    );
-
-    await this.agentChatLiveActivityPublisher.emitPersistedClientEvent({
-      channel: params.channel,
-      conversationId: params.conversationId,
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-      agentIdentifier: params.agentIdentifier,
-      activity,
-    });
-
-    return activity;
+  async setAgentMessagePlatformMessageId(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    activityId: string;
+    platformMessageId: string;
+  }): Promise<void> {
+    return this.ledger.setAgentMessagePlatformMessageId(params);
   }
 
-  async persistMcpConnectionResult(params: PersistMcpConnectionResultParams): Promise<ConversationActivityEntity> {
-    const activity = await this.persistAgentActivity(
-      {
-        ...params,
-        identifier: `mcp-connection:${params.actionId}:result`,
-        content: params.status === 'connected' ? 'Connection completed' : (params.message ?? 'Connection failed'),
-        richContent: {
-          mcpConnection: {
-            actionId: params.actionId,
-            mcpId: params.mcpId,
-            status: params.status,
-            message: params.message,
-          },
-        },
-      },
-      ConversationActivityTypeEnum.MCP_CONNECTION_RESULT,
-      'activity'
-    );
-
-    await this.agentChatLiveActivityPublisher.emitPersistedClientEvent({
-      channel: params.channel,
-      conversationId: params.conversationId,
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-      agentIdentifier: params.agentIdentifier,
-      activity,
-    });
-
-    return activity;
+  async deleteAgentMessage(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    activityId: string;
+  }): Promise<void> {
+    return this.ledger.deleteAgentMessage(params);
   }
 
-  /**
-   * Whoever makes the event real first mints its sequence: live delivery paths
-   * (web) mint before emitting and pass the value here; everything else gets
-   * one at persist time. Channel-agnostic — every conversation is sequenced.
-   */
-  private async resolveEventSequence(
-    conversationId: string,
-    environmentId: string,
-    organizationId: string,
-    sequence?: number
-  ): Promise<number> {
-    if (sequence !== undefined) {
-      return sequence;
-    }
-
-    return this.eventSequenceService.mint({
-      environmentId,
-      organizationId,
-      conversationId,
-    });
+  async persistAgentEdit(params: PersistAgentActivityParams): Promise<ConversationActivityEntity> {
+    return this.ledger.persistAgentEdit(params);
   }
 
-  async persistTriggerSignal(params: PersistTriggerSignalParams): Promise<void> {
-    await this.activityRepository.createSignalActivity({
-      identifier: `act_${shortId(12)}`,
-      conversationId: params.conversationId,
-      platform: params.channel.platform,
-      integrationId: params.channel._integrationId,
-      platformThreadId: params.channel.platformThreadId,
-      agentId: params.agentIdentifier,
-      content: `Triggered workflow: ${params.workflowId}`,
-      signalData: {
-        type: 'trigger',
-        payload: {
-          workflowId: params.workflowId,
-          to: params.to,
-          transactionId: params.transactionId,
-        },
-      },
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-    });
+  async persistAgentDelete(params: PersistAgentActivityParams): Promise<ConversationActivityEntity> {
+    return this.ledger.persistAgentDelete(params);
   }
 
-  /**
-   * Whether this origin is already in the transcript. The signal is the final write of
-   * `persistWorkflowOriginHydration`, so a partially applied hydration reads as not hydrated.
-   */
+  async persistWorkflowOriginHydration(params: PersistWorkflowOriginHydrationParams): Promise<void> {
+    return this.ledger.persistWorkflowOriginHydration(params);
+  }
+
   async isWorkflowOriginHydrated(
     environmentId: string,
     conversationId: string,
     platformMessageId: string
   ): Promise<boolean> {
-    const count = await this.activityRepository.count(
-      {
-        _environmentId: environmentId,
-        _conversationId: conversationId,
-        identifier: workflowOriginSignalIdentifier(platformMessageId),
-      },
-      1
-    );
-
-    return count > 0;
+    return this.ledger.isWorkflowOriginHydrated(environmentId, conversationId, platformMessageId);
   }
 
-  /**
-   * Persist the workflow-origin message + signal. Stable `workflow-dispatch-*`
-   * identifiers collide on the unique index under concurrency; both writes are
-   * duplicate-key tolerant so a retry after a partial success is idempotent.
-   */
-  async persistWorkflowOriginHydration(params: PersistWorkflowOriginHydrationParams): Promise<void> {
-    await this.persistAgentMessage({
-      conversationId: params.conversationId,
-      channel: params.channel,
-      agentIdentifier: params.agentIdentifier,
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-      platformMessageId: params.platformMessageId,
-      platformThreadId: params.platformThreadId,
-      identifier: `workflow-dispatch-msg:${params.platformMessageId}`,
-      content: params.messageContent,
-    });
+  async listForView(params: {
+    view: ActivityView;
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    limit?: number;
+    before?: string;
+  }): Promise<{ data: ConversationActivityEntity[]; hasMore: boolean }> {
+    return this.ledger.listForView(params);
+  }
 
-    try {
-      await this.activityRepository.createSignalActivity({
-        identifier: workflowOriginSignalIdentifier(params.platformMessageId),
-        conversationId: params.conversationId,
-        platform: params.channel.platform,
-        integrationId: params.channel._integrationId,
-        platformThreadId: params.platformThreadId,
-        agentId: params.agentIdentifier,
-        content: `Workflow origin: ${String(params.signalData.workflowIdentifier ?? 'unknown')}`,
-        signalData: {
-          type: 'workflow_origin',
-          payload: params.signalData,
-        },
-        platformMessageId: params.platformMessageId,
-        environmentId: params.environmentId,
-        organizationId: params.organizationId,
-      });
-    } catch (err) {
-      if (!isDuplicateKeyError(err)) {
-        throw err;
-      }
+  // --- Tools ---
 
-      this.logger.warn(
-        { platformMessageId: params.platformMessageId, conversationId: params.conversationId },
-        'Workflow origin already hydrated'
+  async persistToolApprovalRequest(params: PersistToolApprovalRequestParams): Promise<ConversationActivityEntity> {
+    return this.ledger.persistToolApprovalRequest(params);
+  }
+
+  async linkToolApprovalRequestCard(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    activityId: string;
+    platformMessageId: string;
+  }): Promise<void> {
+    return this.ledger.linkToolApprovalRequestCard(params);
+  }
+
+  async persistToolApprovalDecision(params: PersistToolApprovalDecisionParams): Promise<ConversationActivityEntity> {
+    return this.ledger.persistToolApprovalDecision(params);
+  }
+
+  async persistToolResult(params: PersistToolResultParams): Promise<void> {
+    return this.ledger.persistToolResult(params);
+  }
+
+  async persistMcpConnectionRequest(params: PersistMcpConnectionRequestParams): Promise<ConversationActivityEntity> {
+    return this.ledger.persistMcpConnectionRequest(params);
+  }
+
+  async persistMcpConnectionResult(params: PersistMcpConnectionResultParams): Promise<ConversationActivityEntity> {
+    return this.ledger.persistMcpConnectionResult(params);
+  }
+
+  async persistTriggerSignal(params: PersistTriggerSignalParams): Promise<void> {
+    return this.ledger.persistTriggerSignal(params);
+  }
+
+  async persistRunLifecycle(params: PersistRunLifecycleParams): Promise<ConversationActivityEntity | null> {
+    return this.ledger.persistRunLifecycle(params);
+  }
+
+  // --- Lookups ---
+
+  async findByPlatformMessageId(
+    environmentId: string,
+    conversationId: string,
+    platformMessageId: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.ledger.findByPlatformMessageId(environmentId, conversationId, platformMessageId);
+  }
+
+  async findSourceActivity(
+    environmentId: string,
+    conversationId: string,
+    platformMessageId: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.findByPlatformMessageId(environmentId, conversationId, platformMessageId);
+  }
+
+  async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
+    return this.ledger.countAgentMessages(environmentId, conversationId);
+  }
+
+  async findAgentMessageByIdentifier(
+    environmentId: string,
+    conversationId: string,
+    identifier: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.ledger.findAgentMessageByIdentifier(environmentId, conversationId, identifier);
+  }
+
+  async findToolActivitiesByPlanMessageId(
+    environmentId: string,
+    conversationId: string,
+    planMessageId: string
+  ): Promise<ConversationActivityEntity[]> {
+    return this.ledger.findToolActivitiesByPlanMessageId(environmentId, conversationId, planMessageId);
+  }
+
+  async persistToolUseSignal(
+    params: ConversationActivityContext & { content: string; payload: Record<string, unknown> }
+  ): Promise<void> {
+    return this.ledger.persistToolUseSignal(params);
+  }
+
+  async enrichToolUseSignal(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    activityId: string;
+    content: string;
+    payload: Record<string, unknown>;
+  }): Promise<void> {
+    return this.ledger.enrichToolUseSignal(params);
+  }
+
+  async repointSubscriberSender(params: {
+    environmentId: string;
+    organizationId: string;
+    fromSubscriberId: string;
+    toSubscriberId: string;
+  }): Promise<number> {
+    return this.ledger.repointSubscriberSender(params);
+  }
+
+  // --- Sequence ---
+
+  async mintEventSequence(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+  }): Promise<number> {
+    return this.ledger.mint(params);
+  }
+
+  private async ensureParticipant(conversation: ConversationEntity, params: CreateOrGetConversationParams) {
+    const alreadyPresent = conversation.participants.some(
+      (p) => p.id === params.participantId && p.type === params.participantType
+    );
+    if (alreadyPresent) return;
+
+    const platformIdentity = `${params.platform}:${params.platformUserId}`;
+
+    if (params.participantType === ConversationParticipantTypeEnum.SUBSCRIBER) {
+      const platformUserIdx = conversation.participants.findIndex(
+        (p) => p.type === ConversationParticipantTypeEnum.PLATFORM_USER && p.id === platformIdentity
       );
+
+      if (platformUserIdx !== -1) {
+        conversation.participants[platformUserIdx] = { type: params.participantType, id: params.participantId };
+
+        this.logger.debug(
+          `Upgraded participant ${platformIdentity} → subscriber ${params.participantId} in conversation ${conversation._id}`
+        );
+      } else {
+        conversation.participants.push({ type: params.participantType, id: params.participantId });
+      }
+    } else {
+      conversation.participants.push({ type: params.participantType, id: params.participantId });
     }
+
+    await this.conversationRepository.updateParticipants(
+      params.environmentId,
+      params.organizationId,
+      conversation._id,
+      conversation.participants
+    );
   }
 }

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.types.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.types.ts
@@ -1,0 +1,123 @@
+import type { ConversationActivityEntity, ConversationActivitySenderTypeEnum, ConversationChannel } from '@novu/dal';
+import type { TriggerRecipientsPayload } from '@novu/shared';
+
+export interface PersistInboundMessageParams {
+  conversationId: string;
+  platform: string;
+  integrationId: string;
+  platformThreadId: string;
+  senderType: ConversationActivitySenderTypeEnum;
+  senderId: string;
+  senderName?: string;
+  content: string;
+  richContent?: Record<string, unknown>;
+  hasPlatformAttachments?: boolean;
+  platformMessageId?: string;
+  /** Caller-supplied activity identifier; defaults to a server-minted act_* id */
+  identifier?: string;
+  /** Pre-allocated conversation event sequence; minted at persist time when absent */
+  sequence?: number;
+  environmentId: string;
+  organizationId: string;
+}
+
+export interface ConversationActivityContext {
+  conversationId: string;
+  channel: ConversationChannel;
+  agentIdentifier: string;
+  environmentId: string;
+  organizationId: string;
+}
+
+export interface PersistAgentMessageResult {
+  activity: ConversationActivityEntity;
+  /** `false` when the identifier already existed — the caller lost the persist race. */
+  created: boolean;
+}
+
+export interface PersistAgentActivityParams extends ConversationActivityContext {
+  platformMessageId?: string;
+  /** Overrides channel.platformThreadId when delivery returns a different thread ID */
+  platformThreadId?: string;
+  /** Caller-supplied activity identifier; defaults to a server-minted act_* id */
+  identifier?: string;
+  agentName?: string;
+  content: string;
+  richContent?: Record<string, unknown>;
+  /** Pre-allocated conversation event sequence; minted at persist time when absent */
+  sequence?: number;
+}
+
+export interface PersistToolApprovalRequestParams extends ConversationActivityContext {
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  input?: Record<string, unknown>;
+  /** Human-readable preview for the display timeline. */
+  preview?: string;
+  /** When omitted, self-hosted `tool-approval:*` ids are minted. */
+  approveActionId?: string;
+  denyActionId?: string;
+}
+
+export type MetadataOp =
+  | { action: 'set'; key: string; value: unknown }
+  | { action: 'delete'; key: string }
+  | { action: 'clear' };
+
+export interface UpdateMetadataParams extends ConversationActivityContext {
+  currentMetadata: Record<string, unknown>;
+  ops: MetadataOp[];
+}
+
+export interface ResolveConversationParams extends ConversationActivityContext {
+  summary?: string;
+}
+
+export interface PersistTriggerSignalParams extends ConversationActivityContext {
+  workflowId: string;
+  to: TriggerRecipientsPayload;
+  transactionId: string;
+}
+
+export interface PersistWorkflowOriginHydrationParams extends ConversationActivityContext {
+  platformMessageId: string;
+  platformThreadId: string;
+  messageContent: string;
+  signalData: Record<string, unknown>;
+}
+
+export interface PersistToolApprovalDecisionParams extends ConversationActivityContext {
+  approvalId: string;
+  approved: boolean;
+  toolName?: string;
+  actorType:
+    | ConversationActivitySenderTypeEnum.SUBSCRIBER
+    | ConversationActivitySenderTypeEnum.PLATFORM_USER
+    | ConversationActivitySenderTypeEnum.SYSTEM;
+  actorId: string;
+}
+
+export interface PersistToolResultParams extends ConversationActivityContext {
+  toolCallId: string;
+  toolName?: string;
+  /** The tool's output as returned by the model runtime (JSON-serializable). */
+  output: unknown;
+  /** Human-readable preview for the display timeline; defaults to a generic line. */
+  preview?: string;
+}
+
+export interface PersistMcpConnectionRequestParams extends ConversationActivityContext {
+  actionId: string;
+  mcpId: string;
+  displayName: string;
+  authorizeUrl: string;
+  authorizeUrlWithAutoApprove?: string;
+}
+
+export interface PersistMcpConnectionResultParams extends ConversationActivityContext {
+  actionId: string;
+  mcpId: string;
+  status: 'connected' | 'failed';
+  message?: string;
+}

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-adoption.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-adoption.service.spec.ts
@@ -17,7 +17,7 @@ describe('AgentSubscriberAdoptionService', () => {
     const conversationRepository = {
       repointSubscriberParticipant: overrides.repointParticipant ?? sinon.stub().resolves(2),
     };
-    const conversationActivityRepository = {
+    const conversationService = {
       repointSubscriberSender: overrides.repointSender ?? sinon.stub().resolves(5),
     };
     const mcpConnectionRepository = {
@@ -40,7 +40,7 @@ describe('AgentSubscriberAdoptionService', () => {
 
     const service = new AgentSubscriberAdoptionService(
       conversationRepository as any,
-      conversationActivityRepository as any,
+      conversationService as any,
       mcpConnectionRepository as any,
       agentToolTrustRepository as any,
       subscriberRepository as any,
@@ -51,7 +51,7 @@ describe('AgentSubscriberAdoptionService', () => {
     return {
       service,
       conversationRepository,
-      conversationActivityRepository,
+      conversationService,
       mcpConnectionRepository,
       agentToolTrustRepository,
       subscriberRepository,
@@ -68,7 +68,7 @@ describe('AgentSubscriberAdoptionService', () => {
     const {
       service,
       conversationRepository,
-      conversationActivityRepository,
+      conversationService,
       mcpConnectionRepository,
       agentToolTrustRepository,
       subscriberRepository,
@@ -83,8 +83,8 @@ describe('AgentSubscriberAdoptionService', () => {
       fromSubscriberId: 'sub-phantom',
       toSubscriberId: 'sub-real',
     });
-    expect(conversationActivityRepository.repointSubscriberSender.calledOnce).to.equal(true);
-    expect(conversationActivityRepository.repointSubscriberSender.firstCall.args[0]).to.include({
+    expect(conversationService.repointSubscriberSender.calledOnce).to.equal(true);
+    expect(conversationService.repointSubscriberSender.firstCall.args[0]).to.include({
       environmentId: 'env-1',
       organizationId: 'org-1',
       fromSubscriberId: 'sub-phantom',

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-adoption.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-adoption.service.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { AnalyticsService, PinoLogger } from '@novu/application-generic';
 import {
   AgentToolTrustRepository,
-  ConversationActivityRepository,
   ConversationRepository,
   McpConnectionRepository,
   SubscriberRepository,
 } from '@novu/dal';
 import { AGENT_PLATFORM_PROVISION_SOURCE, AGENT_PROVISION_DATA_KEYS } from '@novu/shared';
+import { AgentConversationService } from './agent-conversation.service';
 
 /**
  * Identity pair for a subscriber involved in an adoption merge. The email
@@ -35,7 +35,7 @@ export interface AdoptionSubscriberRef {
 export class AgentSubscriberAdoptionService {
   constructor(
     private readonly conversationRepository: ConversationRepository,
-    private readonly conversationActivityRepository: ConversationActivityRepository,
+    private readonly conversationService: AgentConversationService,
     private readonly mcpConnectionRepository: McpConnectionRepository,
     private readonly agentToolTrustRepository: AgentToolTrustRepository,
     private readonly subscriberRepository: SubscriberRepository,
@@ -81,7 +81,7 @@ export class AgentSubscriberAdoptionService {
         toSubscriberId: real.subscriberId,
       });
 
-      const activities = await this.conversationActivityRepository.repointSubscriberSender({
+      const activities = await this.conversationService.repointSubscriberSender({
         environmentId,
         organizationId,
         fromSubscriberId: phantom.subscriberId,

--- a/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activity-ledger.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activity-ledger.spec.ts
@@ -1,7 +1,8 @@
-import { ConversationActivityTypeEnum } from '@novu/dal';
+import { ConversationActivityTypeEnum, ConversationRepository } from '@novu/dal';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ConversationActivityLedger } from './conversation-activity-ledger';
+import { ConversationEventSequenceService } from './conversation-event-sequence.service';
 
 describe('ConversationActivityLedger', () => {
   const lifecycleParams = {
@@ -18,39 +19,339 @@ describe('ConversationActivityLedger', () => {
     event: { type: 'run-start' } as const,
   };
 
-  function makeLedger(createRunActivity: sinon.SinonStub) {
-    return new ConversationActivityLedger({ createRunActivity } as any, { mint: sinon.stub().resolves(7) } as any);
+  function makeLogger() {
+    return {
+      setContext: sinon.stub(),
+      debug: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      info: sinon.stub(),
+    };
   }
 
-  it('stamps the minted sequence so lifecycle rows interleave with messages in order', async () => {
-    const createRunActivity = sinon.stub().resolves({
-      _id: 'run-1',
-      type: ConversationActivityTypeEnum.RUN_START,
-      sequence: 7,
+  function makeActivityRepository(overrides: Record<string, sinon.SinonStub> = {}) {
+    return {
+      createRunActivity: overrides.createRunActivity ?? sinon.stub(),
+      createAgentActivity:
+        overrides.createAgentActivity ?? sinon.stub().resolves({ _id: 'activity-1', identifier: 'act_generated' }),
+      createToolActivity: overrides.createToolActivity ?? sinon.stub().resolves({ _id: 'tool-activity' }),
+      createSignalActivity: overrides.createSignalActivity ?? sinon.stub().resolves({}),
+      findOne: overrides.findOne ?? sinon.stub().resolves(null),
+      count: overrides.count ?? sinon.stub().resolves(0),
+      ...overrides,
+    };
+  }
+
+  function makeConversationRepository(overrides: Record<string, sinon.SinonStub> = {}) {
+    return {
+      touchActivity: overrides.touchActivity ?? sinon.stub().resolves(undefined),
+      touchPreview: overrides.touchPreview ?? sinon.stub().resolves(undefined),
+      ...overrides,
+    };
+  }
+
+  function makeLedger(
+    activityRepository = makeActivityRepository(),
+    eventSequenceService = { mint: sinon.stub().resolves(7) } as unknown as ConversationEventSequenceService,
+    publisher = { emitPersistedClientEvent: sinon.stub().resolves(undefined) },
+    conversationRepository = makeConversationRepository(),
+    logger = makeLogger()
+  ) {
+    return new ConversationActivityLedger(
+      activityRepository as any,
+      eventSequenceService,
+      publisher as any,
+      conversationRepository as unknown as ConversationRepository,
+      logger as any
+    );
+  }
+
+  function basePersistParams() {
+    return {
+      conversationId: 'conv-1',
+      channel: {
+        platform: 'slack',
+        _integrationId: 'integration-a',
+        platformThreadId: 'thread-1',
+      },
+      platformMessageId: 'msg-1',
+      agentIdentifier: 'agent-a',
+      content: 'hello',
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+    };
+  }
+
+  describe('persistRunLifecycle', () => {
+    it('stamps the minted sequence so lifecycle rows interleave with messages in order', async () => {
+      const createRunActivity = sinon.stub().resolves({
+        _id: 'run-1',
+        type: ConversationActivityTypeEnum.RUN_START,
+        sequence: 7,
+      });
+      const publisher = { emitPersistedClientEvent: sinon.stub().resolves(undefined) };
+
+      await makeLedger(makeActivityRepository({ createRunActivity }), undefined, publisher).persistRunLifecycle(
+        lifecycleParams
+      );
+
+      expect(createRunActivity.firstCall.args[0].sequence).to.equal(7);
+      expect(createRunActivity.firstCall.args[0].identifier).to.equal('run_run-abc_start');
+      expect(publisher.emitPersistedClientEvent.calledOnce).to.equal(true);
     });
 
-    await makeLedger(createRunActivity).persistProtocolEvent(lifecycleParams);
+    it('returns null when the same run event is ingested twice and does not emit', async () => {
+      const createRunActivity = sinon.stub().rejects(Object.assign(new Error('dup'), { code: 11000 }));
+      const publisher = { emitPersistedClientEvent: sinon.stub().resolves(undefined) };
 
-    expect(createRunActivity.firstCall.args[0].sequence).to.equal(7);
-    expect(createRunActivity.firstCall.args[0].identifier).to.equal('run_run-abc_start');
+      const activity = await makeLedger(
+        makeActivityRepository({ createRunActivity }),
+        undefined,
+        publisher
+      ).persistRunLifecycle(lifecycleParams);
+
+      expect(activity).to.equal(null);
+      expect(publisher.emitPersistedClientEvent.called).to.equal(false);
+    });
+
+    it('propagates non-duplicate write failures to the caller', async () => {
+      const createRunActivity = sinon.stub().rejects(new Error('mongo down'));
+
+      try {
+        await makeLedger(makeActivityRepository({ createRunActivity })).persistRunLifecycle(lifecycleParams);
+        expect.fail('expected persistRunLifecycle to reject');
+      } catch (err) {
+        expect((err as Error).message).to.equal('mongo down');
+      }
+    });
   });
 
-  it('returns null when the same run event is ingested twice so it is published once', async () => {
-    const createRunActivity = sinon.stub().rejects(Object.assign(new Error('dup'), { code: 11000 }));
+  describe('persistAgentMessage', () => {
+    it('uses the caller-supplied identifier when provided', async () => {
+      const activityRepository = makeActivityRepository();
+      const ledger = makeLedger(activityRepository);
 
-    const activity = await makeLedger(createRunActivity).persistProtocolEvent(lifecycleParams);
+      const result = await ledger.persistAgentMessage({
+        ...basePersistParams(),
+        identifier: 'client-msg-123',
+      });
 
-    expect(activity).to.equal(null);
+      expect(result.created).to.equal(true);
+      expect(activityRepository.createAgentActivity.calledOnce).to.equal(true);
+      expect(activityRepository.createAgentActivity.firstCall.args[0].identifier).to.equal('client-msg-123');
+      expect(activityRepository.createAgentActivity.firstCall.args[0].type).to.equal(
+        ConversationActivityTypeEnum.MESSAGE
+      );
+    });
+
+    it('mints an act_ identifier when none is supplied', async () => {
+      const activityRepository = makeActivityRepository();
+      const ledger = makeLedger(activityRepository);
+
+      await ledger.persistAgentMessage(basePersistParams());
+
+      const identifier = activityRepository.createAgentActivity.firstCall.args[0].identifier;
+
+      expect(identifier).to.match(/^act_/);
+    });
+
+    it('logs and returns the existing activity on duplicate identifier races', async () => {
+      const duplicateError = Object.assign(new Error('duplicate key'), { code: 11000 });
+      const existingActivity = { _id: 'existing-1', identifier: 'client-msg-123' };
+      const activityRepository = makeActivityRepository({
+        createAgentActivity: sinon.stub().rejects(duplicateError),
+        findOne: sinon.stub().resolves(existingActivity),
+      });
+      const logger = makeLogger();
+      const ledger = makeLedger(activityRepository, undefined, undefined, undefined, logger);
+
+      const result = await ledger.persistAgentMessage({
+        ...basePersistParams(),
+        identifier: 'client-msg-123',
+      });
+
+      expect(result.activity).to.equal(existingActivity);
+      expect(result.created).to.equal(false);
+      expect(logger.warn.calledOnce).to.equal(true);
+    });
+
+    it('pairs touchActivity with agent message persist', async () => {
+      const touchActivity = sinon.stub().resolves(undefined);
+      const conversationRepository = makeConversationRepository({ touchActivity });
+      const ledger = makeLedger(makeActivityRepository(), undefined, undefined, conversationRepository);
+
+      await ledger.persistAgentMessage(basePersistParams());
+
+      expect(touchActivity.calledOnce).to.equal(true);
+    });
   });
 
-  it('propagates non-duplicate write failures to the caller', async () => {
-    const createRunActivity = sinon.stub().rejects(new Error('mongo down'));
-
-    try {
-      await makeLedger(createRunActivity).persistProtocolEvent(lifecycleParams);
-      expect.fail('expected persistProtocolEvent to reject');
-    } catch (err) {
-      expect((err as Error).message).to.equal('mongo down');
+  describe('persistWorkflowOriginHydration', () => {
+    function makeHydrationParams() {
+      return {
+        conversationId: 'conv-1',
+        channel: {
+          platform: 'whatsapp',
+          _integrationId: 'integration-a',
+          platformThreadId: 'whatsapp:15551234567',
+        },
+        agentIdentifier: 'agent-a',
+        environmentId: 'env-1',
+        organizationId: 'org-1',
+        platformMessageId: 'wamid.abc',
+        platformThreadId: 'whatsapp:15551234567',
+        messageContent: 'Your order shipped',
+        signalData: { workflowIdentifier: 'order-alerts' },
+      };
     }
+
+    it('swallows duplicate-key errors from the signal write', async () => {
+      const duplicateError = Object.assign(new Error('duplicate key'), { code: 11000 });
+      const activityRepository = makeActivityRepository({
+        createSignalActivity: sinon.stub().rejects(duplicateError),
+      });
+      const logger = makeLogger();
+      const ledger = makeLedger(activityRepository, undefined, undefined, undefined, logger);
+
+      await ledger.persistWorkflowOriginHydration(makeHydrationParams());
+
+      expect(activityRepository.createSignalActivity.calledOnce).to.equal(true);
+      expect(logger.warn.calledOnce).to.equal(true);
+      expect(logger.warn.firstCall.args[1]).to.equal('Workflow origin already hydrated');
+    });
+
+    it('rethrows non-duplicate errors from the signal write', async () => {
+      const activityRepository = makeActivityRepository({
+        createSignalActivity: sinon.stub().rejects(new Error('mongo timeout')),
+      });
+      const ledger = makeLedger(activityRepository);
+
+      try {
+        await ledger.persistWorkflowOriginHydration(makeHydrationParams());
+        expect.fail('expected persistWorkflowOriginHydration to throw');
+      } catch (err) {
+        expect((err as Error).message).to.equal('mongo timeout');
+      }
+    });
+  });
+
+  describe('isWorkflowOriginHydrated', () => {
+    it('matches the signal identifier written by persistWorkflowOriginHydration', async () => {
+      const activityRepository = makeActivityRepository({ count: sinon.stub().resolves(1) });
+      const ledger = makeLedger(activityRepository);
+
+      const hydrated = await ledger.isWorkflowOriginHydrated('env-1', 'conv-1', 'wamid.abc');
+
+      expect(hydrated).to.equal(true);
+      expect(activityRepository.count.firstCall.args[0]).to.deep.equal({
+        _environmentId: 'env-1',
+        _conversationId: 'conv-1',
+        identifier: 'workflow-dispatch-origin:wamid.abc',
+      });
+    });
+
+    it('returns false when the signal is absent', async () => {
+      const activityRepository = makeActivityRepository({ count: sinon.stub().resolves(0) });
+      const ledger = makeLedger(activityRepository);
+
+      expect(await ledger.isWorkflowOriginHydrated('env-1', 'conv-1', 'wamid.abc')).to.equal(false);
+    });
+  });
+
+  describe('MCP connection activities', () => {
+    it('persists request and result activities and publishes both to agent chat', async () => {
+      const activityRepository = makeActivityRepository();
+      activityRepository.createAgentActivity.callsFake(async (params: Record<string, unknown>) => ({
+        _id: `activity-${activityRepository.createAgentActivity.callCount}`,
+        ...params,
+      }));
+      const mint = sinon.stub().onFirstCall().resolves(10).onSecondCall().resolves(11);
+      const publisher = { emitPersistedClientEvent: sinon.stub().resolves(undefined) };
+      const ledger = makeLedger(activityRepository, { mint } as unknown as ConversationEventSequenceService, publisher);
+      const context = {
+        ...basePersistParams(),
+        channel: {
+          platform: 'agent_chat',
+          _integrationId: 'integration-a',
+          platformThreadId: 'thread-1',
+        },
+      };
+
+      await ledger.persistMcpConnectionRequest({
+        ...context,
+        actionId: 'tool-use-1',
+        mcpId: 'stripe',
+        displayName: 'Stripe',
+        authorizeUrl: 'https://example.com/authorize',
+      });
+      await ledger.persistMcpConnectionResult({
+        ...context,
+        actionId: 'tool-use-1',
+        mcpId: 'stripe',
+        status: 'connected',
+      });
+
+      expect(activityRepository.createAgentActivity.firstCall.args[0]).to.deep.include({
+        identifier: 'mcp-connection:tool-use-1:request',
+        type: ConversationActivityTypeEnum.MCP_CONNECTION_REQUEST,
+        sequence: 10,
+        richContent: {
+          mcpConnection: {
+            actionId: 'tool-use-1',
+            mcpId: 'stripe',
+            displayName: 'Stripe',
+            authorizeUrl: 'https://example.com/authorize',
+            authorizeUrlWithAutoApprove: undefined,
+          },
+        },
+      });
+      expect(activityRepository.createAgentActivity.secondCall.args[0]).to.deep.include({
+        identifier: 'mcp-connection:tool-use-1:result',
+        type: ConversationActivityTypeEnum.MCP_CONNECTION_RESULT,
+        sequence: 11,
+        richContent: {
+          mcpConnection: {
+            actionId: 'tool-use-1',
+            mcpId: 'stripe',
+            status: 'connected',
+            message: undefined,
+          },
+        },
+      });
+      expect(publisher.emitPersistedClientEvent.callCount).to.equal(2);
+    });
+  });
+
+  describe('event sequencing', () => {
+    it('allocates a sequence for durable tool activities on any channel', async () => {
+      const activityRepository = makeActivityRepository();
+      const mint = sinon.stub().resolves(4);
+      const publisher = { emitPersistedClientEvent: sinon.stub().resolves(undefined) };
+      const ledger = makeLedger(activityRepository, { mint } as unknown as ConversationEventSequenceService, publisher);
+
+      await ledger.persistToolResult({
+        conversationId: 'conv-1',
+        channel: {
+          platform: 'slack',
+          _integrationId: 'integration-a',
+          platformThreadId: 'thread-1',
+        },
+        agentIdentifier: 'agent-a',
+        environmentId: 'env-1',
+        organizationId: 'org-1',
+        toolCallId: 'tool-call-1',
+        output: 'done',
+      });
+
+      expect(activityRepository.createToolActivity.firstCall.args[0].sequence).to.equal(4);
+      expect(
+        mint.calledOnceWithExactly({
+          environmentId: 'env-1',
+          organizationId: 'org-1',
+          conversationId: 'conv-1',
+        })
+      ).to.equal(true);
+      expect(publisher.emitPersistedClientEvent.calledOnce).to.equal(true);
+    });
   });
 });

--- a/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activity-ledger.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activity-ledger.ts
@@ -1,11 +1,32 @@
 import { Injectable } from '@nestjs/common';
+import { PinoLogger, shortId } from '@novu/application-generic';
 import {
   ActivityView,
   ConversationActivityEntity,
   ConversationActivityRepository,
+  ConversationActivitySenderTypeEnum,
+  ConversationActivitySignalData,
+  ConversationActivityToolData,
+  ConversationActivityTypeEnum,
+  ConversationRepository,
   isDuplicateKeyError,
 } from '@novu/dal';
-import { AGENT_HISTORY_LIMIT } from './agent-conversation.service';
+import { AgentChatLiveActivityPublisher } from '../../agent-chat/agent-chat-live-activity.publisher';
+import { mintApprovalActionIds } from '../../shared/tool-approval/mint-approval-action-ids';
+import { AGENT_HISTORY_LIMIT, getInboundActivityPreview } from './agent-conversation.helpers';
+import type {
+  ConversationActivityContext,
+  PersistAgentActivityParams,
+  PersistAgentMessageResult,
+  PersistInboundMessageParams,
+  PersistMcpConnectionRequestParams,
+  PersistMcpConnectionResultParams,
+  PersistToolApprovalDecisionParams,
+  PersistToolApprovalRequestParams,
+  PersistToolResultParams,
+  PersistTriggerSignalParams,
+  PersistWorkflowOriginHydrationParams,
+} from './agent-conversation.types';
 import { ConversationEventSequenceService } from './conversation-event-sequence.service';
 import {
   describeRunLifecycleFromEvent,
@@ -22,12 +43,22 @@ export interface ListActivityViewParams {
   before?: string;
 }
 
+/** Stable per-origin identifier for the workflow-origin signal — see `persistWorkflowOriginHydration`. */
+function workflowOriginSignalIdentifier(platformMessageId: string): string {
+  return `workflow-dispatch-origin:${platformMessageId}`;
+}
+
 @Injectable()
 export class ConversationActivityLedger {
   constructor(
     private readonly activityRepository: ConversationActivityRepository,
-    private readonly eventSequenceService: ConversationEventSequenceService
-  ) {}
+    private readonly eventSequenceService: ConversationEventSequenceService,
+    private readonly agentChatLiveActivityPublisher: AgentChatLiveActivityPublisher,
+    private readonly conversationRepository: ConversationRepository,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async listForView(params: ListActivityViewParams): Promise<{ data: ConversationActivityEntity[]; hasMore: boolean }> {
     return this.activityRepository.listForView({
@@ -40,11 +71,15 @@ export class ConversationActivityLedger {
     });
   }
 
+  async mint(params: { environmentId: string; organizationId: string; conversationId: string }): Promise<number> {
+    return this.eventSequenceService.mint(params);
+  }
+
   /**
    * Persist a protocol operational event (run lifecycle today). Returns `null` when the same
-   * event was already persisted, so callers can publish exactly once per event.
+   * event was already persisted. Emits a client event only when the row is newly created.
    */
-  async persistProtocolEvent(params: PersistRunLifecycleParams): Promise<ConversationActivityEntity | null> {
+  async persistRunLifecycle(params: PersistRunLifecycleParams): Promise<ConversationActivityEntity | null> {
     const { type, content, richContent, identifierSuffix } = describeRunLifecycleFromEvent(params.event);
     const identifier = runLifecycleIdentifier(params.runId, identifierSuffix);
     const sequence = await this.eventSequenceService.mint({
@@ -54,7 +89,7 @@ export class ConversationActivityLedger {
     });
 
     try {
-      return await this.activityRepository.createRunActivity({
+      const activity = await this.activityRepository.createRunActivity({
         identifier,
         conversationId: params.conversationId,
         platform: params.channel.platform,
@@ -68,6 +103,10 @@ export class ConversationActivityLedger {
         environmentId: params.environmentId,
         organizationId: params.organizationId,
       });
+
+      await this.emitPersistedClientEvent(params, activity);
+
+      return activity;
     } catch (err) {
       if (isDuplicateKeyError(err)) {
         return null;
@@ -75,5 +114,568 @@ export class ConversationActivityLedger {
 
       throw err;
     }
+  }
+
+  async persistInboundMessage(params: PersistInboundMessageParams): Promise<ConversationActivityEntity> {
+    const content = params.content ?? '';
+    const preview = getInboundActivityPreview(content, {
+      richContent: params.richContent,
+      hasPlatformAttachments: params.hasPlatformAttachments,
+    });
+    const identifier = params.identifier ?? `act_${shortId(12)}`;
+    const sequence = await this.resolveEventSequence(
+      params.conversationId,
+      params.environmentId,
+      params.organizationId,
+      params.sequence
+    );
+
+    try {
+      const [activity] = await Promise.all([
+        this.activityRepository.createUserActivity({
+          identifier,
+          conversationId: params.conversationId,
+          platform: params.platform,
+          integrationId: params.integrationId,
+          platformThreadId: params.platformThreadId,
+          senderType: params.senderType,
+          senderId: params.senderId,
+          senderName: params.senderName,
+          content,
+          richContent: params.richContent,
+          platformMessageId: params.platformMessageId,
+          sequence,
+          environmentId: params.environmentId,
+          organizationId: params.organizationId,
+        }),
+        this.conversationRepository.touchActivity(
+          params.environmentId,
+          params.organizationId,
+          params.conversationId,
+          preview
+        ),
+      ]);
+
+      return activity;
+    } catch (err) {
+      if (params.identifier && isDuplicateKeyError(err)) {
+        const existing = await this.activityRepository.findOne(
+          {
+            _environmentId: params.environmentId,
+            _conversationId: params.conversationId,
+            identifier: params.identifier,
+          },
+          '*'
+        );
+
+        if (existing) {
+          return existing;
+        }
+      }
+
+      throw err;
+    }
+  }
+
+  async persistAgentMessage(params: PersistAgentActivityParams): Promise<PersistAgentMessageResult> {
+    try {
+      const activity = await this.persistAgentActivity(params, ConversationActivityTypeEnum.MESSAGE, 'activity');
+
+      return { activity, created: true };
+    } catch (err) {
+      if (params.identifier && isDuplicateKeyError(err)) {
+        this.logger.warn(
+          { identifier: params.identifier, conversationId: params.conversationId },
+          'Agent message activity already recorded (duplicate identifier)'
+        );
+
+        const existing = await this.activityRepository.findOne(
+          {
+            _environmentId: params.environmentId,
+            _conversationId: params.conversationId,
+            identifier: params.identifier,
+          },
+          '*'
+        );
+
+        if (existing) {
+          return { activity: existing, created: false };
+        }
+      }
+
+      throw err;
+    }
+  }
+
+  async persistAgentEdit(params: PersistAgentActivityParams): Promise<ConversationActivityEntity> {
+    return this.persistAgentActivity(params, ConversationActivityTypeEnum.EDIT, 'preview');
+  }
+
+  async persistAgentDelete(params: PersistAgentActivityParams): Promise<ConversationActivityEntity> {
+    return this.persistAgentActivity(params, ConversationActivityTypeEnum.DELETE, 'preview');
+  }
+
+  async setAgentMessagePlatformMessageId(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    activityId: string;
+    platformMessageId: string;
+  }): Promise<void> {
+    await this.activityRepository.update(
+      {
+        _environmentId: params.environmentId,
+        _organizationId: params.organizationId,
+        _conversationId: params.conversationId,
+        _id: params.activityId,
+      },
+      { $set: { platformMessageId: params.platformMessageId } }
+    );
+  }
+
+  async deleteAgentMessage(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    activityId: string;
+  }): Promise<void> {
+    await this.activityRepository.findOneAndDelete({
+      _environmentId: params.environmentId,
+      _organizationId: params.organizationId,
+      _conversationId: params.conversationId,
+      _id: params.activityId,
+    });
+  }
+
+  async persistToolApprovalRequest(params: PersistToolApprovalRequestParams): Promise<ConversationActivityEntity> {
+    const toolName = params.toolName;
+    const sequence = await this.resolveEventSequence(
+      params.conversationId,
+      params.environmentId,
+      params.organizationId
+    );
+    const actionIds =
+      params.approveActionId && params.denyActionId
+        ? { approveActionId: params.approveActionId, denyActionId: params.denyActionId }
+        : mintApprovalActionIds({ approvalId: params.approvalId });
+
+    const activity = await this.activityRepository.createToolActivity({
+      identifier: `act_${shortId(12)}`,
+      conversationId: params.conversationId,
+      platform: params.channel.platform,
+      integrationId: params.channel._integrationId,
+      platformThreadId: params.channel.platformThreadId,
+      senderType: ConversationActivitySenderTypeEnum.AGENT,
+      senderId: params.agentIdentifier,
+      content: params.preview ?? `Approval required: ${toolName}`,
+      type: ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST,
+      toolData: {
+        approvalId: params.approvalId,
+        toolCallId: params.toolCallId,
+        toolName: params.toolName,
+        input: params.input,
+        approveActionId: actionIds.approveActionId,
+        denyActionId: actionIds.denyActionId,
+      },
+      sequence,
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+    });
+
+    await this.emitPersistedClientEvent(params, activity);
+
+    return activity;
+  }
+
+  async linkToolApprovalRequestCard(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    activityId: string;
+    platformMessageId: string;
+  }): Promise<void> {
+    await this.activityRepository.update(
+      {
+        _environmentId: params.environmentId,
+        _organizationId: params.organizationId,
+        _conversationId: params.conversationId,
+        _id: params.activityId,
+        type: ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST,
+      },
+      { $set: { platformMessageId: params.platformMessageId } }
+    );
+  }
+
+  async persistToolApprovalDecision(params: PersistToolApprovalDecisionParams): Promise<ConversationActivityEntity> {
+    const toolName = params.toolName ?? 'tool call';
+    const sequence = await this.resolveEventSequence(
+      params.conversationId,
+      params.environmentId,
+      params.organizationId
+    );
+
+    const activity = await this.activityRepository.createToolActivity({
+      identifier: `act_${shortId(12)}`,
+      conversationId: params.conversationId,
+      platform: params.channel.platform,
+      integrationId: params.channel._integrationId,
+      platformThreadId: params.channel.platformThreadId,
+      senderType: params.actorType,
+      senderId: params.actorId,
+      content: params.approved ? `Approved ${toolName}` : `Denied ${toolName}`,
+      type: ConversationActivityTypeEnum.TOOL_APPROVAL_DECISION,
+      toolData: { approvalId: params.approvalId, approved: params.approved, toolName: params.toolName },
+      sequence,
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+    });
+
+    await this.emitPersistedClientEvent(params, activity);
+
+    return activity;
+  }
+
+  async persistToolResult(params: PersistToolResultParams): Promise<void> {
+    const sequence = await this.resolveEventSequence(
+      params.conversationId,
+      params.environmentId,
+      params.organizationId
+    );
+
+    const activity = await this.activityRepository.createToolActivity({
+      identifier: `act_${shortId(12)}`,
+      conversationId: params.conversationId,
+      platform: params.channel.platform,
+      integrationId: params.channel._integrationId,
+      platformThreadId: params.channel.platformThreadId,
+      senderType: ConversationActivitySenderTypeEnum.AGENT,
+      senderId: params.agentIdentifier,
+      content: params.preview ?? `Tool result: ${params.toolName ?? params.toolCallId}`,
+      type: ConversationActivityTypeEnum.TOOL_RESULT,
+      toolData: { toolCallId: params.toolCallId, toolName: params.toolName, output: params.output },
+      sequence,
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+    });
+
+    await this.emitPersistedClientEvent(params, activity);
+  }
+
+  async persistMcpConnectionRequest(params: PersistMcpConnectionRequestParams): Promise<ConversationActivityEntity> {
+    const activity = await this.persistAgentActivity(
+      {
+        ...params,
+        identifier: `mcp-connection:${params.actionId}:request`,
+        content: `Connect ${params.displayName}`,
+        richContent: {
+          mcpConnection: {
+            actionId: params.actionId,
+            mcpId: params.mcpId,
+            displayName: params.displayName,
+            authorizeUrl: params.authorizeUrl,
+            authorizeUrlWithAutoApprove: params.authorizeUrlWithAutoApprove,
+          },
+        },
+      },
+      ConversationActivityTypeEnum.MCP_CONNECTION_REQUEST,
+      'activity'
+    );
+
+    await this.emitPersistedClientEvent(params, activity);
+
+    return activity;
+  }
+
+  async persistMcpConnectionResult(params: PersistMcpConnectionResultParams): Promise<ConversationActivityEntity> {
+    const activity = await this.persistAgentActivity(
+      {
+        ...params,
+        identifier: `mcp-connection:${params.actionId}:result`,
+        content: params.status === 'connected' ? 'Connection completed' : (params.message ?? 'Connection failed'),
+        richContent: {
+          mcpConnection: {
+            actionId: params.actionId,
+            mcpId: params.mcpId,
+            status: params.status,
+            message: params.message,
+          },
+        },
+      },
+      ConversationActivityTypeEnum.MCP_CONNECTION_RESULT,
+      'activity'
+    );
+
+    await this.emitPersistedClientEvent(params, activity);
+
+    return activity;
+  }
+
+  async persistMetadataSignal(
+    params: ConversationActivityContext & { content: string; payload: Record<string, unknown> }
+  ) {
+    await this.persistSignal({
+      ...params,
+      signalData: { type: 'metadata', payload: params.payload },
+    });
+  }
+
+  async persistResolveSignal(params: ConversationActivityContext & { content: string; summary?: string }) {
+    await this.persistSignal({
+      ...params,
+      signalData: { type: 'resolve', payload: params.summary ? { summary: params.summary } : undefined },
+    });
+  }
+
+  async persistTriggerSignal(params: PersistTriggerSignalParams): Promise<void> {
+    await this.persistSignal({
+      ...params,
+      content: `Triggered workflow: ${params.workflowId}`,
+      signalData: {
+        type: 'trigger',
+        payload: {
+          workflowId: params.workflowId,
+          to: params.to,
+          transactionId: params.transactionId,
+        },
+      },
+    });
+  }
+
+  async isWorkflowOriginHydrated(
+    environmentId: string,
+    conversationId: string,
+    platformMessageId: string
+  ): Promise<boolean> {
+    const count = await this.activityRepository.count(
+      {
+        _environmentId: environmentId,
+        _conversationId: conversationId,
+        identifier: workflowOriginSignalIdentifier(platformMessageId),
+      },
+      1
+    );
+
+    return count > 0;
+  }
+
+  async persistWorkflowOriginHydration(params: PersistWorkflowOriginHydrationParams): Promise<void> {
+    await this.persistAgentMessage({
+      conversationId: params.conversationId,
+      channel: params.channel,
+      agentIdentifier: params.agentIdentifier,
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+      platformMessageId: params.platformMessageId,
+      platformThreadId: params.platformThreadId,
+      identifier: `workflow-dispatch-msg:${params.platformMessageId}`,
+      content: params.messageContent,
+    });
+
+    try {
+      await this.persistSignal({
+        conversationId: params.conversationId,
+        channel: params.channel,
+        agentIdentifier: params.agentIdentifier,
+        environmentId: params.environmentId,
+        organizationId: params.organizationId,
+        identifier: workflowOriginSignalIdentifier(params.platformMessageId),
+        platformThreadId: params.platformThreadId,
+        platformMessageId: params.platformMessageId,
+        content: `Workflow origin: ${String(params.signalData.workflowIdentifier ?? 'unknown')}`,
+        signalData: {
+          type: 'workflow_origin',
+          payload: params.signalData,
+        },
+      });
+    } catch (err) {
+      if (!isDuplicateKeyError(err)) {
+        throw err;
+      }
+
+      this.logger.warn(
+        { platformMessageId: params.platformMessageId, conversationId: params.conversationId },
+        'Workflow origin already hydrated'
+      );
+    }
+  }
+
+  async findByPlatformMessageId(
+    environmentId: string,
+    conversationId: string,
+    platformMessageId: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.activityRepository.findByPlatformMessageId(environmentId, conversationId, platformMessageId);
+  }
+
+  async findSourceActivity(
+    environmentId: string,
+    conversationId: string,
+    platformMessageId: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.findByPlatformMessageId(environmentId, conversationId, platformMessageId);
+  }
+
+  async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
+    return this.activityRepository.countAgentMessages(environmentId, conversationId);
+  }
+
+  async findAgentMessageByIdentifier(
+    environmentId: string,
+    conversationId: string,
+    identifier: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.activityRepository.findOne(
+      {
+        _environmentId: environmentId,
+        _conversationId: conversationId,
+        identifier,
+        type: ConversationActivityTypeEnum.MESSAGE,
+      },
+      '*'
+    );
+  }
+
+  async findToolActivitiesByPlanMessageId(
+    environmentId: string,
+    conversationId: string,
+    planMessageId: string
+  ): Promise<ConversationActivityEntity[]> {
+    return this.activityRepository.findToolActivitiesByPlanMessageId(environmentId, conversationId, planMessageId);
+  }
+
+  async persistToolUseSignal(
+    params: ConversationActivityContext & { content: string; payload: Record<string, unknown> }
+  ): Promise<void> {
+    await this.persistSignal({
+      ...params,
+      signalData: { type: 'tool-use', payload: params.payload },
+    });
+  }
+
+  async enrichToolUseSignal(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    activityId: string;
+    content: string;
+    payload: Record<string, unknown>;
+  }): Promise<void> {
+    await this.activityRepository.update(
+      {
+        _environmentId: params.environmentId,
+        _organizationId: params.organizationId,
+        _conversationId: params.conversationId,
+        _id: params.activityId,
+      },
+      { $set: { content: params.content, 'signalData.payload': params.payload } }
+    );
+  }
+
+  async repointSubscriberSender(params: {
+    environmentId: string;
+    organizationId: string;
+    fromSubscriberId: string;
+    toSubscriberId: string;
+  }): Promise<number> {
+    return this.activityRepository.repointSubscriberSender(params);
+  }
+
+  private async persistAgentActivity(
+    params: PersistAgentActivityParams & {
+      toolData?: ConversationActivityToolData;
+    },
+    type: ConversationActivityTypeEnum,
+    touch: 'activity' | 'preview'
+  ): Promise<ConversationActivityEntity> {
+    const threadId = params.platformThreadId ?? params.channel.platformThreadId;
+    const sequence = await this.resolveEventSequence(
+      params.conversationId,
+      params.environmentId,
+      params.organizationId,
+      params.sequence
+    );
+
+    const touchFn =
+      touch === 'activity'
+        ? this.conversationRepository.touchActivity.bind(this.conversationRepository)
+        : this.conversationRepository.touchPreview.bind(this.conversationRepository);
+
+    const [activity] = await Promise.all([
+      this.activityRepository.createAgentActivity({
+        identifier: params.identifier ?? `act_${shortId(12)}`,
+        conversationId: params.conversationId,
+        platform: params.channel.platform,
+        integrationId: params.channel._integrationId,
+        platformThreadId: threadId,
+        platformMessageId: params.platformMessageId,
+        agentId: params.agentIdentifier,
+        senderName: params.agentName,
+        content: params.content,
+        richContent: params.richContent,
+        toolData: params.toolData,
+        type,
+        sequence,
+        environmentId: params.environmentId,
+        organizationId: params.organizationId,
+      }),
+      touchFn(params.environmentId, params.organizationId, params.conversationId, params.content),
+    ]);
+
+    return activity;
+  }
+
+  private async resolveEventSequence(
+    conversationId: string,
+    environmentId: string,
+    organizationId: string,
+    sequence?: number
+  ): Promise<number> {
+    if (sequence !== undefined) {
+      return sequence;
+    }
+
+    return this.eventSequenceService.mint({
+      environmentId,
+      organizationId,
+      conversationId,
+    });
+  }
+
+  private async persistSignal(
+    params: ConversationActivityContext & {
+      content: string;
+      signalData: ConversationActivitySignalData;
+      identifier?: string;
+      platformMessageId?: string;
+      platformThreadId?: string;
+    }
+  ): Promise<void> {
+    await this.activityRepository.createSignalActivity({
+      identifier: params.identifier ?? `act_${shortId(12)}`,
+      conversationId: params.conversationId,
+      platform: params.channel.platform,
+      integrationId: params.channel._integrationId,
+      platformThreadId: params.platformThreadId ?? params.channel.platformThreadId,
+      agentId: params.agentIdentifier,
+      content: params.content,
+      signalData: params.signalData,
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+      platformMessageId: params.platformMessageId,
+    });
+  }
+
+  private async emitPersistedClientEvent(
+    params: ConversationActivityContext,
+    activity: ConversationActivityEntity
+  ): Promise<void> {
+    await this.agentChatLiveActivityPublisher.emitPersistedClientEvent({
+      channel: params.channel,
+      conversationId: params.conversationId,
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+      agentIdentifier: params.agentIdentifier,
+      activity,
+    });
   }
 }

--- a/apps/api/src/app/agents/conversation-runtime/ingress/reply-approval-interceptor.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/reply-approval-interceptor.service.spec.ts
@@ -25,8 +25,6 @@ describe('ReplyApprovalInterceptor', () => {
     const conversationService = {
       getPrimaryChannel: sinon.stub().returns(channel),
       persistToolApprovalDecision: sinon.stub().resolves(undefined),
-    };
-    const activityLedger = {
       listForView: sinon.stub().resolves({ data: history, hasMore: false }),
     };
     const outboundGateway = {
@@ -37,14 +35,9 @@ describe('ReplyApprovalInterceptor', () => {
       warn: sinon.stub(),
       setContext: sinon.stub(),
     };
-    const interceptor = new ReplyApprovalInterceptor(
-      conversationService as any,
-      activityLedger as any,
-      outboundGateway as any,
-      logger as any
-    );
+    const interceptor = new ReplyApprovalInterceptor(conversationService as any, outboundGateway as any, logger as any);
 
-    return { interceptor, conversationService, activityLedger, outboundGateway };
+    return { interceptor, conversationService, outboundGateway };
   }
 
   function makeTurn(overrides: Record<string, unknown> = {}) {
@@ -295,14 +288,14 @@ describe('ReplyApprovalInterceptor', () => {
   });
 
   it('should fall through when the platform has interactive buttons', async () => {
-    const { interceptor, activityLedger } = makeDeps();
+    const { interceptor, conversationService } = makeDeps();
     const runtime = { dispatch: sinon.stub().resolves(undefined) };
     const turn = makeTurn({ config: { ...makeTurn().config, platform: 'slack' } });
 
     const consumed = await interceptor.tryHandleAsApprovalReply(turn, runtime as any);
 
     expect(consumed).to.equal(false);
-    expect(activityLedger.listForView.called).to.equal(false);
+    expect(conversationService.listForView.called).to.equal(false);
     expect(runtime.dispatch.called).to.equal(false);
   });
 
@@ -566,38 +559,38 @@ describe('ReplyApprovalInterceptor', () => {
     });
 
     it('should fall through when the reaction was removed rather than added', async () => {
-      const { interceptor, activityLedger } = makeDeps();
+      const { interceptor, conversationService } = makeDeps();
       const runtime = { dispatch: sinon.stub().resolves(undefined) };
       const turn = makeReactionTurn({ reaction: { emoji: 'thumbs_up', added: false, messageId: 'msg-approval' } });
 
       const consumed = await interceptor.tryHandleAsApprovalReaction(turn, runtime as any);
 
       expect(consumed).to.equal(false);
-      expect(activityLedger.listForView.called).to.equal(false);
+      expect(conversationService.listForView.called).to.equal(false);
       expect(runtime.dispatch.called).to.equal(false);
     });
 
     it('should fall through for an emoji that is not a verdict', async () => {
-      const { interceptor, activityLedger } = makeDeps();
+      const { interceptor, conversationService } = makeDeps();
       const runtime = { dispatch: sinon.stub().resolves(undefined) };
       const turn = makeReactionTurn({ reaction: { emoji: 'heart', added: true, messageId: 'msg-approval' } });
 
       const consumed = await interceptor.tryHandleAsApprovalReaction(turn, runtime as any);
 
       expect(consumed).to.equal(false);
-      expect(activityLedger.listForView.called).to.equal(false);
+      expect(conversationService.listForView.called).to.equal(false);
       expect(runtime.dispatch.called).to.equal(false);
     });
 
     it('should fall through when the platform has interactive buttons', async () => {
-      const { interceptor, activityLedger } = makeDeps();
+      const { interceptor, conversationService } = makeDeps();
       const runtime = { dispatch: sinon.stub().resolves(undefined) };
       const turn = makeReactionTurn({ config: { ...makeTurn().config, platform: 'slack' } });
 
       const consumed = await interceptor.tryHandleAsApprovalReaction(turn, runtime as any);
 
       expect(consumed).to.equal(false);
-      expect(activityLedger.listForView.called).to.equal(false);
+      expect(conversationService.listForView.called).to.equal(false);
       expect(runtime.dispatch.called).to.equal(false);
     });
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/reply-approval-interceptor.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/reply-approval-interceptor.service.ts
@@ -16,7 +16,6 @@ import {
   resolveApprovalRequesterId,
 } from '../../shared/tool-approval/unresolved-approvals';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
-import { ConversationActivityLedger } from '../conversation/conversation-activity-ledger';
 import { OutboundGateway } from '../egress/outbound.gateway';
 import type { AgentRuntime } from '../runtime/agent-runtime.port';
 import type { ConversationTurn } from '../runtime/conversation-turn';
@@ -62,7 +61,6 @@ function quoteContainsToolName(normalizedQuote: string, toolName: string): boole
 export class ReplyApprovalInterceptor {
   constructor(
     private readonly conversationService: AgentConversationService,
-    private readonly activityLedger: ConversationActivityLedger,
     private readonly outboundGateway: OutboundGateway,
     private readonly logger: PinoLogger
   ) {
@@ -360,7 +358,7 @@ export class ReplyApprovalInterceptor {
     const { config, conversation } = turn;
 
     try {
-      const page = await this.activityLedger.listForView({
+      const page = await this.conversationService.listForView({
         view: 'approval_activities',
         environmentId: config.environmentId,
         organizationId: config.organizationId,

--- a/apps/api/src/app/agents/conversation-runtime/link/confirm-linked-auth-cards.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/link/confirm-linked-auth-cards.usecase.ts
@@ -1,11 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InstrumentUsecase, PinoLogger } from '@novu/application-generic';
-import {
-  ConversationActivityRepository,
-  ConversationChannel,
-  ConversationEntity,
-  ConversationRepository,
-} from '@novu/dal';
+import { ConversationChannel, ConversationEntity, ConversationRepository } from '@novu/dal';
 import { AGENT_AUTH_METADATA_KEYS } from '@novu/shared';
 import type { CardElement } from 'chat';
 import { AgentConfigResolver } from '../../channels/agent-config-resolver.service';
@@ -28,7 +23,6 @@ import { ConfirmLinkedAuthCardsCommand } from './confirm-linked-auth-cards.comma
 export class ConfirmLinkedAuthCards {
   constructor(
     private readonly conversationRepository: ConversationRepository,
-    private readonly conversationActivityRepository: ConversationActivityRepository,
     private readonly outboundGateway: OutboundGateway,
     private readonly conversationService: AgentConversationService,
     private readonly agentConfigResolver: AgentConfigResolver,
@@ -143,9 +137,10 @@ export class ConfirmLinkedAuthCards {
     conversationId: string,
     storedMessageId: string
   ): Promise<string | undefined> {
-    const activity = await this.conversationActivityRepository.findOne(
-      { _environmentId: environmentId, _conversationId: conversationId, identifier: storedMessageId },
-      ['platformMessageId']
+    const activity = await this.conversationService.findAgentMessageByIdentifier(
+      environmentId,
+      conversationId,
+      storedMessageId
     );
 
     if (activity?.platformMessageId) {

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase.ts
@@ -1,9 +1,8 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import { PinoLogger, shortId } from '@novu/application-generic';
+import { PinoLogger } from '@novu/application-generic';
 import {
   AgentRepository,
   ConversationActivityEntity,
-  ConversationActivityRepository,
   type ConversationChannel,
   ConversationEntity,
   ConversationRepository,
@@ -27,7 +26,6 @@ interface ToolTask {
 @Injectable()
 export class HandlePlanProgress {
   constructor(
-    private readonly activityRepository: ConversationActivityRepository,
     private readonly agentRepository: AgentRepository,
     private readonly conversationRepository: ConversationRepository,
     private readonly conversationService: AgentConversationService,
@@ -52,7 +50,7 @@ export class HandlePlanProgress {
     const channel = this.conversationService.getPrimaryChannel(conversation);
     const activePlanMessageId = conversation.activePlanMessageId;
     const existingActivities = activePlanMessageId
-      ? await this.activityRepository.findToolActivitiesByPlanMessageId(
+      ? await this.conversationService.findToolActivitiesByPlanMessageId(
           command.environmentId,
           command.conversationId,
           activePlanMessageId
@@ -205,32 +203,25 @@ export class HandlePlanProgress {
     if (isEnrichingInProgress) {
       const activity = this.findLatestInProgressToolActivity(existingActivities, taskInput.id);
       if (activity) {
-        await this.activityRepository.update(
-          {
-            _environmentId: command.environmentId,
-            _organizationId: command.organizationId,
-            _conversationId: command.conversationId,
-            _id: activity._id,
-          },
-          { $set: { content, 'signalData.payload': payload } }
-        );
+        await this.conversationService.enrichToolUseSignal({
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          conversationId: command.conversationId,
+          activityId: activity._id,
+          content,
+          payload,
+        });
 
         return;
       }
     }
 
-    await this.activityRepository.createSignalActivity({
-      identifier: `act_${shortId(12)}`,
+    await this.conversationService.persistToolUseSignal({
       conversationId: command.conversationId,
-      platform: channel.platform,
-      integrationId: channel._integrationId,
-      platformThreadId: channel.platformThreadId,
-      agentId: command.agentIdentifier,
+      channel,
+      agentIdentifier: command.agentIdentifier,
       content,
-      signalData: {
-        type: 'tool-use',
-        payload,
-      },
+      payload,
       environmentId: command.environmentId,
       organizationId: command.organizationId,
     });

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.spec.ts
@@ -33,18 +33,18 @@ describe('BridgeExecutorService', () => {
   ) {
     const logger = makeLogger();
     const attachmentStorage = overrides.attachmentStorage ?? { signRead: sinon.stub().resolves('https://signed/read') };
-    const activityLedger = { listForView: sinon.stub().resolves({ data: [], hasMore: false }) };
+    const conversationService = { listForView: sinon.stub().resolves({ data: [], hasMore: false }) };
     const featureFlagsService = makeFeatureFlagsService(overrides.isEventProtocolEnabled);
 
     const service = new BridgeExecutorService(
       {} as any,
       logger as any,
       attachmentStorage as any,
-      activityLedger as any,
+      conversationService as any,
       featureFlagsService as unknown as FeatureFlagsService
     );
 
-    return { service, logger, attachmentStorage, activityLedger, featureFlagsService };
+    return { service, logger, attachmentStorage, conversationService, featureFlagsService };
   }
 
   function makeExecutionParams() {

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
@@ -35,7 +35,7 @@ import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.servic
 import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { buildAgentApiRootUrl } from '../../shared/util/agent-api-root-url';
 import { AgentAttachmentStorage, type StoredAttachment } from '../conversation/agent-attachment-storage.service';
-import { ConversationActivityLedger } from '../conversation/conversation-activity-ledger';
+import { AgentConversationService } from '../conversation/agent-conversation.service';
 
 const MAX_RETRIES = 2;
 
@@ -171,7 +171,7 @@ export class BridgeExecutorService {
     private readonly getDecryptedSecretKey: GetDecryptedSecretKey,
     private readonly logger: PinoLogger,
     private readonly attachmentStorage: AgentAttachmentStorage,
-    private readonly activityLedger: ConversationActivityLedger,
+    private readonly conversationService: AgentConversationService,
     private readonly featureFlagsService: FeatureFlagsService
   ) {
     this.logger.setContext(this.constructor.name);
@@ -421,7 +421,7 @@ export class BridgeExecutorService {
     organizationId: string
   ): Promise<ConversationActivityEntity[]> {
     try {
-      const page = await this.activityLedger.listForView({
+      const page = await this.conversationService.listForView({
         view: 'agent_handoff',
         environmentId,
         organizationId,

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-expire-superseded-approvals.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-expire-superseded-approvals.service.spec.ts
@@ -36,8 +36,6 @@ describe('BridgeExpireSupersededApprovalsService', () => {
     const conversationService = {
       getPrimaryChannel: sinon.stub().returns(channel),
       persistToolApprovalDecision: sinon.stub().resolves(undefined),
-    };
-    const activityLedger = {
       listForView: sinon.stub().resolves({ data: [pendingRequest], hasMore: false }),
     };
     const outboundGateway = {
@@ -46,7 +44,6 @@ describe('BridgeExpireSupersededApprovalsService', () => {
     };
     const service = new BridgeExpireSupersededApprovalsService(
       conversationService as any,
-      activityLedger as any,
       outboundGateway as any,
       makeLogger() as any
     );
@@ -93,8 +90,6 @@ describe('BridgeExpireSupersededApprovalsService', () => {
     const conversationService = {
       getPrimaryChannel: sinon.stub().returns({ platform: 'slack', platformThreadId: 'thread-1' }),
       persistToolApprovalDecision: sinon.stub().resolves(undefined),
-    };
-    const activityLedger = {
       listForView: sinon.stub().resolves({ data: [approvedDecision, request], hasMore: false }),
     };
     const outboundGateway = {
@@ -102,7 +97,6 @@ describe('BridgeExpireSupersededApprovalsService', () => {
     };
     const service = new BridgeExpireSupersededApprovalsService(
       conversationService as any,
-      activityLedger as any,
       outboundGateway as any,
       makeLogger() as any
     );
@@ -125,8 +119,6 @@ describe('BridgeExpireSupersededApprovalsService', () => {
     const conversationService = {
       getPrimaryChannel: sinon.stub().returns({ platform: 'slack', platformThreadId: 'thread-1' }),
       persistToolApprovalDecision: sinon.stub().resolves(undefined),
-    };
-    const activityLedger = {
       listForView: sinon.stub().resolves({ data: [pendingRequest], hasMore: false }),
     };
     const outboundGateway = {
@@ -134,7 +126,6 @@ describe('BridgeExpireSupersededApprovalsService', () => {
     };
     const service = new BridgeExpireSupersededApprovalsService(
       conversationService as any,
-      activityLedger as any,
       outboundGateway as any,
       makeLogger() as any
     );

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-expire-superseded-approvals.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-expire-superseded-approvals.service.ts
@@ -12,7 +12,6 @@ import {
   findUnresolvedToolApprovalRequests,
 } from '../../shared/tool-approval/unresolved-approvals';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
-import { ConversationActivityLedger } from '../conversation/conversation-activity-ledger';
 import { OutboundGateway } from '../egress/outbound.gateway';
 import type { ConversationTurn } from './conversation-turn';
 
@@ -28,7 +27,6 @@ import type { ConversationTurn } from './conversation-turn';
 export class BridgeExpireSupersededApprovalsService {
   constructor(
     private readonly conversationService: AgentConversationService,
-    private readonly activityLedger: ConversationActivityLedger,
     private readonly outboundGateway: OutboundGateway,
     private readonly logger: PinoLogger
   ) {
@@ -37,7 +35,7 @@ export class BridgeExpireSupersededApprovalsService {
 
   async expireOnNewMessage(turn: ConversationTurn): Promise<void> {
     const { config, conversation } = turn;
-    const page = await this.activityLedger.listForView({
+    const page = await this.conversationService.listForView({
       view: 'approval_activities',
       environmentId: config.environmentId,
       organizationId: config.organizationId,

--- a/apps/api/src/app/agents/managed-runtime/managed-agent.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent.service.ts
@@ -3,7 +3,6 @@ import { type IAgentRuntimeProvider, PinoLogger } from '@novu/application-generi
 import {
   type AgentEntity,
   AgentRepository,
-  ConversationActivityRepository,
   ConversationActivitySenderTypeEnum,
   ConversationActivityTypeEnum,
   ConversationEntity,
@@ -17,7 +16,6 @@ import type { Request, Response } from 'express';
 import type { ResolvedAgentConfig } from '../channels/agent-config-resolver.service';
 import { InboundAckService } from '../conversation-runtime/ack/inbound-ack.service';
 import { AgentConversationService } from '../conversation-runtime/conversation/agent-conversation.service';
-import { ConversationActivityLedger } from '../conversation-runtime/conversation/conversation-activity-ledger';
 import { AgentMcpSessionService } from '../mcp/runtime/agent-mcp-session.service';
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
 import { AgentRuntimeDefinitionService } from './agent-runtime-definition.service';
@@ -70,9 +68,7 @@ export class ManagedAgentService implements OnModuleInit {
     private readonly providerFactory: ManagedAgentProviderFactory,
     private readonly eventHandler: ManagedAgentEventHandler,
     private readonly conversationRepository: ConversationRepository,
-    private readonly conversationActivityRepository: ConversationActivityRepository,
     private readonly conversationService: AgentConversationService,
-    private readonly activityLedger: ConversationActivityLedger,
     private readonly subscriberRepository: SubscriberRepository,
     private readonly agentMcpSessionService: AgentMcpSessionService,
     private readonly demoQuota: DemoClaudeQuotaPolicy,
@@ -119,9 +115,7 @@ export class ManagedAgentService implements OnModuleInit {
       subscriberMongoId: context.subscriber?._id,
     });
 
-    const messages = sessionId
-      ? buildLiveSessionMessages(context)
-      : await this.buildMessagesWithHistory(context);
+    const messages = sessionId ? buildLiveSessionMessages(context) : await this.buildMessagesWithHistory(context);
 
     const sendResult = await provider.send({
       messages,
@@ -166,13 +160,10 @@ export class ManagedAgentService implements OnModuleInit {
     pendingPlatformMessageId: string;
     agent: Pick<AgentEntity, '_id' | 'managedRuntime'>;
   }): Promise<ManagedAgentDispatchResult | null> {
-    const activity = await this.conversationActivityRepository.findOne(
-      {
-        _conversationId: params.conversation._id,
-        _environmentId: params.config.environmentId,
-        platformMessageId: params.pendingPlatformMessageId,
-      },
-      '*'
+    const activity = await this.conversationService.findByPlatformMessageId(
+      params.config.environmentId,
+      String(params.conversation._id),
+      params.pendingPlatformMessageId
     );
 
     if (!activity) {
@@ -412,7 +403,7 @@ export class ManagedAgentService implements OnModuleInit {
   }
 
   private async buildMessagesWithHistory(context: ManagedAgentContext): Promise<Message[]> {
-    const page = await this.activityLedger.listForView({
+    const page = await this.conversationService.listForView({
       view: 'llm_transcript',
       environmentId: context.config.environmentId,
       organizationId: context.config.organizationId,

--- a/apps/api/src/app/agents/shared/agent-event-sink.service.ts
+++ b/apps/api/src/app/agents/shared/agent-event-sink.service.ts
@@ -1,18 +1,11 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { type AgentEvent, type AgentEventEnvelope, isDeltaEvent } from '@novu/agent-event-protocol';
 import { PinoLogger } from '@novu/application-generic';
-import {
-  ConversationActivityEntity,
-  ConversationActivityRepository,
-  type ConversationChannel,
-  ConversationRepository,
-} from '@novu/dal';
+import { ConversationActivityEntity, type ConversationChannel, ConversationRepository } from '@novu/dal';
 import { isNovuInternalToolName } from '@novu/shared';
 import type { Response as ThalamusResponse } from '@novu/thalamus';
-import { AgentChatLiveActivityPublisher } from '../agent-chat/agent-chat-live-activity.publisher';
 import { InboundAckService } from '../conversation-runtime/ack/inbound-ack.service';
 import { AgentConversationService } from '../conversation-runtime/conversation/agent-conversation.service';
-import { ConversationActivityLedger } from '../conversation-runtime/conversation/conversation-activity-ledger';
 import { type RunLifecycleEvent } from '../conversation-runtime/conversation/run-lifecycle-activity';
 import { OutboundGateway } from '../conversation-runtime/egress/outbound.gateway';
 import { HandleAgentReplyCommand } from '../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command';
@@ -77,12 +70,9 @@ export class AgentEventSink {
     private readonly inboundAck: InboundAckService,
     private readonly demoQuota: DemoClaudeQuotaPolicy,
     private readonly conversationRepository: ConversationRepository,
-    private readonly activityRepository: ConversationActivityRepository,
-    private readonly activityLedger: ConversationActivityLedger,
     private readonly outboundGateway: OutboundGateway,
     private readonly conversationService: AgentConversationService,
     private readonly mcpConnectionErrorHandler: McpConnectionErrorHandler,
-    private readonly agentChatLiveActivityPublisher: AgentChatLiveActivityPublisher,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -763,7 +753,7 @@ export class AgentEventSink {
     }
 
     try {
-      const activity = await this.activityLedger.persistProtocolEvent({
+      await this.conversationService.persistRunLifecycle({
         conversationId: context.conversationId,
         channel,
         agentIdentifier: context.agentIdentifier,
@@ -772,17 +762,6 @@ export class AgentEventSink {
         runId,
         event,
       });
-
-      if (activity) {
-        await this.agentChatLiveActivityPublisher.emitPersistedClientEvent({
-          channel,
-          conversationId: context.conversationId,
-          environmentId: context.environmentId,
-          organizationId: context.organizationId,
-          agentIdentifier: context.agentIdentifier,
-          activity,
-        });
-      }
     } catch (err) {
       this.logger.error(err, `run lifecycle persist failed: run=${runId}`);
       captureAgentException(err, {
@@ -802,9 +781,10 @@ export class AgentEventSink {
       return false;
     }
 
-    const existing = await this.activityRepository.findOne(
-      { _environmentId: environmentId, _conversationId: conversationId, identifier: messageId },
-      '*'
+    const existing = await this.conversationService.findAgentMessageByIdentifier(
+      environmentId,
+      conversationId,
+      messageId
     );
 
     return existing !== null;
@@ -830,9 +810,10 @@ export class AgentEventSink {
     }
 
     for (let attempt = 0; attempt < ACTIVITY_RESOLVE_MAX_ATTEMPTS; attempt += 1) {
-      const activity = await this.activityRepository.findOne(
-        { _environmentId: environmentId, _conversationId: conversationId, identifier: messageId },
-        '*'
+      const activity = await this.conversationService.findAgentMessageByIdentifier(
+        environmentId,
+        conversationId,
+        messageId
       );
 
       if (activity) {
@@ -844,7 +825,7 @@ export class AgentEventSink {
       }
     }
 
-    return this.activityRepository.findByPlatformMessageId(environmentId, conversationId, messageId);
+    return this.conversationService.findByPlatformMessageId(environmentId, conversationId, messageId);
   }
 
   private async resolveConversationAgentId(context: AgentEventContext): Promise<string | null> {

--- a/biome.json
+++ b/biome.json
@@ -269,6 +269,96 @@
       }
     },
     {
+      "includes": [
+        "apps/api/src/app/agents/**/*.{ts,tsx,js}",
+        "!apps/api/src/app/agents/agents.module.ts",
+        "!apps/api/src/app/agents/conversation-runtime/conversation/conversation-activity-ledger.ts",
+        "!apps/api/src/app/agents/conversation-runtime/conversation/conversation-event-sequence.service.ts",
+        "!apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts",
+        "!apps/api/src/app/agents/**/*.spec.ts",
+        "!apps/api/src/app/agents/**/*.test.ts",
+        "!apps/api/src/app/agents/**/*.e2e.ts",
+        "!apps/api/src/app/agents/e2e/**/*.{ts,tsx,js}"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "@novu/*/**/*": "Please import only from the root package entry point. For example, use 'import { Client } from '@novu/api';' instead of 'import { Client } from '@novu/api/src';'",
+                  "@nestjs/common": {
+                    "importNames": ["Logger"],
+                    "message": "Please use the PinoLogger from @novu/application-generic instead"
+                  },
+                  "@novu/application-generic": {
+                    "importNames": ["Logger", "validateUrlSsrf"],
+                    "message": "Logger: use PinoLogger from @novu/application-generic. validateUrlSsrf: use safeOutboundRequest / safeOutboundJsonRequest (or HttpClientService with enforceSsrfProtection: true) — see https://novu.atlassian.net/browse/NV-7560"
+                  },
+                  "@novu/shared/utils/ssrf-url-validation": {
+                    "importNames": ["validateUrlSsrf"],
+                    "message": "validateUrlSsrf is a one-shot pre-flight check vulnerable to redirects and DNS rebinding. Use safeOutboundRequest / safeOutboundJsonRequest from '@novu/shared/utils/safe-outbound-http' (or HttpClientService with enforceSsrfProtection: true)."
+                  },
+                  "@novu/dal": {
+                    "importNames": ["ConversationActivityRepository"],
+                    "message": "Import ConversationActivityRepository only from agents.module.ts, conversation-activity-ledger.ts, conversation-event-sequence.service.ts, or test files — see https://novu.atlassian.net/browse/NV-8576"
+                  },
+                  "svix": {
+                    "importNames": ["Svix"],
+                    "message": "Please use the SvixClient from @novu/application-generic instead"
+                  },
+                  "@nestjs/swagger": {
+                    "importNames": [
+                      "ApiOkResponse",
+                      "ApiCreatedResponse",
+                      "ApiAcceptedResponse",
+                      "ApiNoContentResponse",
+                      "ApiMovedPermanentlyResponse",
+                      "ApiFoundResponse",
+                      "ApiBadRequestResponse",
+                      "ApiUnauthorizedResponse",
+                      "ApiTooManyRequestsResponse",
+                      "ApiNotFoundResponse",
+                      "ApiInternalServerErrorResponse",
+                      "ApiBadGatewayResponse",
+                      "ApiConflictResponse",
+                      "ApiForbiddenResponse",
+                      "ApiGatewayTimeoutResponse",
+                      "ApiGoneResponse",
+                      "ApiMethodNotAllowedResponse",
+                      "ApiNotAcceptableResponse",
+                      "ApiNotImplementedResponse",
+                      "ApiPreconditionFailedResponse",
+                      "ApiPayloadTooLargeResponse",
+                      "ApiRequestTimeoutResponse",
+                      "ApiServiceUnavailableResponse",
+                      "ApiUnprocessableEntityResponse",
+                      "ApiUnsupportedMediaTypeResponse",
+                      "ApiDefaultResponse"
+                    ],
+                    "message": "Use 'Api<Error>Response' from '/shared/framework/response.decorator' instead."
+                  }
+                },
+                "patterns": [
+                  {
+                    "group": ["**/conversation-activity-ledger", "**/conversation-activity-ledger.ts"],
+                    "importNamePattern": "ConversationActivityLedger",
+                    "message": "Import ConversationActivityLedger only from agents.module.ts, agent-conversation.service.ts, or test files — see https://novu.atlassian.net/browse/NV-8576"
+                  },
+                  {
+                    "group": ["**/conversation-event-sequence.service", "**/conversation-event-sequence.service.ts"],
+                    "importNamePattern": "ConversationEventSequenceService",
+                    "message": "Import ConversationEventSequenceService only from agents.module.ts, conversation-activity-ledger.ts, or test files — see https://novu.atlassian.net/browse/NV-8576"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "includes": ["libs/application-generic/**/*.{ts,tsx,js}"],
       "linter": {
         "rules": {


### PR DESCRIPTION
## Summary
- make `AgentConversationService` the only feature-facing conversation interface
- move activity persistence, lookup, idempotency, sequencing, and selected live fan-out into the private `ConversationActivityLedger`
- rewire agent feature callers away from direct ledger, sequence service, and activity repository access
- add a scoped Biome guard that prevents future feature code from bypassing the service

## Architecture

```mermaid
flowchart LR
  Feature[Agent feature code] --> Service[AgentConversationService]
  Service --> ConversationRepo[(ConversationRepository)]
  Service --> Ledger[ConversationActivityLedger]
  Ledger --> ActivityRepo[(ConversationActivityRepository)]
  Ledger --> Sequence[ConversationEventSequenceService]
  Ledger --> Publisher[Live activity publisher]
```

Messages persist without live fan-out from the ledger; platform delivery owns message WebSocket delivery. Run, tool, approval, and MCP activities emit after successful persistence. Typing only mints a sequence and does not create an activity row.

## Breaking changes
- None. Existing `AgentConversationService` method names remain available.

## Test plan
- [x] Pre-commit `lint-staged` (Biome and stop-only)
- [x] `pnpm biome lint apps/api/src/app/agents` (no errors; existing warnings remain)
- [x] Positive and negative Biome import-guard fixtures
- [x] Monorepo build completed for 34 projects
- [ ] Agent unit suite and `agent-events-ingest.e2e.ts` (local runner could not resolve built workspace packages)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes feature-facing conversation activity access behind `AgentConversationService`, moving persistence, sequencing, activity lookup, and selected live publication into the private ledger.
- Rewires agent feature services away from direct ledger, sequence-service, and activity-repository access.
- Preserves conversation lifecycle orchestration while delegating activity operations.
- Adds a scoped Biome import guard to enforce the service boundary.
- Updates unit tests around delegation and ledger behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failure identified.

The centralized service delegates to ledger implementations that preserve the existing persistence, sequencing, idempotency, query scoping, and live-publication contracts, and the rewired providers remain available through the agents module.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts | Retains conversation lifecycle ownership and exposes delegated activity, lookup, and sequencing operations through the centralized feature interface. |
| apps/api/src/app/agents/conversation-runtime/conversation/conversation-activity-ledger.ts | Consolidates activity persistence, idempotency, sequencing, repository access, and selected post-persistence live publication without an established behavioral regression. |
| apps/api/src/app/agents/shared/agent-event-sink.service.ts | Replaces direct activity, ledger, and publisher dependencies with equivalent AgentConversationService calls. |
| apps/api/src/app/agents/agents.module.ts | Keeps the service and private ledger registered while removing the ledger from the module's public exports. |
| biome.json | Adds scoped import restrictions that prevent feature code from bypassing AgentConversationService. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Feature[Agent feature code] --> Service[AgentConversationService]
  Service --> ConversationRepo[(ConversationRepository)]
  Service --> Ledger[ConversationActivityLedger]
  Ledger --> ActivityRepo[(ConversationActivityRepository)]
  Ledger --> Sequence[ConversationEventSequenceService]
  Ledger --> Publisher[Agent Chat live publisher]
```

<sub>Reviews (1): Last reviewed commit: ["refactor(api-service): centralize agent ..."](https://github.com/novuhq/novu/commit/a7678a91cafdba2c7bf063e17168979d6d518c4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53964155)</sub>

**Context used:**

- Knowledge Base — [API App (apps/api)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/api-app.md)
- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)

<!-- /greptile_comment -->