### PR TITLE
feat(dashboard): add optional agent interaction questionnaire fixes NV-8609

### DIFF
--- a/apps/dashboard/src/components/onboarding/personalize/channel-chip.tsx
+++ b/apps/dashboard/src/components/onboarding/personalize/channel-chip.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/utils/ui';
 
 type ChannelChipProps = {
   label: string;
-  icon: ReactNode;
+  icon?: ReactNode;
   accent: string;
   isSelected: boolean;
   onToggle: () => void;
@@ -21,7 +21,7 @@ export function ChannelChip({ label, icon, accent, isSelected, onToggle }: Chann
       )}
       style={isSelected ? { backgroundColor: `${accent}1f`, borderColor: `${accent}3d` } : undefined}
     >
-      <span className="flex size-4 shrink-0 items-center justify-center">{icon}</span>
+      {icon ? <span className="flex size-4 shrink-0 items-center justify-center">{icon}</span> : null}
       {label}
     </button>
   );

--- a/apps/dashboard/src/components/onboarding/personalize/personalize-options.tsx
+++ b/apps/dashboard/src/components/onboarding/personalize/personalize-options.tsx
@@ -130,7 +130,7 @@ const INTERACTION_ACCENT = '#525866';
 export const AGENT_INTERACTION_OPTIONS: InteractionOption[] = [
   {
     value: 'agent_reaches_out_or_asks',
-    label: 'The agent reaches out or asks for input',
+    label: 'Agent reaches out for input (human-in-the-loop)',
     icon: <Hash className="size-4" strokeWidth={1.5} />,
     accent: INTERACTION_ACCENT,
   },

--- a/apps/dashboard/src/components/onboarding/personalize/personalize-options.tsx
+++ b/apps/dashboard/src/components/onboarding/personalize/personalize-options.tsx
@@ -1,5 +1,5 @@
 import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
-import { Mails } from 'lucide-react';
+import { AtSign, Hash, Laptop, Mails } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { AGENT_IMESSAGE_LABEL, getAgentChannelIconFileName } from '@/utils/agent-channel-branding';
 
@@ -11,6 +11,9 @@ import { AGENT_IMESSAGE_LABEL, getAgentChannelIconFileName } from '@/utils/agent
 export type AgentReadiness = 'live_in_production' | 'in_development' | 'planned_not_started' | 'just_exploring';
 
 export type AgentAudience = 'customers_end_users' | 'employees_internal_teams' | 'both' | 'not_sure_yet';
+
+/** How users and the agent initiate conversations — optional survey answer. */
+export type AgentInteraction = 'agent_reaches_out_or_asks' | 'users_message_or_tag' | 'both';
 
 /** Survey channel ids only — real provider ids so they join the rest of the agent funnel. */
 export const AGENT_CHANNEL_VALUES = [
@@ -110,5 +113,37 @@ export const AGENT_CHANNEL_OPTIONS: ChannelOption[] = [
     label: 'Agent Chat',
     icon: providerIcon(ChatProviderIdEnum.NovuAgentChat),
     accent: '#DC224E',
+  },
+];
+
+export type InteractionOption = {
+  value: AgentInteraction;
+  label: string;
+  icon: ReactNode;
+  /** Brand colour the chip tints itself with while selected. */
+  accent: string;
+};
+
+/** Neutral accent shared by interaction chips (no per-option brand colour). */
+const INTERACTION_ACCENT = '#525866';
+
+export const AGENT_INTERACTION_OPTIONS: InteractionOption[] = [
+  {
+    value: 'agent_reaches_out_or_asks',
+    label: 'The agent reaches out or asks for input',
+    icon: <Hash className="size-4" strokeWidth={1.5} />,
+    accent: INTERACTION_ACCENT,
+  },
+  {
+    value: 'users_message_or_tag',
+    label: 'Users message or tag the agent',
+    icon: <AtSign className="size-4" strokeWidth={1.5} />,
+    accent: INTERACTION_ACCENT,
+  },
+  {
+    value: 'both',
+    label: 'Both',
+    icon: <Laptop className="size-4" strokeWidth={1.5} />,
+    accent: INTERACTION_ACCENT,
   },
 ];

--- a/apps/dashboard/src/components/onboarding/personalize/personalize-options.tsx
+++ b/apps/dashboard/src/components/onboarding/personalize/personalize-options.tsx
@@ -1,5 +1,5 @@
 import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
-import { AtSign, Hash, Laptop, Mails } from 'lucide-react';
+import { AtSign, Hash, Mails } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { AGENT_IMESSAGE_LABEL, getAgentChannelIconFileName } from '@/utils/agent-channel-branding';
 
@@ -119,7 +119,7 @@ export const AGENT_CHANNEL_OPTIONS: ChannelOption[] = [
 export type InteractionOption = {
   value: AgentInteraction;
   label: string;
-  icon: ReactNode;
+  icon?: ReactNode;
   /** Brand colour the chip tints itself with while selected. */
   accent: string;
 };
@@ -143,7 +143,6 @@ export const AGENT_INTERACTION_OPTIONS: InteractionOption[] = [
   {
     value: 'both',
     label: 'Both',
-    icon: <Laptop className="size-4" strokeWidth={1.5} />,
     accent: INTERACTION_ACCENT,
   },
 ];

--- a/apps/dashboard/src/pages/agents-personalize-page.tsx
+++ b/apps/dashboard/src/pages/agents-personalize-page.tsx
@@ -9,9 +9,11 @@ import { ChannelChip } from '@/components/onboarding/personalize/channel-chip';
 import {
   AGENT_AUDIENCE_OPTIONS,
   AGENT_CHANNEL_OPTIONS,
+  AGENT_INTERACTION_OPTIONS,
   AGENT_READINESS_OPTIONS,
   type AgentAudience,
   type AgentChannel,
+  type AgentInteraction,
   type AgentReadiness,
   type PersonalizeOption,
 } from '@/components/onboarding/personalize/personalize-options';
@@ -128,6 +130,40 @@ function ChannelQuestion({
   );
 }
 
+/**
+ * Optional single-select chips. Clicking the selected chip again clears the answer so the
+ * question stays skippable without a required pick.
+ */
+function InteractionQuestion({
+  selected,
+  onSelect,
+}: {
+  selected: AgentInteraction | undefined;
+  onSelect: (value: AgentInteraction) => void;
+}) {
+  const labelId = useId();
+
+  return (
+    <fieldset aria-labelledby={labelId} className="flex flex-col gap-2 border-0 p-0">
+      <Label id={labelId} className="text-text-sub cursor-default font-normal">
+        How should users interact with your agent?
+      </Label>
+      <div className="flex max-w-[400px] flex-wrap gap-2">
+        {AGENT_INTERACTION_OPTIONS.map((option) => (
+          <ChannelChip
+            key={option.value}
+            label={option.label}
+            icon={option.icon}
+            accent={option.accent}
+            isSelected={selected === option.value}
+            onToggle={() => onSelect(option.value)}
+          />
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
 export function AgentsPersonalizePage() {
   const areAgentsAvailable = useAreConversationalAgentsAvailable();
   const isLaunchDarklyReady = useLaunchDarklyReady();
@@ -140,6 +176,7 @@ export function AgentsPersonalizePage() {
   const [readiness, setReadiness] = useState<AgentReadiness | undefined>(undefined);
   const [audience, setAudience] = useState<AgentAudience | undefined>(undefined);
   const [channels, setChannels] = useState<AgentChannel[]>([]);
+  const [interaction, setInteraction] = useState<AgentInteraction | undefined>(undefined);
 
   // `product_type=agents` signups land here without ever seeing the picker, so sending them "back"
   // to it would push them into a screen that defaults to Inbox and reverses their choice. Setup may
@@ -181,11 +218,23 @@ export function AgentsPersonalizePage() {
     });
   };
 
+  const handleInteractionSelect = (value: AgentInteraction) => {
+    const next = interaction === value ? undefined : value;
+
+    setInteraction(next);
+    telemetry(TelemetryEvent.ONBOARDING_PERSONALIZE_ANSWERED, {
+      question: 'agent_interaction',
+      value,
+      selected: next !== undefined,
+    });
+  };
+
   const handleContinue = () => {
     telemetry(TelemetryEvent.ONBOARDING_PERSONALIZE_SUBMITTED, {
       agentReadiness: readiness,
       agentAudience: audience,
       agentChannels: channels,
+      agentInteraction: interaction,
     });
     // The agents setup page waits on the org, so the loader plays across that hand-off.
     beginOnboardingProvisioning('agents');
@@ -242,6 +291,10 @@ export function AgentsPersonalizePage() {
 
         <RevealedField isRevealed={Boolean(audience)}>
           <ChannelQuestion selected={channels} onToggle={handleChannelToggle} />
+        </RevealedField>
+
+        <RevealedField isRevealed={Boolean(audience)}>
+          <InteractionQuestion selected={interaction} onSelect={handleInteractionSelect} />
         </RevealedField>
       </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Adds a fourth question to the Conversations onboarding personalize step ([NV-8609](https://linear.app/novu/issue/NV-8609)): **How should users interact with your agent?**

[Design](https://www.figma.com/design/IAKQhLxU0GEVjsMHUUScYx/ACI?node-id=11525-24803)

**Options** (single-select chips, optional / skippable)
- The agent reaches out or asks for input
- Users message or tag the agent
- Both (text only, no icon)

**Behavior**
- Reveals with the channels question after audience is answered
- Does not gate Continue — leave unanswered or click the selected chip again to clear
- Telemetry: `agent_interaction` on answer; `agentInteraction` on submit

```mermaid
flowchart TD
  Q1[Readiness] --> Q2[Audience]
  Q2 --> Q3[Channels optional]
  Q2 --> Q4[Interaction optional]
  Q2 --> Continue
```

### Screenshots

![Q4 chips; Both has no icon](https://cursor.com/artifacts/c/art-67bcd346-3927-4f8f-9a12-bc8c7538c617)
<a href="https://cursor.com/agents/bc-29172397-b43d-4766-b725-b88458f91e50/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpersonalize_interaction_questionnaire_demo.mp4"><img src="https://cursor.com/artifacts/c/art-b5f6626e-2664-46d8-84c8-0765a4acb8ed" alt="personalize_interaction_questionnaire_demo.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A — dashboard-only

### Special notes for your reviewer

- Figma label is “How should users interact with your agent?” (Linear summary used “conversations … start”)
- Reuses `ChannelChip` for the pill UI; icons are Hash / AtSign for the first two options; Both is text-only
- Stable analytics values live in `personalize-options.tsx`

</details>

## Test plan
- [x] Personalize: answer readiness + audience → channels and interaction chips appear; Continue is available without selecting interaction
- [x] Selecting an interaction chip highlights it; selecting again clears; switching chips is single-select
- [x] Both chip renders without an icon
- [ ] Inbox onboarding path unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8609](https://linear.app/novu/issue/NV-8609/add-conversation-start-questionnaire-to-agent-setup)

<div><a href="https://cursor.com/agents/bc-29172397-b43d-4766-b725-b88458f91e50?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29172397-b43d-4766-b725-b88458f91e50&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an optional agent-interaction question to the Conversations onboarding personalization flow.
- Adds three stable single-select interaction options, including a text-only “Both” option.
- Reveals the question after audience selection and supports clearing the selected answer.
- Includes the optional response in answer and submission telemetry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/onboarding/personalize/channel-chip.tsx | Makes chip icons optional so the “Both” interaction choice can render without an icon. |
| apps/dashboard/src/components/onboarding/personalize/personalize-options.tsx | Defines the interaction answer type and three stable questionnaire options. |
| apps/dashboard/src/pages/agents-personalize-page.tsx | Adds optional interaction selection state, rendering, clear-on-repeat behavior, and telemetry fields. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Readiness[Readiness answer] --> Audience[Audience answer]
  Audience --> Channels[Optional channel choices]
  Audience --> Interaction[Optional interaction choice]
  Audience --> Continue[Continue]
  Interaction -->|Select or clear| Telemetry[Answer telemetry]
  Continue --> Submit[Submission telemetry and provisioning]
```

<sub>Reviews (3): Last reviewed commit: ["Apply suggestion from @twentyone24"](https://github.com/novuhq/novu/commit/1e5283386d4cb25f60ed3b719462485776dad2a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54311276)</sub>

<!-- /greptile_comment -->