### PR TITLE
fix(api-service): inject stripAgentReplyToken into email adapter fixes NV-8613

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -5,6 +5,7 @@ import type { WhatsAppAdapter } from '@chat-adapter/whatsapp';
 import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { CacheService, PinoLogger } from '@novu/application-generic';
 import type { NovuAgentChatAdapter } from '@novu/chat-adapter-agent-chat';
+import { stripAgentReplyToken } from '@novu/shared';
 import type { Adapter, Chat, Message, ReactionEvent, SlashCommandEvent, Thread } from 'chat';
 import { LRUCache } from 'lru-cache';
 import { resolveWhatsAppAppSecret } from '../../../integrations/usecases/whatsapp/whatsapp-credentials.utils';
@@ -465,6 +466,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
             senderName: resolveAgentEmailSenderName(config),
             signingSecret: credentials.secretKey,
             sendEmail: this.agentEmailSender.buildSendEmailCallback(config, outboundIntegrationId),
+            stripAgentReplyToken,
             actionUrlBuilder: async ({ threadId, messageId, actionId, value, label, style }) => {
               const userIdentifier = extractRecipientFromThreadId(threadId);
               const { url } = await this.emailActionTokenService.signActionToken({

--- a/packages/chat-adapter-email/src/adapter.ts
+++ b/packages/chat-adapter-email/src/adapter.ts
@@ -10,7 +10,6 @@ import type {
   ThreadInfo,
   WebhookOptions,
 } from 'chat';
-import { stripAgentReplyToken } from '@novu/shared';
 import type { CardNode } from './card-renderer.js';
 import { EmailFormatConverter } from './format-converter.js';
 import { MessageParser } from './message-parser.js';
@@ -109,9 +108,7 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
       references: payload.references,
     });
 
-    const agentAddress = payload.to[0]?.address
-      ? stripAgentReplyToken(payload.to[0].address)
-      : undefined;
+    const agentAddress = payload.to[0]?.address ? this.config.stripAgentReplyToken(payload.to[0].address) : undefined;
     await Promise.all([
       this.threadResolver.trackSubject(threadId, payload.subject),
       agentAddress ? this.threadResolver.trackAgentAddress(threadId, agentAddress) : Promise.resolve(),
@@ -128,7 +125,7 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
       id: payload.messageId,
       messageId: payload.messageId,
       from: payload.from.name ? `${payload.from.name} <${payload.from.address}>` : payload.from.address,
-      to: payload.to.map((t: { address: string; name?: string }) => stripAgentReplyToken(t.address)),
+      to: payload.to.map((t: { address: string; name?: string }) => this.config.stripAgentReplyToken(t.address)),
       subject: payload.subject,
       text: payload.text,
       html: payload.html,

--- a/packages/chat-adapter-email/src/types.ts
+++ b/packages/chat-adapter-email/src/types.ts
@@ -12,6 +12,7 @@ export interface NovuEmailAdapterConfig {
   senderName?: string;
   signingSecret: string;
   sendEmail: (params: SendEmailParams) => Promise<{ messageId?: string }>;
+  stripAgentReplyToken: (address: string) => string;
   /**
    * Resolves a URL for an interactive `<Button id="…">` rendered inside an outbound email.
    * Called once per button before the email HTML is rendered. When omitted, action buttons


### PR DESCRIPTION
## Summary

- Inbound agent email webhooks were 500ing because `@novu/chat-adapter-email` (native ESM via `esmImport`) imported `stripAgentReplyToken` from `@novu/shared` at runtime, and shared's `dist/esm` is not Node-resolvable (`ERR_UNSUPPORTED_DIR_IMPORT`).
- Hotfix: remove the runtime shared import from the email adapter and inject `stripAgentReplyToken` from the CJS API registry (same pattern as `sendEmail` / `actionUrlBuilder`).
- Behavior unchanged — same shared helper, resolved through working `dist/cjs` instead of broken `dist/esm`.

```mermaid
sequenceDiagram
  participant Webhook as Inbound email webhook
  participant Registry as ChatInstanceRegistry (CJS)
  participant Shared as @novu/shared dist/cjs
  participant Adapter as @novu/chat-adapter-email (ESM)

  Webhook->>Registry: build email adapter
  Registry->>Shared: import stripAgentReplyToken
  Registry->>Adapter: esmImport + createNovuEmailAdapter({ stripAgentReplyToken })
  Note over Adapter: no runtime import of @novu/shared
  Adapter-->>Webhook: adapter ready
```

Linear: [NV-8613](https://linear.app/novu/issue/NV-8613)

## Breaking changes

- `NovuEmailAdapterConfig.stripAgentReplyToken` is now required. Only call site is `ChatInstanceRegistry` (updated).

## Test plan

- [x] Rebuild `@novu/chat-adapter-email` and confirm native `import('./packages/chat-adapter-email/dist/index.js')` succeeds
- [x] Uncached `@novu/api-service` dependency build passes
- [ ] Send an inbound reply to an agent email address with a `+nv…` Reply-To token and confirm webhook returns 200
- [ ] Confirm agent address tracking / outbound From still use the stripped stable address

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the email adapter’s runtime dependency on `@novu/shared` and injects the existing reply-token normalization helper from the API’s CommonJS registry instead.
- Adds `stripAgentReplyToken` to the email adapter configuration contract.
- Supplies the helper when `ChatInstanceRegistry` constructs the email adapter.
- Preserves address normalization for inbound recipient tracking and raw-message conversion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the sole repository construction path updated and the intended address-normalization behavior preserved.

The API resolves `@novu/shared` through its CommonJS export, passes the helper into the ESM adapter, and all changed normalization call sites use that supplied function without altering their inputs or outputs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts | Imports the shared normalization helper through the API’s CommonJS-compatible dependency path and supplies it to the dynamically loaded email adapter. |
| packages/chat-adapter-email/src/adapter.ts | Replaces the problematic runtime shared-package import with equivalent calls through the injected configuration callback. |
| packages/chat-adapter-email/src/types.ts | Makes the injected address-normalization callback a required part of the adapter’s public configuration contract. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Webhook as Inbound email webhook
  participant Registry as ChatInstanceRegistry (CJS)
  participant Shared as @novu/shared (CJS)
  participant Adapter as Email adapter (ESM)
  Webhook->>Registry: Resolve email adapter
  Registry->>Shared: Import stripAgentReplyToken
  Registry->>Adapter: createNovuEmailAdapter(config + helper)
  Webhook->>Adapter: Handle inbound message
  Adapter->>Adapter: Normalize recipient addresses
  Adapter-->>Webhook: Return normalized event
```

<sub>Reviews (1): Last reviewed commit: ["Pass agent reply token stripping to emai..."](https://github.com/novuhq/novu/commit/f11c2381238bc3a77d124fe425748f50ba8b86d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54697382)</sub>

**Context used:**

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)

<!-- /greptile_comment -->