### PR TITLE
feat(api-service,worker): MS Teams workflow-origin DM catch-up hydration fixes NV-8591

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -431,6 +431,7 @@ export class AgentInboundHandler implements OnModuleInit {
       subscriberId,
       message,
       existingConversation,
+      isDirectMessage: thread.isDM,
     });
 
     const conversation = await this.conversationService.createOrGetConversation({
@@ -1149,6 +1150,7 @@ export class AgentInboundHandler implements OnModuleInit {
       subscriberId,
       message: null,
       existingConversation,
+      isDirectMessage: thread.isDM,
     });
 
     const conversation = await this.conversationService.createOrGetConversation({

--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.helpers.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.helpers.ts
@@ -77,6 +77,31 @@ export function extractTelegramQuotedMessageId(message: Message | null): string 
   return typeof quotedId === 'string' && quotedId.length > 0 ? quotedId : null;
 }
 
+/** Teams quote-reply activity id from `message.raw.entities[].quotedReply.messageId`, else `replyToId`. */
+export function extractTeamsQuotedActivityId(message: Message | null): string | null {
+  if (!message) {
+    return null;
+  }
+
+  const raw = asRecord(message.raw);
+  const entities = Array.isArray(raw?.entities) ? raw.entities : [];
+  for (const entity of entities) {
+    const record = asRecord(entity);
+    if (record?.type !== 'quotedReply') {
+      continue;
+    }
+
+    const messageId = asRecord(record.quotedReply)?.messageId;
+    if (typeof messageId === 'string' && messageId.length > 0) {
+      return messageId;
+    }
+  }
+
+  const replyToId = raw?.replyToId;
+
+  return typeof replyToId === 'string' && replyToId.length > 0 ? replyToId : null;
+}
+
 /**
  * Bare chat id from `telegram:{chatId}` or `telegram:{chatId}:{messageThreadId}` (forum topics).
  * Returns null when the prefix is absent or the segment is empty.

--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.helpers.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.helpers.ts
@@ -11,6 +11,7 @@ export const RECHECK_WORKFLOW_ORIGIN_PLATFORMS: ReadonlySet<AgentPlatformEnum> =
   AgentPlatformEnum.WHATSAPP,
   AgentPlatformEnum.TELEGRAM,
   AgentPlatformEnum.SENDBLUE,
+  AgentPlatformEnum.TEAMS,
 ]);
 
 export function buildWorkflowOriginSummary(
@@ -101,7 +102,7 @@ export function isSendblueDirectThreadId(platformThreadId: string): boolean {
   return segments.length === 3 && segments[0] === 'sendblue' && segments[1].length > 0 && segments[2].length > 0;
 }
 
-/** Email → Message._id; WhatsApp → wamid; Sendblue → message_handle; Slack `{channel}:{ts}` → `ts`; Telegram → `{chatId}:{message_id}`. */
+/** Email → Message._id; WhatsApp → wamid; Sendblue → message_handle; Teams → activity id; Slack `{channel}:{ts}` → `ts`; Telegram → `{chatId}:{message_id}`. */
 export function resolvePlatformMessageId(
   platform: AgentPlatformEnum,
   originMessage: MessageEntity,
@@ -115,7 +116,11 @@ export function resolvePlatformMessageId(
     return undefined;
   }
 
-  if (platform === AgentPlatformEnum.WHATSAPP || platform === AgentPlatformEnum.SENDBLUE) {
+  if (
+    platform === AgentPlatformEnum.WHATSAPP ||
+    platform === AgentPlatformEnum.SENDBLUE ||
+    platform === AgentPlatformEnum.TEAMS
+  ) {
     return originMessage.identifier;
   }
 
@@ -132,6 +137,7 @@ export function resolvePlatformMessageId(
     return `${chatId}:${originMessage.identifier}`;
   }
 
+  // Slack-only: Message.identifier is `{channel}:{ts}`; hydration keys off the bare `ts`.
   const colon = originMessage.identifier.indexOf(':');
   if (colon <= 0 || colon === originMessage.identifier.length - 1) {
     return undefined;

--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts
@@ -1051,6 +1051,82 @@ describe('WorkflowOriginService', () => {
       expect(result).to.deep.equal({ origin: teamsOrigin, notificationId: 'teams-notif1' });
     });
 
+    it('prefers a quotedReply entity messageId over latest-by-subscriber and bypasses the catch-up window', async () => {
+      const lastActivityAt = new Date().toISOString();
+      const existingConversation = {
+        ...conversation,
+        lastActivityAt,
+        participants: [{ type: 'subscriber', id: 'sub1' }],
+      };
+      const { service, messageRepository } = makeService({
+        findOne: sinon.stub().resolves({
+          ...teamsOrigin,
+          createdAt: new Date(Date.now() - 86_400_000).toISOString(),
+        }),
+      });
+
+      const result = await service.resolve({
+        agentId: 'agent1',
+        config: teamsConfig as any,
+        platformThreadId: teamsDmThreadId,
+        subscriberId: 'sub1',
+        message: {
+          id: 'inbound',
+          text: 'hi',
+          author: { userId: '29:user1' },
+          raw: {
+            entities: [
+              { type: 'clientInfo' },
+              { type: 'quotedReply', quotedReply: { messageId: teamsOrigin.identifier } },
+            ],
+          },
+        } as any,
+        existingConversation: existingConversation as any,
+        isDirectMessage: true,
+      });
+
+      expect(messageRepository.findOne.calledOnce).to.equal(true);
+      expect(messageRepository.findOne.firstCall.args[0]).to.deep.equal({
+        _environmentId: 'env1',
+        _agentId: 'agent1',
+        _subscriberId: 'subscriber-mongo-1',
+        providerId: 'msteams',
+        channel: ChannelTypeEnum.CHAT,
+        _notificationId: { $exists: true, $ne: null },
+        'channelData.type': ENDPOINT_TYPES.MS_TEAMS_USER,
+        identifier: teamsOrigin.identifier,
+      });
+      expect(messageRepository.find.called).to.equal(false);
+      expect(result?.origin.identifier).to.equal(teamsOrigin.identifier);
+      expect(result?.notificationId).to.equal(undefined);
+    });
+
+    it('falls back to replyToId when no quotedReply entity is present', async () => {
+      const { service, messageRepository } = makeService({
+        findOne: sinon.stub().resolves(teamsOrigin),
+      });
+
+      const result = await service.resolve({
+        agentId: 'agent1',
+        config: teamsConfig as any,
+        platformThreadId: teamsDmThreadId,
+        subscriberId: 'sub1',
+        message: {
+          id: 'inbound',
+          text: 'hi',
+          author: { userId: '29:user1' },
+          raw: { replyToId: teamsOrigin.identifier },
+        } as any,
+        existingConversation: null,
+        isDirectMessage: true,
+      });
+
+      expect(messageRepository.findOne.calledOnce).to.equal(true);
+      expect(messageRepository.findOne.firstCall.args[0].identifier).to.equal(teamsOrigin.identifier);
+      expect(messageRepository.find.called).to.equal(false);
+      expect(result?.origin.identifier).to.equal(teamsOrigin.identifier);
+    });
+
     it('catch-up hydrates an existing DM conversation when the origin is not hydrated yet', async () => {
       const existingConversation = {
         ...conversation,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts
@@ -1,4 +1,4 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ENDPOINT_TYPES } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
@@ -991,6 +991,201 @@ describe('WorkflowOriginService', () => {
       expect(messageRepository.findOne.called).to.equal(false);
       expect(messageRepository.find.calledOnce).to.equal(true);
       expect(result?.origin.identifier).to.equal(sendblueOrigin.identifier);
+    });
+  });
+
+  describe('Teams', () => {
+    const teamsDmThreadId = 'teams:YToxMjM:aHR0cHM6Ly9zbWJhLnRyYWZmaWNtYW5hZ2VyLm5ldC90ZWFtcw';
+    const teamsConfig = {
+      environmentId: 'env1',
+      organizationId: 'org1',
+      platform: AgentPlatformEnum.TEAMS,
+      agentIdentifier: 'support-agent',
+      providerId: 'msteams',
+    };
+
+    const teamsOrigin = {
+      _id: 'teams-msg1',
+      _notificationId: 'teams-notif1',
+      _jobId: 'teams-job1',
+      transactionId: 'teams-txn1',
+      templateIdentifier: 'order-alerts',
+      stepId: 'chat-1',
+      content: 'Your order shipped',
+      identifier: 'activity-abc123',
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+      providerId: 'msteams',
+    };
+
+    it('hydrates the latest ms_teams_user origin on a new DM conversation', async () => {
+      const { service, messageRepository } = makeService({
+        find: sinon.stub().resolves([teamsOrigin]),
+      });
+
+      const before = Date.now();
+      const result = await service.resolve({
+        agentId: 'agent1',
+        config: teamsConfig as any,
+        platformThreadId: teamsDmThreadId,
+        subscriberId: 'sub1',
+        message: { id: 'inbound', text: 'hi', author: { userId: '29:user1' }, raw: {} } as any,
+        existingConversation: null,
+        isDirectMessage: true,
+      });
+      const after = Date.now();
+
+      expect(messageRepository.find.calledOnce).to.equal(true);
+      const [query, , options] = messageRepository.find.firstCall.args;
+      expect(query).to.include({
+        _environmentId: 'env1',
+        _agentId: 'agent1',
+        _subscriberId: 'subscriber-mongo-1',
+        providerId: 'msteams',
+        channel: ChannelTypeEnum.CHAT,
+        'channelData.type': ENDPOINT_TYPES.MS_TEAMS_USER,
+      });
+      expect(query._notificationId).to.deep.equal({ $exists: true, $ne: null });
+      expect(query.createdAt.$gt.getTime()).to.be.at.least(before - WORKFLOW_ORIGIN_LOOKBACK_MS - 5);
+      expect(query.createdAt.$gt.getTime()).to.be.at.most(after - WORKFLOW_ORIGIN_LOOKBACK_MS + 5);
+      expect(options).to.deep.equal({ sort: { createdAt: -1 }, limit: 1 });
+      expect(result).to.deep.equal({ origin: teamsOrigin, notificationId: 'teams-notif1' });
+    });
+
+    it('catch-up hydrates an existing DM conversation when the origin is not hydrated yet', async () => {
+      const existingConversation = {
+        ...conversation,
+        lastActivityAt: new Date(Date.now() - 3_600_000).toISOString(),
+        participants: [{ type: 'subscriber', id: 'sub1' }],
+      };
+      const { service, messageRepository, conversationService } = makeService({
+        find: sinon.stub().resolves([teamsOrigin]),
+      });
+
+      const result = await service.resolve({
+        agentId: 'agent1',
+        config: teamsConfig as any,
+        platformThreadId: teamsDmThreadId,
+        subscriberId: 'sub1',
+        message: { id: 'inbound', text: 'hi', author: { userId: '29:user1' }, raw: {} } as any,
+        existingConversation: existingConversation as any,
+        isDirectMessage: true,
+      });
+
+      expect(messageRepository.find.calledOnce).to.equal(true);
+      expect(conversationService.isWorkflowOriginHydrated.firstCall.args).to.deep.equal([
+        'env1',
+        'conversation1',
+        teamsOrigin.identifier,
+      ]);
+      expect(result).to.deep.equal({ origin: teamsOrigin, notificationId: undefined });
+    });
+
+    it('skips an origin already hydrated into the conversation', async () => {
+      const existingConversation = {
+        ...conversation,
+        lastActivityAt: new Date(Date.now() - 3_600_000).toISOString(),
+        participants: [{ type: 'subscriber', id: 'sub1' }],
+      };
+      const { service } = makeService({
+        find: sinon.stub().resolves([teamsOrigin]),
+        isWorkflowOriginHydrated: sinon.stub().resolves(true),
+      });
+
+      const result = await service.resolve({
+        agentId: 'agent1',
+        config: teamsConfig as any,
+        platformThreadId: teamsDmThreadId,
+        subscriberId: 'sub1',
+        message: { id: 'inbound', text: 'hi', author: { userId: '29:user1' }, raw: {} } as any,
+        existingConversation: existingConversation as any,
+        isDirectMessage: true,
+      });
+
+      expect(result).to.equal(null);
+    });
+
+    it('fails closed for non-DM turns without looking up an origin', async () => {
+      const { service, messageRepository } = makeService({
+        find: sinon.stub().resolves([teamsOrigin]),
+      });
+
+      for (const isDirectMessage of [false, undefined] as const) {
+        messageRepository.find.resetHistory();
+        messageRepository.findOne.resetHistory();
+
+        const result = await service.resolve({
+          agentId: 'agent1',
+          config: teamsConfig as any,
+          platformThreadId: teamsDmThreadId,
+          subscriberId: 'sub1',
+          message: { id: 'inbound', text: 'hi', author: { userId: '29:user1' }, raw: {} } as any,
+          existingConversation: null,
+          ...(isDirectMessage === undefined ? {} : { isDirectMessage }),
+        });
+
+        expect(result).to.equal(null);
+        expect(messageRepository.find.called).to.equal(false);
+        expect(messageRepository.findOne.called).to.equal(false);
+      }
+    });
+
+    it('resolves on action turns without a message using latest-by-subscriber', async () => {
+      const { service, messageRepository } = makeService({
+        find: sinon.stub().resolves([teamsOrigin]),
+      });
+
+      const result = await service.resolve({
+        agentId: 'agent1',
+        config: teamsConfig as any,
+        platformThreadId: teamsDmThreadId,
+        subscriberId: 'sub1',
+        message: null,
+        existingConversation: null,
+        isDirectMessage: true,
+      });
+
+      expect(messageRepository.find.calledOnce).to.equal(true);
+      expect(result?.notificationId).to.equal('teams-notif1');
+    });
+
+    it('scopes the origin lookup to the resolved subscriber', async () => {
+      const { service, messageRepository } = makeService({
+        findBySubscriberId: sinon.stub().resolves({ _id: 'attacker-mongo' }),
+        find: sinon.stub().resolves([]),
+      });
+
+      await service.resolve({
+        agentId: 'agent1',
+        config: teamsConfig as any,
+        platformThreadId: teamsDmThreadId,
+        subscriberId: 'attacker-subscriber',
+        message: { id: 'inbound', text: 'hi', author: { userId: '29:user1' }, raw: {} } as any,
+        existingConversation: null,
+        isDirectMessage: true,
+      });
+
+      expect(messageRepository.find.firstCall.args[0]._subscriberId).to.equal('attacker-mongo');
+    });
+
+    it('hydrates using the bare activity id as platformMessageId', async () => {
+      const { service, conversationService } = makeService({
+        notificationFindOne: sinon.stub().resolves({ payload: { orderId: 'ORD-9' } }),
+      });
+
+      await service.hydrate({
+        agentId: 'agent1',
+        config: teamsConfig as any,
+        conversation: conversation as any,
+        platformThreadId: teamsDmThreadId,
+        origin: teamsOrigin as any,
+      });
+
+      expect(conversationService.persistWorkflowOriginHydration.firstCall.args[0].platformMessageId).to.equal(
+        teamsOrigin.identifier
+      );
+      expect(
+        conversationService.persistWorkflowOriginHydration.firstCall.args[0].signalData.workflowIdentifier
+      ).to.equal('order-alerts');
     });
   });
 });

--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts
@@ -19,6 +19,7 @@ import {
   extractAgentEmailOriginToken,
   extractTelegramChatIdFromThreadId,
   extractTelegramQuotedMessageId,
+  extractTeamsQuotedActivityId,
   extractWhatsAppQuotedWamid,
   isSendblueDirectThreadId,
   RECHECK_WORKFLOW_ORIGIN_PLATFORMS,
@@ -114,9 +115,13 @@ export class WorkflowOriginService {
           break;
         case AgentPlatformEnum.TEAMS:
           origin = isDirectMessage
-            ? await this.findRecentChatWorkflowOriginMessage(agentId, config, subscriber._id, null, {
-                'channelData.type': ENDPOINT_TYPES.MS_TEAMS_USER,
-              })
+            ? await this.findRecentChatWorkflowOriginMessage(
+                agentId,
+                config,
+                subscriber._id,
+                extractTeamsQuotedActivityId(message),
+                { 'channelData.type': ENDPOINT_TYPES.MS_TEAMS_USER }
+              )
             : null;
           break;
         case AgentPlatformEnum.AGENT_CHAT:

--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts
@@ -8,7 +8,7 @@ import {
   NotificationRepository,
   SubscriberRepository,
 } from '@novu/dal';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ENDPOINT_TYPES } from '@novu/shared';
 import type { Message } from 'chat';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
@@ -50,8 +50,9 @@ export class WorkflowOriginService {
     subscriberId: string | null;
     message: Message | null;
     existingConversation: ConversationEntity | null;
+    isDirectMessage?: boolean;
   }): Promise<WorkflowOriginResolution | null> {
-    const { agentId, config, platformThreadId, subscriberId, message, existingConversation } = params;
+    const { agentId, config, platformThreadId, subscriberId, message, existingConversation, isDirectMessage } = params;
 
     if (!subscriberId) {
       return null;
@@ -112,6 +113,12 @@ export class WorkflowOriginService {
             : null;
           break;
         case AgentPlatformEnum.TEAMS:
+          origin = isDirectMessage
+            ? await this.findRecentChatWorkflowOriginMessage(agentId, config, subscriber._id, null, {
+                'channelData.type': ENDPOINT_TYPES.MS_TEAMS_USER,
+              })
+            : null;
+          break;
         case AgentPlatformEnum.AGENT_CHAT:
           break;
         default: {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.spec.ts
@@ -336,17 +336,28 @@ describe('SendMessageChat - agent assigned path', () => {
     sinon.restore();
   });
 
-  function buildAgentUsecase(options: {
-    channelData?: unknown[];
-    linked?: boolean;
-    chatHandlerSend?: sinon.SinonStub;
-    updateMessage?: sinon.SinonStub;
-    jobAgentId?: string | null;
-    workflowAgentIdentifier?: string;
-  } = {}) {
+  function buildAgentUsecase(
+    options: {
+      channelData?: unknown[];
+      linked?: boolean;
+      linkedRefs?: Array<{ identifier: string; providerId: string }>;
+      integration?: {
+        _id: string;
+        identifier: string;
+        providerId: ChatProviderIdEnum;
+        channel: ChannelTypeEnum;
+        credentials: Record<string, unknown>;
+      };
+      chatHandlerSend?: sinon.SinonStub;
+      updateMessage?: sinon.SinonStub;
+      jobAgentId?: string | null;
+      workflowAgentIdentifier?: string;
+    } = {}
+  ) {
     const {
       channelData = [slackUserData],
       linked = true,
+      integration = slackIntegration,
       chatHandlerSend = sinon.stub().resolves({
         id: 'D123:1777837477.371619',
         date: new Date().toISOString(),
@@ -355,6 +366,9 @@ describe('SendMessageChat - agent assigned path', () => {
       jobAgentId,
       workflowAgentIdentifier,
     } = options;
+    const linkedRefs =
+      options.linkedRefs ??
+      (linked ? [{ identifier: integration.identifier, providerId: integration.providerId }] : []);
 
     sinon.stub(ChatFactory.prototype, 'getHandler').returns({
       send: chatHandlerSend,
@@ -365,9 +379,7 @@ describe('SendMessageChat - agent assigned path', () => {
       findOne: sinon.stub().resolves(workflowAgentIdentifier ? { _id: 'agent_from_workflow' } : null),
     };
     const agentIntegrationRepository = {
-      listLinkedIntegrationRefs: sinon
-        .stub()
-        .resolves(linked ? [{ identifier: 'slack-main', providerId: ChatProviderIdEnum.Slack }] : []),
+      listLinkedIntegrationRefs: sinon.stub().resolves(linkedRefs),
     };
     const createExecutionDetails = { execute: sinon.stub().resolves(undefined) };
     const sendWebhookMessage = { execute: sinon.stub().resolves(undefined) };
@@ -377,7 +389,7 @@ describe('SendMessageChat - agent assigned path', () => {
       update: updateMessage,
     };
     const selectIntegration = {
-      execute: sinon.stub().resolves(slackIntegration),
+      execute: sinon.stub().resolves(integration),
     };
     const featureFlagsService = {
       getFlag: sinon.stub().resolves(false),
@@ -400,8 +412,8 @@ describe('SendMessageChat - agent assigned path', () => {
       {
         execute: sinon.stub().resolves([
           {
-            integrationIdentifier: 'slack-main',
-            providerId: ChatProviderIdEnum.Slack,
+            integrationIdentifier: integration.identifier,
+            providerId: integration.providerId,
             channelData,
           },
         ]),
@@ -454,9 +466,7 @@ describe('SendMessageChat - agent assigned path', () => {
           content: 'agent hello',
         },
       } as never,
-      workflow: workflowAgentIdentifier
-        ? ({ agent: { identifier: workflowAgentIdentifier } } as never)
-        : undefined,
+      workflow: workflowAgentIdentifier ? ({ agent: { identifier: workflowAgentIdentifier } } as never) : undefined,
       job: {
         _id: 'job_1',
         _environmentId: 'env_1',
@@ -618,6 +628,48 @@ describe('SendMessageChat - agent assigned path', () => {
           "No chat channels linked to the assigned agent were available; sent using the subscriber's configured channels",
       }),
     });
+  });
+
+  it('routes agent-assigned MS Teams user endpoints without the chat-channels fallback', async () => {
+    const teamsActivityId = 'activity-abc123';
+    const chatHandlerSend = sinon.stub().resolves({ id: teamsActivityId, date: new Date().toISOString() });
+    const { usecase, updateMessage, createExecutionDetails } = buildAgentUsecase({
+      jobAgentId: 'agent_1',
+      chatHandlerSend,
+      integration: {
+        _id: 'integration_teams',
+        identifier: 'msteams-main',
+        providerId: ChatProviderIdEnum.MsTeams,
+        channel: ChannelTypeEnum.CHAT,
+        credentials: {},
+      },
+      channelData: [
+        {
+          type: ENDPOINT_TYPES.MS_TEAMS_USER,
+          identifier: 'ep_teams_user',
+          token: 'bot-framework-token',
+          endpoint: { userId: '29:user1' },
+          subscriberTenantId: 'tenant-1',
+          clientId: 'client-1',
+        },
+      ],
+    });
+
+    const result = await usecase.execute(buildAgentCommand({ jobAgentId: 'agent_1' }));
+
+    expect(result.status).to.equal(SendMessageStatus.SUCCESS);
+    sinon.assert.calledOnce(chatHandlerSend);
+    sinon.assert.calledOnce(updateMessage);
+    expect(updateMessage.firstCall.args[1]).to.deep.equal({
+      $set: {
+        identifier: teamsActivityId,
+        _agentId: 'agent_1',
+      },
+    });
+    const fallbackWarning = createExecutionDetails.execute
+      .getCalls()
+      .find((call) => call.args[0]?.detail === DetailEnum.CHAT_AGENT_CHANNELS_FALLBACK);
+    expect(fallbackWarning).to.equal(undefined);
   });
 
   it('resolves workflow.agent when job._agentId is unset and stamps with that agent', async () => {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
@@ -89,7 +89,11 @@ type MessageContext = {
   assignedAgentId: string | null;
 };
 
-const AGENT_SUPPORTED_ENDPOINT_TYPES = new Set<string>([ENDPOINT_TYPES.SLACK_USER, ENDPOINT_TYPES.SLACK_CHANNEL]);
+const AGENT_SUPPORTED_ENDPOINT_TYPES = new Set<string>([
+  ENDPOINT_TYPES.SLACK_USER,
+  ENDPOINT_TYPES.SLACK_CHANNEL,
+  ENDPOINT_TYPES.MS_TEAMS_USER,
+]);
 
 function filterAgentSupportedEndpoints(endpoints: ChannelData[]): ChannelData[] {
   return endpoints.filter((endpoint) => {


### PR DESCRIPTION
## Summary

- Hydrate workflow origin on MS Teams **personal DMs**: latest agent-attributed `ms_teams_user` message in the 7-day lookback, re-checked on later turns like WhatsApp / Telegram / Sendblue.
- Prefer a quoted reply (`entities[].quotedReply.messageId`, else `replyToId`) over latest-by-subscriber so a user quoting an older notification hydrates that origin.
- Channel / group turns fail closed. Worker now delivers agent-assigned `ms_teams_user` endpoints without `CHAT_AGENT_CHANNELS_FALLBACK`.

Fixes [NV-8591](https://linear.app/novu/issue/NV-8591/agent-ms-teams-workflow-origin-hydration-for-dm-catch-up)

```mermaid
flowchart TD
  inbound[Teams inbound DM or action]
  dm{isDirectMessage?}
  quote{quotedReply.messageId or replyToId?}
  findQuote[findOne by Message.identifier]
  findLatest[find newest ms_teams_user origin in lookback]
  hydrate[hydrate origin into conversation]
  skip[no origin lookup]
  inbound --> dm
  dm -->|no| skip
  dm -->|yes| quote
  quote -->|yes| findQuote
  quote -->|no| findLatest
  findQuote --> hydrate
  findLatest --> hydrate
```

## Test plan

- [ ] Quote a Teams DM notification and reply — origin hydrates that message, not a newer one
- [ ] Reply in a Teams DM without quoting — latest `ms_teams_user` origin in 7 days hydrates
- [ ] Existing conversation skips when already hydrated; retries if the hydration marker is missing
- [ ] Channel / group inbound does not look up an origin
- [ ] Adaptive-card action with no message still resolves latest-by-subscriber on a DM
- [ ] Agent-assigned Teams user endpoints deliver without chat-agent channels fallback

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds workflow-origin hydration for Microsoft Teams personal conversations and enables agent-assigned delivery through Teams user endpoints.
- Passes direct-message context from inbound message and action handlers into origin resolution.
- Prefers a quoted Teams activity ID and otherwise finds the latest subscriber-scoped Teams user notification within the catch-up window.
- Persists and reuses the bare Teams activity ID as the hydration key.
- Allows linked `MS_TEAMS_USER` endpoints through agent-assigned worker routing without triggering the channel fallback.
- Adds focused coverage for DM gating, quoted replies, catch-up hydration, subscriber scoping, action turns, and worker persistence.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The Teams user delivery path, persisted activity identifier, subscriber-scoped origin lookup, quoted-reply preference, direct-message gating, and idempotent hydration behavior are aligned across the API and worker changes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Propagates the normalized thread DM classification into workflow-origin resolution for both message and action ingress. |
| apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.helpers.ts | Adds Teams quote extraction, Teams recheck eligibility, and bare activity-ID correlation. |
| apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts | Resolves subscriber- and agent-scoped Teams user origins only for direct-message turns. |
| apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts | Covers Teams DM gating, quote precedence, catch-up behavior, subscriber scoping, action ingress, and hydration IDs. |
| apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts | Allows token-bearing Teams user endpoints through linked agent-assigned routing. |
| apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.spec.ts | Verifies Teams user delivery avoids fallback and persists the provider activity ID with the assigned agent. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Teams
  participant API as Inbound handler
  participant Origin as WorkflowOriginService
  participant DB as Message repository
  participant Conversation
  participant Worker as SendMessageChat
  participant Provider as Teams provider

  Worker->>Provider: Send agent-assigned Teams user message
  Provider-->>Worker: Bot Framework activity ID
  Worker->>DB: Persist activity ID and agent ID
  Teams->>API: Personal DM or adaptive-card action
  API->>Origin: Resolve with isDirectMessage
  alt Quoted activity ID exists
    Origin->>DB: Find scoped message by activity ID
  else No quoted activity ID
    Origin->>DB: Find latest scoped Teams user origin within 7 days
  end
  Origin->>Conversation: Persist idempotent workflow-origin hydration
```

<sub>Reviews (1): Last reviewed commit: ["Handle Teams quotedReply activity id"](https://github.com/novuhq/novu/commit/a84120f2a9d21a113d97b86380b9b9109d8cab28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54688756)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)
</details>

<!-- /greptile_comment -->