### PR TITLE
chore(dashboard): performance improvements, app chunks based on routes

### DIFF
--- a/apps/dashboard/src/components/animated-outlet.tsx
+++ b/apps/dashboard/src/components/animated-outlet.tsx
@@ -1,8 +1,12 @@
 import { AnimatePresence } from 'motion/react';
-import React, { useRef } from 'react';
+import React, { Suspense, useRef } from 'react';
 import { useLocation, useOutlet } from 'react-router-dom';
 
-export const AnimatedOutlet = (): React.JSX.Element => {
+type AnimatedOutletProps = {
+  fallback?: React.ReactNode;
+};
+
+export const AnimatedOutlet = ({ fallback = null }: AnimatedOutletProps): React.JSX.Element => {
   const { pathname, state } = useLocation();
   const keyRef = useRef(pathname);
   const element = useOutlet();
@@ -12,8 +16,10 @@ export const AnimatedOutlet = (): React.JSX.Element => {
   }
 
   return (
-    <AnimatePresence mode="wait" initial>
-      {element && React.cloneElement(element, { key: keyRef.current })}
-    </AnimatePresence>
+    <Suspense fallback={fallback}>
+      <AnimatePresence mode="wait" initial>
+        {element && React.cloneElement(element, { key: keyRef.current })}
+      </AnimatePresence>
+    </Suspense>
   );
 };

--- a/apps/dashboard/src/components/dashboard-layout.tsx
+++ b/apps/dashboard/src/components/dashboard-layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { HeaderNavigation } from '@/components/header-navigation/header-navigation';
 import { MobileDesktopPrompt } from '@/components/mobile-desktop-prompt';
 import { LegacySideNavigation } from '@/components/side-navigation/side-navigation';
+import { PageHeaderSlot } from '@/context/page-header';
 
 type DashboardLayoutProps = {
   children: ReactNode;
@@ -25,7 +26,7 @@ export const DashboardLayout = ({
       )}
       <div className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden">
         <HeaderNavigation
-          startItems={headerStartItems}
+          startItems={headerStartItems ?? <PageHeaderSlot />}
           hideBridgeUrl={!showBridgeUrl}
           showMobileNav={showSideNavigation}
         />

--- a/apps/dashboard/src/components/full-page-layout.tsx
+++ b/apps/dashboard/src/components/full-page-layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { HeaderNavigation } from '@/components/header-navigation/header-navigation';
 import { MobileDesktopPrompt } from '@/components/mobile-desktop-prompt';
+import { PageHeaderSlot } from '@/context/page-header';
 
 export const FullPageLayout = ({
   children,
@@ -12,7 +13,7 @@ export const FullPageLayout = ({
   return (
     <div className="relative flex h-full w-full">
       <div className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden">
-        <HeaderNavigation startItems={headerStartItems} hideBridgeUrl />
+        <HeaderNavigation startItems={headerStartItems ?? <PageHeaderSlot />} hideBridgeUrl />
 
         <div className="relative flex flex-1 flex-col overflow-y-auto overflow-x-hidden">{children}</div>
       </div>

--- a/apps/dashboard/src/components/page-content-skeleton.tsx
+++ b/apps/dashboard/src/components/page-content-skeleton.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from '@/components/primitives/skeleton';
+
+export function PageContentSkeleton() {
+  return (
+    <div className="flex flex-col gap-3 p-2" aria-busy="true" aria-label="Loading page">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/route-fallback.tsx
+++ b/apps/dashboard/src/components/route-fallback.tsx
@@ -1,0 +1,9 @@
+import { RiLoader4Line } from 'react-icons/ri';
+
+export function RouteFallback() {
+  return (
+    <div className="flex h-full min-h-[50vh] w-full items-center justify-center">
+      <RiLoader4Line className="text-primary-base size-8 animate-spin" aria-label="Loading" />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step.tsx
@@ -1,10 +1,17 @@
+import { useEffect } from 'react';
 import { ConfigureStepForm } from '@/components/workflow-editor/steps/configure-step-form';
 import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
 import { useEnvironment } from '@/context/environment/hooks';
 
+const loadEditStepTemplateV2Page = () => import('@/pages/edit-step-template-v2');
+
 export const ConfigureStep = () => {
   const { workflow, step, update } = useWorkflow();
   const { currentEnvironment } = useEnvironment();
+
+  useEffect(() => {
+    void loadEditStepTemplateV2Page();
+  }, []);
 
   if (!currentEnvironment || !step || !workflow) {
     return null;

--- a/apps/dashboard/src/components/workflow-editor/steps/step-editor-skeleton.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-editor-skeleton.tsx
@@ -1,0 +1,55 @@
+import { RiCodeBlock, RiEdit2Line, RiEyeLine } from 'react-icons/ri';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { PanelHeader } from '@/components/workflow-editor/steps/layout/panel-header';
+import { ResizableLayout } from '@/components/workflow-editor/steps/layout/resizable-layout';
+
+export function StepEditorSkeleton() {
+  return (
+    <div className="h-full w-full">
+      <ResizableLayout autoSaveId="step-editor-main-layout">
+        <ResizableLayout.ContextPanel defaultSize="27%" minSize="27%" maxSize="80%">
+          <PanelHeader icon={RiCodeBlock} title="Preview sandbox" className="py-2" />
+          <div className="bg-bg-weak flex-1 overflow-hidden">
+            <div className="h-full overflow-y-auto p-3">
+              <Skeleton className="h-full w-full" />
+            </div>
+          </div>
+        </ResizableLayout.ContextPanel>
+
+        <ResizableLayout.Handle />
+
+        <ResizableLayout.MainContentPanel>
+          <div className="flex min-h-0 flex-1 flex-col">
+            <ResizableLayout autoSaveId="step-editor-content-layout">
+              <ResizableLayout.EditorPanel>
+                <PanelHeader icon={() => <RiEdit2Line />} title="Editor" className="min-h-[45px] py-2" />
+                <div className="flex-1 overflow-y-auto">
+                  <div className="h-full p-3">
+                    <Skeleton className="h-full w-full" />
+                  </div>
+                </div>
+              </ResizableLayout.EditorPanel>
+
+              <ResizableLayout.Handle />
+
+              <ResizableLayout.PreviewPanel>
+                <PanelHeader icon={RiEyeLine} title="Preview" isLoading className="min-h-[45px] py-2" />
+                <div className="flex-1 overflow-hidden">
+                  <div
+                    className="bg-bg-weak relative h-full overflow-y-auto p-3"
+                    style={{
+                      backgroundImage: 'radial-gradient(circle, hsl(var(--neutral-alpha-100)) 1px, transparent 1px)',
+                      backgroundSize: '20px 20px',
+                    }}
+                  >
+                    <Skeleton className="h-full w-full" />
+                  </div>
+                </div>
+              </ResizableLayout.PreviewPanel>
+            </ResizableLayout>
+          </div>
+        </ResizableLayout.MainContentPanel>
+      </ResizableLayout>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/workflow-editor/workflow-editor-skeleton.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-editor-skeleton.tsx
@@ -1,0 +1,76 @@
+import { RouteFill } from '@/components/icons/route-fill';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { SidebarContent, SidebarHeader } from '@/components/side-navigation/sidebar';
+
+export function EditorAsideSkeleton() {
+  return (
+    <>
+      <SidebarHeader className="items-center border-b py-3 text-sm font-medium">
+        <div className="flex items-center gap-1">
+          <RouteFill />
+          <span>Configure workflow</span>
+        </div>
+      </SidebarHeader>
+      <SidebarContent size="md">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-3 w-12" />
+          <Skeleton className="h-5 w-14 rounded-full" />
+        </div>
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+      </SidebarContent>
+    </>
+  );
+}
+
+export function WorkflowEditorSkeleton() {
+  return (
+    <div className="flex h-full w-full flex-1 flex-nowrap">
+      <div className="-mt-px flex h-full max-w-full flex-1 flex-col">
+        <div className="border-neutral-alpha-200 relative flex h-11 w-full items-center gap-6 border-b border-t px-3.5">
+          <span className="text-foreground-950 text-label-sm relative px-1 py-3.5 font-medium">
+            Workflow
+            <span className="bg-primary absolute inset-x-1 bottom-0 h-0.5" />
+          </span>
+          <span className="text-foreground-600 text-label-sm px-1 py-3.5 font-medium">Activity</span>
+          <div className="ml-auto flex items-center gap-2">
+            <Skeleton className="h-6 w-32 rounded-md" />
+            <Skeleton className="h-6 w-28 rounded-md" />
+          </div>
+        </div>
+
+        <div className="flex h-full min-h-0 max-w-full flex-1 overflow-hidden">
+          <div className="border-neutral-200 flex h-full w-11 shrink-0 flex-col items-center border-r">
+            <Skeleton className="mt-2 size-7 rounded-md" />
+            <Skeleton className="mt-auto mb-2 size-7 rounded-md" />
+          </div>
+
+          <div
+            className="bg-bg-weak relative flex flex-1 items-start justify-center overflow-hidden pt-16"
+            style={{
+              backgroundImage: 'radial-gradient(circle, hsl(var(--bg-muted)) 1px, transparent 1px)',
+              backgroundSize: '24px 24px',
+            }}
+          >
+            <div className="flex flex-col items-center">
+              <Skeleton className="h-16 w-[300px] rounded-xl" />
+              <Skeleton className="h-8 w-px rounded-none" />
+              <Skeleton className="h-16 w-[300px] rounded-xl" />
+              <Skeleton className="h-8 w-px rounded-none" />
+              <Skeleton className="h-16 w-[300px] rounded-xl" />
+              <Skeleton className="mt-2 size-6 rounded-full" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <aside className="flex h-full w-[350px] max-w-[350px] shrink-0 flex-col border-l">
+        <EditorAsideSkeleton />
+      </aside>
+    </div>
+  );
+}

--- a/apps/dashboard/src/context/page-header/hooks.ts
+++ b/apps/dashboard/src/context/page-header/hooks.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { createContextHook } from '@/utils/context';
+import { PageHeaderContext, PersistentLayoutContext } from './page-header-context';
+
+export const usePageHeader = createContextHook(PageHeaderContext);
+
+export function useIsPersistentLayout() {
+  return useContext(PersistentLayoutContext);
+}

--- a/apps/dashboard/src/context/page-header/index.ts
+++ b/apps/dashboard/src/context/page-header/index.ts
@@ -1,0 +1,3 @@
+export { useIsPersistentLayout, usePageHeader } from './hooks';
+export { PersistentLayoutContext } from './page-header-context';
+export { PageHeader, PageHeaderProvider, PageHeaderSlot } from './page-header-provider';

--- a/apps/dashboard/src/context/page-header/page-header-context.tsx
+++ b/apps/dashboard/src/context/page-header/page-header-context.tsx
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+
+export type PageHeaderContextValue = {
+  container: HTMLElement | null;
+  setContainer: (node: HTMLElement | null) => void;
+};
+
+export const PageHeaderContext = createContext<PageHeaderContextValue>({} as PageHeaderContextValue);
+PageHeaderContext.displayName = 'PageHeaderContext';
+
+export const PersistentLayoutContext = createContext(false);
+PersistentLayoutContext.displayName = 'PersistentLayoutContext';

--- a/apps/dashboard/src/context/page-header/page-header-provider.tsx
+++ b/apps/dashboard/src/context/page-header/page-header-provider.tsx
@@ -1,0 +1,27 @@
+import { ReactNode, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { usePageHeader } from './hooks';
+import { PageHeaderContext } from './page-header-context';
+
+export function PageHeaderProvider({ children }: { children: ReactNode }) {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const value = useMemo(() => ({ container, setContainer }), [container]);
+
+  return <PageHeaderContext.Provider value={value}>{children}</PageHeaderContext.Provider>;
+}
+
+export function PageHeaderSlot() {
+  const { setContainer } = usePageHeader();
+
+  return <div ref={setContainer} className="flex min-w-0 items-center" />;
+}
+
+export function PageHeader({ children }: { children: ReactNode }) {
+  const { container } = usePageHeader();
+
+  if (!container) {
+    return null;
+  }
+
+  return createPortal(children, container);
+}

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -5,98 +5,157 @@ import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 import './index.css';
 
-import { ConfigureWorkflow } from '@/components/workflow-editor/configure-workflow';
-import { EditStepConditions } from '@/components/workflow-editor/steps/conditions/edit-step-conditions';
-import { ConfigureStep } from '@/components/workflow-editor/steps/configure-step';
-
-import {
-  ActivityFeed,
-  AnalyticsPage,
-  ApiKeysPage,
-  CreateLayoutPage,
-  CreateWorkflowPage,
-  ErrorPage,
-  IntegrationsListPage,
-  InvitationAcceptPage,
-  LayoutsPage,
-  OrganizationListPage,
-  SettingsPage,
-  SignInPage,
-  SignUpPage,
-  SSOSignInPage,
-  TemplateModal,
-  TranslationsPage,
-  VerifyEmailPage,
-  WelcomePage,
-  WorkflowsPage,
-} from '@/pages';
-import { DuplicateWorkflowPage } from '@/pages/duplicate-workflow';
-import { EditStepTemplateV2Page } from '@/pages/edit-step-template-v2';
-import { Landing1SignUpPage } from '@/pages/landing-1-signup';
-import { SubscribersPage } from '@/pages/subscribers';
-import { TranslationSettingsPage } from '@/pages/translation-settings-page';
-import { WebhooksPage } from '@/pages/webhooks-page';
 import { ConnectSubscriberProvider } from './components/connect/connect-subscriber-provider';
-import { CreateIntegrationSidebar } from './components/integrations/components/create-integration-sidebar';
-import { UpdateIntegrationSidebar } from './components/integrations/components/update-integration-sidebar';
-import { ChannelPreferences } from './components/workflow-editor/channel-preferences';
-import { WorkflowAgentAssignment } from './components/workflow-editor/workflow-agent-assignment';
 import { EE_AUTH_PROVIDER, IS_CLOUD, IS_SELF_HOSTED, IS_SELF_HOSTED_CE } from './config';
 import { FeatureFlagsProvider } from './context/feature-flags-provider';
-import { AgentDetailsPage } from './pages/agent-details';
-import { AgentSlackSetupPage } from './pages/agent-slack-setup-page';
-import { AgentTelegramMobileSetupPage } from './pages/agent-telegram-mobile-setup-page';
-import { AgentWhatsAppSignupPage } from './pages/agent-whatsapp-signup-page';
-import { AgentsPage } from './pages/agents';
-import { AgentsPersonalizePage } from './pages/agents-personalize-page';
-import { AgentsSetupPage } from './pages/agents-setup-page';
-import { CliAuthPage } from './pages/cli-auth';
-import { ConnectClaimPage } from './pages/connect-claim';
-import { ContextsPage } from './pages/contexts';
-import { CreateContextPage } from './pages/create-context';
-import { CreateSubscriberPage } from './pages/create-subscriber';
-import { CreateTopicPage } from './pages/create-topic';
-import { DomainDetailPage } from './pages/domain-detail';
-import { DomainsPage } from './pages/domains';
-import { DuplicateLayoutPage } from './pages/duplicate-layout-page';
-import { EditContextPage } from './pages/edit-context';
-import { EditLayoutPage } from './pages/edit-layout';
-import { EditSubscriberPage } from './pages/edit-subscriber-page';
-import { EditTopicPage } from './pages/edit-topic';
-import { EditTranslationPage } from './pages/edit-translation';
-import { EditWorkflowPage } from './pages/edit-workflow';
-import { EnvironmentsPage } from './pages/environments';
-import { ForgotPasswordPage } from './pages/forgot-password';
-import { InboxEmbedPage } from './pages/inbox-embed-page';
-import { InboxEmbedSuccessPage } from './pages/inbox-embed-success-page';
-import { InboxUsecasePage } from './pages/inbox-usecase-page';
-import { IntegrationStoreTelegramMobileSetupPage } from './pages/integration-store-telegram-mobile-setup-page';
-import { LocalEditWorkflowPage } from './pages/local-edit-workflow';
-import { LocalHandshakePage } from './pages/local-handshake';
-import { LocalWorkflowsPage } from './pages/local-workflows';
-import { RedirectToLegacyStudioAuth } from './pages/redirect-to-legacy-studio-auth';
-import { ResetPasswordPage } from './pages/reset-password';
-import { TestWorkflowDrawerPage } from './pages/test-workflow-drawer-page';
-import { TestWorkflowRouteHandler } from './pages/test-workflow-route-handler';
-import { TopicsPage } from './pages/topics';
-import { UpsertVariablePage } from './pages/upsert-variable';
-import { UsecaseSelectPage } from './pages/usecase-select-page';
-import { VariablesPage } from './pages/variables';
-import { VercelIntegrationPage } from './pages/vercel-integration-page';
+import { ErrorPage } from './pages/error-page';
 import { AuthRoute, CatchAllRoute, DashboardRoute, ProtectedAuthRoute, RootRoute } from './routes';
+import { EditorLayout } from './routes/editor-layout';
 import { OnboardingParentRoute } from './routes/onboarding';
 import { ProtectedRoute } from './routes/protected-route';
+import { SideNavLayout } from './routes/side-nav-layout';
 import { captureAgentTemplateIdFromUrl } from './utils/agent-template-identity';
 import { captureConnectClaimTokenFromUrl } from './utils/connect-claim-pending';
+import { lazyPage } from './utils/lazy-page';
+import { DashboardRouteHandle } from './utils/route-handle';
 import { ROUTES } from './utils/routes';
 import { initializeSentry } from './utils/sentry';
 import { overrideZodErrorMap } from './utils/validation';
 
+const Landing1SignUpPage = lazyPage(() => import('./pages/landing-1-signup'), 'Landing1SignUpPage');
+const CliAuthPage = lazyPage(() => import('./pages/cli-auth'), 'CliAuthPage');
+const ConnectClaimPage = lazyPage(() => import('./pages/connect-claim'), 'ConnectClaimPage');
+const AgentSlackSetupPage = lazyPage(() => import('./pages/agent-slack-setup-page'), 'AgentSlackSetupPage');
+const AgentTelegramMobileSetupPage = lazyPage(
+  () => import('./pages/agent-telegram-mobile-setup-page'),
+  'AgentTelegramMobileSetupPage'
+);
+const AgentWhatsAppSignupPage = lazyPage(() => import('./pages/agent-whatsapp-signup-page'), 'AgentWhatsAppSignupPage');
+const IntegrationStoreTelegramMobileSetupPage = lazyPage(
+  () => import('./pages/integration-store-telegram-mobile-setup-page'),
+  'IntegrationStoreTelegramMobileSetupPage'
+);
+const SignInPage = lazyPage(() => import('./pages/sign-in'), 'SignInPage');
+const SignUpPage = lazyPage(() => import('./pages/sign-up'), 'SignUpPage');
+const ForgotPasswordPage = lazyPage(() => import('./pages/forgot-password'), 'ForgotPasswordPage');
+const ResetPasswordPage = lazyPage(() => import('./pages/reset-password'), 'ResetPasswordPage');
+const SSOSignInPage = lazyPage(() => import('./pages/sso-sign-in'), 'SSOSignInPage');
+const VerifyEmailPage = lazyPage(() => import('./pages/verify-email'), 'VerifyEmailPage');
+const OrganizationListPage = lazyPage(() => import('./pages/organization-list'), 'OrganizationListPage');
+const InvitationAcceptPage = lazyPage(() => import('./pages/invitation-accept'), 'InvitationAcceptPage');
+const UsecaseSelectPage = lazyPage(() => import('./pages/usecase-select-page'), 'UsecaseSelectPage');
+const AgentsPersonalizePage = lazyPage(() => import('./pages/agents-personalize-page'), 'AgentsPersonalizePage');
+const AgentsSetupPage = lazyPage(() => import('./pages/agents-setup-page'), 'AgentsSetupPage');
+const InboxUsecasePage = lazyPage(() => import('./pages/inbox-usecase-page'), 'InboxUsecasePage');
+const InboxEmbedPage = lazyPage(() => import('./pages/inbox-embed-page'), 'InboxEmbedPage');
+const InboxEmbedSuccessPage = lazyPage(() => import('./pages/inbox-embed-success-page'), 'InboxEmbedSuccessPage');
+const WelcomePage = lazyPage(() => import('./pages/welcome-page'), 'WelcomePage');
+const WorkflowsPage = lazyPage(() => import('./pages/workflows'), 'WorkflowsPage');
+const TemplateModal = lazyPage(() => import('./pages/workflows'), 'TemplateModal');
+const CreateWorkflowPage = lazyPage(() => import('./pages/create-workflow'), 'CreateWorkflowPage');
+const DuplicateWorkflowPage = lazyPage(() => import('./pages/duplicate-workflow'), 'DuplicateWorkflowPage');
+const SubscribersPage = lazyPage(() => import('./pages/subscribers'), 'SubscribersPage');
+const EditSubscriberPage = lazyPage(() => import('./pages/edit-subscriber-page'), 'EditSubscriberPage');
+const CreateSubscriberPage = lazyPage(() => import('./pages/create-subscriber'), 'CreateSubscriberPage');
+const TopicsPage = lazyPage(() => import('./pages/topics'), 'TopicsPage');
+const CreateTopicPage = lazyPage(() => import('./pages/create-topic'), 'CreateTopicPage');
+const EditTopicPage = lazyPage(() => import('./pages/edit-topic'), 'EditTopicPage');
+const ContextsPage = lazyPage(() => import('./pages/contexts'), 'ContextsPage');
+const CreateContextPage = lazyPage(() => import('./pages/create-context'), 'CreateContextPage');
+const EditContextPage = lazyPage(() => import('./pages/edit-context'), 'EditContextPage');
+const LayoutsPage = lazyPage(() => import('./pages/layouts'), 'LayoutsPage');
+const CreateLayoutPage = lazyPage(() => import('./pages/create-layout'), 'CreateLayoutPage');
+const DuplicateLayoutPage = lazyPage(() => import('./pages/duplicate-layout-page'), 'DuplicateLayoutPage');
+const EditLayoutPage = lazyPage(() => import('./pages/edit-layout'), 'EditLayoutPage');
+const TranslationsPage = lazyPage(() => import('./pages/translations'), 'TranslationsPage');
+const TranslationSettingsPage = lazyPage(() => import('./pages/translation-settings-page'), 'TranslationSettingsPage');
+const EditTranslationPage = lazyPage(() => import('./pages/edit-translation'), 'EditTranslationPage');
+const AgentsPage = lazyPage(() => import('./pages/agents'), 'AgentsPage');
+const AgentDetailsPage = lazyPage(() => import('./pages/agent-details'), 'AgentDetailsPage');
+const DomainsPage = lazyPage(() => import('./pages/domains'), 'DomainsPage');
+const DomainDetailPage = lazyPage(() => import('./pages/domain-detail'), 'DomainDetailPage');
+const ApiKeysPage = lazyPage(() => import('./pages/api-keys'), 'ApiKeysPage');
+const EnvironmentsPage = lazyPage(() => import('./pages/environments'), 'EnvironmentsPage');
+const VariablesPage = lazyPage(() => import('./pages/variables'), 'VariablesPage');
+const UpsertVariablePage = lazyPage(() => import('./pages/upsert-variable'), 'UpsertVariablePage');
+const ActivityFeed = lazyPage(() => import('./pages/activity-feed'), 'ActivityFeed');
+const AnalyticsPage = lazyPage(() => import('./pages/analytics'), 'AnalyticsPage');
+const LocalWorkflowsPage = lazyPage(() => import('./pages/local-workflows'), 'LocalWorkflowsPage');
+const LocalEditWorkflowPage = lazyPage(() => import('./pages/local-edit-workflow'), 'LocalEditWorkflowPage');
+const EditWorkflowPage = lazyPage(() => import('./pages/edit-workflow'), 'EditWorkflowPage');
+const TestWorkflowRouteHandler = lazyPage(
+  () => import('./pages/test-workflow-route-handler'),
+  'TestWorkflowRouteHandler'
+);
+const TestWorkflowDrawerPage = lazyPage(() => import('./pages/test-workflow-drawer-page'), 'TestWorkflowDrawerPage');
+const WebhooksPage = lazyPage(() => import('./pages/webhooks-page'), 'WebhooksPage');
+const IntegrationsListPage = lazyPage(() => import('./pages/integrations-list-page'), 'IntegrationsListPage');
+const SettingsPage = lazyPage(() => import('./pages/settings'), 'SettingsPage');
+const VercelIntegrationPage = lazyPage(() => import('./pages/vercel-integration-page'), 'VercelIntegrationPage');
+const RedirectToLegacyStudioAuth = lazyPage(
+  () => import('./pages/redirect-to-legacy-studio-auth'),
+  'RedirectToLegacyStudioAuth'
+);
+const LocalHandshakePage = lazyPage(() => import('./pages/local-handshake'), 'LocalHandshakePage');
+const EditStepTemplateV2Page = lazyPage(() => import('./pages/edit-step-template-v2'), 'EditStepTemplateV2Page');
+const ConfigureWorkflow = lazyPage(
+  () => import('./components/workflow-editor/configure-workflow'),
+  'ConfigureWorkflow'
+);
+const ConfigureStep = lazyPage(() => import('./components/workflow-editor/steps/configure-step'), 'ConfigureStep');
+const EditStepConditions = lazyPage(
+  () => import('./components/workflow-editor/steps/conditions/edit-step-conditions'),
+  'EditStepConditions'
+);
+const ChannelPreferences = lazyPage(
+  () => import('./components/workflow-editor/channel-preferences'),
+  'ChannelPreferences'
+);
+const WorkflowAgentAssignment = lazyPage(
+  () => import('./components/workflow-editor/workflow-agent-assignment'),
+  'WorkflowAgentAssignment'
+);
+const CreateIntegrationSidebar = lazyPage(
+  () => import('./components/integrations/components/create-integration-sidebar'),
+  'CreateIntegrationSidebar'
+);
+const UpdateIntegrationSidebar = lazyPage(
+  () => import('./components/integrations/components/update-integration-sidebar'),
+  'UpdateIntegrationSidebar'
+);
+
+const hideBridgeUrlHandle: DashboardRouteHandle = { hideBridgeUrl: true };
+
+const editorChildren = [
+  {
+    element: <ConfigureWorkflow />,
+    index: true,
+  },
+  {
+    element: <ConfigureStep />,
+    path: ROUTES.EDIT_STEP,
+  },
+  {
+    element: <EditStepTemplateV2Page />,
+    path: ROUTES.EDIT_STEP_TEMPLATE,
+  },
+  {
+    element: <EditStepConditions />,
+    path: ROUTES.EDIT_STEP_CONDITIONS,
+  },
+  {
+    element: <ChannelPreferences />,
+    path: ROUTES.EDIT_WORKFLOW_PREFERENCES,
+  },
+  {
+    element: <WorkflowAgentAssignment />,
+    path: ROUTES.EDIT_WORKFLOW_AGENT,
+  },
+];
+
 initializeSentry();
 overrideZodErrorMap();
-// Stash an incoming `?agentTemplateId=` before Clerk's auth redirects drop the query params.
 captureAgentTemplateIdFromUrl();
-// Stash an incoming connect claim token before Clerk's auth redirects drop the query params.
 captureConnectClaimTokenFromUrl();
 
 const router = createBrowserRouter([
@@ -117,27 +176,18 @@ const router = createBrowserRouter([
         element: <ConnectClaimPage />,
       },
       {
-        // Public, unauthenticated setup page for Slack. Mounted outside
-        // AuthRoute so unauthenticated visitors are not redirected to sign-in.
         path: ROUTES.AGENT_SLACK_SETUP,
         element: <AgentSlackSetupPage />,
       },
       {
-        // Public, unauthenticated mobile setup page for Telegram. Mounted outside
-        // AuthRoute so unauthenticated visitors are not redirected to sign-in.
         path: ROUTES.AGENT_TELEGRAM_MOBILE_SETUP,
         element: <AgentTelegramMobileSetupPage />,
       },
       {
-        // Public, unauthenticated WhatsApp Embedded Signup page opened by
-        // `npx novu connect`. Trust comes from the opaque token in the URL, so
-        // it is mounted outside AuthRoute (keyless CLI users have no session).
         path: ROUTES.AGENT_WHATSAPP_SIGNUP,
         element: <AgentWhatsAppSignupPage />,
       },
       {
-        // Public, unauthenticated mobile setup page for the Telegram integration
-        // store create flow. Creates a new integration server-side on submit.
         path: ROUTES.INTEGRATION_TELEGRAM_MOBILE_SETUP,
         element: <IntegrationStoreTelegramMobileSetupPage />,
       },
@@ -221,531 +271,513 @@ const router = createBrowserRouter([
         path: ROUTES.ROOT,
         element: <DashboardRoute />,
         children: [
-          /* Direct routes matching environment-specific paths (e.g., /topics -> /env/:envId/topics) 
-             will be automatically redirected by the CatchAllRoute component */
           {
             index: true,
             element: <CatchAllRoute />,
           },
           {
-            path: ROUTES.ENV,
+            element: <SideNavLayout />,
             children: [
               {
-                path: ROUTES.WELCOME,
-                element: <WelcomePage />,
-              },
-              {
-                path: ROUTES.WORKFLOWS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
-                    <WorkflowsPage />
-                  </ProtectedRoute>
-                ),
+                path: ROUTES.ENV,
                 children: [
                   {
-                    path: ROUTES.TEMPLATE_STORE,
-                    element: <TemplateModal />,
+                    path: ROUTES.WELCOME,
+                    element: <WelcomePage />,
                   },
                   {
-                    path: ROUTES.TEMPLATE_STORE_CREATE_WORKFLOW,
+                    path: ROUTES.WORKFLOWS,
                     element: (
-                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
-                        <TemplateModal />
+                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
+                        <WorkflowsPage />
+                      </ProtectedRoute>
+                    ),
+                    children: [
+                      {
+                        path: ROUTES.TEMPLATE_STORE,
+                        element: <TemplateModal />,
+                      },
+                      {
+                        path: ROUTES.TEMPLATE_STORE_CREATE_WORKFLOW,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
+                            <TemplateModal />
+                          </ProtectedRoute>
+                        ),
+                      },
+                      {
+                        path: ROUTES.WORKFLOWS_CREATE,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
+                            <CreateWorkflowPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                      {
+                        path: ROUTES.WORKFLOWS_DUPLICATE,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
+                            <DuplicateWorkflowPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    path: ROUTES.SUBSCRIBERS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.SUBSCRIBER_READ}>
+                        <SubscribersPage />
+                      </ProtectedRoute>
+                    ),
+                    children: [
+                      {
+                        path: ROUTES.EDIT_SUBSCRIBER,
+                        element: (
+                          <ProtectedRoute
+                            condition={(has) =>
+                              has({ permission: PermissionsEnum.SUBSCRIBER_WRITE }) ||
+                              has({ permission: PermissionsEnum.SUBSCRIBER_READ })
+                            }
+                            isDrawerRoute
+                          >
+                            <EditSubscriberPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                      {
+                        path: ROUTES.CREATE_SUBSCRIBER,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.SUBSCRIBER_WRITE} isDrawerRoute>
+                            <CreateSubscriberPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    path: ROUTES.TOPICS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.TOPIC_READ}>
+                        <TopicsPage />
+                      </ProtectedRoute>
+                    ),
+                    children: [
+                      {
+                        path: ROUTES.TOPICS_CREATE,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.TOPIC_WRITE} isDrawerRoute>
+                            <CreateTopicPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                      {
+                        path: ROUTES.TOPICS_EDIT,
+                        element: (
+                          <ProtectedRoute
+                            condition={(has) =>
+                              has({ permission: PermissionsEnum.TOPIC_WRITE }) ||
+                              has({ permission: PermissionsEnum.TOPIC_READ })
+                            }
+                            isDrawerRoute
+                          >
+                            <EditTopicPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    path: ROUTES.CONTEXTS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
+                        <ContextsPage />
+                      </ProtectedRoute>
+                    ),
+                    children: [
+                      {
+                        path: ROUTES.CONTEXTS_CREATE,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
+                            <CreateContextPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                      {
+                        path: ROUTES.CONTEXTS_EDIT,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ} isDrawerRoute>
+                            <EditContextPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    path: ROUTES.LAYOUTS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
+                        <LayoutsPage />
+                      </ProtectedRoute>
+                    ),
+                    children: [
+                      {
+                        path: ROUTES.LAYOUTS_CREATE,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
+                            <CreateLayoutPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                      {
+                        path: ROUTES.LAYOUTS_DUPLICATE,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
+                            <DuplicateLayoutPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    path: ROUTES.TRANSLATIONS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
+                        <TranslationsPage />
+                      </ProtectedRoute>
+                    ),
+                    children: [
+                      {
+                        path: ROUTES.TRANSLATION_SETTINGS,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
+                            <TranslationSettingsPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                      {
+                        path: ROUTES.TRANSLATIONS_EDIT,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
+                            <EditTranslationPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    path: ROUTES.AGENTS,
+                    element: <AgentsPage />,
+                  },
+                  {
+                    path: ROUTES.AGENT_DETAILS_INTEGRATIONS_DETAIL,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
+                        <AgentDetailsPage />
                       </ProtectedRoute>
                     ),
                   },
                   {
-                    path: ROUTES.WORKFLOWS_CREATE,
+                    path: ROUTES.AGENT_DETAILS_TAB,
                     element: (
-                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
-                        <CreateWorkflowPage />
+                      <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
+                        <AgentDetailsPage />
                       </ProtectedRoute>
                     ),
                   },
                   {
-                    path: ROUTES.WORKFLOWS_DUPLICATE,
+                    path: ROUTES.AGENT_DETAILS,
                     element: (
-                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
-                        <DuplicateWorkflowPage />
+                      <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
+                        <AgentDetailsPage />
                       </ProtectedRoute>
                     ),
                   },
-                ],
-              },
-              {
-                path: ROUTES.SUBSCRIBERS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.SUBSCRIBER_READ}>
-                    <SubscribersPage />
-                  </ProtectedRoute>
-                ),
-                children: [
                   {
-                    path: ROUTES.EDIT_SUBSCRIBER,
+                    path: ROUTES.DOMAINS,
+                    element: !IS_SELF_HOSTED_CE ? <DomainsPage /> : <Navigate to={ROUTES.ROOT} replace />,
+                  },
+                  {
+                    path: ROUTES.DOMAIN_DETAIL,
+                    element: !IS_SELF_HOSTED_CE ? <DomainDetailPage /> : <Navigate to={ROUTES.ROOT} replace />,
+                  },
+                  {
+                    path: ROUTES.API_KEYS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.API_KEY_READ}>
+                        <ApiKeysPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.ENVIRONMENTS,
+                    element: <EnvironmentsPage />,
+                  },
+                  {
+                    path: ROUTES.VARIABLES,
+                    element: <VariablesPage />,
+                    children: [
+                      {
+                        path: ROUTES.VARIABLES_CREATE,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.ORG_SETTINGS_WRITE} isDrawerRoute>
+                            <UpsertVariablePage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    path: ROUTES.ACTIVITY_FEED,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
+                        <ActivityFeed />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.ACTIVITY_WORKFLOW_RUNS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
+                        <ActivityFeed />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.ACTIVITY_REQUESTS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
+                        <ActivityFeed />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.ACTIVITY_CONVERSATIONS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
+                        <ActivityFeed />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.ANALYTICS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
+                        <AnalyticsPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.LOCAL_WORKFLOWS,
+                    handle: hideBridgeUrlHandle,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.BRIDGE_WRITE}>
+                        <LocalWorkflowsPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.WEBHOOKS_ENDPOINTS,
                     element: (
                       <ProtectedRoute
                         condition={(has) =>
-                          has({ permission: PermissionsEnum.SUBSCRIBER_WRITE }) ||
-                          has({ permission: PermissionsEnum.SUBSCRIBER_READ })
+                          has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
+                          has({ permission: PermissionsEnum.WEBHOOK_WRITE })
                         }
-                        isDrawerRoute
                       >
-                        <EditSubscriberPage />
+                        <WebhooksPage />
                       </ProtectedRoute>
                     ),
                   },
                   {
-                    path: ROUTES.CREATE_SUBSCRIBER,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.SUBSCRIBER_WRITE} isDrawerRoute>
-                        <CreateSubscriberPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                ],
-              },
-              {
-                path: ROUTES.TOPICS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.TOPIC_READ}>
-                    <TopicsPage />
-                  </ProtectedRoute>
-                ),
-                children: [
-                  {
-                    path: ROUTES.TOPICS_CREATE,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.TOPIC_WRITE} isDrawerRoute>
-                        <CreateTopicPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                  {
-                    path: ROUTES.TOPICS_EDIT,
+                    path: ROUTES.WEBHOOKS_EVENT_CATALOG,
                     element: (
                       <ProtectedRoute
                         condition={(has) =>
-                          has({ permission: PermissionsEnum.TOPIC_WRITE }) ||
-                          has({ permission: PermissionsEnum.TOPIC_READ })
+                          has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
+                          has({ permission: PermissionsEnum.WEBHOOK_WRITE })
+                        }
+                      >
+                        <WebhooksPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.WEBHOOKS_LOGS,
+                    element: (
+                      <ProtectedRoute
+                        condition={(has) =>
+                          has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
+                          has({ permission: PermissionsEnum.WEBHOOK_WRITE })
+                        }
+                      >
+                        <WebhooksPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.WEBHOOKS_ACTIVITY,
+                    element: (
+                      <ProtectedRoute
+                        condition={(has) =>
+                          has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
+                          has({ permission: PermissionsEnum.WEBHOOK_WRITE })
+                        }
+                      >
+                        <WebhooksPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.WEBHOOKS,
+                    element: (
+                      <ProtectedRoute
+                        condition={(has) =>
+                          has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
+                          has({ permission: PermissionsEnum.WEBHOOK_WRITE })
+                        }
+                      >
+                        <Navigate to={ROUTES.WEBHOOKS_ENDPOINTS} replace />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: '*',
+                    element: <CatchAllRoute />,
+                  },
+                ],
+              },
+              {
+                path: ROUTES.INTEGRATIONS,
+                element: (
+                  <ProtectedRoute permission={PermissionsEnum.INTEGRATION_READ}>
+                    <IntegrationsListPage />
+                  </ProtectedRoute>
+                ),
+                children: [
+                  {
+                    path: ROUTES.INTEGRATIONS_CONNECT,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.INTEGRATION_WRITE} isDrawerRoute>
+                        <CreateIntegrationSidebar isOpened />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.INTEGRATIONS_CONNECT_PROVIDER,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.INTEGRATION_WRITE} isDrawerRoute>
+                        <CreateIntegrationSidebar isOpened />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.INTEGRATIONS_UPDATE,
+                    element: (
+                      <ProtectedRoute
+                        condition={(has) =>
+                          has({ permission: PermissionsEnum.INTEGRATION_WRITE }) ||
+                          has({ permission: PermissionsEnum.INTEGRATION_READ })
                         }
                         isDrawerRoute
                       >
-                        <EditTopicPage />
+                        <UpdateIntegrationSidebar isOpened />
                       </ProtectedRoute>
                     ),
                   },
                 ],
               },
               {
-                path: ROUTES.CONTEXTS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
-                    <ContextsPage />
-                  </ProtectedRoute>
-                ),
-                children: [
-                  {
-                    path: ROUTES.CONTEXTS_CREATE,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
-                        <CreateContextPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                  {
-                    path: ROUTES.CONTEXTS_EDIT,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ} isDrawerRoute>
-                        <EditContextPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                ],
+                path: ROUTES.SETTINGS,
+                element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
               },
               {
-                path: ROUTES.LAYOUTS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
-                    <LayoutsPage />
-                  </ProtectedRoute>
-                ),
-                children: [
-                  {
-                    path: ROUTES.LAYOUTS_CREATE,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
-                        <CreateLayoutPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                  {
-                    path: ROUTES.LAYOUTS_DUPLICATE,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_WRITE} isDrawerRoute>
-                        <DuplicateLayoutPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                ],
+                path: ROUTES.SETTINGS_ACCOUNT,
+                element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
               },
               {
-                path: ROUTES.LAYOUTS_EDIT,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
-                    <EditLayoutPage />
-                  </ProtectedRoute>
-                ),
+                path: ROUTES.SETTINGS_ORGANIZATION,
+                element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
               },
               {
-                path: ROUTES.TRANSLATIONS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
-                    <TranslationsPage />
-                  </ProtectedRoute>
-                ),
-                children: [
-                  {
-                    path: ROUTES.TRANSLATION_SETTINGS,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
-                        <TranslationSettingsPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                  {
-                    path: ROUTES.TRANSLATIONS_EDIT,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
-                        <EditTranslationPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                ],
+                path: ROUTES.SETTINGS_TEAM,
+                element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
               },
               {
-                path: ROUTES.AGENTS,
-                element: <AgentsPage />,
-              },
-              {
-                path: ROUTES.AGENT_DETAILS_INTEGRATIONS_DETAIL,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
-                    <AgentDetailsPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.AGENT_DETAILS_TAB,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
-                    <AgentDetailsPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.AGENT_DETAILS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
-                    <AgentDetailsPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.DOMAINS,
-                element: !IS_SELF_HOSTED_CE ? <DomainsPage /> : <Navigate to={ROUTES.ROOT} replace />,
-              },
-              {
-                path: ROUTES.DOMAIN_DETAIL,
-                element: !IS_SELF_HOSTED_CE ? <DomainDetailPage /> : <Navigate to={ROUTES.ROOT} replace />,
-              },
-              {
-                path: ROUTES.API_KEYS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.API_KEY_READ}>
-                    <ApiKeysPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.ENVIRONMENTS,
-                element: <EnvironmentsPage />,
-              },
-              {
-                path: ROUTES.VARIABLES,
-                element: <VariablesPage />,
-                children: [
-                  {
-                    path: ROUTES.VARIABLES_CREATE,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.ORG_SETTINGS_WRITE} isDrawerRoute>
-                        <UpsertVariablePage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                ],
-              },
-              {
-                path: ROUTES.ACTIVITY_FEED,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
-                    <ActivityFeed />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.ACTIVITY_WORKFLOW_RUNS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
-                    <ActivityFeed />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.ACTIVITY_REQUESTS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
-                    <ActivityFeed />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.ACTIVITY_CONVERSATIONS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
-                    <ActivityFeed />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.ANALYTICS,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
-                    <AnalyticsPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.LOCAL_WORKFLOWS,
-                element: (
-                  // BRIDGE_WRITE mirrors the stateless bridge API guard: local
-                  // mode signs requests to the caller's tunnel with the env key.
-                  <ProtectedRoute permission={PermissionsEnum.BRIDGE_WRITE}>
-                    <LocalWorkflowsPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                // Workflow editor mounted on virtual local-bridge workflows;
-                // children mirror ROUTES.EDIT_WORKFLOW so relative step
-                // navigation behaves identically.
-                path: ROUTES.LOCAL_EDIT_WORKFLOW,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.BRIDGE_WRITE}>
-                    <LocalEditWorkflowPage />
-                  </ProtectedRoute>
-                ),
-                children: [
-                  {
-                    element: <ConfigureWorkflow />,
-                    index: true,
-                  },
-                  {
-                    element: <ConfigureStep />,
-                    path: ROUTES.EDIT_STEP,
-                  },
-                  {
-                    element: <EditStepTemplateV2Page />,
-                    path: ROUTES.EDIT_STEP_TEMPLATE,
-                  },
-                  {
-                    element: <EditStepConditions />,
-                    path: ROUTES.EDIT_STEP_CONDITIONS,
-                  },
-                  {
-                    element: <ChannelPreferences />,
-                    path: ROUTES.EDIT_WORKFLOW_PREFERENCES,
-                  },
-                  {
-                    element: <WorkflowAgentAssignment />,
-                    path: ROUTES.EDIT_WORKFLOW_AGENT,
-                  },
-                  {
-                    path: ROUTES.LOCAL_TRIGGER_WORKFLOW,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.EVENT_WRITE} isDrawerRoute>
-                        <TestWorkflowDrawerPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                ],
-              },
-              {
-                path: ROUTES.EDIT_WORKFLOW,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
-                    <EditWorkflowPage />
-                  </ProtectedRoute>
-                ),
-                children: [
-                  {
-                    element: <ConfigureWorkflow />,
-                    index: true,
-                  },
-                  {
-                    element: <ConfigureStep />,
-                    path: ROUTES.EDIT_STEP,
-                  },
-
-                  {
-                    element: <EditStepTemplateV2Page />,
-                    path: ROUTES.EDIT_STEP_TEMPLATE,
-                  },
-                  {
-                    element: <EditStepConditions />,
-                    path: ROUTES.EDIT_STEP_CONDITIONS,
-                  },
-                  {
-                    element: <ChannelPreferences />,
-                    path: ROUTES.EDIT_WORKFLOW_PREFERENCES,
-                  },
-                  {
-                    element: <WorkflowAgentAssignment />,
-                    path: ROUTES.EDIT_WORKFLOW_AGENT,
-                  },
-                  {
-                    path: ROUTES.TRIGGER_WORKFLOW,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.EVENT_WRITE} isDrawerRoute>
-                        <TestWorkflowDrawerPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                ],
-              },
-              {
-                path: ROUTES.EDIT_WORKFLOW_ACTIVITY,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
-                    <EditWorkflowPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.TEST_WORKFLOW,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.EVENT_WRITE}>
-                    <TestWorkflowRouteHandler />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.WEBHOOKS_ENDPOINTS,
-                element: (
-                  <ProtectedRoute
-                    condition={(has) =>
-                      has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
-                      has({ permission: PermissionsEnum.WEBHOOK_WRITE })
-                    }
-                  >
-                    <WebhooksPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.WEBHOOKS_EVENT_CATALOG,
-                element: (
-                  <ProtectedRoute
-                    condition={(has) =>
-                      has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
-                      has({ permission: PermissionsEnum.WEBHOOK_WRITE })
-                    }
-                  >
-                    <WebhooksPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.WEBHOOKS_LOGS,
-                element: (
-                  <ProtectedRoute
-                    condition={(has) =>
-                      has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
-                      has({ permission: PermissionsEnum.WEBHOOK_WRITE })
-                    }
-                  >
-                    <WebhooksPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.WEBHOOKS_ACTIVITY,
-                element: (
-                  <ProtectedRoute
-                    condition={(has) =>
-                      has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
-                      has({ permission: PermissionsEnum.WEBHOOK_WRITE })
-                    }
-                  >
-                    <WebhooksPage />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.WEBHOOKS,
-                element: (
-                  <ProtectedRoute
-                    condition={(has) =>
-                      has({ permission: PermissionsEnum.WEBHOOK_READ }) ||
-                      has({ permission: PermissionsEnum.WEBHOOK_WRITE })
-                    }
-                  >
-                    <Navigate to={ROUTES.WEBHOOKS_ENDPOINTS} replace />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: '*',
-                element: <CatchAllRoute />,
+                path: ROUTES.SETTINGS_BILLING,
+                element: IS_SELF_HOSTED ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
               },
             ],
           },
           {
-            path: ROUTES.INTEGRATIONS,
-            element: (
-              <ProtectedRoute permission={PermissionsEnum.INTEGRATION_READ}>
-                <IntegrationsListPage />
-              </ProtectedRoute>
-            ),
+            element: <EditorLayout />,
             children: [
               {
-                path: ROUTES.INTEGRATIONS_CONNECT,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.INTEGRATION_WRITE} isDrawerRoute>
-                    <CreateIntegrationSidebar isOpened />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.INTEGRATIONS_CONNECT_PROVIDER,
-                element: (
-                  <ProtectedRoute permission={PermissionsEnum.INTEGRATION_WRITE} isDrawerRoute>
-                    <CreateIntegrationSidebar isOpened />
-                  </ProtectedRoute>
-                ),
-              },
-              {
-                path: ROUTES.INTEGRATIONS_UPDATE,
-                element: (
-                  <ProtectedRoute
-                    condition={(has) =>
-                      has({ permission: PermissionsEnum.INTEGRATION_WRITE }) ||
-                      has({ permission: PermissionsEnum.INTEGRATION_READ })
-                    }
-                    isDrawerRoute
-                  >
-                    <UpdateIntegrationSidebar isOpened />
-                  </ProtectedRoute>
-                ),
+                path: ROUTES.ENV,
+                children: [
+                  {
+                    path: ROUTES.LOCAL_EDIT_WORKFLOW,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.BRIDGE_WRITE}>
+                        <LocalEditWorkflowPage />
+                      </ProtectedRoute>
+                    ),
+                    children: [
+                      ...editorChildren,
+                      {
+                        path: ROUTES.LOCAL_TRIGGER_WORKFLOW,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.EVENT_WRITE} isDrawerRoute>
+                            <TestWorkflowDrawerPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    path: ROUTES.EDIT_WORKFLOW,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
+                        <EditWorkflowPage />
+                      </ProtectedRoute>
+                    ),
+                    children: [
+                      ...editorChildren,
+                      {
+                        path: ROUTES.TRIGGER_WORKFLOW,
+                        element: (
+                          <ProtectedRoute permission={PermissionsEnum.EVENT_WRITE} isDrawerRoute>
+                            <TestWorkflowDrawerPage />
+                          </ProtectedRoute>
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    path: ROUTES.EDIT_WORKFLOW_ACTIVITY,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
+                        <EditWorkflowPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.TEST_WORKFLOW,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.EVENT_WRITE}>
+                        <TestWorkflowRouteHandler />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.LAYOUTS_EDIT,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.WORKFLOW_READ}>
+                        <EditLayoutPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                ],
               },
             ],
           },
@@ -761,31 +793,10 @@ const router = createBrowserRouter([
               ),
           },
           {
-            path: ROUTES.SETTINGS,
-            element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
-          },
-          {
-            path: ROUTES.SETTINGS_ACCOUNT,
-            element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
-          },
-          {
-            path: ROUTES.SETTINGS_ORGANIZATION,
-            element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
-          },
-          {
-            path: ROUTES.SETTINGS_TEAM,
-            element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
-          },
-          {
-            path: ROUTES.SETTINGS_BILLING,
-            element: IS_SELF_HOSTED ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
-          },
-          {
             path: ROUTES.LOCAL_STUDIO_AUTH,
             element: <RedirectToLegacyStudioAuth />,
           },
           {
-            // Handshake target opened by `novu dev` (new dashboard local mode).
             path: ROUTES.LOCAL_HANDSHAKE,
             element: (
               <ProtectedRoute permission={PermissionsEnum.BRIDGE_WRITE}>

--- a/apps/dashboard/src/pages/activity-feed.tsx
+++ b/apps/dashboard/src/pages/activity-feed.tsx
@@ -3,9 +3,9 @@ import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ActivityFeedContent } from '@/components/activity/activity-feed-content';
 import { ConversationsContent } from '@/components/conversations/conversations-content';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { useEnvironment } from '@/context/environment/hooks';
+import { PageHeader } from '@/context/page-header';
 import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -92,42 +92,39 @@ export function ActivityFeed() {
   return (
     <>
       <PageMeta title="Activity Feed" />
-      <DashboardLayout
-        headerStartItems={
-          <h1 className="text-foreground-950 flex items-center gap-1">
-            <span>Activity Feed</span>
-          </h1>
-        }
-      >
-        <Tabs value={currentTab} onValueChange={handleTabChange} className="-mx-2">
-          <TabsList variant="regular" className="border-t-0">
-            <TabsTrigger value="workflow-runs" variant="regular" size="lg">
-              Workflow Runs
-            </TabsTrigger>
-            {areAgentsAvailable && (
-              <TabsTrigger value="conversations" variant="regular" size="lg">
-                Agent conversations
-              </TabsTrigger>
-            )}
-            {isHttpLogsPageEnabled && (
-              <TabsTrigger value="requests" variant="regular" size="lg">
-                Requests
-              </TabsTrigger>
-            )}
-          </TabsList>
-          <TabsContent value="workflow-runs">
-            <ActivityFeedContent contentHeight="h-[calc(100vh-170px)]" />
-          </TabsContent>
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">
+          <span>Activity Feed</span>
+        </h1>
+      </PageHeader>
+      <Tabs value={currentTab} onValueChange={handleTabChange} className="-mx-2">
+        <TabsList variant="regular" className="border-t-0">
+          <TabsTrigger value="workflow-runs" variant="regular" size="lg">
+            Workflow Runs
+          </TabsTrigger>
           {areAgentsAvailable && (
-            <TabsContent value="conversations">
-              <ConversationsContent contentHeight="h-[calc(100vh-170px)]" />
-            </TabsContent>
+            <TabsTrigger value="conversations" variant="regular" size="lg">
+              Agent conversations
+            </TabsTrigger>
           )}
-          <TabsContent value="requests" className="h-[calc(100vh-140px)]">
-            <RequestsTable />
+          {isHttpLogsPageEnabled && (
+            <TabsTrigger value="requests" variant="regular" size="lg">
+              Requests
+            </TabsTrigger>
+          )}
+        </TabsList>
+        <TabsContent value="workflow-runs">
+          <ActivityFeedContent contentHeight="h-[calc(100vh-170px)]" />
+        </TabsContent>
+        {areAgentsAvailable && (
+          <TabsContent value="conversations">
+            <ConversationsContent contentHeight="h-[calc(100vh-170px)]" />
           </TabsContent>
-        </Tabs>
-      </DashboardLayout>
+        )}
+        <TabsContent value="requests" className="h-[calc(100vh-140px)]">
+          <RequestsTable />
+        </TabsContent>
+      </Tabs>
     </>
   );
 }

--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -21,7 +21,6 @@ import { AgentExceedsPlanBanner } from '@/components/agents/agents-plan-limit-ba
 import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
 import { getAgentChatIntegrationIdentifier } from '@/components/agents/is-agent-integration-connected';
 import { ConnectSubscriberProvider } from '@/components/connect/connect-subscriber-provider';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
 import { Badge } from '@/components/primitives/badge';
 import {
@@ -38,6 +37,7 @@ import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import TruncatedText from '@/components/truncated-text';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { PageHeader } from '@/context/page-header';
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -317,108 +317,107 @@ export function AgentDetailsPage() {
   return (
     <>
       <PageMeta title={pageTitle} />
-      <DashboardLayout headerStartItems={headerStartItems}>
-        {isNotFound ? (
-          <div className="text-text-soft text-label-sm max-w-3xl px-4 py-6 md:px-6">
-            <p>This agent does not exist or was removed.</p>
-            <Link to={agentsListPath} className="text-primary-base mt-3 inline-block text-label-sm font-medium">
-              Back to agents
-            </Link>
-          </div>
-        ) : null}
+      <PageHeader>{headerStartItems}</PageHeader>
+      {isNotFound ? (
+        <div className="text-text-soft text-label-sm max-w-3xl px-4 py-6 md:px-6">
+          <p>This agent does not exist or was removed.</p>
+          <Link to={agentsListPath} className="text-primary-base mt-3 inline-block text-label-sm font-medium">
+            Back to agents
+          </Link>
+        </div>
+      ) : null}
 
-        {error && !isNotFound ? (
-          <div className="text-error-base text-label-sm max-w-3xl px-4 py-6 md:px-6">
-            Could not load this agent. Try again later.
-          </div>
-        ) : null}
+      {error && !isNotFound ? (
+        <div className="text-error-base text-label-sm max-w-3xl px-4 py-6 md:px-6">
+          Could not load this agent. Try again later.
+        </div>
+      ) : null}
 
-        {!error && isLoading ? (
-          <>
-            <AgentDetailsHeader agent={undefined} isLoading />
-            <AgentDetailsTabsSkeleton />
-          </>
-        ) : null}
+      {!error && isLoading ? (
+        <>
+          <AgentDetailsHeader agent={undefined} isLoading />
+          <AgentDetailsTabsSkeleton />
+        </>
+      ) : null}
 
-        {!error && !isLoading && agent ? (
-          <>
-            <AgentDetailsHeader agent={agent} isLoading={false} onRequestDelete={setAgentToDelete} />
+      {!error && !isLoading && agent ? (
+        <>
+          <AgentDetailsHeader agent={agent} isLoading={false} onRequestDelete={setAgentToDelete} />
 
-            {agent.exceedsPlanLimit ? (
-              <div className="px-4 pb-2 md:px-6">
-                <AgentExceedsPlanBanner />
-              </div>
-            ) : null}
+          {agent.exceedsPlanLimit ? (
+            <div className="px-4 pb-2 md:px-6">
+              <AgentExceedsPlanBanner />
+            </div>
+          ) : null}
 
-            <Tabs value={currentTab} onValueChange={handleTabChange} className="-mx-2 w-full">
-              <TabsList align="start" variant="regular" className="border-t-transparent px-4 py-0! md:px-6">
-                <TabsTrigger variant="regular" value="overview" size="xl">
-                  Overview
-                </TabsTrigger>
-                <TabsTrigger variant="regular" value="integrations" size="xl">
-                  Channels
-                </TabsTrigger>
-                {hasAgentChat ? (
-                  <TabsTrigger variant="regular" value={AGENT_DETAILS_CHAT_TAB} size="xl">
-                    Chat
-                  </TabsTrigger>
-                ) : null}
-              </TabsList>
-
-              <TabsContent value="overview" className="outline-none">
-                <ConnectSubscriberProvider>
-                  <AgentOverviewTab agent={agent} />
-                </ConnectSubscriberProvider>
-              </TabsContent>
-              <TabsContent value="integrations" className="outline-none">
-                {currentTab === 'integrations' ? (
-                  <ConnectSubscriberProvider>
-                    <AgentIntegrationsTab agent={agent} integrationIdentifier={integrationIdentifier} />
-                  </ConnectSubscriberProvider>
-                ) : null}
-              </TabsContent>
+          <Tabs value={currentTab} onValueChange={handleTabChange} className="-mx-2 w-full">
+            <TabsList align="start" variant="regular" className="border-t-transparent px-4 py-0! md:px-6">
+              <TabsTrigger variant="regular" value="overview" size="xl">
+                Overview
+              </TabsTrigger>
+              <TabsTrigger variant="regular" value="integrations" size="xl">
+                Channels
+              </TabsTrigger>
               {hasAgentChat ? (
-                <TabsContent value={AGENT_DETAILS_CHAT_TAB} className="outline-none">
-                  {currentTab === AGENT_DETAILS_CHAT_TAB ? (
-                    <AgentChatPanel agent={agent} agentChatIntegrationIdentifier={agentChatIntegrationIdentifier} />
-                  ) : null}
-                </TabsContent>
+                <TabsTrigger variant="regular" value={AGENT_DETAILS_CHAT_TAB} size="xl">
+                  Chat
+                </TabsTrigger>
               ) : null}
-            </Tabs>
+            </TabsList>
 
-            <DeleteAgentDialog
-              open={Boolean(agentToDelete)}
-              onOpenChange={(open) => {
-                if (!open) {
-                  setAgentToDelete(null);
-                }
-              }}
-              onConfirm={({ deleteFromProvider }) => {
-                if (agentToDelete) {
-                  deleteMutation.mutate({
-                    identifier: agentToDelete.identifier,
-                    name: agentToDelete.name,
-                    deleteFromProvider,
-                  });
-                }
-              }}
-              agentName={agentToDelete?.name ?? ''}
-              agentIdentifier={agentToDelete?.identifier ?? ''}
-              isDeleting={deleteMutation.isPending}
-              isManagedRuntime={agentToDelete?.runtime === 'managed'}
-            />
+            <TabsContent value="overview" className="outline-none">
+              <ConnectSubscriberProvider>
+                <AgentOverviewTab agent={agent} />
+              </ConnectSubscriberProvider>
+            </TabsContent>
+            <TabsContent value="integrations" className="outline-none">
+              {currentTab === 'integrations' ? (
+                <ConnectSubscriberProvider>
+                  <AgentIntegrationsTab agent={agent} integrationIdentifier={integrationIdentifier} />
+                </ConnectSubscriberProvider>
+              ) : null}
+            </TabsContent>
+            {hasAgentChat ? (
+              <TabsContent value={AGENT_DETAILS_CHAT_TAB} className="outline-none">
+                {currentTab === AGENT_DETAILS_CHAT_TAB ? (
+                  <AgentChatPanel agent={agent} agentChatIntegrationIdentifier={agentChatIntegrationIdentifier} />
+                ) : null}
+              </TabsContent>
+            ) : null}
+          </Tabs>
 
-            <AgentSetupModal
-              isOpen={showSetupModal}
-              onClose={() => setSetupModalDismissed(true)}
-              onSetupClick={() => {
-                setSetupModalDismissed(true);
-                handleTabChange('integrations');
-              }}
-            />
-          </>
-        ) : null}
-      </DashboardLayout>
+          <DeleteAgentDialog
+            open={Boolean(agentToDelete)}
+            onOpenChange={(open) => {
+              if (!open) {
+                setAgentToDelete(null);
+              }
+            }}
+            onConfirm={({ deleteFromProvider }) => {
+              if (agentToDelete) {
+                deleteMutation.mutate({
+                  identifier: agentToDelete.identifier,
+                  name: agentToDelete.name,
+                  deleteFromProvider,
+                });
+              }
+            }}
+            agentName={agentToDelete?.name ?? ''}
+            agentIdentifier={agentToDelete?.identifier ?? ''}
+            isDeleting={deleteMutation.isPending}
+            isManagedRuntime={agentToDelete?.runtime === 'managed'}
+          />
+
+          <AgentSetupModal
+            isOpen={showSetupModal}
+            onClose={() => setSetupModalDismissed(true)}
+            onSetupClick={() => {
+              setSetupModalDismissed(true);
+              handleTabChange('integrations');
+            }}
+          />
+        </>
+      ) : null}
     </>
   );
 }

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -26,7 +26,6 @@ import { NovuApiError, post } from '@/api/api.client';
 import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
 import { AgentsList } from '@/components/agents/agents-list';
 import { UPGRADE_CTA_LABEL, usePlanUpgradeClick } from '@/components/billing/use-plan-upgrade-click';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
 import { Badge } from '@/components/primitives/badge';
 import { Button } from '@/components/primitives/button';
@@ -39,6 +38,7 @@ import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner
 import { DismissButton, Icon as TagIcon, Root as TagRoot } from '@/components/primitives/tag';
 import { Textarea } from '@/components/primitives/textarea';
 import { IS_CLOUD, IS_EU, IS_SELF_HOSTED } from '@/config';
+import { PageHeader } from '@/context/page-header';
 import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { ROUTES } from '@/utils/routes';
@@ -433,48 +433,45 @@ export function AgentsPage() {
       {!areAgentsAvailable && IS_CLOUD ? (
         <AgentsEarlyAccessDialog open={earlyAccessOpen} onOpenChange={setEarlyAccessOpen} />
       ) : null}
-      <DashboardLayout
-        headerStartItems={
-          <h1 className="text-foreground-950 flex items-center gap-1">
-            Agents{' '}
-            <Badge color="gray" size="sm" variant="lighter">
-              BETA
-            </Badge>
-          </h1>
-        }
-      >
-        {areAgentsAvailable ? (
-          <AgentsList />
-        ) : (
-          <AgentsEmptyTeaser
-            cta={
-              IS_SELF_HOSTED ? (
-                <Button
-                  variant="primary"
-                  mode="gradient"
-                  size="xs"
-                  leadingIcon={RiSparkling2Line}
-                  type="button"
-                  onClick={handleUpgradeClick}
-                >
-                  {UPGRADE_CTA_LABEL}
-                </Button>
-              ) : (
-                <Button
-                  variant="secondary"
-                  mode="gradient"
-                  size="xs"
-                  trailingIcon={RiArrowRightSLine}
-                  type="button"
-                  onClick={() => setEarlyAccessOpen(true)}
-                >
-                  Request early access
-                </Button>
-              )
-            }
-          />
-        )}
-      </DashboardLayout>
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">
+          Agents{' '}
+          <Badge color="gray" size="sm" variant="lighter">
+            BETA
+          </Badge>
+        </h1>
+      </PageHeader>
+      {areAgentsAvailable ? (
+        <AgentsList />
+      ) : (
+        <AgentsEmptyTeaser
+          cta={
+            IS_SELF_HOSTED ? (
+              <Button
+                variant="primary"
+                mode="gradient"
+                size="xs"
+                leadingIcon={RiSparkling2Line}
+                type="button"
+                onClick={handleUpgradeClick}
+              >
+                {UPGRADE_CTA_LABEL}
+              </Button>
+            ) : (
+              <Button
+                variant="secondary"
+                mode="gradient"
+                size="xs"
+                trailingIcon={RiArrowRightSLine}
+                type="button"
+                onClick={() => setEarlyAccessOpen(true)}
+              >
+                Request early access
+              </Button>
+            )
+          }
+        />
+      )}
     </>
   );
 }

--- a/apps/dashboard/src/pages/analytics.tsx
+++ b/apps/dashboard/src/pages/analytics.tsx
@@ -22,12 +22,12 @@ import {
 import { ActiveSubscribersTrendChart } from '../components/analytics/charts/active-subscribers-trend-chart';
 import { ProvidersByVolume } from '../components/analytics/charts/providers-by-volume';
 import { WorkflowRunsTrendChart } from '../components/analytics/charts/workflow-runs-trend-chart';
-import { DashboardLayout } from '../components/dashboard-layout';
 import { PageMeta } from '../components/page-meta';
 import { Badge } from '../components/primitives/badge';
 import { FacetedFormFilter } from '../components/primitives/form/faceted-filter/facated-form-filter';
 import { InlineToast } from '../components/primitives/inline-toast';
 import { useEnvironment } from '../context/environment/hooks';
+import { PageHeader } from '../context/page-header';
 import { useFeatureFlag } from '../hooks/use-feature-flag';
 import { useFetchCharts } from '../hooks/use-fetch-charts';
 import { useFetchSubscription } from '../hooks/use-fetch-subscription';
@@ -132,118 +132,110 @@ export function AnalyticsPage() {
   return (
     <>
       <PageMeta title="Usage" />
-      <DashboardLayout
-        headerStartItems={
-          <h1 className="text-foreground-950 flex items-center gap-1">
-            <span>Usage</span>
-            {isDevMockMode && (
-              <Badge variant="filled" color="orange" className="text-xs">
-                DEV MOCK DATA
-              </Badge>
-            )}
-          </h1>
-        }
-      >
-        <motion.div
-          className="flex flex-col gap-1.5"
-          variants={ANIMATION_VARIANTS.page}
-          initial="hidden"
-          animate="show"
-        >
-          <motion.div variants={ANIMATION_VARIANTS.section} className="flex justify-start gap-2">
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">
+          <span>Usage</span>
+          {isDevMockMode && (
+            <Badge variant="filled" color="orange" className="text-xs">
+              DEV MOCK DATA
+            </Badge>
+          )}
+        </h1>
+      </PageHeader>
+      <motion.div className="flex flex-col gap-1.5" variants={ANIMATION_VARIANTS.page} initial="hidden" animate="show">
+        <motion.div variants={ANIMATION_VARIANTS.section} className="flex justify-start gap-2">
+          <FacetedFormFilter
+            size="small"
+            type="single"
+            hideClear
+            hideSearch
+            hideTitle
+            title="Time period"
+            options={dateFilterOptions}
+            selected={[selectedDateRange]}
+            onSelect={(values) => setSelectedDateRange(values[0])}
+            icon={CalendarIcon}
+          />
+          {isWorkflowFilterEnabled && (
             <FacetedFormFilter
               size="small"
-              type="single"
-              hideClear
-              hideSearch
-              hideTitle
-              title="Time period"
-              options={dateFilterOptions}
-              selected={[selectedDateRange]}
-              onSelect={(values) => setSelectedDateRange(values[0])}
-              icon={CalendarIcon}
-            />
-            {isWorkflowFilterEnabled && (
-              <FacetedFormFilter
-                size="small"
-                type="multi"
-                title="Workflows"
-                options={
-                  workflowTemplates?.workflows?.map((workflow) => ({
-                    label: workflow.name,
-                    value: workflow._id,
-                  })) || []
-                }
-                selected={selectedWorkflows}
-                onSelect={(values) => setSelectedWorkflows(values)}
-              />
-            )}
-          </motion.div>
-
-          <motion.div variants={ANIMATION_VARIANTS.section}>
-            <AnalyticsSection
-              messagesDeliveredData={messagesDeliveredData}
-              activeSubscribersData={activeSubscribersData}
-              avgMessagesPerSubscriberData={avgMessagesPerSubscriberData}
-              totalInteractionsData={totalInteractionsData}
-              isLoading={isMetricsLoading}
-            />
-          </motion.div>
-
-          <motion.div variants={ANIMATION_VARIANTS.section}>
-            <ChartsSection
-              charts={chartsData}
-              isTrendsLoading={isTrendsLoading}
-              isWorkflowLoading={isWorkflowLoading}
-              trendsError={trendsError}
-              workflowError={workflowError}
-            />
-          </motion.div>
-
-          <motion.div variants={ANIMATION_VARIANTS.section}>
-            <WorkflowRunsTrendChart
-              data={chartsData?.[ReportTypeEnum.WORKFLOW_RUNS_TREND] as WorkflowRunsTrendDataPoint[]}
-              count={workflowRunsCount}
-              periodLabel={selectedPeriodLabel}
-              isLoading={isWorkflowLoading}
-              error={workflowError}
-            />
-          </motion.div>
-
-          <motion.div
-            variants={ANIMATION_VARIANTS.section}
-            className="grid grid-cols-1 lg:grid-cols-12 gap-1.5 items-stretch lg:h-[200px]"
-          >
-            <div className="lg:col-span-8 h-full min-h-0">
-              <ActiveSubscribersTrendChart
-                data={chartsData?.[ReportTypeEnum.ACTIVE_SUBSCRIBERS_TREND] as ActiveSubscribersTrendDataPoint[]}
-                isLoading={isTrendsLoading}
-                error={trendsError}
-              />
-            </div>
-            <div className="lg:col-span-4 h-full min-h-0">
-              <ProvidersByVolume
-                data={chartsData?.[ReportTypeEnum.PROVIDER_BY_VOLUME] as ProviderVolumeDataPoint[]}
-                isLoading={isTrendsLoading}
-                error={trendsError}
-              />
-            </div>
-          </motion.div>
-
-          {currentEnvironment?.type === EnvironmentTypeEnum.DEV && (
-            <InlineToast
-              title="You're viewing usage for the Development environment"
-              variant="tip"
-              ctaLabel="Switch to production"
-              onCtaClick={() => {
-                if (oppositeEnvironment?.slug) {
-                  switchEnvironment(oppositeEnvironment.slug);
-                }
-              }}
+              type="multi"
+              title="Workflows"
+              options={
+                workflowTemplates?.workflows?.map((workflow) => ({
+                  label: workflow.name,
+                  value: workflow._id,
+                })) || []
+              }
+              selected={selectedWorkflows}
+              onSelect={(values) => setSelectedWorkflows(values)}
             />
           )}
         </motion.div>
-      </DashboardLayout>
+
+        <motion.div variants={ANIMATION_VARIANTS.section}>
+          <AnalyticsSection
+            messagesDeliveredData={messagesDeliveredData}
+            activeSubscribersData={activeSubscribersData}
+            avgMessagesPerSubscriberData={avgMessagesPerSubscriberData}
+            totalInteractionsData={totalInteractionsData}
+            isLoading={isMetricsLoading}
+          />
+        </motion.div>
+
+        <motion.div variants={ANIMATION_VARIANTS.section}>
+          <ChartsSection
+            charts={chartsData}
+            isTrendsLoading={isTrendsLoading}
+            isWorkflowLoading={isWorkflowLoading}
+            trendsError={trendsError}
+            workflowError={workflowError}
+          />
+        </motion.div>
+
+        <motion.div variants={ANIMATION_VARIANTS.section}>
+          <WorkflowRunsTrendChart
+            data={chartsData?.[ReportTypeEnum.WORKFLOW_RUNS_TREND] as WorkflowRunsTrendDataPoint[]}
+            count={workflowRunsCount}
+            periodLabel={selectedPeriodLabel}
+            isLoading={isWorkflowLoading}
+            error={workflowError}
+          />
+        </motion.div>
+
+        <motion.div
+          variants={ANIMATION_VARIANTS.section}
+          className="grid grid-cols-1 lg:grid-cols-12 gap-1.5 items-stretch lg:h-[200px]"
+        >
+          <div className="lg:col-span-8 h-full min-h-0">
+            <ActiveSubscribersTrendChart
+              data={chartsData?.[ReportTypeEnum.ACTIVE_SUBSCRIBERS_TREND] as ActiveSubscribersTrendDataPoint[]}
+              isLoading={isTrendsLoading}
+              error={trendsError}
+            />
+          </div>
+          <div className="lg:col-span-4 h-full min-h-0">
+            <ProvidersByVolume
+              data={chartsData?.[ReportTypeEnum.PROVIDER_BY_VOLUME] as ProviderVolumeDataPoint[]}
+              isLoading={isTrendsLoading}
+              error={trendsError}
+            />
+          </div>
+        </motion.div>
+
+        {currentEnvironment?.type === EnvironmentTypeEnum.DEV && (
+          <InlineToast
+            title="You're viewing usage for the Development environment"
+            variant="tip"
+            ctaLabel="Switch to production"
+            onCtaClick={() => {
+              if (oppositeEnvironment?.slug) {
+                switchEnvironment(oppositeEnvironment.slug);
+              }
+            }}
+          />
+        )}
+      </motion.div>
     </>
   );
 }

--- a/apps/dashboard/src/pages/api-keys.tsx
+++ b/apps/dashboard/src/pages/api-keys.tsx
@@ -11,9 +11,9 @@ import { Input } from '@/components/primitives/input';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { ExternalLink } from '@/components/shared/external-link';
 import { useEnvironment } from '@/context/environment/hooks';
+import { PageHeader } from '@/context/page-header';
 import { getRegionConfig, useRegion } from '@/context/region';
 import { apiHostnameManager } from '@/utils/api-hostname-manager';
-import { DashboardLayout } from '../components/dashboard-layout';
 import { Button } from '../components/primitives/button';
 import { Container } from '../components/primitives/container';
 import { HelpTooltipIndicator } from '../components/primitives/help-tooltip-indicator';
@@ -107,143 +107,144 @@ export function ApiKeysPage() {
   return (
     <>
       <PageMeta title={`API Keys for ${currentEnvironment?.name} environment`} />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950">API Keys</h1>}>
-        <Container className="flex w-full max-w-[800px] flex-col gap-6">
-          <Form {...form}>
-            <Card className="w-full overflow-hidden shadow-none">
-              <CardHeader>
-                {'<Inbox />'}
-                <p className="text-foreground-500 mt-1 text-xs font-normal">
-                  {'Use the public application identifier in Novu <Inbox />. '}
-                  <ExternalLink href="https://docs.novu.co/platform/inbox/overview" className="text-foreground-500">
-                    Learn more
-                  </ExternalLink>
-                </p>
-              </CardHeader>
-              <CardContent className="rounded-b-xl border-t bg-neutral-50 bg-white p-4">
-                <div className="space-y-4">
-                  <SettingField
-                    label="Application Identifier"
-                    tooltip={`This is unique for the ${currentEnvironment.name} environment.`}
-                    value={form.getValues('identifier')}
-                    isLoading={isLoading}
-                  />
-                </div>
-              </CardContent>
-            </Card>
-            <Card className="w-full overflow-hidden shadow-none">
-              <CardHeader>
-                Secret Keys
-                <p className="text-foreground-500 mt-1 text-xs font-normal">
-                  {'Use the secret key to authenticate your SDK requests. Keep it secure and never share it publicly. '}
-                  <ExternalLink href="https://docs.novu.co/platform/sdks/overview" className="text-foreground-500">
-                    Learn more
-                  </ExternalLink>
-                </p>
-              </CardHeader>
+      <PageHeader>
+        <h1 className="text-foreground-950">API Keys</h1>
+      </PageHeader>
+      <Container className="flex w-full max-w-[800px] flex-col gap-6">
+        <Form {...form}>
+          <Card className="w-full overflow-hidden shadow-none">
+            <CardHeader>
+              {'<Inbox />'}
+              <p className="text-foreground-500 mt-1 text-xs font-normal">
+                {'Use the public application identifier in Novu <Inbox />. '}
+                <ExternalLink href="https://docs.novu.co/platform/inbox/overview" className="text-foreground-500">
+                  Learn more
+                </ExternalLink>
+              </p>
+            </CardHeader>
+            <CardContent className="rounded-b-xl border-t bg-neutral-50 bg-white p-4">
+              <div className="space-y-4">
+                <SettingField
+                  label="Application Identifier"
+                  tooltip={`This is unique for the ${currentEnvironment.name} environment.`}
+                  value={form.getValues('identifier')}
+                  isLoading={isLoading}
+                />
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="w-full overflow-hidden shadow-none">
+            <CardHeader>
+              Secret Keys
+              <p className="text-foreground-500 mt-1 text-xs font-normal">
+                {'Use the secret key to authenticate your SDK requests. Keep it secure and never share it publicly. '}
+                <ExternalLink href="https://docs.novu.co/platform/sdks/overview" className="text-foreground-500">
+                  Learn more
+                </ExternalLink>
+              </p>
+            </CardHeader>
 
-              <CardContent className="rounded-b-xl border-t bg-neutral-50 bg-white p-4">
-                {isMultipleSecretKeysAllowed ? (
-                  <div className="space-y-4">
-                    {isLoading && <SettingField label="Secret Key" secret isLoading />}
-                    {!isLoading &&
-                      apiKeys?.map((apiKey, index) => (
-                        <SettingField
-                          key={apiKey.hash ?? apiKey.key}
-                          label={index === 0 ? 'Secret Key' : 'Secret Key (new)'}
-                          tooltip="Keep it secure and never share it publicly"
-                          value={apiKey.key}
-                          secret
-                          showRegenerateButton={canRegenerateApiKeys && index === 0}
-                          onRegenerateClick={() => setIsRegenerateDialogOpen(true)}
-                          isRegenerateLoading={regenerateApiKeysMutation.isPending}
-                          showDeleteButton={canRegenerateApiKeys && (apiKeys?.length ?? 0) > 1}
-                          onDeleteClick={() => setKeyPendingDeletion(apiKey)}
-                          isDeleteLoading={deleteApiKeyMutation.isPending && keyPendingDeletion?.hash === apiKey.hash}
-                        />
-                      ))}
-                    {canRegenerateApiKeys && (
-                      <div className="flex items-center justify-between gap-3 border-t border-neutral-100 pt-3">
-                        <p className="text-foreground-500 text-xs">
-                          Key rotation: generate a new key, switch your apps to it, then delete the old key.
-                        </p>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span>
-                              <Button
-                                size="xs"
-                                variant="secondary"
-                                mode="outline"
-                                leadingIcon={RiAddLine}
-                                onClick={handleCreateKey}
-                                disabled={isLoading || hasMaxSecretKeys}
-                                isLoading={createApiKeyMutation.isPending}
-                              >
-                                Generate new key
-                              </Button>
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            {hasMaxSecretKeys
-                              ? `You can have up to ${MAX_SECRET_KEYS} secret keys. Delete a key to generate a new one.`
-                              : 'Generate an additional secret key for a rolling rotation'}
-                          </TooltipContent>
-                        </Tooltip>
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <div className="space-y-4">
-                    <SettingField
-                      label="Secret Key"
-                      tooltip="Keep it secure and never share it publicly"
-                      value={form.getValues('apiKey')}
-                      secret
-                      isLoading={isLoading}
-                      showRegenerateButton={canRegenerateApiKeys}
-                      onRegenerateClick={() => setIsRegenerateDialogOpen(true)}
-                      isRegenerateLoading={regenerateApiKeysMutation.isPending}
-                    />
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-            <Card className="w-full overflow-hidden shadow-none">
-              <CardHeader>
-                API URLs
-                <p className="text-foreground-500 mt-1 text-xs font-normal">
-                  {IS_SELF_HOSTED
-                    ? 'API and WebSocket endpoints for your self-hosted Novu instance. '
-                    : `API and WebSocket URLs for Novu Cloud in the ${region} region. `}
-                  <ExternalLink href="https://docs.novu.co/api-reference/overview" className="text-foreground-500">
-                    Learn more
-                  </ExternalLink>
-                </p>
-              </CardHeader>
-              <CardContent className="rounded-b-xl border-t bg-neutral-50 bg-white p-4">
+            <CardContent className="rounded-b-xl border-t bg-neutral-50 bg-white p-4">
+              {isMultipleSecretKeysAllowed ? (
+                <div className="space-y-4">
+                  {isLoading && <SettingField label="Secret Key" secret isLoading />}
+                  {!isLoading &&
+                    apiKeys?.map((apiKey, index) => (
+                      <SettingField
+                        key={apiKey.hash ?? apiKey.key}
+                        label={index === 0 ? 'Secret Key' : 'Secret Key (new)'}
+                        tooltip="Keep it secure and never share it publicly"
+                        value={apiKey.key}
+                        secret
+                        showRegenerateButton={canRegenerateApiKeys && index === 0}
+                        onRegenerateClick={() => setIsRegenerateDialogOpen(true)}
+                        isRegenerateLoading={regenerateApiKeysMutation.isPending}
+                        showDeleteButton={canRegenerateApiKeys && (apiKeys?.length ?? 0) > 1}
+                        onDeleteClick={() => setKeyPendingDeletion(apiKey)}
+                        isDeleteLoading={deleteApiKeyMutation.isPending && keyPendingDeletion?.hash === apiKey.hash}
+                      />
+                    ))}
+                  {canRegenerateApiKeys && (
+                    <div className="flex items-center justify-between gap-3 border-t border-neutral-100 pt-3">
+                      <p className="text-foreground-500 text-xs">
+                        Key rotation: generate a new key, switch your apps to it, then delete the old key.
+                      </p>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span>
+                            <Button
+                              size="xs"
+                              variant="secondary"
+                              mode="outline"
+                              leadingIcon={RiAddLine}
+                              onClick={handleCreateKey}
+                              disabled={isLoading || hasMaxSecretKeys}
+                              isLoading={createApiKeyMutation.isPending}
+                            >
+                              Generate new key
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {hasMaxSecretKeys
+                            ? `You can have up to ${MAX_SECRET_KEYS} secret keys. Delete a key to generate a new one.`
+                            : 'Generate an additional secret key for a rolling rotation'}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+                </div>
+              ) : (
                 <div className="space-y-4">
                   <SettingField
-                    label="API Hostname"
-                    tooltip={
-                      IS_SELF_HOSTED ? 'Your self-hosted Novu API endpoint' : `For Novu Cloud in the ${region} region`
-                    }
-                    value={apiHostnameManager.getHostname()}
-                  />
-                  <SettingField
-                    label="WebSocket Hostname"
-                    tooltip={
-                      IS_SELF_HOSTED
-                        ? 'Your self-hosted Novu WebSocket endpoint'
-                        : `WebSocket endpoint for Novu Cloud in the ${region} region`
-                    }
-                    value={getWebSocketUrl(apiHostnameManager.getWebSocketHostname())}
+                    label="Secret Key"
+                    tooltip="Keep it secure and never share it publicly"
+                    value={form.getValues('apiKey')}
+                    secret
+                    isLoading={isLoading}
+                    showRegenerateButton={canRegenerateApiKeys}
+                    onRegenerateClick={() => setIsRegenerateDialogOpen(true)}
+                    isRegenerateLoading={regenerateApiKeysMutation.isPending}
                   />
                 </div>
-              </CardContent>
-            </Card>
-          </Form>
-        </Container>
-      </DashboardLayout>
+              )}
+            </CardContent>
+          </Card>
+          <Card className="w-full overflow-hidden shadow-none">
+            <CardHeader>
+              API URLs
+              <p className="text-foreground-500 mt-1 text-xs font-normal">
+                {IS_SELF_HOSTED
+                  ? 'API and WebSocket endpoints for your self-hosted Novu instance. '
+                  : `API and WebSocket URLs for Novu Cloud in the ${region} region. `}
+                <ExternalLink href="https://docs.novu.co/api-reference/overview" className="text-foreground-500">
+                  Learn more
+                </ExternalLink>
+              </p>
+            </CardHeader>
+            <CardContent className="rounded-b-xl border-t bg-neutral-50 bg-white p-4">
+              <div className="space-y-4">
+                <SettingField
+                  label="API Hostname"
+                  tooltip={
+                    IS_SELF_HOSTED ? 'Your self-hosted Novu API endpoint' : `For Novu Cloud in the ${region} region`
+                  }
+                  value={apiHostnameManager.getHostname()}
+                />
+                <SettingField
+                  label="WebSocket Hostname"
+                  tooltip={
+                    IS_SELF_HOSTED
+                      ? 'Your self-hosted Novu WebSocket endpoint'
+                      : `WebSocket endpoint for Novu Cloud in the ${region} region`
+                  }
+                  value={getWebSocketUrl(apiHostnameManager.getWebSocketHostname())}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </Form>
+      </Container>
       <RegenerateApiKeysDialog
         environment={currentEnvironment}
         open={isRegenerateDialogOpen}

--- a/apps/dashboard/src/pages/contexts.tsx
+++ b/apps/dashboard/src/pages/contexts.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
 import { AnimatedOutlet } from '@/components/animated-outlet';
 import { ContextList } from '@/components/contexts';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
+import { PageHeader } from '@/context/page-header';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
 
@@ -16,10 +16,11 @@ export const ContextsPage = () => {
   return (
     <>
       <PageMeta title="Contexts" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Contexts</h1>}>
-        <ContextList />
-        <AnimatedOutlet />
-      </DashboardLayout>
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">Contexts</h1>
+      </PageHeader>
+      <ContextList />
+      <AnimatedOutlet />
     </>
   );
 };

--- a/apps/dashboard/src/pages/domain-detail.tsx
+++ b/apps/dashboard/src/pages/domain-detail.tsx
@@ -16,7 +16,6 @@ import {
 import { SiCloudflare, SiVercel } from 'react-icons/si';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { ConfirmationModal } from '@/components/confirmation-modal';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import {
   DetailsSidebar,
   DetailsSidebarCard,
@@ -50,6 +49,7 @@ import { Skeleton } from '@/components/primitives/skeleton';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { TimeDisplayHoverCard } from '@/components/time-display-hover-card';
 import { useEnvironment } from '@/context/environment/hooks';
+import { PageHeader } from '@/context/page-header';
 import {
   useFetchDomain,
   useFetchDomainAutoConfigure,
@@ -359,7 +359,8 @@ export function DomainDetailPage() {
   );
 
   return (
-    <DashboardLayout headerStartItems={headerStartItems}>
+    <>
+      <PageHeader>{headerStartItems}</PageHeader>
       <PageMeta title={domain?.name ?? 'Domain'} />
 
       {showVerifiedConfetti &&
@@ -646,7 +647,7 @@ export function DomainDetailPage() {
         confirmButtonVariant="error"
         isLoading={deleteDomain.isPending}
       />
-    </DashboardLayout>
+    </>
   );
 }
 

--- a/apps/dashboard/src/pages/domains.tsx
+++ b/apps/dashboard/src/pages/domains.tsx
@@ -5,7 +5,6 @@ import { RiAddLine, RiMore2Fill } from 'react-icons/ri';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import type { DomainResponse } from '@/api/domains';
 import { ConfirmationModal } from '@/components/confirmation-modal';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { AddDomainDialog } from '@/components/domains/add-domain-dialog';
 import { DomainsIllustrationSvg, DomainsPaywallBanner } from '@/components/domains/domains-paywall-banner';
 import { PageMeta } from '@/components/page-meta';
@@ -31,6 +30,7 @@ import {
 } from '@/components/primitives/table';
 import { TablePaginationFooter } from '@/components/primitives/table-pagination-footer';
 import { useEnvironment } from '@/context/environment/hooks';
+import { PageHeader } from '@/context/page-header';
 import { useDeleteDomain, useFetchDomains } from '@/hooks/use-domains';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { usePersistedPageSize } from '@/hooks/use-persisted-page-size';
@@ -231,17 +231,21 @@ export function DomainsPage() {
 
   if (!domainsEnabled) {
     return (
-      <DashboardLayout
-        headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Inbound Email</h1>}
-      >
+      <>
+        <PageHeader>
+          <h1 className="text-foreground-950 flex items-center gap-1">Inbound Email</h1>
+        </PageHeader>
         <PageMeta title="Inbound Email" />
         <DomainsPaywallBanner />
-      </DashboardLayout>
+      </>
     );
   }
 
   return (
-    <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Inbound Email</h1>}>
+    <>
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">Inbound Email</h1>
+      </PageHeader>
       <PageMeta title="Inbound Email" />
       <div className="flex h-full w-full flex-col">
         {isEmptyDomainsState ? (
@@ -351,6 +355,6 @@ export function DomainsPage() {
         confirmButtonVariant="error"
         isLoading={deleteDomain.isPending}
       />
-    </DashboardLayout>
+    </>
   );
 }

--- a/apps/dashboard/src/pages/edit-layout.tsx
+++ b/apps/dashboard/src/pages/edit-layout.tsx
@@ -1,9 +1,9 @@
 import { useParams } from 'react-router-dom';
-import { FullPageLayout } from '@/components/full-page-layout';
 import { LayoutBreadcrumbs } from '@/components/layouts/layout-breadcrumbs';
 import { LayoutEditor } from '@/components/layouts/layout-editor';
 import { LayoutEditorProvider } from '@/components/layouts/layout-editor-provider';
 import { PageMeta } from '@/components/page-meta';
+import { PageHeader } from '@/context/page-header';
 import { useFetchLayout } from '@/hooks/use-fetch-layout';
 import { LayoutEditorSkeleton } from '../components/layouts/layout-editor-skeleton';
 
@@ -17,9 +17,10 @@ export const EditLayoutPage = () => {
     return (
       <>
         <PageMeta title={`Edit Layout`} />
-        <FullPageLayout headerStartItems={<LayoutBreadcrumbs />}>
-          <LayoutEditorSkeleton />
-        </FullPageLayout>
+        <PageHeader>
+          <LayoutBreadcrumbs />
+        </PageHeader>
+        <LayoutEditorSkeleton />
       </>
     );
   }
@@ -27,11 +28,12 @@ export const EditLayoutPage = () => {
   return (
     <>
       <PageMeta title={`Edit ${layout?.name} Layout`} />
-      <FullPageLayout headerStartItems={<LayoutBreadcrumbs layout={layout} />}>
-        <LayoutEditorProvider layout={layout} layoutSlug={layoutSlug} isPending={isPending}>
-          <LayoutEditor />
-        </LayoutEditorProvider>
-      </FullPageLayout>
+      <PageHeader>
+        <LayoutBreadcrumbs layout={layout} />
+      </PageHeader>
+      <LayoutEditorProvider layout={layout} layoutSlug={layoutSlug} isPending={isPending}>
+        <LayoutEditor />
+      </LayoutEditorProvider>
     </>
   );
 };

--- a/apps/dashboard/src/pages/edit-workflow.tsx
+++ b/apps/dashboard/src/pages/edit-workflow.tsx
@@ -1,9 +1,11 @@
 import { useLocation, useMatch, useParams } from 'react-router-dom';
 import { AnimatedOutlet } from '@/components/animated-outlet';
-import { FullPageLayout } from '@/components/full-page-layout';
 import { EditorBreadcrumbs } from '@/components/workflow-editor/editor-breadcrumbs';
+import { StepEditorSkeleton } from '@/components/workflow-editor/steps/step-editor-skeleton';
+import { EditorAsideSkeleton } from '@/components/workflow-editor/workflow-editor-skeleton';
 import { WorkflowProvider } from '@/components/workflow-editor/workflow-provider';
 import { WorkflowTabs } from '@/components/workflow-editor/workflow-tabs';
+import { PageHeader } from '@/context/page-header';
 import { ROUTES } from '@/utils/routes';
 
 // Define routes that should render without WorkflowTabs (full-page routes)
@@ -15,7 +17,7 @@ const FULL_PAGE_ROUTES = [
 function renderFullPageLayout() {
   return (
     <div className="flex h-full w-full">
-      <AnimatedOutlet />
+      <AnimatedOutlet fallback={<StepEditorSkeleton />} />
     </div>
   );
 }
@@ -34,7 +36,7 @@ function renderTraditionalLayout({ isNewWorkflowSlug }: { isNewWorkflowSlug: boo
       <WorkflowTabs />
       {!isNewWorkflowSlug && (
         <aside className="text-foreground-950 [&_textarea]:text-neutral-600'; flex h-full w-[350px] max-w-[350px] flex-col border-l [&_input]:text-xs [&_input]:text-neutral-600 [&_label]:text-xs [&_label]:font-medium [&_textarea]:text-xs">
-          <AnimatedOutlet />
+          <AnimatedOutlet fallback={<EditorAsideSkeleton />} />
         </aside>
       )}
     </div>
@@ -70,7 +72,10 @@ export const EditWorkflowPage = () => {
 
   return (
     <WorkflowProvider>
-      <FullPageLayout headerStartItems={<EditorBreadcrumbs />}>{getLayoutContent()}</FullPageLayout>
+      <PageHeader>
+        <EditorBreadcrumbs />
+      </PageHeader>
+      {getLayoutContent()}
     </WorkflowProvider>
   );
 };

--- a/apps/dashboard/src/pages/environments.tsx
+++ b/apps/dashboard/src/pages/environments.tsx
@@ -1,7 +1,7 @@
 import { ApiServiceLevelEnum, FeatureNameEnum, getFeatureForTierAsBoolean } from '@novu/shared';
 import { useEffect } from 'react';
 import { PageMeta } from '@/components/page-meta';
-import { DashboardLayout } from '../components/dashboard-layout';
+import { PageHeader } from '@/context/page-header';
 import { CreateEnvironmentButton } from '../components/environments/create-environment-button';
 import { FreeTierState } from '../components/environments/environments-free-state';
 import { EnvironmentsList } from '../components/environments/environments-list';
@@ -36,18 +36,19 @@ export function EnvironmentsPage() {
   return (
     <>
       <PageMeta title={`Environments`} />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Environments</h1>}>
-        {canAccessEnvironments ? (
-          <div className="flex flex-col justify-between gap-2 py-2">
-            <div className="flex justify-end">
-              <CreateEnvironmentButton />
-            </div>
-            <EnvironmentsList environments={environments} isLoading={areEnvironmentsInitialLoading} />
+      <PageHeader>
+        <h1 className="text-foreground-950">Environments</h1>
+      </PageHeader>
+      {canAccessEnvironments ? (
+        <div className="flex flex-col justify-between gap-2 py-2">
+          <div className="flex justify-end">
+            <CreateEnvironmentButton />
           </div>
-        ) : (
-          <FreeTierState />
-        )}
-      </DashboardLayout>
+          <EnvironmentsList environments={environments} isLoading={areEnvironmentsInitialLoading} />
+        </div>
+      ) : (
+        <FreeTierState />
+      )}
     </>
   );
 }

--- a/apps/dashboard/src/pages/integrations-list-page.tsx
+++ b/apps/dashboard/src/pages/integrations-list-page.tsx
@@ -3,8 +3,8 @@ import { useCallback } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { PermissionButton } from '@/components/primitives/permission-button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
+import { PageHeader } from '@/context/page-header';
 import { buildRoute, ROUTES } from '@/utils/routes';
-import { DashboardLayout } from '../components/dashboard-layout';
 import { IntegrationsList } from '../components/integrations/components/integrations-list';
 import { TableIntegration } from '../components/integrations/types';
 
@@ -20,13 +20,12 @@ export function IntegrationsListPage() {
   }, [navigate]);
 
   return (
-    <DashboardLayout
-      headerStartItems={
+    <>
+      <PageHeader>
         <h1 className="text-foreground-950 flex items-center gap-1">
           <span>Integration Store</span>
         </h1>
-      }
-    >
+      </PageHeader>
       <Tabs defaultValue="providers" className="-mx-2">
         <div className="border-neutral-alpha-200 flex items-center justify-between border-b">
           <TabsList variant="regular" className="border-b-0 border-transparent p-0 px-2!">
@@ -50,6 +49,6 @@ export function IntegrationsListPage() {
         </TabsContent>
       </Tabs>
       <Outlet />
-    </DashboardLayout>
+    </>
   );
 }

--- a/apps/dashboard/src/pages/layouts.tsx
+++ b/apps/dashboard/src/pages/layouts.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 
 import { AnimatedOutlet } from '@/components/animated-outlet';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { LayoutList } from '@/components/layouts/layout-list';
 import { PageMeta } from '@/components/page-meta';
+import { PageHeader } from '@/context/page-header';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
 
@@ -17,12 +17,11 @@ export const LayoutsPage = () => {
   return (
     <>
       <PageMeta title="Email Layouts" />
-      <DashboardLayout
-        headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Email Layouts</h1>}
-      >
-        <LayoutList />
-        <AnimatedOutlet />
-      </DashboardLayout>
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">Email Layouts</h1>
+      </PageHeader>
+      <LayoutList />
+      <AnimatedOutlet />
     </>
   );
 };

--- a/apps/dashboard/src/pages/local-edit-workflow.tsx
+++ b/apps/dashboard/src/pages/local-edit-workflow.tsx
@@ -1,13 +1,14 @@
 import { Navigate, useLocation } from 'react-router-dom';
 import { AnimatedOutlet } from '@/components/animated-outlet';
-import { FullPageLayout } from '@/components/full-page-layout';
 import { EditorBreadcrumbs } from '@/components/workflow-editor/editor-breadcrumbs';
 import { LocalWorkflowProvider } from '@/components/workflow-editor/local-workflow-provider';
+import { StepEditorSkeleton } from '@/components/workflow-editor/steps/step-editor-skeleton';
+import { EditorAsideSkeleton } from '@/components/workflow-editor/workflow-editor-skeleton';
 import { WorkflowTabs } from '@/components/workflow-editor/workflow-tabs';
 import { useLocalMode } from '@/context/local-mode';
+import { PageHeader } from '@/context/page-header';
 import { ROUTES } from '@/utils/routes';
 
-// Same full-page routes as the regular editor (see pages/edit-workflow.tsx)
 const FULL_PAGE_ROUTES = [ROUTES.EDIT_STEP_TEMPLATE];
 
 /**
@@ -31,20 +32,21 @@ export const LocalEditWorkflowPage = () => {
 
   return (
     <LocalWorkflowProvider>
-      <FullPageLayout headerStartItems={<EditorBreadcrumbs />}>
-        {isFullPageRoute ? (
-          <div className="flex h-full w-full">
-            <AnimatedOutlet />
-          </div>
-        ) : (
-          <div className="flex h-full flex-1 flex-nowrap">
-            <WorkflowTabs />
-            <aside className="text-foreground-950 [&_textarea]:text-neutral-600'; flex h-full w-[350px] max-w-[350px] flex-col border-l [&_input]:text-xs [&_input]:text-neutral-600 [&_label]:text-xs [&_label]:font-medium [&_textarea]:text-xs">
-              <AnimatedOutlet />
-            </aside>
-          </div>
-        )}
-      </FullPageLayout>
+      <PageHeader>
+        <EditorBreadcrumbs />
+      </PageHeader>
+      {isFullPageRoute ? (
+        <div className="flex h-full w-full">
+          <AnimatedOutlet fallback={<StepEditorSkeleton />} />
+        </div>
+      ) : (
+        <div className="flex h-full flex-1 flex-nowrap">
+          <WorkflowTabs />
+          <aside className="text-foreground-950 [&_textarea]:text-neutral-600'; flex h-full w-[350px] max-w-[350px] flex-col border-l [&_input]:text-xs [&_input]:text-neutral-600 [&_label]:text-xs [&_label]:font-medium [&_textarea]:text-xs">
+            <AnimatedOutlet fallback={<EditorAsideSkeleton />} />
+          </aside>
+        </div>
+      )}
     </LocalWorkflowProvider>
   );
 };

--- a/apps/dashboard/src/pages/local-workflows.tsx
+++ b/apps/dashboard/src/pages/local-workflows.tsx
@@ -2,7 +2,6 @@ import { WorkflowResponseDto } from '@novu/shared';
 import { FaCode } from 'react-icons/fa6';
 import { RiRefreshLine, RiTerminalBoxLine } from 'react-icons/ri';
 import { Link, Navigate, useParams } from 'react-router-dom';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { Badge } from '@/components/primitives/badge';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/primitives/table';
@@ -10,6 +9,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import TruncatedText from '@/components/truncated-text';
 import { WorkflowSteps } from '@/components/workflow-steps';
 import { useLocalMode } from '@/context/local-mode';
+import { PageHeader } from '@/context/page-header';
 import type { StepTypeEnum } from '@/utils/enums';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { ConnectionStatus } from '@/utils/types';
@@ -157,15 +157,13 @@ export const LocalWorkflowsPage = () => {
   const isDisconnected = healthStatus === ConnectionStatus.DISCONNECTED && !workflows;
 
   return (
-    <DashboardLayout
-      showBridgeUrl={false}
-      headerStartItems={
+    <>
+      <PageHeader>
         <div className="flex items-center gap-2.5">
           <h1 className="text-foreground-950">Local workflows</h1>
           <LocalBridgePill />
         </div>
-      }
-    >
+      </PageHeader>
       {isDisconnected ? (
         <DisconnectedState />
       ) : isDiscoverPending && !workflows ? (
@@ -188,6 +186,6 @@ export const LocalWorkflowsPage = () => {
           </div>
         </div>
       )}
-    </DashboardLayout>
+    </>
   );
 };

--- a/apps/dashboard/src/pages/settings.tsx
+++ b/apps/dashboard/src/pages/settings.tsx
@@ -1,10 +1,13 @@
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { SettingsTabs } from '@/components/settings/settings-tabs';
+import { PageHeader } from '@/context/page-header';
 import { ROUTES } from '@/utils/routes';
 
 export function SettingsPage() {
   return (
-    <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Settings</h1>}>
+    <>
+      <PageHeader>
+        <h1 className="text-foreground-950">Settings</h1>
+      </PageHeader>
       <SettingsTabs
         rootRoute={ROUTES.SETTINGS}
         routes={{
@@ -14,6 +17,6 @@ export function SettingsPage() {
           billing: ROUTES.SETTINGS_BILLING,
         }}
       />
-    </DashboardLayout>
+    </>
   );
 }

--- a/apps/dashboard/src/pages/subscribers.tsx
+++ b/apps/dashboard/src/pages/subscribers.tsx
@@ -1,11 +1,11 @@
 import { AnimatePresence } from 'motion/react';
 import { useEffect } from 'react';
 import { useMatch, useOutlet } from 'react-router-dom';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
 import { ProtectedDrawer } from '@/components/protected-drawer';
 import { useSubscribersNavigate } from '@/components/subscribers/hooks/use-subscribers-navigate';
 import { SubscriberList } from '@/components/subscribers/subscriber-list';
+import { PageHeader } from '@/context/page-header';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -24,19 +24,20 @@ export const SubscribersPage = () => {
   return (
     <>
       <PageMeta title="Subscribers" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Subscribers</h1>}>
-        <SubscriberList />
-        <AnimatePresence mode="wait" initial>
-          <ProtectedDrawer
-            open={isEditMatches || isCreateMatches}
-            onOpenChange={() => {
-              navigateToSubscribersCurrentPage();
-            }}
-          >
-            {element}
-          </ProtectedDrawer>
-        </AnimatePresence>
-      </DashboardLayout>
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">Subscribers</h1>
+      </PageHeader>
+      <SubscriberList />
+      <AnimatePresence mode="wait" initial>
+        <ProtectedDrawer
+          open={isEditMatches || isCreateMatches}
+          onOpenChange={() => {
+            navigateToSubscribersCurrentPage();
+          }}
+        >
+          {element}
+        </ProtectedDrawer>
+      </AnimatePresence>
     </>
   );
 };

--- a/apps/dashboard/src/pages/test-workflow.tsx
+++ b/apps/dashboard/src/pages/test-workflow.tsx
@@ -1,9 +1,9 @@
 import { useParams } from 'react-router-dom';
-import { FullPageLayout } from '@/components/full-page-layout';
 import { PageMeta } from '@/components/page-meta';
 import { Toaster } from '@/components/primitives/sonner';
 import { EditorBreadcrumbs } from '@/components/workflow-editor/editor-breadcrumbs';
 import { TestWorkflowTabs } from '@/components/workflow-editor/test-workflow/test-workflow-tabs';
+import { PageHeader } from '@/context/page-header';
 import { useFetchWorkflow } from '@/hooks/use-fetch-workflow';
 import { useFetchWorkflowTestData } from '@/hooks/use-fetch-workflow-test-data';
 import { WorkflowProvider } from '../components/workflow-editor/workflow-provider';
@@ -19,10 +19,11 @@ export const TestWorkflowPage = () => {
     <>
       <PageMeta title={`Trigger ${workflow?.name}`} />
       <WorkflowProvider>
-        <FullPageLayout headerStartItems={<EditorBreadcrumbs />}>
-          <TestWorkflowTabs testData={testData} />
-          <Toaster />
-        </FullPageLayout>
+        <PageHeader>
+          <EditorBreadcrumbs />
+        </PageHeader>
+        <TestWorkflowTabs testData={testData} />
+        <Toaster />
       </WorkflowProvider>
     </>
   );

--- a/apps/dashboard/src/pages/topics.tsx
+++ b/apps/dashboard/src/pages/topics.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
 import { AnimatedOutlet } from '@/components/animated-outlet';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
 import { TopicList } from '@/components/topics/topic-list';
+import { PageHeader } from '@/context/page-header';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
 
@@ -16,10 +16,11 @@ export const TopicsPage = () => {
   return (
     <>
       <PageMeta title="Topics" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Topics</h1>}>
-        <TopicList />
-        <AnimatedOutlet />
-      </DashboardLayout>
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">Topics</h1>
+      </PageHeader>
+      <TopicList />
+      <AnimatedOutlet />
     </>
   );
 };

--- a/apps/dashboard/src/pages/translations.tsx
+++ b/apps/dashboard/src/pages/translations.tsx
@@ -1,18 +1,17 @@
 import { AnimatedOutlet } from '@/components/animated-outlet';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
 import { TranslationList } from '@/components/translations/translation-list';
+import { PageHeader } from '@/context/page-header';
 
 export const TranslationsPage = () => {
   return (
     <>
       <PageMeta title="Translations" />
-      <DashboardLayout
-        headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Translations</h1>}
-      >
-        <TranslationList />
-        <AnimatedOutlet />
-      </DashboardLayout>
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">Translations</h1>
+      </PageHeader>
+      <TranslationList />
+      <AnimatedOutlet />
     </>
   );
 };

--- a/apps/dashboard/src/pages/variables.tsx
+++ b/apps/dashboard/src/pages/variables.tsx
@@ -1,16 +1,17 @@
 import { AnimatedOutlet } from '@/components/animated-outlet';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
 import { VariableList } from '@/components/variables/variable-list';
+import { PageHeader } from '@/context/page-header';
 
 export const VariablesPage = () => {
   return (
     <>
       <PageMeta title="Variables" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Variables</h1>}>
-        <VariableList />
-        <AnimatedOutlet />
-      </DashboardLayout>
+      <PageHeader>
+        <h1 className="text-foreground-950">Variables</h1>
+      </PageHeader>
+      <VariableList />
+      <AnimatedOutlet />
     </>
   );
 };

--- a/apps/dashboard/src/pages/webhooks-page.tsx
+++ b/apps/dashboard/src/pages/webhooks-page.tsx
@@ -15,10 +15,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitive
 import { EmptyStateSvg, WebhooksPaywallState } from '@/components/webhooks/webhooks-paywall-state';
 import { IS_CLOUD } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
+import { PageHeader } from '@/context/page-header';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { buildRoute, ROUTES } from '@/utils/routes';
-import { DashboardLayout } from '../components/dashboard-layout';
 import { Badge } from '../components/primitives/badge';
 import { QueryKeys } from '../utils/query-keys';
 
@@ -133,9 +133,12 @@ export function WebhooksPage() {
 
   if (IS_CLOUD && !isTierEligibleForWebhooks && !isLoadingEligibility) {
     return (
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Webhooks</h1>}>
+      <>
+        <PageHeader>
+          <h1 className="text-foreground-950">Webhooks</h1>
+        </PageHeader>
         <WebhooksPaywallState />
-      </DashboardLayout>
+      </>
     );
   }
 
@@ -144,7 +147,10 @@ export function WebhooksPage() {
 
   if (currentEnvironment && !currentEnvironment?.webhookAppId) {
     return (
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Webhooks</h1>}>
+      <>
+        <PageHeader>
+          <h1 className="text-foreground-950">Webhooks</h1>
+        </PageHeader>
         <div className="flex h-full w-full flex-col items-center justify-center gap-6 px-4">
           <div className="flex w-full max-w-[480px] flex-col items-center gap-6 text-center">
             <div className="flex w-full flex-col gap-3">
@@ -179,7 +185,7 @@ export function WebhooksPage() {
             </div>
           </div>
         </div>
-      </DashboardLayout>
+      </>
     );
   }
 
@@ -199,7 +205,10 @@ export function WebhooksPage() {
   };
 
   return (
-    <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Webhooks</h1>}>
+    <>
+      <PageHeader>
+        <h1 className="text-foreground-950">Webhooks</h1>
+      </PageHeader>
       <Tabs
         value={activeTabDefinition.value}
         onValueChange={(value) => {
@@ -278,6 +287,6 @@ export function WebhooksPage() {
           </>
         )}
       </Tabs>
-    </DashboardLayout>
+    </>
   );
 }

--- a/apps/dashboard/src/pages/welcome-page.tsx
+++ b/apps/dashboard/src/pages/welcome-page.tsx
@@ -1,7 +1,6 @@
 import { motion } from 'motion/react';
 import { ReactElement, useEffect } from 'react';
 import { RiChat3Line, RiNotification3Line } from 'react-icons/ri';
-import { DashboardLayout } from '../components/dashboard-layout';
 import { PageMeta } from '../components/page-meta';
 import { SetupStepsCard } from '../components/welcome/home/setup-steps-card';
 import { useWelcomeSetup } from '../components/welcome/home/use-welcome-setup';
@@ -40,56 +39,54 @@ export function WelcomePage(): ReactElement {
   return (
     <>
       <PageMeta title="Get Started with Novu" />
-      <DashboardLayout>
-        <motion.div className="flex flex-col gap-2.5 p-2.5" variants={pageVariants} initial="hidden" animate="show">
-          <motion.div variants={sectionVariants}>
-            <WelcomeHeading />
-          </motion.div>
-
-          <div className="grid grid-cols-1 gap-2.5 lg:grid-cols-[minmax(0,1fr)_375px]">
-            <div className="flex min-w-0 flex-col gap-2.5">
-              <motion.div variants={sectionVariants}>
-                <SetupStepsCard steps={steps} onLearnMore={openDocs} />
-              </motion.div>
-
-              {showWorkflowsBanner ? (
-                <motion.div variants={sectionVariants}>
-                  <WelcomeBanner
-                    badgeLabel="Notifications"
-                    badgeIcon={RiNotification3Line}
-                    badgeColorClassName="text-[#fb3748]"
-                    badgeBackgroundClassName="bg-primary-alpha-10"
-                    title="Send transactional notifications with Workflows"
-                    description="Trigger product events, orchestrate delivery across channels, and optionally connect notifications to your agents for follow-up conversations."
-                    ctaLabel="Setup workflows"
-                    onCtaClick={goToWorkflows}
-                  />
-                </motion.div>
-              ) : null}
-
-              {showAgentsBanner ? (
-                <motion.div variants={sectionVariants}>
-                  <WelcomeBanner
-                    badgeLabel="Conversations"
-                    badgeIcon={RiChat3Line}
-                    badgeColorClassName="text-[#7d52f4]"
-                    badgeBackgroundClassName="bg-[rgba(125,82,244,0.1)]"
-                    title="Setup agents to let your users respond to the notifications."
-                    description="Workflows can notify users when something happens, and with agents, your users can respond to those notifications and get a response back or take action."
-                    ctaLabel="Setup agents"
-                    onCtaClick={goToAgentsSetup}
-                    learnMore={{ onClick: openDocs }}
-                  />
-                </motion.div>
-              ) : null}
-            </div>
-
-            <motion.div variants={sectionVariants}>
-              <WelcomeSidebar />
-            </motion.div>
-          </div>
+      <motion.div className="flex flex-col gap-2.5 p-2.5" variants={pageVariants} initial="hidden" animate="show">
+        <motion.div variants={sectionVariants}>
+          <WelcomeHeading />
         </motion.div>
-      </DashboardLayout>
+
+        <div className="grid grid-cols-1 gap-2.5 lg:grid-cols-[minmax(0,1fr)_375px]">
+          <div className="flex min-w-0 flex-col gap-2.5">
+            <motion.div variants={sectionVariants}>
+              <SetupStepsCard steps={steps} onLearnMore={openDocs} />
+            </motion.div>
+
+            {showWorkflowsBanner ? (
+              <motion.div variants={sectionVariants}>
+                <WelcomeBanner
+                  badgeLabel="Notifications"
+                  badgeIcon={RiNotification3Line}
+                  badgeColorClassName="text-[#fb3748]"
+                  badgeBackgroundClassName="bg-primary-alpha-10"
+                  title="Send transactional notifications with Workflows"
+                  description="Trigger product events, orchestrate delivery across channels, and optionally connect notifications to your agents for follow-up conversations."
+                  ctaLabel="Setup workflows"
+                  onCtaClick={goToWorkflows}
+                />
+              </motion.div>
+            ) : null}
+
+            {showAgentsBanner ? (
+              <motion.div variants={sectionVariants}>
+                <WelcomeBanner
+                  badgeLabel="Conversations"
+                  badgeIcon={RiChat3Line}
+                  badgeColorClassName="text-[#7d52f4]"
+                  badgeBackgroundClassName="bg-[rgba(125,82,244,0.1)]"
+                  title="Setup agents to let your users respond to the notifications."
+                  description="Workflows can notify users when something happens, and with agents, your users can respond to those notifications and get a response back or take action."
+                  ctaLabel="Setup agents"
+                  onCtaClick={goToAgentsSetup}
+                  learnMore={{ onClick: openDocs }}
+                />
+              </motion.div>
+            ) : null}
+          </div>
+
+          <motion.div variants={sectionVariants}>
+            <WelcomeSidebar />
+          </motion.div>
+        </div>
+      </motion.div>
     </>
   );
 }

--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -22,7 +22,6 @@ import {
 import { Link, Outlet, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { fetchWorkflowSuggestions } from '@/api/ai';
 import { Shimmer } from '@/components/ai-elements/shimmer';
-import { DashboardLayout } from '@/components/dashboard-layout';
 import { AiThinking } from '@/components/icons/ai-thinking';
 import { Broom } from '@/components/icons/broom';
 import { PageMeta } from '@/components/page-meta';
@@ -46,6 +45,7 @@ import { WorkflowTemplateModal } from '@/components/template-store/workflow-temp
 import { SortableColumn, WorkflowList } from '@/components/workflow-list';
 import { IS_AI_FEATURES_ENABLED } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
+import { PageHeader } from '@/context/page-header';
 import { useDebounce } from '@/hooks/use-debounce';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchWorkflows } from '@/hooks/use-fetch-workflows';
@@ -253,285 +253,279 @@ export const WorkflowsPage = () => {
   return (
     <>
       <PageMeta title="Workflows" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}>
-        <div className="flex h-full w-full flex-col">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-wrap items-center gap-2 py-2.5">
-              <FacetedFormFilter
-                type="text"
-                size="small"
-                title="Search"
-                value={form.watch('query') || ''}
-                onChange={(value) => {
-                  form.setValue('query', value || '');
-                }}
-                placeholder="Search workflows..."
-              />
-              <FacetedFormFilter
-                size="small"
-                type="multi"
-                title="Tags"
-                placeholder="Filter by tags"
-                options={tags?.map((tag) => ({ label: tag.name, value: tag.name })) || []}
-                selected={form.watch('tags')}
-                onSelect={(values) => {
-                  form.setValue('tags', values, { shouldDirty: true, shouldTouch: true });
-                }}
-              />
-              <FacetedFormFilter
-                size="small"
-                type="multi"
-                title="Status"
-                placeholder="Filter by status"
-                options={[
-                  { label: 'Active', value: WorkflowStatusEnum.ACTIVE },
-                  { label: 'Inactive', value: WorkflowStatusEnum.INACTIVE },
-                  { label: 'Error', value: WorkflowStatusEnum.ERROR },
-                ]}
-                selected={form.watch('status')}
-                onSelect={(values) => {
-                  form.setValue('status', values, { shouldDirty: true, shouldTouch: true });
-                }}
-              />
+      <PageHeader>
+        <h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>
+      </PageHeader>
+      <div className="flex h-full w-full flex-col">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-2 py-2.5">
+            <FacetedFormFilter
+              type="text"
+              size="small"
+              title="Search"
+              value={form.watch('query') || ''}
+              onChange={(value) => {
+                form.setValue('query', value || '');
+              }}
+              placeholder="Search workflows..."
+            />
+            <FacetedFormFilter
+              size="small"
+              type="multi"
+              title="Tags"
+              placeholder="Filter by tags"
+              options={tags?.map((tag) => ({ label: tag.name, value: tag.name })) || []}
+              selected={form.watch('tags')}
+              onSelect={(values) => {
+                form.setValue('tags', values, { shouldDirty: true, shouldTouch: true });
+              }}
+            />
+            <FacetedFormFilter
+              size="small"
+              type="multi"
+              title="Status"
+              placeholder="Filter by status"
+              options={[
+                { label: 'Active', value: WorkflowStatusEnum.ACTIVE },
+                { label: 'Inactive', value: WorkflowStatusEnum.INACTIVE },
+                { label: 'Error', value: WorkflowStatusEnum.ERROR },
+              ]}
+              selected={form.watch('status')}
+              onSelect={(values) => {
+                form.setValue('status', values, { shouldDirty: true, shouldTouch: true });
+              }}
+            />
 
-              {hasActiveFilters && (
-                <div className="flex items-center gap-1">
-                  <Button variant="secondary" mode="ghost" size="2xs" onClick={clearFilters}>
-                    Reset
-                  </Button>
-                  {isFetching && !isPending && <RiLoader4Line className="h-3 w-3 animate-spin text-neutral-400" />}
-                </div>
-              )}
-            </div>
-            <CreateWorkflowButton />
-          </div>
-          {shouldShowStartWithTemplatesSection && (
-            <div className="mb-2">
-              <div className="my-2 flex items-center justify-between">
-                <div className="text-label-xs text-text-soft">Start with</div>
-                <LinkButton
-                  size="sm"
-                  variant="gray"
-                  onClick={() =>
-                    navigate(
-                      `${buildRoute(ROUTES.TEMPLATE_STORE, {
-                        environmentSlug: environmentSlug || '',
-                      })}?source=start-with`
-                    )
-                  }
-                  trailingIcon={RiArrowRightSLine}
-                >
-                  Explore templates
-                </LinkButton>
+            {hasActiveFilters && (
+              <div className="flex items-center gap-1">
+                <Button variant="secondary" mode="ghost" size="2xs" onClick={clearFilters}>
+                  Reset
+                </Button>
+                {isFetching && !isPending && <RiLoader4Line className="h-3 w-3 animate-spin text-neutral-400" />}
               </div>
+            )}
+          </div>
+          <CreateWorkflowButton />
+        </div>
+        {shouldShowStartWithTemplatesSection && (
+          <div className="mb-2">
+            <div className="my-2 flex items-center justify-between">
+              <div className="text-label-xs text-text-soft">Start with</div>
+              <LinkButton
+                size="sm"
+                variant="gray"
+                onClick={() =>
+                  navigate(
+                    `${buildRoute(ROUTES.TEMPLATE_STORE, {
+                      environmentSlug: environmentSlug || '',
+                    })}?source=start-with`
+                  )
+                }
+                trailingIcon={RiArrowRightSLine}
+              >
+                Explore templates
+              </LinkButton>
+            </div>
 
-              <AnimatePresence mode="wait">
-                {/* State 1: Generating personalized suggestions */}
-                {isOnboardingGenerating && (
-                  <motion.div
-                    key="onboarding-generating"
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -8, scale: 0.98, filter: 'blur(4px)' }}
-                    transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
-                    className="bg-bg-white border border-border-sub shadow-sm rounded-12 flex items-start gap-3 px-3 py-3"
-                  >
-                    <div className="flex flex-col gap-2">
-                      <span className="flex items-center gap-1 text-label-sm text-text-strong">
-                        <Broom fill="#525866" className="text-text-sub h-3 w-3 shrink-0 animate-pulse" />
-                        <Shimmer className="text-label-xs">Generating personal suggestions for you...</Shimmer>
-                      </span>
-                      <span className="text-paragraph-xs text-text-soft">
-                        Identifying common notification flows used by similar products. View{' '}
-                        <LinkButton
-                          size="sm"
-                          variant="gray"
-                          className="inline cursor-pointer"
-                          onClick={() =>
-                            navigate(
-                              `${buildRoute(ROUTES.TEMPLATE_STORE, {
-                                environmentSlug: environmentSlug || '',
-                              })}?source=generating-fallback`
-                            )
-                          }
-                        >
-                          Template library
-                        </LinkButton>{' '}
-                        instead →
-                      </span>
-                    </div>
-                  </motion.div>
-                )}
-
-                {/* State 2: Personalized suggestions ready */}
-                {hasPersonalizedSuggestions && !isOnboardingGenerating && (
-                  <motion.div
-                    key="onboarding-personalized"
-                    initial={{ opacity: 0, y: 12 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -6, transition: { duration: 0.18 } }}
-                    transition={{ duration: 0.28, ease: [0.25, 0.1, 0.25, 1] }}
-                    className="w-full"
-                  >
-                    <ScrollArea className="w-full">
-                      <motion.div
-                        className="bg-bg-weak rounded-12 flex gap-4 p-3"
-                        initial="hidden"
-                        animate="visible"
-                        variants={startWithCardsRowVariants}
+            <AnimatePresence mode="wait">
+              {/* State 1: Generating personalized suggestions */}
+              {isOnboardingGenerating && (
+                <motion.div
+                  key="onboarding-generating"
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -8, scale: 0.98, filter: 'blur(4px)' }}
+                  transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
+                  className="bg-bg-white border border-border-sub shadow-sm rounded-12 flex items-start gap-3 px-3 py-3"
+                >
+                  <div className="flex flex-col gap-2">
+                    <span className="flex items-center gap-1 text-label-sm text-text-strong">
+                      <Broom fill="#525866" className="text-text-sub h-3 w-3 shrink-0 animate-pulse" />
+                      <Shimmer className="text-label-xs">Generating personal suggestions for you...</Shimmer>
+                    </span>
+                    <span className="text-paragraph-xs text-text-soft">
+                      Identifying common notification flows used by similar products. View{' '}
+                      <LinkButton
+                        size="sm"
+                        variant="gray"
+                        className="inline cursor-pointer"
+                        onClick={() =>
+                          navigate(
+                            `${buildRoute(ROUTES.TEMPLATE_STORE, {
+                              environmentSlug: environmentSlug || '',
+                            })}?source=generating-fallback`
+                          )
+                        }
                       >
-                        {isAiWorkflowGenerationEnabled && (
-                          <motion.div className="w-[250px] shrink-0" variants={itemVariants}>
-                            <WorkflowCard
-                              name="Generate with Copilot"
-                              description="Create a workflow with AI assistance"
-                              steps={[]}
-                              onClick={() => {
-                                track(TelemetryEvent.CREATE_WORKFLOW_CLICK);
-                                navigate(
-                                  buildRoute(ROUTES.WORKFLOWS_CREATE, { environmentSlug: environmentSlug || '' })
-                                );
-                              }}
-                            >
-                              <AiThinking className="w-[100px]" />
-                            </WorkflowCard>
-                          </motion.div>
-                        )}
-                        {personalizedQuickTemplates.map((template, index) => (
-                          <motion.div key={template.workflowId} className="w-[250px] shrink-0" variants={itemVariants}>
-                            <WorkflowCard
-                              name={template.name}
-                              description={template.description}
-                              steps={template.steps}
-                              onClick={() => setSelectedOnboardingTemplate(personalizedSuggestions[index])}
-                            />
-                          </motion.div>
-                        ))}
-                      </motion.div>
-                      <ScrollBar orientation="horizontal" />
-                    </ScrollArea>
-                    <WorkflowTemplateModal
-                      open={!!selectedOnboardingTemplate}
-                      onOpenChange={(open) => {
-                        if (!open) setSelectedOnboardingTemplate(null);
-                      }}
-                      selectedTemplate={selectedOnboardingTemplate ?? undefined}
-                    />
-                  </motion.div>
-                )}
+                        Template library
+                      </LinkButton>{' '}
+                      instead →
+                    </span>
+                  </div>
+                </motion.div>
+              )}
 
-                {/* State 3: Fallback - no personalized suggestions available */}
-                {!hasPersonalizedSuggestions && !isOnboardingGenerating && (
-                  <motion.div
-                    key="onboarding-fallback"
-                    initial={{ opacity: 0, y: 12 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -6, transition: { duration: 0.18 } }}
-                    transition={{ duration: 0.28, ease: [0.25, 0.1, 0.25, 1] }}
-                    className="w-full"
-                  >
-                    <ScrollArea className="w-full">
-                      <div className="bg-bg-weak rounded-12 flex flex-col gap-3 p-3">
-                        <div className="flex gap-4">
-                          {isLoadingQuickStart && (
-                            <>
-                              <Skeleton className="h-[140px] w-[250px] shrink-0" />
-                              <Skeleton className="h-[140px] w-[250px] shrink-0" />
-                              <Skeleton className="h-[140px] w-[250px] shrink-0" />
-                              <Skeleton className="h-[140px] w-[250px] shrink-0" />
-                              <Skeleton className="h-[140px] w-[250px] shrink-0" />
-                            </>
-                          )}
-                          {!isLoadingQuickStart && (
-                            <motion.div
-                              className="flex gap-4"
-                              initial="hidden"
-                              animate="visible"
-                              variants={startWithCardsRowVariants}
-                            >
-                              {isAiWorkflowGenerationEnabled && (
-                                <motion.div className="w-[250px] shrink-0" variants={itemVariants}>
-                                  <WorkflowCard
-                                    name="Generate with Copilot"
-                                    description="Create a workflow with AI assistance"
-                                    steps={[]}
-                                    onClick={() => {
-                                      track(TelemetryEvent.CREATE_WORKFLOW_CLICK);
-                                      navigate(
-                                        buildRoute(ROUTES.WORKFLOWS_CREATE, { environmentSlug: environmentSlug || '' })
-                                      );
-                                    }}
-                                  >
-                                    <AiThinking className="w-[100px]" />
-                                  </WorkflowCard>
-                                </motion.div>
-                              )}
-                              {quickStartTemplates.map((template) => (
-                                <motion.div
-                                  key={template.workflowId}
-                                  className="w-[250px] shrink-0"
-                                  variants={itemVariants}
+              {/* State 2: Personalized suggestions ready */}
+              {hasPersonalizedSuggestions && !isOnboardingGenerating && (
+                <motion.div
+                  key="onboarding-personalized"
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -6, transition: { duration: 0.18 } }}
+                  transition={{ duration: 0.28, ease: [0.25, 0.1, 0.25, 1] }}
+                  className="w-full"
+                >
+                  <ScrollArea className="w-full">
+                    <motion.div
+                      className="bg-bg-weak rounded-12 flex gap-4 p-3"
+                      initial="hidden"
+                      animate="visible"
+                      variants={startWithCardsRowVariants}
+                    >
+                      {isAiWorkflowGenerationEnabled && (
+                        <motion.div className="w-[250px] shrink-0" variants={itemVariants}>
+                          <WorkflowCard
+                            name="Generate with Copilot"
+                            description="Create a workflow with AI assistance"
+                            steps={[]}
+                            onClick={() => {
+                              track(TelemetryEvent.CREATE_WORKFLOW_CLICK);
+                              navigate(buildRoute(ROUTES.WORKFLOWS_CREATE, { environmentSlug: environmentSlug || '' }));
+                            }}
+                          >
+                            <AiThinking className="w-[100px]" />
+                          </WorkflowCard>
+                        </motion.div>
+                      )}
+                      {personalizedQuickTemplates.map((template, index) => (
+                        <motion.div key={template.workflowId} className="w-[250px] shrink-0" variants={itemVariants}>
+                          <WorkflowCard
+                            name={template.name}
+                            description={template.description}
+                            steps={template.steps}
+                            onClick={() => setSelectedOnboardingTemplate(personalizedSuggestions[index])}
+                          />
+                        </motion.div>
+                      ))}
+                    </motion.div>
+                    <ScrollBar orientation="horizontal" />
+                  </ScrollArea>
+                  <WorkflowTemplateModal
+                    open={!!selectedOnboardingTemplate}
+                    onOpenChange={(open) => {
+                      if (!open) setSelectedOnboardingTemplate(null);
+                    }}
+                    selectedTemplate={selectedOnboardingTemplate ?? undefined}
+                  />
+                </motion.div>
+              )}
+
+              {/* State 3: Fallback - no personalized suggestions available */}
+              {!hasPersonalizedSuggestions && !isOnboardingGenerating && (
+                <motion.div
+                  key="onboarding-fallback"
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -6, transition: { duration: 0.18 } }}
+                  transition={{ duration: 0.28, ease: [0.25, 0.1, 0.25, 1] }}
+                  className="w-full"
+                >
+                  <ScrollArea className="w-full">
+                    <div className="bg-bg-weak rounded-12 flex flex-col gap-3 p-3">
+                      <div className="flex gap-4">
+                        {isLoadingQuickStart && (
+                          <>
+                            <Skeleton className="h-[140px] w-[250px] shrink-0" />
+                            <Skeleton className="h-[140px] w-[250px] shrink-0" />
+                            <Skeleton className="h-[140px] w-[250px] shrink-0" />
+                            <Skeleton className="h-[140px] w-[250px] shrink-0" />
+                            <Skeleton className="h-[140px] w-[250px] shrink-0" />
+                          </>
+                        )}
+                        {!isLoadingQuickStart && (
+                          <motion.div
+                            className="flex gap-4"
+                            initial="hidden"
+                            animate="visible"
+                            variants={startWithCardsRowVariants}
+                          >
+                            {isAiWorkflowGenerationEnabled && (
+                              <motion.div className="w-[250px] shrink-0" variants={itemVariants}>
+                                <WorkflowCard
+                                  name="Generate with Copilot"
+                                  description="Create a workflow with AI assistance"
+                                  steps={[]}
+                                  onClick={() => {
+                                    track(TelemetryEvent.CREATE_WORKFLOW_CLICK);
+                                    navigate(
+                                      buildRoute(ROUTES.WORKFLOWS_CREATE, { environmentSlug: environmentSlug || '' })
+                                    );
+                                  }}
                                 >
-                                  <WorkflowCard
-                                    name={template.name}
-                                    description={template.description}
-                                    steps={template.steps}
-                                    onClick={() => handleTemplateClick(template)}
-                                  />
-                                </motion.div>
-                              ))}
-                            </motion.div>
-                          )}
-                        </div>
-                        {onboardingStatus === 'skipped' && (
-                          <div className="text-paragraph-xs text-text-soft flex items-center gap-1.5 px-1">
-                            <RiInformation2Line className="text-icon-strong h-3 w-3 shrink-0" />
-                            <p>
-                              <span className="text-icon-strong">Tip: </span>Generate suggestions tailored to your
-                              product. Add your{' '}
-                              <Link
-                                to={ROUTES.SETTINGS_ORGANIZATION}
-                                className="inline cursor-pointer text-icon-strong"
+                                  <AiThinking className="w-[100px]" />
+                                </WorkflowCard>
+                              </motion.div>
+                            )}
+                            {quickStartTemplates.map((template) => (
+                              <motion.div
+                                key={template.workflowId}
+                                className="w-[250px] shrink-0"
+                                variants={itemVariants}
                               >
-                                domain →
-                              </Link>
-                            </p>
-                          </div>
+                                <WorkflowCard
+                                  name={template.name}
+                                  description={template.description}
+                                  steps={template.steps}
+                                  onClick={() => handleTemplateClick(template)}
+                                />
+                              </motion.div>
+                            ))}
+                          </motion.div>
                         )}
                       </div>
-                      <ScrollBar orientation="horizontal" />
-                    </ScrollArea>
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </div>
-          )}
-          {shouldShowStartWithTemplatesSection && (
-            <div className="text-label-xs text-text-soft my-2">Your Workflows</div>
-          )}
-          <WorkflowList
-            hasActiveFilters={!!hasActiveFilters}
-            onClearFilters={clearFilters}
-            orderBy={searchParams.get('orderBy') as SortableColumn}
-            orderDirection={searchParams.get('orderDirection') as DirectionEnum}
-            data={workflowsData}
-            isLoading={isPending}
-            isError={isError}
-            limit={limit}
-            onPageSizeChange={(newPageSize) => {
-              setPersistedPageSize(newPageSize);
-              setSearchParams((prev) => {
-                const sp = new URLSearchParams(prev);
-                sp.set('limit', newPageSize.toString());
-                sp.delete('offset');
+                      {onboardingStatus === 'skipped' && (
+                        <div className="text-paragraph-xs text-text-soft flex items-center gap-1.5 px-1">
+                          <RiInformation2Line className="text-icon-strong h-3 w-3 shrink-0" />
+                          <p>
+                            <span className="text-icon-strong">Tip: </span>Generate suggestions tailored to your
+                            product. Add your{' '}
+                            <Link to={ROUTES.SETTINGS_ORGANIZATION} className="inline cursor-pointer text-icon-strong">
+                              domain →
+                            </Link>
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                    <ScrollBar orientation="horizontal" />
+                  </ScrollArea>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        )}
+        {shouldShowStartWithTemplatesSection && <div className="text-label-xs text-text-soft my-2">Your Workflows</div>}
+        <WorkflowList
+          hasActiveFilters={!!hasActiveFilters}
+          onClearFilters={clearFilters}
+          orderBy={searchParams.get('orderBy') as SortableColumn}
+          orderDirection={searchParams.get('orderDirection') as DirectionEnum}
+          data={workflowsData}
+          isLoading={isPending}
+          isError={isError}
+          limit={limit}
+          onPageSizeChange={(newPageSize) => {
+            setPersistedPageSize(newPageSize);
+            setSearchParams((prev) => {
+              const sp = new URLSearchParams(prev);
+              sp.set('limit', newPageSize.toString());
+              sp.delete('offset');
 
-                return sp;
-              });
-            }}
-          />
-        </div>
-        <Outlet />
-      </DashboardLayout>
+              return sp;
+            });
+          }}
+        />
+      </div>
+      <Outlet />
     </>
   );
 };

--- a/apps/dashboard/src/routes/auth.tsx
+++ b/apps/dashboard/src/routes/auth.tsx
@@ -1,11 +1,15 @@
 import { RedirectToSignIn, Show, useAuth, useClerk } from '@clerk/react';
+import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
 import { AuthLayout } from '@/components/auth-layout';
+import { RouteFallback } from '@/components/route-fallback';
 
 export const AuthRoute = () => {
   return (
     <AuthLayout>
-      <Outlet />
+      <Suspense fallback={<RouteFallback />}>
+        <Outlet />
+      </Suspense>
     </AuthLayout>
   );
 };
@@ -22,7 +26,9 @@ export const ProtectedAuthRoute = () => {
     <>
       <Show when="signed-in">
         <AuthLayout>
-          <Outlet />
+          <Suspense fallback={<RouteFallback />}>
+            <Outlet />
+          </Suspense>
         </AuthLayout>
       </Show>
       <Show when="signed-out">

--- a/apps/dashboard/src/routes/dashboard.tsx
+++ b/apps/dashboard/src/routes/dashboard.tsx
@@ -1,11 +1,14 @@
+import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
 import { AiDrawerProvider } from '@/components/ai-drawer';
 import { CommandPalette } from '@/components/command-palette';
 import { CommandPaletteProvider } from '@/components/command-palette/command-palette-provider';
 import { Toaster } from '@/components/primitives/sonner';
+import { RouteFallback } from '@/components/route-fallback';
 import { useAuth } from '@/context/auth/hooks';
 import { LocalModeProvider } from '@/context/local-mode';
 import { OptInProvider } from '@/context/opt-in-provider';
+import { PageHeaderProvider } from '@/context/page-header';
 import { useOnboardingProvisioningDismiss } from '@/hooks/use-onboarding-provisioning';
 import { ProtectedRoute } from './protected-route';
 
@@ -25,18 +28,22 @@ function DashboardProvisioningDismiss() {
 export const DashboardRoute = () => {
   return (
     <ProtectedRoute>
-      <DashboardProvisioningDismiss />
-      <OptInProvider>
-        <LocalModeProvider>
-          <AiDrawerProvider>
-            <CommandPaletteProvider>
-              <Outlet />
-              <CommandPalette />
-              <Toaster />
-            </CommandPaletteProvider>
-          </AiDrawerProvider>
-        </LocalModeProvider>
-      </OptInProvider>
+      <PageHeaderProvider>
+        <DashboardProvisioningDismiss />
+        <OptInProvider>
+          <LocalModeProvider>
+            <AiDrawerProvider>
+              <CommandPaletteProvider>
+                <Suspense fallback={<RouteFallback />}>
+                  <Outlet />
+                </Suspense>
+                <CommandPalette />
+                <Toaster />
+              </CommandPaletteProvider>
+            </AiDrawerProvider>
+          </LocalModeProvider>
+        </OptInProvider>
+      </PageHeaderProvider>
     </ProtectedRoute>
   );
 };

--- a/apps/dashboard/src/routes/editor-layout.tsx
+++ b/apps/dashboard/src/routes/editor-layout.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react';
+import { Outlet, useMatch } from 'react-router-dom';
+import { FullPageLayout } from '@/components/full-page-layout';
+import { LayoutEditorSkeleton } from '@/components/layouts/layout-editor-skeleton';
+import { WorkflowEditorSkeleton } from '@/components/workflow-editor/workflow-editor-skeleton';
+import { PersistentLayoutContext } from '@/context/page-header';
+import { ROUTES } from '@/utils/routes';
+
+export function EditorLayout() {
+  const isLayoutEditor = useMatch(ROUTES.LAYOUTS_EDIT);
+
+  return (
+    <PersistentLayoutContext.Provider value={true}>
+      <FullPageLayout>
+        <Suspense fallback={isLayoutEditor ? <LayoutEditorSkeleton /> : <WorkflowEditorSkeleton />}>
+          <Outlet />
+        </Suspense>
+      </FullPageLayout>
+    </PersistentLayoutContext.Provider>
+  );
+}

--- a/apps/dashboard/src/routes/onboarding.tsx
+++ b/apps/dashboard/src/routes/onboarding.tsx
@@ -1,6 +1,8 @@
 import { RedirectToSignIn, Show, useAuth } from '@clerk/react';
+import { Suspense } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AnimatedOutlet } from '@/components/animated-outlet';
+import { RouteFallback } from '@/components/route-fallback';
 import { AuthLayout } from '../components/auth-layout';
 import { EnvironmentProvider } from '../context/environment/environment-provider';
 import { ROUTES } from '../utils/routes';
@@ -22,7 +24,9 @@ export const OnboardingParentRoute = () => {
       <Show when="signed-in">
         <EnvironmentProvider>
           <AuthLayout>
-            <AnimatedOutlet />
+            <Suspense fallback={<RouteFallback />}>
+              <AnimatedOutlet />
+            </Suspense>
           </AuthLayout>
         </EnvironmentProvider>
       </Show>

--- a/apps/dashboard/src/routes/permission-protected-route.tsx
+++ b/apps/dashboard/src/routes/permission-protected-route.tsx
@@ -11,10 +11,11 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
+import { PageHeader, useIsPersistentLayout } from '@/context/page-header';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { useHasPermission } from '@/hooks/use-has-permission';
-import { AccessDeniedPage } from '@/pages';
+import { AccessDeniedPage } from '@/pages/access-denied-page';
 
 interface PermissionProtectedRouteProps {
   children: ReactNode;
@@ -34,6 +35,7 @@ export function PermissionProtectedRoute({
   const location = useLocation();
   const navigate = useNavigate();
   const isRbacFlagEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_RBAC_ENABLED);
+  const isPersistentLayout = useIsPersistentLayout();
 
   const isRbacFeatureEnabled =
     getFeatureForTierAsBoolean(
@@ -62,12 +64,21 @@ export function PermissionProtectedRoute({
   }
 
   if (!hasAccess && !isDrawerRoute) {
+    const unauthorizedHeader = <h1 className="text-foreground-950">Unauthorized</h1>;
+
     return (
       <>
         <PageMeta title="Unauthorized" />
-        <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Unauthorized</h1>}>
-          <AccessDeniedPage />
-        </DashboardLayout>
+        {isPersistentLayout ? (
+          <>
+            <PageHeader>{unauthorizedHeader}</PageHeader>
+            <AccessDeniedPage />
+          </>
+        ) : (
+          <DashboardLayout headerStartItems={unauthorizedHeader}>
+            <AccessDeniedPage />
+          </DashboardLayout>
+        )}
       </>
     );
   }

--- a/apps/dashboard/src/routes/root.tsx
+++ b/apps/dashboard/src/routes/root.tsx
@@ -1,11 +1,13 @@
 import { ClerkLoaded } from '@clerk/react';
 import { ErrorBoundary, withProfiler } from '@sentry/react';
 import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Suspense } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { Outlet } from 'react-router-dom';
 import { ToastIcon } from '@/components/primitives/sonner';
 import { showToast } from '@/components/primitives/sonner-helpers';
 import { TooltipProvider } from '@/components/primitives/tooltip';
+import { RouteFallback } from '@/components/route-fallback';
 import { AuthProvider } from '@/context/auth/auth-provider';
 import { CustomerIoProvider } from '@/context/customer-io';
 import { EEAuthProvider as ClerkProvider } from '@/context/ee-auth-provider';
@@ -62,7 +64,9 @@ const RootRouteInternal = () => {
                         <HelmetProvider>
                           <TooltipProvider delayDuration={100}>
                             <EscapeKeyManagerProvider>
-                              <Outlet />
+                              <Suspense fallback={<RouteFallback />}>
+                                <Outlet />
+                              </Suspense>
                             </EscapeKeyManagerProvider>
                           </TooltipProvider>
                         </HelmetProvider>

--- a/apps/dashboard/src/routes/side-nav-layout.tsx
+++ b/apps/dashboard/src/routes/side-nav-layout.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react';
+import { Outlet, useMatches } from 'react-router-dom';
+import { DashboardLayout } from '@/components/dashboard-layout';
+import { PageContentSkeleton } from '@/components/page-content-skeleton';
+import { PersistentLayoutContext } from '@/context/page-header';
+import { DashboardRouteHandle } from '@/utils/route-handle';
+
+export function SideNavLayout() {
+  const matches = useMatches();
+  const hideBridgeUrl = matches.some((match) => (match.handle as DashboardRouteHandle | undefined)?.hideBridgeUrl);
+
+  return (
+    <PersistentLayoutContext.Provider value={true}>
+      <DashboardLayout showBridgeUrl={!hideBridgeUrl}>
+        <Suspense fallback={<PageContentSkeleton />}>
+          <Outlet />
+        </Suspense>
+      </DashboardLayout>
+    </PersistentLayoutContext.Provider>
+  );
+}

--- a/apps/dashboard/src/utils/lazy-page.ts
+++ b/apps/dashboard/src/utils/lazy-page.ts
@@ -1,0 +1,44 @@
+import { ComponentType, lazy } from 'react';
+
+const CHUNK_RELOAD_KEY = 'novu:dashboard-chunk-reload';
+
+function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|Loading chunk [\d]+ failed/i.test(
+    error.message
+  );
+}
+
+function reloadOnceOnChunkError(error: unknown): never | Promise<never> {
+  if (typeof window !== 'undefined' && isChunkLoadError(error) && sessionStorage.getItem(CHUNK_RELOAD_KEY) !== '1') {
+    sessionStorage.setItem(CHUNK_RELOAD_KEY, '1');
+    window.location.reload();
+
+    return new Promise(() => {});
+  }
+
+  throw error;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: named-export lazy() helper must accept arbitrary component props
+export function lazyPage<M extends Record<string, ComponentType<any>>, K extends keyof M>(
+  importer: () => Promise<M>,
+  exportName: K
+) {
+  return lazy(async () => {
+    try {
+      const module = await importer();
+
+      if (typeof window !== 'undefined') {
+        sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+      }
+
+      return { default: module[exportName] };
+    } catch (error) {
+      return reloadOnceOnChunkError(error);
+    }
+  });
+}

--- a/apps/dashboard/src/utils/route-handle.ts
+++ b/apps/dashboard/src/utils/route-handle.ts
@@ -1,0 +1,3 @@
+export type DashboardRouteHandle = {
+  hideBridgeUrl?: boolean;
+};


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR splits dashboard pages into route-level chunks and introduces persistent side-navigation and editor shells so navigation can retain layout chrome while lazy content loads.
- Converts dashboard, authentication, onboarding, and editor pages from eager imports to named-export lazy imports.
- Reorganizes the router beneath persistent `SideNavLayout` and `EditorLayout` boundaries while retaining existing permissions and environment guards.
- Adds route-specific loading fallbacks, editor skeletons, chunk-load recovery, and a portal-based page-header slot.
- Removes page-owned layout wrappers in favor of shared route layouts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The inspected lazy export mappings resolve, existing route guards remain in place, and the new page-header consumers are consistently enclosed by the required provider and persistent layout slot.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/main.tsx | Converts page imports to route chunks and reorganizes the route tree beneath persistent side-navigation and editor layouts while preserving the checked guards. |
| apps/dashboard/src/utils/lazy-page.ts | Adds named-export lazy loading with one-time reload recovery for recognized stale chunk failures. |
| apps/dashboard/src/routes/side-nav-layout.tsx | Introduces the persistent dashboard shell, route-aware bridge URL visibility, and a page-content loading boundary. |
| apps/dashboard/src/routes/editor-layout.tsx | Introduces the persistent full-page editor shell with workflow- and layout-specific loading skeletons. |
| apps/dashboard/src/context/page-header/page-header-provider.tsx | Adds a provider and portal slot that lets pages populate headers owned by persistent route layouts. |
| apps/dashboard/src/components/animated-outlet.tsx | Adds a configurable Suspense boundary around animated nested route content. |
| apps/dashboard/src/routes/dashboard.tsx | Mounts page-header state and a dashboard-level lazy-route fallback around the existing provider stack. |
| apps/dashboard/src/routes/permission-protected-route.tsx | Adapts unauthorized pages to populate persistent layout headers without nesting another dashboard shell. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Router[createBrowserRouter] --> Root[RootRoute and Suspense]
  Root --> Auth[Auth and onboarding routes]
  Root --> Dashboard[DashboardRoute]
  Dashboard --> HeaderProvider[PageHeaderProvider]
  HeaderProvider --> SideNav[SideNavLayout]
  HeaderProvider --> Editor[EditorLayout]
  SideNav --> SideFallback[PageContentSkeleton]
  Editor --> EditorFallback[Workflow or layout skeleton]
  SideNav --> LazyPages[Lazy dashboard page chunks]
  Editor --> LazyEditors[Lazy editor page chunks]
  LazyPages --> HeaderPortal[PageHeader portal]
  LazyEditors --> HeaderPortal
```

<sub>Reviews (1): Last reviewed commit: ["chore(dashboard): performance improvemen..."](https://github.com/novuhq/novu/commit/601d07d51833f483731201a776e4a53f9bd269e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54366038)</sub>

**Context used:**

- Knowledge Base — [Dashboard App (apps/dashboard)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dashboard-app.md)

<!-- /greptile_comment -->