### PR TITLE
fix(worker): prevent digest job from merging into itself on re-execution

### DIFF
--- a/apps/worker/src/app/workflow/usecases/add-job/digest-self-merge.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/digest-self-merge.spec.ts
@@ -1,0 +1,127 @@
+import { CreateExecutionDetails, StepRunRepository } from '@novu/application-generic';
+import { JobEntity, JobRepository, JobStatusEnum, NotificationRepository } from '@novu/dal';
+import {
+  DigestCreationResultEnum,
+  DigestTypeEnum,
+  DigestUnitEnum,
+  IDigestBaseMetadata,
+  StepTypeEnum,
+} from '@novu/shared';
+import { expect } from 'chai';
+import { Types } from 'mongoose';
+import sinon from 'sinon';
+import { MergeOrCreateDigestCommand } from './merge-or-create-digest.command';
+import { MergeOrCreateDigest } from './merge-or-create-digest.usecase';
+
+const DIGEST_VALUE = 'digest-value-regression';
+
+function validObjectId(): string {
+  return new Types.ObjectId().toString();
+}
+
+/**
+ * Builds a digest job in the exact state a re-executed digest master starts from:
+ * already `DELAYED` (i.e. `markJobAsDigestMaster` has been applied) and carrying a
+ * matching `digest.digestValue`.
+ */
+function buildDelayedDigestMaster(): JobEntity {
+  return {
+    _id: validObjectId(),
+    _environmentId: validObjectId(),
+    _organizationId: validObjectId(),
+    _subscriberId: validObjectId(),
+    _notificationId: validObjectId(),
+    _templateId: validObjectId(),
+    status: JobStatusEnum.DELAYED,
+    type: StepTypeEnum.DIGEST,
+    subscriberId: 'external-subscriber-id',
+    transactionId: 'transaction-id',
+    identifier: 'workflow-identifier',
+    providerId: 'digest-provider',
+    digest: {
+      type: DigestTypeEnum.REGULAR,
+      amount: 1,
+      unit: DigestUnitEnum.MINUTES,
+      digestValue: DIGEST_VALUE,
+    },
+  } as unknown as JobEntity;
+}
+
+/**
+ * Minimal in-memory stand-in for the Mongoose Job model. It mirrors the semantics
+ * the repository query relies on: key equality, `$ne` on `_id`, and dotted-path
+ * (`digest.digestValue`) lookups. The only way behaviour can change is the shape of
+ * the `filter` handed in by the repository method under test.
+ */
+function createModelLookup(sandbox: sinon.SinonSandbox, storedJobs: Array<{ _id: string }>) {
+  return sandbox.stub().callsFake(async (filter: Record<string, unknown>) => {
+    const hit = storedJobs.find((doc) =>
+      Object.entries(filter).every(([key, rule]) => {
+        const docValue = key.split('.').reduce((obj: any, part: string) => obj?.[part], doc);
+        if (rule && typeof rule === 'object' && '$ne' in rule) {
+          return String(docValue) !== String(rule.$ne);
+        }
+
+        return String(docValue) === String(rule);
+      })
+    );
+
+    return hit ?? null;
+  });
+}
+
+function createRepository(
+  sandbox: sinon.SinonSandbox,
+  storedJob: JobEntity
+): JobRepository & { _model: { findOne: sinon.SinonStub; updateOne: sinon.SinonStub } } {
+  const repository = Object.create(JobRepository.prototype) as JobRepository & { _model: any };
+
+  repository._model = {
+    findOne: createModelLookup(sandbox, [storedJob]),
+    updateOne: sandbox.stub().resolves(),
+  };
+  sinon.stub(repository, 'update').resolves();
+  sinon.stub(repository, 'updateAllChildJobStatus').resolves([] as JobEntity[]);
+
+  return repository;
+}
+
+describe('Digest self-merge regression', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('excludes the job being processed from the existing delayed digest lookup', async () => {
+    const job = buildDelayedDigestMaster();
+    const repository = createRepository(sandbox, job);
+
+    const existing = await repository.getExistingDelayedJobWithTheSameDigestValue(
+      job,
+      job.digest as IDigestBaseMetadata
+    );
+
+    expect(existing).to.equal(null);
+  });
+
+  it('treats a re-executed digest master as the digest master instead of merging it into itself', async () => {
+    const job = buildDelayedDigestMaster();
+    const repository = createRepository(sandbox, job);
+
+    const usecase = new MergeOrCreateDigest(
+      repository,
+      { execute: sandbox.stub().resolves() } as unknown as CreateExecutionDetails,
+      { update: sandbox.stub().resolves() } as unknown as NotificationRepository,
+      { createMany: sandbox.stub().resolves() } as unknown as StepRunRepository
+    );
+
+    const result = await usecase.execute(MergeOrCreateDigestCommand.create({ job }));
+
+    expect(result).to.equal(DigestCreationResultEnum.CREATED);
+  });
+});

--- a/libs/dal/src/repositories/job/job.repository.ts
+++ b/libs/dal/src/repositories/job/job.repository.ts
@@ -437,6 +437,7 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
         _environmentId: this.convertStringToObjectId(job._environmentId),
         _subscriberId: this.convertStringToObjectId(job._subscriberId),
         'digest.digestValue': digestMeta?.digestValue,
+        _id: { $ne: job._id },
       },
       '_id _notificationId'
     );


### PR DESCRIPTION
## What

Digest steps can silently drop the entire notification batch when a digest job's `MergeOrCreateDigest` processing runs more than once for the same job (e.g. the `@RetryOnError("MongoServerError", { maxRetries: 3 })` retry after MongoDB applied the `markJobAsDigestMaster` write but surfaced the error client-side, or an SQS/BullMQ redelivery of the same digest job).

## Root cause

`JobRepository.getExistingDelayedJobWithTheSameDigestValue` queries for a DELAYED digest job with the same `_templateId`/`_environmentId`/`_subscriberId`/`digest.digestValue` but never excludes the job being processed (`_id: job._id`).

Flow:

1. First execution: no existing DELAYED digest job -> `markJobAsDigestMaster` sets the job to `DELAYED`.
2. On a transient `MongoServerError` (write applied server-side), `@RetryOnError` re-runs `computeDigestLogicBasedOnExistingDigestState`.
3. The retry's `findOne` now matches the **same job** -> `digestResult: MERGED` with `activeDigestId === job._id`.
4. `processMergedDigest` marks the master (and children) `MERGED` and points the notification at itself; the digest batch notification is never dispatched.

This became reachable in `eff37ccd8c` "fix(api-service): Remove redlock (#7845)", which swapped the find-then-mark ordering (where the job could only be marked master if no delayed job existed) for an un-guarded find with no self-exclusion.

## Fix

Exclude the job being processed from the existing-digest lookup:

```diff
   _environmentId: this.convertStringToObjectId(job._environmentId),
   _subscriberId: this.convertStringToObjectId(job._subscriberId),
   'digest.digestValue': digestMeta?.digestValue,
+  _id: { $ne: job._id },
```

The `$ne` clause is a no-op for the happy path (the job is not `DELAYED` yet on first execution) and only prevents self-matching on re-execution.

## Validation

Added `apps/worker/src/app/workflow/usecases/add-job/digest-self-merge.spec.ts` with two regression tests:

- `excludes the job being processed from the existing delayed digest lookup` - fails before (returns the job itself), passes after.
- `treats a re-executed digest master as the digest master instead of merging it into itself` - pre-fix returns `MERGED` (self-merge), post-fix returns `CREATED`.

Both tests verified: fail on `next`, pass with this change (full ts-node typecheck). `biome check` clean on the touched files.

#12373

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents a re-executed delayed digest master from being returned as its own merge target.

- Adds an `_id` exclusion to the delayed digest lookup while retaining environment, subscriber, template, and digest-value scoping.
- Adds regression coverage for both the repository lookup and the `MergeOrCreateDigest` result on re-execution.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and directly addresses the digest self-merge path without weakening tenant or digest matching.

The new predicate excludes only the current job while preserving all existing digest identity constraints, and no concrete blocking or non-blocking defect remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/dal/src/repositories/job/job.repository.ts | Narrows the existing delayed-digest query to exclude the job currently being processed, preventing self-merges on retries or redelivery. |
| apps/worker/src/app/workflow/usecases/add-job/digest-self-merge.spec.ts | Adds focused regression tests proving self-exclusion and the resulting CREATED outcome for a re-executed digest master. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Process digest job] --> B[Look up matching delayed digest]
  B --> C{Another matching job exists?}
  C -->|Yes| D[Merge into other digest master]
  C -->|No| E[Mark current job as digest master]
  E --> F[Queue delayed digest]
  G[Re-execute current delayed master] --> B
  B -. Current job excluded by ID .-> C
```

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;next&#39; into fix/digest-self..."](https://github.com/novuhq/novu/commit/1e688b39c7b6ecda4b8b5bcfac70a64e0f2484f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54696540)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [DAL and Data Model](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dal-and-data-model.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)
</details>

<!-- /greptile_comment -->