### PR TITLE
fix(api-service): recover Slack multi-tool approvals and section limits fixes NV-8607

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -11,6 +11,7 @@ import { extractCardPlainText } from '../../shared/util/card-plain-text.util';
 import { toDeliveryError } from '../../shared/util/delivery-error.util';
 import { esmImport } from '../../shared/util/esm-import';
 import { buildBrandedMarkdownReply, contentHasPoweredByWatermark } from '../../shared/util/novu-powered-by-watermark';
+import { splitOversizedSlackText } from '../../shared/util/slack-section-limits';
 import { type AgentActionTokenBinding, AgentActionTokenService } from '../action-token/agent-action-token.service';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
 import { ChatInstanceRegistry, type ChatWithAdapters, type PlatformAdapters } from '../ingress/chat-instance.registry';
@@ -932,7 +933,10 @@ export class OutboundGateway {
 
     if (deliveryContent.card) {
       return {
-        card: deliveryContent.card,
+        card:
+          branding.platform === AgentPlatformEnum.SLACK
+            ? splitOversizedSlackText(deliveryContent.card)
+            : deliveryContent.card,
         ...(deliveryContent.files?.length ? { files: deliveryContent.files } : {}),
       } as AdapterPostableMessage;
     }

--- a/apps/api/src/app/agents/shared/agent-event-sink.service.ts
+++ b/apps/api/src/app/agents/shared/agent-event-sink.service.ts
@@ -652,9 +652,14 @@ export class AgentEventSink {
     }
 
     if (approvals.length === 0) {
-      this.logger.error({ runId }, 'paused run-finish carried zero approvals — skipping tool approval dispatch');
-
-      return;
+      // Expected when the run is parked on a tool whose `tool_use` event was emitted in an
+      // earlier run: approvals are accumulated per run, and a resumed stream is a live tail,
+      // so it never re-sees them. Dispatch anyway — HandlePendingToolApprovals falls back to
+      // reading the still-pending approvals off the session.
+      this.logger.warn(
+        { runId, sessionId },
+        'paused run-finish carried zero approvals — recovering pending approvals from the session'
+      );
     }
 
     try {
@@ -665,7 +670,7 @@ export class AgentEventSink {
         messages: [],
         finishReason: 'requires-action',
         usage: toThalamusUsage(event.usage),
-        actionsRequired: approvals.map(toActionRequired),
+        actionsRequired: approvals.length > 0 ? approvals.map(toActionRequired) : undefined,
       };
 
       await this.handlePendingToolApprovals.execute(

--- a/apps/api/src/app/agents/shared/agent-event-sink.service.ts
+++ b/apps/api/src/app/agents/shared/agent-event-sink.service.ts
@@ -652,10 +652,8 @@ export class AgentEventSink {
     }
 
     if (approvals.length === 0) {
-      // Expected when the run is parked on a tool whose `tool_use` event was emitted in an
-      // earlier run: approvals are accumulated per run, and a resumed stream is a live tail,
-      // so it never re-sees them. Dispatch anyway — HandlePendingToolApprovals falls back to
-      // reading the still-pending approvals off the session.
+      // Empty when the pending tool_use came from an earlier run (resumed streams are a live
+      // tail). HandlePendingToolApprovals recovers from the session.
       this.logger.warn(
         { runId, sessionId },
         'paused run-finish carried zero approvals — recovering pending approvals from the session'
@@ -670,7 +668,7 @@ export class AgentEventSink {
         messages: [],
         finishReason: 'requires-action',
         usage: toThalamusUsage(event.usage),
-        actionsRequired: approvals.length > 0 ? approvals.map(toActionRequired) : undefined,
+        actionsRequired: approvals.map(toActionRequired),
       };
 
       await this.handlePendingToolApprovals.execute(

--- a/apps/api/src/app/agents/shared/util/slack-section-limits.spec.ts
+++ b/apps/api/src/app/agents/shared/util/slack-section-limits.spec.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import type { CardElement } from 'chat';
+
+import { splitForSlackSections, splitOversizedSlackText } from './slack-section-limits';
+
+const LIMIT = 3000;
+const LONG_MARKDOWN = Array.from(
+  { length: 40 },
+  (_, index) => `Paragraph ${index}: ${'restaurant details '.repeat(12)}`
+).join('\n\n');
+
+describe('slack-section-limits', () => {
+  describe('splitForSlackSections', () => {
+    it('leaves text within the section limit untouched', () => {
+      expect(splitForSlackSections('short reply')).to.deep.equal(['short reply']);
+    });
+
+    it('splits a long reply on paragraph breaks without losing content', () => {
+      const chunks = splitForSlackSections(LONG_MARKDOWN);
+
+      expect(chunks.length).to.be.greaterThan(1);
+      expect(chunks.every((chunk) => chunk.length <= LIMIT)).to.equal(true);
+      expect(chunks.join('\n\n')).to.equal(LONG_MARKDOWN);
+    });
+
+    it('splits text that has no paragraph or line breaks to fall back on', () => {
+      const unbroken = 'x'.repeat(7500);
+      const chunks = splitForSlackSections(unbroken);
+
+      expect(chunks.every((chunk) => chunk.length <= LIMIT)).to.equal(true);
+      expect(chunks.join('')).to.equal(unbroken);
+    });
+  });
+
+  describe('splitOversizedSlackText', () => {
+    it('returns the same card when every text child fits', () => {
+      const card: CardElement = { type: 'card', children: [{ type: 'text', content: 'hello' }] };
+
+      expect(splitOversizedSlackText(card)).to.equal(card);
+    });
+
+    it('expands an oversized text child and keeps the trailing watermark', () => {
+      const card: CardElement = {
+        type: 'card',
+        children: [
+          { type: 'text', content: LONG_MARKDOWN },
+          { type: 'text', content: 'Powered by <https://novu.co|Novu>', style: 'muted' },
+        ],
+      };
+
+      const children = splitOversizedSlackText(card).children;
+      const textChildren = children.filter((child) => child.type === 'text');
+
+      expect(children.length).to.be.greaterThan(card.children.length);
+      expect(textChildren.every((child) => child.content.length <= LIMIT)).to.equal(true);
+      expect(textChildren[textChildren.length - 1]).to.deep.equal(card.children[1]);
+    });
+  });
+});

--- a/apps/api/src/app/agents/shared/util/slack-section-limits.spec.ts
+++ b/apps/api/src/app/agents/shared/util/slack-section-limits.spec.ts
@@ -30,6 +30,16 @@ describe('slack-section-limits', () => {
       expect(chunks.every((chunk) => chunk.length <= LIMIT)).to.equal(true);
       expect(chunks.join('')).to.equal(unbroken);
     });
+
+    it('prefers a space near the limit over a mid-word hard cut', () => {
+      const head = `${'a'.repeat(2900)} `;
+      const tail = 'b'.repeat(200);
+      const line = `${head}${tail}`;
+      const chunks = splitForSlackSections(line);
+
+      expect(chunks).to.deep.equal([head, tail]);
+      expect(chunks.join('')).to.equal(line);
+    });
   });
 
   describe('splitOversizedSlackText', () => {

--- a/apps/api/src/app/agents/shared/util/slack-section-limits.ts
+++ b/apps/api/src/app/agents/shared/util/slack-section-limits.ts
@@ -1,0 +1,88 @@
+import type { CardElement } from 'chat';
+
+/**
+ * Slack's per-section text limit. Crossing it does not truncate the section — Slack rejects
+ * the entire `chat.postMessage` payload with `invalid_blocks`, so the reply is lost instead
+ * of shortened.
+ */
+const SLACK_SECTION_TEXT_LIMIT = 3000;
+
+function pack(parts: string[], separator: string, limit: number, splitPart: (part: string) => string[]): string[] {
+  const chunks: string[] = [];
+  let current = '';
+
+  for (const part of parts) {
+    const candidate = current ? `${current}${separator}${part}` : part;
+
+    if (candidate.length <= limit) {
+      current = candidate;
+
+      continue;
+    }
+
+    if (current) {
+      chunks.push(current);
+      current = '';
+    }
+
+    if (part.length <= limit) {
+      current = part;
+
+      continue;
+    }
+
+    chunks.push(...splitPart(part));
+  }
+
+  if (current) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}
+
+function sliceToLimit(text: string, limit: number): string[] {
+  const chunks: string[] = [];
+
+  for (let index = 0; index < text.length; index += limit) {
+    chunks.push(text.slice(index, index + limit));
+  }
+
+  return chunks;
+}
+
+/** Prefer paragraph breaks, then line breaks, then a hard cut at `limit`. */
+export function splitForSlackSections(text: string, limit: number = SLACK_SECTION_TEXT_LIMIT): string[] {
+  if (text.length <= limit) {
+    return [text];
+  }
+
+  return pack(text.split('\n\n'), '\n\n', limit, (paragraph) =>
+    pack(paragraph.split('\n'), '\n', limit, (line) => sliceToLimit(line, limit))
+  );
+}
+
+/**
+ * Expands over-long text children into within-limit ones. The Slack adapter maps one text
+ * child to one section block; oversize sections are rejected as `invalid_blocks`.
+ */
+export function splitOversizedSlackText(card: CardElement): CardElement {
+  const needsSplit = card.children.some(
+    (child) => child.type === 'text' && child.content.length > SLACK_SECTION_TEXT_LIMIT
+  );
+
+  if (!needsSplit) {
+    return card;
+  }
+
+  return {
+    ...card,
+    children: card.children.flatMap((child) => {
+      if (child.type !== 'text' || child.content.length <= SLACK_SECTION_TEXT_LIMIT) {
+        return [child];
+      }
+
+      return splitForSlackSections(child.content).map((content) => ({ ...child, content }));
+    }),
+  };
+}

--- a/apps/api/src/app/agents/shared/util/slack-section-limits.ts
+++ b/apps/api/src/app/agents/shared/util/slack-section-limits.ts
@@ -41,17 +41,28 @@ function pack(parts: string[], separator: string, limit: number, splitPart: (par
   return chunks;
 }
 
+/** Last resort for a single oversize line: prefer a nearby space, else hard-cut. */
 function sliceToLimit(text: string, limit: number): string[] {
   const chunks: string[] = [];
+  let remaining = text;
 
-  for (let index = 0; index < text.length; index += limit) {
-    chunks.push(text.slice(index, index + limit));
+  while (remaining.length > limit) {
+    const window = remaining.slice(0, limit);
+    const spaceAt = window.lastIndexOf(' ');
+    const cut = spaceAt > Math.floor(limit / 2) ? spaceAt + 1 : limit;
+
+    chunks.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut);
+  }
+
+  if (remaining) {
+    chunks.push(remaining);
   }
 
   return chunks;
 }
 
-/** Prefer paragraph breaks, then line breaks, then a hard cut at `limit`. */
+/** Prefer paragraph breaks, then line breaks, then a space-aware cut at `limit`. */
 export function splitForSlackSections(text: string, limit: number = SLACK_SECTION_TEXT_LIMIT): string[] {
   if (text.length <= limit) {
     return [text];


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixes [NV-8607](https://linear.app/novu/issue/NV-8607/second-slack-tool-approval-card-missing-after-first-approval).

Two Slack agent delivery issues:

1. **Multi-tool approvals** — After approving the first tool, the next paused `run-finish` can arrive with an empty `approvals` list (resumed streams are a live tail and don't re-see earlier `tool_use` events). The sink used to return early, so the second Approve/Deny card never posted. It now still dispatches to `HandlePendingToolApprovals`, which recovers pending tools from the session.
2. **Slack 3000-char section limit** — Slack rejects oversized section text with `invalid_blocks` instead of truncating, so long card replies were dropped. Oversized Slack text children are split at the outbound chokepoint before post.

### Screenshots

N/A — backend delivery / approval dispatch only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- Empty-approval pause path is expected on resume; session fallback in `HandlePendingToolApprovals.fetchPendingTools` is the recovery mechanism.
- Section splitting is Slack-only in `buildAdapterPostableMessage`; other platforms unchanged.
- Unit coverage: `slack-section-limits.spec.ts`.

</details>

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR recovers pending Slack tool approvals from session state and splits oversized Slack card text before delivery.
- Continues approval dispatch when a resumed paused run has no inline approvals.
- Applies Slack-specific section-length normalization at the outbound gateway.
- Adds tests for paragraph, line, space-aware, and hard-cut splitting.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the outstanding Slack splitting path can still corrupt formatting when a Markdown construct crosses the section boundary.

The fallback splitter chooses its boundary solely by character count and nearby spaces, then emits each fragment as a separate Slack text section, leaving the previously reported malformed-Markdown behavior reachable.

**Files Needing Attention:** apps/api/src/app/agents/shared/util/slack-section-limits.ts, apps/api/src/app/agents/shared/util/slack-section-limits.spec.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts | Applies the new section-length normalization only to Slack cards at the central outbound rendering boundary. |
| apps/api/src/app/agents/shared/agent-event-sink.service.ts | Allows empty-approval paused events to proceed to the existing session-backed approval recovery handler. |
| apps/api/src/app/agents/shared/util/slack-section-limits.ts | Splits oversized text children into valid-size sections, but the raw fallback still divides Markdown constructs across independently rendered sections. |
| apps/api/src/app/agents/shared/util/slack-section-limits.spec.ts | Covers length and content preservation for plain text but does not cover Markdown constructs spanning a fallback split. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Prefer splitting on nearby space for Sla..."](https://github.com/novuhq/novu/commit/c56805e6435b25c1b08b864b00c5e1f7c4a2a72d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54075808)</sub>

**Context used:**

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)

<!-- /greptile_comment -->