### PR TITLE
fix(api-service, worker): enhance error handling for invalid JSON bodies in HTTP requests fixes NV-8597

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import {
   assertSafeOutboundUrl,
+  buildInvalidJsonBodyDetail,
   buildNovuSignatureHeader,
   enhanceStepsMap,
   GetDecryptedSecretKey,
@@ -66,8 +67,6 @@ export class TestHttpEndpointUsecase {
     const method = (compiled.method as string) ?? 'GET';
     const compiledHeaders = (compiled.headers as KeyValuePair[]) ?? [];
     const compiledBody = compiled.body as string | KeyValuePair[] | undefined;
-    const resolvedBodyInput =
-      typeof compiledBody === 'string' && compiledBody.trim() ? repairJsonString(compiledBody) : compiledBody;
 
     const resolvedHeaders: Record<string, string> = Object.fromEntries(
       compiledHeaders.filter(({ key }) => key).map(({ key, value }) => [key, value])
@@ -77,13 +76,15 @@ export class TestHttpEndpointUsecase {
 
     let resolvedBody: Record<string, unknown> | unknown[] | undefined;
     try {
+      // `repairJsonString` throws on bodies it cannot repair, so it has to stay inside this
+      // try/catch to return a 400 with the reason instead of an unhandled 500.
+      const resolvedBodyInput =
+        typeof compiledBody === 'string' && compiledBody.trim() ? repairJsonString(compiledBody) : compiledBody;
       resolvedBody = resolveHttpRequestBody(resolvedBodyInput);
     } catch (parseError) {
-      const errorMessage = parseError instanceof Error ? parseError.message : 'Failed to parse raw JSON body';
-
       return {
         statusCode: 400,
-        body: { error: `Invalid raw JSON body: ${errorMessage}` },
+        body: buildInvalidJsonBodyDetail(parseError, compiledBody),
         headers: {},
         durationMs: Math.round(performance.now() - startTime),
         resolvedRequest: {

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { ExecuteHttpRequestStep } from './execute-http-request-step.usecase';
 import { SendMessageChannelCommand } from './send-message-channel.command';
-import { SendMessageStatus } from './send-message-type.usecase';
+import { SendMessageResultFailed, SendMessageStatus } from './send-message-type.usecase';
 
 describe('ExecuteHttpRequestStep - steps namespace', () => {
   function buildDigestStepsMap() {
@@ -78,7 +78,15 @@ describe('ExecuteHttpRequestStep - steps namespace', () => {
       usecase,
       httpClientService,
       executeBridgeJob,
+      createExecutionDetails,
     };
+  }
+
+  function findFailureDetail(createExecutionDetails: { execute: sinon.SinonStub }) {
+    return createExecutionDetails.execute
+      .getCalls()
+      .map((call) => call.args[0] as { detail: string; raw?: string })
+      .find((args) => args.raw?.includes('Invalid raw JSON body'));
   }
 
   function buildCommand() {
@@ -188,5 +196,42 @@ describe('ExecuteHttpRequestStep - steps namespace', () => {
     expect(requestArgs.url).to.equal('https://example.com/2 notifications');
     expect(requestArgs.headers['X-Digest-Summary']).to.equal('Ada, Grace');
     expect(requestArgs.body).to.deep.equal({ summary: '2 notifications' });
+  });
+
+  it('records an execution detail when the compiled body cannot be repaired into valid JSON', async () => {
+    const { usecase, httpClientService, createExecutionDetails } = buildUsecase({
+      url: 'https://example.com/webhook',
+      method: 'POST',
+      body: '{"order":{"lines":[{"item":{"sku" }}]}}',
+    });
+
+    const result = (await usecase.execute(buildCommand())) as SendMessageResultFailed;
+
+    expect(result.status).to.equal(SendMessageStatus.FAILED);
+    expect(result.shouldHalt).to.equal(true);
+    expect(httpClientService.request.called).to.equal(false);
+
+    const failureDetail = findFailureDetail(createExecutionDetails);
+    expect(failureDetail, 'expected a failed execution detail for the unrepairable body').to.not.equal(undefined);
+
+    const raw = JSON.parse(failureDetail?.raw ?? '{}');
+    expect(raw.error).to.contain('Colon expected');
+    expect(raw.bodyExcerpt).to.contain('"sku"');
+    expect(raw.hint).to.be.a('string');
+  });
+
+  it('does not halt the chain for an unrepairable body when continueOnFailure is enabled', async () => {
+    const { usecase, createExecutionDetails } = buildUsecase({
+      url: 'https://example.com/webhook',
+      method: 'POST',
+      continueOnFailure: true,
+      body: '{"order":{"lines":[{"item":{"sku" }}]}}',
+    });
+
+    const result = (await usecase.execute(buildCommand())) as SendMessageResultFailed;
+
+    expect(result.status).to.equal(SendMessageStatus.FAILED);
+    expect(result.shouldHalt).to.equal(false);
+    expect(findFailureDetail(createExecutionDetails)).to.not.equal(undefined);
   });
 });

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.spec.ts
@@ -1,3 +1,4 @@
+import { SECRET_MASK } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ExecuteHttpRequestStep } from './execute-http-request-step.usecase';
@@ -89,7 +90,7 @@ describe('ExecuteHttpRequestStep - steps namespace', () => {
       .find((args) => args.raw?.includes('Invalid raw JSON body'));
   }
 
-  function buildCommand() {
+  function buildCommand(env: Record<string, string> = { name: 'Development', type: 'dev' }) {
     return SendMessageChannelCommand.create({
       environmentId: 'env_1',
       organizationId: 'org_1',
@@ -136,7 +137,7 @@ describe('ExecuteHttpRequestStep - steps namespace', () => {
           events: undefined,
           total_count: undefined,
         },
-        env: { name: 'Development', type: 'dev' },
+        env,
       } as never,
       bridgeData: null,
       environment: { _id: 'env_1' } as never,
@@ -233,5 +234,25 @@ describe('ExecuteHttpRequestStep - steps namespace', () => {
     expect(result.status).to.equal(SendMessageStatus.FAILED);
     expect(result.shouldHalt).to.equal(false);
     expect(findFailureDetail(createExecutionDetails)).to.not.equal(undefined);
+  });
+
+  it('masks rendered environment variable secrets out of the persisted excerpt', async () => {
+    const secret = 'sk_live_51NQpZmKq7xTvR3wY';
+    const { usecase, createExecutionDetails } = buildUsecase({
+      url: 'https://example.com/webhook',
+      method: 'POST',
+      body: '{"token":"{{env.PARTNER_API_KEY}}","tier":"{{env.type}}","order":{"sku" }}',
+    });
+
+    const result = await usecase.execute(buildCommand({ name: 'Production', type: 'prod', PARTNER_API_KEY: secret }));
+
+    expect(result.status).to.equal(SendMessageStatus.FAILED);
+
+    const raw = JSON.parse(findFailureDetail(createExecutionDetails)?.raw ?? '{}');
+    expect(raw.bodyExcerpt, 'the excerpt must not carry the decrypted env secret').to.not.contain(secret);
+    expect(raw.bodyExcerpt).to.contain(SECRET_MASK);
+    // System env values are not secrets, and masking them would gut the excerpt.
+    expect(raw.bodyExcerpt).to.contain('"tier":"prod"');
+    expect(raw.bodyExcerpt).to.contain('"order":{"sku" }');
   });
 });

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import {
   assertSafeOutboundUrl,
+  buildInvalidJsonBodyDetail,
   buildNovuSignatureHeader,
   CreateExecutionDetails,
   CreateExecutionDetailsCommand,
@@ -137,8 +138,6 @@ export class ExecuteHttpRequestStep extends SendMessageType {
     const method = (compiled.method as string) ?? 'POST';
     const rawHeaders = (compiled.headers as Array<{ key: string; value: string }> | undefined) ?? [];
     const compiledBody = compiled.body as string | Array<{ key: string; value: string }> | undefined;
-    const rawBody =
-      typeof compiledBody === 'string' && compiledBody.trim() ? repairJsonString(compiledBody) : compiledBody;
     const timeout = (compiled.timeout as number | undefined) ?? 5000;
 
     if (!url) {
@@ -191,10 +190,12 @@ export class ExecuteHttpRequestStep extends SendMessageType {
 
     let bodyObject: Record<string, unknown> | unknown[] | undefined;
     try {
+      // `repairJsonString` throws on bodies it cannot repair, so it has to stay inside this
+      // try/catch to surface the failure as an execution detail instead of an unhandled job error.
+      const rawBody =
+        typeof compiledBody === 'string' && compiledBody.trim() ? repairJsonString(compiledBody) : compiledBody;
       bodyObject = resolveHttpRequestBody(rawBody);
     } catch (parseError) {
-      const errorMessage = parseError instanceof Error ? parseError.message : 'Failed to parse raw JSON body';
-
       await this.createExecutionDetails.execute(
         CreateExecutionDetailsCommand.create({
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
@@ -203,7 +204,7 @@ export class ExecuteHttpRequestStep extends SendMessageType {
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-          raw: JSON.stringify({ error: `Invalid raw JSON body: ${errorMessage}` }),
+          raw: JSON.stringify(buildInvalidJsonBodyDetail(parseError, compiledBody)),
         })
       );
 

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
@@ -26,6 +26,7 @@ import {
   ControlValuesLevelEnum,
   DeliveryLifecycleDetail,
   DeliveryLifecycleStatusEnum,
+  EnvironmentSystemVariables,
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
   isOutboundSsrfProtectionEnabled,
@@ -204,7 +205,9 @@ export class ExecuteHttpRequestStep extends SendMessageType {
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-          raw: JSON.stringify(buildInvalidJsonBodyDetail(parseError, compiledBody)),
+          raw: JSON.stringify(
+            buildInvalidJsonBodyDetail(parseError, compiledBody, collectSecretEnvValues(command.compileContext?.env))
+          ),
         })
       );
 
@@ -425,6 +428,26 @@ export class ExecuteHttpRequestStep extends SendMessageType {
 
     return rawControls;
   }
+}
+
+/**
+ * Compile-safe: adding a field to EnvironmentSystemVariables will cause a TS error here.
+ */
+const SYSTEM_ENV_KEYS: Record<keyof EnvironmentSystemVariables, true> = { name: true, type: true };
+
+/**
+ * `env` merges decrypted environment variables, which can hold API keys and tokens, with the
+ * environment's system variables. Only the user-defined values are treated as secrets: the system
+ * values are not sensitive, and masking strings as common as `prod` would gut the excerpt.
+ */
+function collectSecretEnvValues(env: unknown): string[] {
+  if (!env || typeof env !== 'object') {
+    return [];
+  }
+
+  return Object.entries(env as Record<string, unknown>)
+    .filter(([key, value]) => !(key in SYSTEM_ENV_KEYS) && typeof value === 'string' && value.length > 0)
+    .map(([, value]) => value as string);
 }
 
 function getSkipRules(controlValues: Record<string, unknown>): RulesLogic<AdditionalOperation> | undefined {

--- a/libs/application-generic/src/services/http-client/http-request.utils.spec.ts
+++ b/libs/application-generic/src/services/http-client/http-request.utils.spec.ts
@@ -1,3 +1,4 @@
+import { SECRET_MASK } from '@novu/shared';
 import { expect } from 'chai';
 import {
   buildInvalidJsonBodyDetail,
@@ -143,6 +144,66 @@ describe('http-request.utils', () => {
       const detail = buildInvalidJsonBodyDetail('boom', '{}');
 
       expect(detail.error).to.equal('Invalid raw JSON body: Failed to parse raw JSON body');
+    });
+
+    it('should mask secret values that land inside the excerpt', () => {
+      const secret = 'sk_live_51NQpZmKq7xTvR3wY';
+      const body = `{"token":"${secret}","order":{"sku" }}`;
+      const position = body.indexOf('{"sku" }') + 7;
+      const detail = buildInvalidJsonBodyDetail(Object.assign(new Error('Colon expected'), { position }), body, [
+        secret,
+      ]);
+
+      expect(detail.bodyExcerpt).to.not.contain(secret);
+      expect(detail.bodyExcerpt).to.contain(SECRET_MASK);
+      expect(detail.bodyExcerpt).to.contain('"order":{"sku" }');
+    });
+
+    it('should mask a secret rendered in its JSON-escaped form', () => {
+      const secret = 'pa$$"word\nline';
+      const escaped = JSON.stringify(secret).slice(1, -1);
+      const body = `{"token":"${escaped}","order":{"sku" }}`;
+      const position = body.indexOf('{"sku" }') + 7;
+      const detail = buildInvalidJsonBodyDetail(Object.assign(new Error('Colon expected'), { position }), body, [
+        secret,
+      ]);
+
+      expect(detail.bodyExcerpt).to.not.contain(escaped);
+      expect(detail.bodyExcerpt).to.contain(SECRET_MASK);
+    });
+
+    it('should not leak a partial secret straddling the excerpt boundary', () => {
+      const secret = `sk_live_${'a'.repeat(80)}_tail`;
+      // Places the secret so that only its tail would fall inside an unmasked window.
+      const body = `{"token":"${secret}","order":{"sku" }}`;
+      const position = body.indexOf('{"sku" }') + 7;
+      const detail = buildInvalidJsonBodyDetail(Object.assign(new Error('Colon expected'), { position }), body, [
+        secret,
+      ]);
+
+      expect(detail.bodyExcerpt).to.not.contain('aaaa');
+      expect(detail.bodyExcerpt).to.not.contain('_tail');
+      expect(detail.bodyExcerpt).to.contain('"order":{"sku" }');
+    });
+
+    it('should keep the excerpt centered on the failure after masking', () => {
+      const secret = 'sk_live_51NQpZmKq7xTvR3wY';
+      const body = `{"token":"${secret}","padding":"${'y'.repeat(300)}","order":{"sku" }}`;
+      const position = body.indexOf('{"sku" }') + 7;
+      const detail = buildInvalidJsonBodyDetail(Object.assign(new Error('Colon expected'), { position }), body, [
+        secret,
+      ]);
+
+      expect(detail.bodyExcerpt).to.contain('"order":{"sku" }');
+    });
+
+    it('should ignore empty secret values', () => {
+      const body = '{"order":{"sku" }}';
+      const detail = buildInvalidJsonBodyDetail(Object.assign(new Error('Colon expected'), { position: 16 }), body, [
+        '',
+      ]);
+
+      expect(detail.bodyExcerpt).to.equal(body);
     });
   });
 });

--- a/libs/application-generic/src/services/http-client/http-request.utils.spec.ts
+++ b/libs/application-generic/src/services/http-client/http-request.utils.spec.ts
@@ -1,5 +1,11 @@
 import { expect } from 'chai';
-import { parseRawBody, resolveHttpRequestBody, toBodyRecord, toHeadersRecord } from './http-request.utils';
+import {
+  buildInvalidJsonBodyDetail,
+  parseRawBody,
+  resolveHttpRequestBody,
+  toBodyRecord,
+  toHeadersRecord,
+} from './http-request.utils';
 
 describe('http-request.utils', () => {
   describe('toBodyRecord', () => {
@@ -86,6 +92,57 @@ describe('http-request.utils', () => {
 
     it('should throw for invalid raw JSON string bodies', () => {
       expect(() => resolveHttpRequestBody('not json')).to.throw();
+    });
+  });
+
+  describe('buildInvalidJsonBodyDetail', () => {
+    const buildLongBody = (broken: string) => `{"padding":"${'x'.repeat(500)}","order":${broken}}`;
+
+    it('should excerpt the body around a position carried on the error', () => {
+      const body = buildLongBody('{"sku" }');
+      const position = body.indexOf('{"sku" }') + 7;
+      const detail = buildInvalidJsonBodyDetail(Object.assign(new Error('Colon expected'), { position }), body);
+
+      expect(detail.error).to.equal('Invalid raw JSON body: Colon expected');
+      expect(detail.bodyExcerpt).to.contain('"order":{"sku" }');
+      expect(detail.bodyExcerpt).to.contain('...');
+      expect(detail.bodyExcerpt).to.not.contain('x'.repeat(200));
+    });
+
+    it('should read the position out of a JSON.parse message when none is attached', () => {
+      const body = buildLongBody('{"sku" }');
+      let thrown: unknown;
+      try {
+        JSON.parse(body);
+      } catch (error) {
+        thrown = error;
+      }
+
+      const detail = buildInvalidJsonBodyDetail(thrown, body);
+
+      expect(detail.bodyExcerpt).to.contain('"order":{"sku" }');
+    });
+
+    it('should omit the excerpt when the position cannot be determined', () => {
+      const detail = buildInvalidJsonBodyDetail(new Error('Raw body must be a JSON object or array'), '"hello"');
+
+      expect(detail.error).to.equal('Invalid raw JSON body: Raw body must be a JSON object or array');
+      expect(detail.bodyExcerpt).to.equal(undefined);
+      expect(detail.hint).to.be.a('string');
+    });
+
+    it('should omit the excerpt for key-value pair bodies', () => {
+      const detail = buildInvalidJsonBodyDetail(Object.assign(new Error('Colon expected'), { position: 3 }), [
+        { key: 'name', value: 'test' },
+      ]);
+
+      expect(detail.bodyExcerpt).to.equal(undefined);
+    });
+
+    it('should fall back to a generic message for non-Error throwables', () => {
+      const detail = buildInvalidJsonBodyDetail('boom', '{}');
+
+      expect(detail.error).to.equal('Invalid raw JSON body: Failed to parse raw JSON body');
     });
   });
 });

--- a/libs/application-generic/src/services/http-client/http-request.utils.ts
+++ b/libs/application-generic/src/services/http-client/http-request.utils.ts
@@ -45,3 +45,56 @@ export function shouldIncludeBody(body: Record<string, unknown> | unknown[] | un
 
   return !!body && !methodsWithoutBody.includes(method);
 }
+
+export interface InvalidJsonBodyDetail {
+  error: string;
+  hint: string;
+  bodyExcerpt?: string;
+}
+
+const BODY_EXCERPT_RADIUS = 60;
+
+const INVALID_JSON_BODY_HINT =
+  'The body is parsed as JSON after Liquid variables are rendered. A variable that resolves to an unescaped quote, a line break, or a raw object can break the surrounding JSON.';
+
+/**
+ * `jsonrepair` exposes the offset as `position`; `JSON.parse` only mentions it in the message.
+ */
+function extractFailurePosition(error: unknown): number | undefined {
+  const { position } = (error ?? {}) as { position?: unknown };
+
+  if (typeof position === 'number' && Number.isFinite(position)) {
+    return position;
+  }
+
+  const match = error instanceof Error ? /position (\d+)/.exec(error.message) : null;
+
+  return match ? Number(match[1]) : undefined;
+}
+
+function buildBodyExcerpt(body: HttpRequestBodyControl, position: number | undefined): string | undefined {
+  if (typeof body !== 'string' || position === undefined) {
+    return undefined;
+  }
+
+  const start = Math.max(0, position - BODY_EXCERPT_RADIUS);
+  const end = Math.min(body.length, position + BODY_EXCERPT_RADIUS);
+
+  return `${start > 0 ? '...' : ''}${body.slice(start, end)}${end < body.length ? '...' : ''}`;
+}
+
+/**
+ * Turns a JSON parse/repair failure into something a user can act on. The parsers only report a
+ * character offset into the rendered body, which nobody can locate by hand, so resolve it against
+ * the body and show the surrounding text instead.
+ */
+export function buildInvalidJsonBodyDetail(error: unknown, body: HttpRequestBodyControl): InvalidJsonBodyDetail {
+  const message = error instanceof Error ? error.message : 'Failed to parse raw JSON body';
+  const bodyExcerpt = buildBodyExcerpt(body, extractFailurePosition(error));
+
+  return {
+    error: `Invalid raw JSON body: ${message}`,
+    hint: INVALID_JSON_BODY_HINT,
+    ...(bodyExcerpt ? { bodyExcerpt } : {}),
+  };
+}

--- a/libs/application-generic/src/services/http-client/http-request.utils.ts
+++ b/libs/application-generic/src/services/http-client/http-request.utils.ts
@@ -1,3 +1,5 @@
+import { SECRET_MASK } from '@novu/shared';
+
 export type KeyValuePair = { key: string; value: string };
 export type HttpRequestBodyControl = string | KeyValuePair[] | undefined;
 
@@ -72,25 +74,57 @@ function extractFailurePosition(error: unknown): number | undefined {
   return match ? Number(match[1]) : undefined;
 }
 
-function buildBodyExcerpt(body: HttpRequestBodyControl, position: number | undefined): string | undefined {
+/**
+ * Replaces every occurrence of a secret, both raw and in the JSON-escaped form it takes once
+ * rendered into a JSON body.
+ */
+function maskSecrets(text: string, secretValues: readonly string[]): string {
+  return secretValues.filter(Boolean).reduce((masked, secret) => {
+    const escaped = JSON.stringify(secret).slice(1, -1);
+
+    return masked.split(secret).join(SECRET_MASK).split(escaped).join(SECRET_MASK);
+  }, text);
+}
+
+function buildBodyExcerpt(
+  body: HttpRequestBodyControl,
+  position: number | undefined,
+  secretValues: readonly string[]
+): string | undefined {
   if (typeof body !== 'string' || position === undefined) {
     return undefined;
   }
 
-  const start = Math.max(0, position - BODY_EXCERPT_RADIUS);
-  const end = Math.min(body.length, position + BODY_EXCERPT_RADIUS);
+  /**
+   * Mask the whole body before slicing: masking only the excerpt would leak a partial secret
+   * whenever one straddles the window boundary. Masking the prefix separately re-derives the
+   * reported position within the masked body so the excerpt stays centered on the failure.
+   */
+  const maskedBody = maskSecrets(body, secretValues);
+  const maskedPosition = maskSecrets(body.slice(0, position), secretValues).length;
 
-  return `${start > 0 ? '...' : ''}${body.slice(start, end)}${end < body.length ? '...' : ''}`;
+  const start = Math.max(0, maskedPosition - BODY_EXCERPT_RADIUS);
+  const end = Math.min(maskedBody.length, maskedPosition + BODY_EXCERPT_RADIUS);
+
+  return `${start > 0 ? '...' : ''}${maskedBody.slice(start, end)}${end < maskedBody.length ? '...' : ''}`;
 }
 
 /**
  * Turns a JSON parse/repair failure into something a user can act on. The parsers only report a
  * character offset into the rendered body, which nobody can locate by hand, so resolve it against
  * the body and show the surrounding text instead.
+ *
+ * `secretValues` are masked out of the excerpt. Callers that persist the result must pass every
+ * decrypted environment variable value, since execution details are readable by low-privilege
+ * roles through the activity feed.
  */
-export function buildInvalidJsonBodyDetail(error: unknown, body: HttpRequestBodyControl): InvalidJsonBodyDetail {
+export function buildInvalidJsonBodyDetail(
+  error: unknown,
+  body: HttpRequestBodyControl,
+  secretValues: readonly string[] = []
+): InvalidJsonBodyDetail {
   const message = error instanceof Error ? error.message : 'Failed to parse raw JSON body';
-  const bodyExcerpt = buildBodyExcerpt(body, extractFailurePosition(error));
+  const bodyExcerpt = buildBodyExcerpt(body, extractFailurePosition(error), secretValues);
 
   return {
     error: `Invalid raw JSON body: ${message}`,


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR catches unrecoverable JSON body errors in API test requests and worker HTTP steps, returning actionable excerpts and preserving continue-on-failure behavior.
- Adds shared invalid-JSON diagnostic construction with position-based body excerpts.
- Persists worker parse failures as execution details and adds coverage for failure handling.
- Attempts to redact environment secrets from persisted excerpts, but does not cover sensitive values from other rendered namespaces.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until malformed-body execution details stop exposing sensitive rendered values outside the environment-variable namespace.

The attempted fix masks only string-valued environment variables even though HTTP bodies render several other workflow-context namespaces, leaving the previously reported execution-detail disclosure reachable.

**Files Needing Attention:** apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts; libs/application-generic/src/services/http-client/http-request.utils.ts

<details open><summary><h3>Security Review</h3></summary>

The persisted malformed-body excerpt remains capable of disclosing sensitive payload, subscriber, tenant, context, webhook, prior-step, or literal values because the redaction set contains only string-valued environment variables.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts | Catches body repair failures and records actionable execution details, but the new masking path leaves non-environment rendered secrets exposed. |
| libs/application-generic/src/services/http-client/http-request.utils.ts | Adds position-aware invalid-JSON diagnostics and exact-value masking, whose safety depends on callers supplying every sensitive rendered value. |
| apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts | Moves JSON repair into error handling and returns the shared structured diagnostic for test requests. |
| apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.spec.ts | Covers parse failures, continue-on-failure behavior, and environment-secret masking, but not sensitive values from other compile namespaces. |
| libs/application-generic/src/services/http-client/http-request.utils.spec.ts | Thoroughly covers excerpt positioning and supplied-secret masking behavior. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312372%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12372&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fusecases%2Fsend-message%2Fexecute-http-request-step.usecase.ts%3A208-210%0A**Non-environment%20secrets%20remain%20exposed**%0A%0AWhen%20a%20malformed%20HTTP%20body%20contains%20a%20sensitive%20value%20rendered%20from%20%60payload%60%2C%20%60subscriber%60%2C%20%60tenant%60%2C%20%60context%60%2C%20%60webhook%60%2C%20prior-step%20output%2C%20or%20a%20literal%2C%20this%20path%20masks%20only%20string-valued%20environment%20variables%20before%20persisting%20the%20nearby%20excerpt.%20The%20unmasked%20value%20is%20consequently%20exposed%20through%20execution-detail%20and%20activity%20views.%0A%0A**How%20this%20was%20verified%3A**%20The%20compiled%20body%20receives%20all%20workflow-context%20namespaces%2C%20but%20the%20persisted%20diagnostic%20passes%20only%20values%20collected%20from%20%60compileContext.env%60%20to%20the%20masking%20helper.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12372&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts:208-210
**Non-environment secrets remain exposed**

When a malformed HTTP body contains a sensitive value rendered from `payload`, `subscriber`, `tenant`, `context`, `webhook`, prior-step output, or a literal, this path masks only string-valued environment variables before persisting the nearby excerpt. The unmasked value is consequently exposed through execution-detail and activity views.

**How this was verified:** The compiled body receives all workflow-context namespaces, but the persisted diagnostic passes only values collected from `compileContext.env` to the masking helper.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(worker): mask sensitive environment ..."](https://github.com/novuhq/novu/commit/a2676b842192879d4af7f4df900d2f9c5efacef3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54382995)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)

<!-- /greptile_comment -->