### PR TITLE
feat(activity): show message preview in Workflow Activity feed

### DIFF
--- a/apps/api/src/app/activity/dtos/workflow-run-response.dto.ts
+++ b/apps/api/src/app/activity/dtos/workflow-run-response.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { StepRunStatus } from '@novu/application-generic';
-import { ExecutionDetailsStatusEnum } from '@novu/shared';
+import { ChannelTypeEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
 import { Type } from 'class-transformer';
 import { IsDate, IsEnum, IsIn, IsObject, IsOptional, IsString } from 'class-validator';
 import { DigestMetadataDto } from '../../notifications/dtos/activities-response.dto';
@@ -98,6 +98,40 @@ export class StepRunDto {
     type: Number,
   })
   scheduleExtensionsCount?: number;
+
+  @ApiPropertyOptional({
+    description: 'Identifier of the delivered message entity, used to render the channel preview',
+  })
+  @IsOptional()
+  @IsString()
+  messageId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Channel type of the delivered message (email, sms, push, chat, in_app)',
+    enum: ChannelTypeEnum,
+    enumName: 'ChannelTypeEnum',
+  })
+  @IsOptional()
+  @IsEnum(ChannelTypeEnum)
+  channel?: ChannelTypeEnum;
+
+  @ApiPropertyOptional({
+    description:
+      'Rendered message content. For email this is the final HTML; for sms/push/chat it is the plain text body.',
+  })
+  @IsOptional()
+  @IsString()
+  content?: string | null;
+
+  @ApiPropertyOptional({ description: 'Subject of the delivered message (email channel)' })
+  @IsOptional()
+  @IsString()
+  subject?: string | null;
+
+  @ApiPropertyOptional({ description: 'Title of the delivered message (push/in-app channels)' })
+  @IsOptional()
+  @IsString()
+  title?: string | null;
 }
 
 export class GetWorkflowRunResponseDto extends GetWorkflowRunResponseBaseDto {

--- a/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
@@ -9,7 +9,7 @@ import {
   WorkflowRun,
   WorkflowRunRepository,
 } from '@novu/application-generic';
-import { JobEntity, JobRepository } from '@novu/dal';
+import { JobEntity, JobRepository, MessageEntity, MessageRepository } from '@novu/dal';
 import { StepTypeEnum } from '@novu/shared';
 import { subDays } from 'date-fns';
 import { GetWorkflowRunResponseDto, StepRunDto } from '../../dtos/workflow-run-response.dto';
@@ -72,6 +72,7 @@ type TraceFetchResult = Pick<Trace, (typeof traceSelectColumns)[number]>;
 
 interface IStepRunWithDetails extends StepRunFetchResult {
   executionDetails?: TraceFetchResult[];
+  message?: Pick<MessageEntity, '_id' | 'content' | 'subject' | 'title' | 'channel'> | undefined;
 }
 
 @Injectable()
@@ -81,6 +82,7 @@ export class GetWorkflowRun {
     private stepRunRepository: StepRunRepository,
     private traceLogRepository: TraceLogRepository,
     private jobRepository: JobRepository,
+    private messageRepository: MessageRepository,
     private logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -241,12 +243,20 @@ export class GetWorkflowRun {
           ? await this.getJobDigestDataByTransactionId(workflowRun.transaction_id, command)
           : new Map<string, string | null>();
 
+      // Load the delivered message content for each step run so the activity feed
+      // can render a channel-aware preview (email HTML, SMS text, push/chat body).
+      const messageIds = stepRunsResult.data
+        .map((stepRun) => stepRun.message_id)
+        .filter((id): id is string => Boolean(id));
+      const messagesByMessageId = await this.getMessagesByMessageId(messageIds, command);
+
       return stepRunsResult.data.map(
         (stepRun) =>
           ({
             ...stepRun,
             executionDetails: executionDetailsByStepRunId.get(stepRun.step_run_id) || [],
             digest: stepRun.digest ? stepRun.digest : digestDataByStepId.get(stepRun.step_run_id) || null,
+            message: stepRun.message_id ? messagesByMessageId.get(stepRun.message_id) : undefined,
           }) satisfies IStepRunWithDetails
       );
     } catch (error) {
@@ -328,6 +338,12 @@ export class GetWorkflowRun {
   }
 
   private mapStepRunToDto(stepRun: IStepRunWithDetails): StepRunDto {
+    const message = stepRun.message;
+
+    // Email content is persisted as the rendered HTML string; for other channels
+    // it is the plain text body. Stringify block-array content defensively.
+    const normalizedContent = this.normalizeMessageContent(message?.content);
+
     return {
       stepRunId: stepRun.step_run_id,
       stepId: stepRun.step_id,
@@ -339,7 +355,79 @@ export class GetWorkflowRun {
       digest: stepRun.digest ? JSON.parse(stepRun.digest) : undefined,
       executionDetails: mapTraceToExecutionDetailDto(stepRun.executionDetails || []),
       scheduleExtensionsCount: stepRun.schedule_extensions_count,
+      messageId: stepRun.message_id || undefined,
+      channel: message?.channel,
+      content: normalizedContent ?? null,
+      subject: message?.subject ?? null,
+      title: message?.title ?? null,
     };
+  }
+
+  /**
+   * Email message content can be stored either as a rendered HTML string or as an
+   * array of IEmailBlock. The activity feed preview only needs the HTML form, so we
+   * collapse block arrays to a best-effort text preview and leave strings untouched.
+   */
+  private normalizeMessageContent(content: MessageEntity['content'] | undefined): string | null {
+    if (content == null) {
+      return null;
+    }
+
+    if (typeof content === 'string') {
+      return content.length > 0 ? content : null;
+    }
+
+    if (Array.isArray(content)) {
+      const text = content
+        .map((block) => (typeof block?.content === 'string' ? block.content : ''))
+        .filter(Boolean)
+        .join('\n');
+
+      return text.length > 0 ? text : null;
+    }
+
+    return null;
+  }
+
+  private async getMessagesByMessageId(
+    messageIds: string[],
+    command: GetWorkflowRunCommand
+  ): Promise<Map<string, Pick<MessageEntity, '_id' | 'content' | 'subject' | 'title' | 'channel'>>> {
+    const messagesByMessageId = new Map<
+      string,
+      Pick<MessageEntity, '_id' | 'content' | 'subject' | 'title' | 'channel'>
+    >();
+
+    if (messageIds.length === 0) {
+      return messagesByMessageId;
+    }
+
+    try {
+      const messages = await this.messageRepository.find(
+        {
+          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
+          _id: { $in: messageIds },
+        },
+        '_id content subject title channel'
+      );
+
+      for (const message of messages) {
+        messagesByMessageId.set(message._id, message);
+      }
+
+      return messagesByMessageId;
+    } catch (error) {
+      this.logger.warn(
+        {
+          error: error.message,
+          messageIds,
+        },
+        'Failed to get message content for step runs'
+      );
+
+      return messagesByMessageId;
+    }
   }
 
   private mapWorkflowRunToDto(

--- a/apps/dashboard/src/api/activity.ts
+++ b/apps/dashboard/src/api/activity.ts
@@ -33,6 +33,11 @@ export interface StepRunDto {
   executionDetails: any[];
   digest?: any;
   scheduleExtensionsCount?: number;
+  messageId?: string;
+  channel?: string;
+  content?: string | null;
+  subject?: string | null;
+  title?: string | null;
 }
 
 export interface GetWorkflowRunsDto {
@@ -129,12 +134,11 @@ function mapWorkflowRunToActivity(workflowRun: GetWorkflowRunResponse | GetWorkf
           _organizationId: workflowRun.organizationId,
           _creatorId: '',
           type: step.stepType as any,
-          content: '',
+          content: step.content ?? '',
           variables: [],
           name: step.stepType,
-          subject: '',
-          title: step.stepType,
-          preheader: '',
+          subject: step.subject ?? '',
+          title: step.title ?? step.stepType,
           senderName: '',
           _feedId: '',
           cta: {
@@ -162,6 +166,13 @@ function mapWorkflowRunToActivity(workflowRun: GetWorkflowRunResponse | GetWorkf
       createdAt: workflowRun.createdAt,
       updatedAt: workflowRun.updatedAt,
       scheduleExtensionsCount: step.scheduleExtensionsCount,
+      // Channel preview metadata used by the activity feed to render a
+      // channel-aware preview (email HTML, SMS text, push/chat body).
+      messageId: step.messageId,
+      channel: step.channel,
+      messageContent: step.content ?? null,
+      messageSubject: step.subject ?? null,
+      messageTitle: step.title ?? null,
     })),
   };
 }

--- a/apps/dashboard/src/components/activity/activity-job-item.tsx
+++ b/apps/dashboard/src/components/activity/activity-job-item.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent, CardHeader } from '../primitives/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../primitives/tooltip';
 import { TimeDisplayHoverCard } from '../time-display-hover-card';
 import TruncatedText from '../truncated-text';
+import { MessagePreview } from './components/message-preview';
 import { JOB_STATUS_CONFIG } from './constants';
 import { ExecutionDetailItem } from './execution-detail-item';
 
@@ -284,9 +285,28 @@ function getJobClasses(status: JobStatusEnum) {
 }
 
 function JobDetails({ job }: { job: IActivityJob }) {
+  const isDeliverableChannel =
+    job.type === StepTypeEnum.EMAIL ||
+    job.type === StepTypeEnum.SMS ||
+    job.type === StepTypeEnum.PUSH ||
+    job.type === StepTypeEnum.CHAT ||
+    job.type === StepTypeEnum.IN_APP;
+
+  const hasMessageContent = Boolean(job.messageId || job.messageContent || job.messageSubject || job.messageTitle);
+
+  const showPreview = isDeliverableChannel && hasMessageContent;
+
   return (
     <div className="border-t border-neutral-100 p-4">
       <div className="flex flex-col gap-4">
+        {showPreview && (
+          <MessagePreview
+            channel={job.channel}
+            content={job.messageContent}
+            subject={job.messageSubject}
+            title={job.messageTitle}
+          />
+        )}
         {job.executionDetails && job.executionDetails.length > 0 && (
           <div className="flex flex-col gap-2">
             {job.executionDetails.map((detail, index) => (

--- a/apps/dashboard/src/components/activity/components/message-preview.tsx
+++ b/apps/dashboard/src/components/activity/components/message-preview.tsx
@@ -1,0 +1,164 @@
+import { ChannelTypeEnum, ResourceOriginEnum } from '@novu/shared';
+import { RiInformationLine, RiMailLine, RiMessage3Line, RiNotification3Line, RiPhoneLine } from 'react-icons/ri';
+import { EmailPreviewBody } from '@/components/workflow-editor/steps/email/email-preview';
+import { SmsPhone } from '@/components/workflow-editor/steps/sms/sms-phone';
+import { cn } from '@/utils/ui';
+
+interface MessagePreviewProps {
+  channel?: ChannelTypeEnum;
+  content?: string | null;
+  subject?: string | null;
+  title?: string | null;
+  className?: string;
+}
+
+export function MessagePreview({ channel, content, subject, title, className }: MessagePreviewProps) {
+  const hasContent = typeof content === 'string' && content.length > 0;
+
+  if (!hasContent && !subject && !title) {
+    return <EmptyPreview label="No message content stored for this step" />;
+  }
+
+  switch (channel) {
+    case ChannelTypeEnum.EMAIL:
+      return <EmailChannelPreview content={content} subject={subject} className={className} />;
+    case ChannelTypeEnum.SMS:
+      return <SmsChannelPreview content={content} className={className} />;
+    case ChannelTypeEnum.PUSH:
+      return <PushChannelPreview content={content} title={title} className={className} />;
+    case ChannelTypeEnum.CHAT:
+    case ChannelTypeEnum.IN_APP:
+    case ChannelTypeEnum.TOOL:
+      return <TextChannelPreview content={content} title={title} className={className} />;
+    default:
+      return <TextChannelPreview content={content} title={title} className={className} />;
+  }
+}
+
+function PreviewShell({
+  icon,
+  label,
+  children,
+  className,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('overflow-hidden rounded-lg border border-neutral-200 bg-white', className)}>
+      <div className="flex items-center gap-1.5 border-b border-neutral-100 bg-neutral-50 px-3 py-2">
+        <span className="text-foreground-600">{icon}</span>
+        <span className="text-foreground-950 text-xs font-medium">{label}</span>
+      </div>
+      <div className="p-3">{children}</div>
+    </div>
+  );
+}
+
+function EmptyPreview({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-dashed border-neutral-200 bg-neutral-50 px-3 py-4">
+      <RiInformationLine className="text-foreground-400 h-4 w-4 shrink-0" />
+      <span className="text-foreground-400 text-xs">{label}</span>
+    </div>
+  );
+}
+
+function EmailChannelPreview({
+  content,
+  subject,
+  className,
+}: {
+  content?: string | null;
+  subject?: string | null;
+  className?: string;
+}) {
+  const body = typeof content === 'string' && content.length > 0 ? content : '';
+  const isHtml = body.trim().startsWith('<');
+
+  return (
+    <PreviewShell icon={<RiMailLine className="h-3.5 w-3.5" />} label="Email preview" className={className}>
+      <div className="flex flex-col gap-2">
+        {subject ? (
+          <div className="border-b border-neutral-100 pb-2">
+            <span className="text-foreground-950 block text-sm font-semibold">{subject}</span>
+          </div>
+        ) : null}
+        {body ? (
+          isHtml ? (
+            <EmailPreviewBody body={body} resourceOrigin={ResourceOriginEnum.NOVU_CLOUD} />
+          ) : (
+            <pre className="text-foreground-700 max-h-96 w-full overflow-auto whitespace-pre-wrap break-words rounded bg-neutral-50 p-2 text-xs">
+              {body}
+            </pre>
+          )
+        ) : (
+          <EmptyPreview label="No email body stored for this message" />
+        )}
+      </div>
+    </PreviewShell>
+  );
+}
+
+function SmsChannelPreview({ content, className }: { content?: string | null; className?: string }) {
+  const body = typeof content === 'string' ? content : '';
+
+  return (
+    <PreviewShell icon={<RiPhoneLine className="h-3.5 w-3.5" />} label="SMS preview" className={className}>
+      <div className="flex justify-center">
+        <SmsPhone smsBody={body} />
+      </div>
+    </PreviewShell>
+  );
+}
+
+function PushChannelPreview({
+  content,
+  title,
+  className,
+}: {
+  content?: string | null;
+  title?: string | null;
+  className?: string;
+}) {
+  const body = typeof content === 'string' ? content : '';
+
+  return (
+    <PreviewShell icon={<RiNotification3Line className="h-3.5 w-3.5" />} label="Push preview" className={className}>
+      <div className="flex max-w-sm flex-col gap-1 rounded-xl border border-neutral-200 bg-white p-3 shadow-xs">
+        {title ? <span className="text-foreground-950 text-sm font-semibold">{title}</span> : null}
+        {body ? <span className="text-foreground-600 text-xs">{body}</span> : null}
+        {!title && !body ? <span className="text-foreground-400 text-xs">No push content stored</span> : null}
+      </div>
+    </PreviewShell>
+  );
+}
+
+function TextChannelPreview({
+  content,
+  title,
+  className,
+}: {
+  content?: string | null;
+  title?: string | null;
+  className?: string;
+}) {
+  const body = typeof content === 'string' ? content : '';
+
+  return (
+    <PreviewShell icon={<RiMessage3Line className="h-3.5 w-3.5" />} label="Message preview" className={className}>
+      <div className="flex flex-col gap-1">
+        {title ? <span className="text-foreground-950 text-sm font-semibold">{title}</span> : null}
+        {body ? (
+          <pre className="text-foreground-700 max-h-96 w-full overflow-auto whitespace-pre-wrap break-words rounded bg-neutral-50 p-2 text-xs">
+            {body}
+          </pre>
+        ) : (
+          <EmptyPreview label="No message content stored" />
+        )}
+      </div>
+    </PreviewShell>
+  );
+}

--- a/apps/dashboard/src/components/activity/components/message-preview.tsx
+++ b/apps/dashboard/src/components/activity/components/message-preview.tsx
@@ -12,11 +12,13 @@ interface MessagePreviewProps {
   className?: string;
 }
 
+const BODY_NOT_STORED_LABEL = 'Message body was not stored for this delivery';
+
 export function MessagePreview({ channel, content, subject, title, className }: MessagePreviewProps) {
   const hasContent = typeof content === 'string' && content.length > 0;
 
   if (!hasContent && !subject && !title) {
-    return <EmptyPreview label="No message content stored for this step" />;
+    return <EmptyPreview label={BODY_NOT_STORED_LABEL} />;
   }
 
   switch (channel) {
@@ -95,7 +97,7 @@ function EmailChannelPreview({
             </pre>
           )
         ) : (
-          <EmptyPreview label="No email body stored for this message" />
+          <EmptyPreview label={BODY_NOT_STORED_LABEL} />
         )}
       </div>
     </PreviewShell>
@@ -104,6 +106,14 @@ function EmailChannelPreview({
 
 function SmsChannelPreview({ content, className }: { content?: string | null; className?: string }) {
   const body = typeof content === 'string' ? content : '';
+
+  if (!body) {
+    return (
+      <PreviewShell icon={<RiPhoneLine className="h-3.5 w-3.5" />} label="SMS preview" className={className}>
+        <EmptyPreview label={BODY_NOT_STORED_LABEL} />
+      </PreviewShell>
+    );
+  }
 
   return (
     <PreviewShell icon={<RiPhoneLine className="h-3.5 w-3.5" />} label="SMS preview" className={className}>
@@ -129,8 +139,11 @@ function PushChannelPreview({
     <PreviewShell icon={<RiNotification3Line className="h-3.5 w-3.5" />} label="Push preview" className={className}>
       <div className="flex max-w-sm flex-col gap-1 rounded-xl border border-neutral-200 bg-white p-3 shadow-xs">
         {title ? <span className="text-foreground-950 text-sm font-semibold">{title}</span> : null}
-        {body ? <span className="text-foreground-600 text-xs">{body}</span> : null}
-        {!title && !body ? <span className="text-foreground-400 text-xs">No push content stored</span> : null}
+        {body ? (
+          <span className="text-foreground-600 text-xs">{body}</span>
+        ) : (
+          <span className="text-foreground-400 text-xs">{BODY_NOT_STORED_LABEL}</span>
+        )}
       </div>
     </PreviewShell>
   );
@@ -156,7 +169,7 @@ function TextChannelPreview({
             {body}
           </pre>
         ) : (
-          <EmptyPreview label="No message content stored" />
+          <EmptyPreview label={BODY_NOT_STORED_LABEL} />
         )}
       </div>
     </PreviewShell>

--- a/packages/shared/src/entities/job/job.interface.ts
+++ b/packages/shared/src/entities/job/job.interface.ts
@@ -1,4 +1,4 @@
-import { EnvironmentId, ITenantDefine, OrganizationId, StepTypeEnum } from '../../types';
+import { ChannelTypeEnum, EnvironmentId, ITenantDefine, OrganizationId, StepTypeEnum } from '../../types';
 import { INotificationTemplateStep } from '../notification-template';
 import { IWorkflowStepMetadata } from '../step';
 import { JobStatusEnum } from './status.enum';
@@ -32,4 +32,12 @@ export interface IJob {
   type?: StepTypeEnum;
   _actorId?: string;
   scheduleExtensionsCount?: number;
+  // Activity feed channel preview metadata. Populated from the delivered
+  // MessageEntity so the activity feed can render the actual message content
+  // (email HTML, SMS text, push/chat body) without re-fetching per step.
+  messageId?: string;
+  channel?: ChannelTypeEnum;
+  messageContent?: string | null;
+  messageSubject?: string | null;
+  messageTitle?: string | null;
 }


### PR DESCRIPTION
Render channel-aware previews (email, SMS, push, in-app/chat) in the expanded job detail view of the Workflow Activity feed.

Pipeline:
- Backend get-workflow-run usecase fetches delivered MessageEntity data via getMessagesByMessageId() and maps channel/content/subject/title into StepRunDto
- Shared IJob and dashboard StepRunDto/mapping carry preview metadata (messageId/channel/messageContent/subject/title); dropped unused preheader fields
- New MessagePreview component renders per-channel previews; JobDetails renders it when a deliverable channel has message content

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds channel-aware delivered-message previews to expanded Workflow Activity job details.
- Fetches persisted message metadata while assembling workflow runs.
- Carries preview fields through the API, dashboard mapping, and shared job interface.
- Renders dedicated email, SMS, push, chat, and in-app preview layouts.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the default content-retention configuration still prevents the feature from showing delivered message bodies for non-in-app channels.

The previously reported failure remains: non-in-app message bodies are not persisted under the default configuration, while the new activity response has no alternative source for the rendered delivery content.

**Files Needing Attention:** apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts | Loads persisted messages and maps their preview metadata into step-run responses, but the previously reported default-retention limitation remains. |
| apps/dashboard/src/components/activity/components/message-preview.tsx | Adds channel-specific preview layouts and explicitly displays an unavailable-body state when content was not persisted. |
| apps/dashboard/src/api/activity.ts | Propagates the API preview metadata into activity jobs. |
| apps/dashboard/src/components/activity/activity-job-item.tsx | Displays previews for deliverable channel jobs that have message metadata. |
| apps/api/src/app/activity/dtos/workflow-run-response.dto.ts | Extends step-run responses with validated optional message-preview fields. |
| packages/shared/src/entities/job/job.interface.ts | Extends the shared job contract with optional channel-preview metadata. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Activity Dashboard
    participant API as GetWorkflowRun
    participant Steps as StepRunRepository
    participant Messages as MessageRepository
    UI->>API: Request workflow run
    API->>Steps: Load step runs and message IDs
    API->>Messages: Load persisted channel/content/subject/title
    Messages-->>API: Message metadata
    API-->>UI: StepRunDto with preview fields
    UI->>UI: Render channel-aware MessagePreview
```

<sub>Reviews (2): Last reviewed commit: ["fix(activity): clarify message preview w..."](https://github.com/novuhq/novu/commit/d7bf68e107c0b9286ef467a7075c97a9dfe147f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54033901)</sub>

<!-- /greptile_comment -->