### PR TITLE
fix(api-service): mask secret env vars in preview and delivery fixes NV-8614

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -632,6 +632,66 @@ describe('Trigger event - /v1/events/trigger (POST) #novu-v2', () => {
           }
         }
       });
+
+      it('should mask secret environment variables in delivered channel content', async () => {
+        const secretValue = `sk_live_delivery_exfil_${uuid()}`;
+        const publicValue = 'https://cdn.example.com/assets';
+
+        const createSecretResponse = await session.testAgent.post('/v1/environment-variables').send({
+          key: 'DELIVERY_STRIPE_SECRET',
+          isSecret: true,
+          values: [{ _environmentId: session.environment._id, value: secretValue }],
+        });
+        expect(createSecretResponse.status).to.equal(200);
+
+        const createPublicResponse = await session.testAgent.post('/v1/environment-variables').send({
+          key: 'DELIVERY_CDN_URL',
+          isSecret: false,
+          values: [{ _environmentId: session.environment._id, value: publicValue }],
+        });
+        expect(createPublicResponse.status).to.equal(200);
+
+        const workflowBody: CreateWorkflowDto = {
+          name: 'Secret Env Delivery Mask Workflow',
+          workflowId: `secret-env-delivery-mask-${uuid()}`,
+          __source: WorkflowCreationSourceEnum.DASHBOARD,
+          steps: [
+            {
+              type: StepTypeEnum.IN_APP,
+              name: 'In-App Step',
+              controlValues: {
+                subject: 'Secret delivery check',
+                body: 'secret={{env.DELIVERY_STRIPE_SECRET}} public={{env.DELIVERY_CDN_URL}}',
+              },
+            },
+          ],
+        };
+
+        const workflowResponse = await session.testAgent.post('/v2/workflows').send(workflowBody);
+        expect(workflowResponse.status).to.equal(201);
+        const v2Workflow = workflowResponse.body.data as WorkflowResponseDto;
+
+        await novuClient.trigger({
+          workflowId: v2Workflow.workflowId,
+          to: [subscriber.subscriberId],
+          payload: {},
+        });
+
+        await session.waitForJobCompletion(v2Workflow._id);
+
+        const messages = await messageRepository.find({
+          _environmentId: session.environment._id,
+          _subscriberId: subscriber._id,
+          channel: StepTypeEnum.IN_APP,
+          _templateId: v2Workflow._id,
+        });
+        expect(messages.length).to.equal(1);
+
+        const content = String(messages[0].content ?? '');
+        expect(content).to.include(publicValue);
+        expect(content).to.include(SECRET_MASK);
+        expect(content).to.not.include(secretValue);
+      });
     });
 
     it('should digest events with filters', async () => {

--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -24,6 +24,7 @@ import {
   ChatProviderIdEnum,
   CronExpressionEnum,
   RedirectTargetEnum,
+  SECRET_MASK,
   StepTypeEnum,
   slugify,
   ToolProviderIdEnum,
@@ -1706,6 +1707,43 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
   });
 
   describe('payload sanitation', () => {
+    it('should mask secret environment variables in preview output (VULN-082)', async () => {
+      const secretValue = `sk_live_preview_exfil_${randomUUID()}`;
+      const publicValue = 'https://cdn.example.com';
+
+      const createSecretResponse = await session.testAgent.post('/v1/environment-variables').send({
+        key: 'PREVIEW_STRIPE_SECRET',
+        isSecret: true,
+        values: [{ _environmentId: session.environment._id, value: secretValue }],
+      });
+      expect(createSecretResponse.status).to.equal(200);
+
+      const createPublicResponse = await session.testAgent.post('/v1/environment-variables').send({
+        key: 'PREVIEW_CDN_URL',
+        isSecret: false,
+        values: [{ _environmentId: session.environment._id, value: publicValue }],
+      });
+      expect(createPublicResponse.status).to.equal(200);
+
+      const { stepDatabaseId, workflowId } = await createWorkflowAndReturnId(novuClient, StepTypeEnum.SMS);
+      const previewResponseDto = await generatePreview(novuClient, workflowId, stepDatabaseId, {
+        controlValues: {
+          body: 'secret={{env.PREVIEW_STRIPE_SECRET}} public={{env.PREVIEW_CDN_URL}}',
+        },
+      });
+
+      expect(previewResponseDto.result!.preview).to.exist;
+      if (previewResponseDto.result!.type !== 'sms') {
+        throw new Error('Expected sms');
+      }
+
+      const previewBody = previewResponseDto.result!.preview.body;
+      expect(previewBody).to.include(publicValue);
+      expect(previewBody).to.include(SECRET_MASK);
+      expect(previewBody).to.not.include(secretValue);
+      expect(JSON.stringify(previewResponseDto)).to.not.include(secretValue);
+    });
+
     it('Should produce a correct payload when pipe is used etc {{payload.variable | upper}}', async () => {
       const { stepDatabaseId, workflowId } = await createWorkflowAndReturnId(novuClient, StepTypeEnum.SMS);
       const requestDto = {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -490,7 +490,8 @@ export class SendMessage {
 
   @Instrument()
   private async getEnvironmentVariables(command: SendMessageCommand): Promise<Record<string, string>> {
-    const cacheKey = `${command.organizationId}:${command.environmentId}`;
+    const includeSecrets = shouldIncludeEnvironmentSecrets(command.job?.type);
+    const cacheKey = `${command.organizationId}:${command.environmentId}:${includeSecrets ? 'full' : 'masked'}`;
 
     return this.inMemoryLRUCacheService.get(
       InMemoryLRUCacheStore.ENVIRONMENT_VARIABLES,
@@ -502,7 +503,7 @@ export class SendMessage {
             command.environmentId
           );
 
-          return resolveEnvironmentVariables(rawEnvVars);
+          return resolveEnvironmentVariables(rawEnvVars, { includeSecrets });
         } catch (error) {
           Logger.warn(
             { err: error, organizationId: command.organizationId, environmentId: command.environmentId },
@@ -638,4 +639,13 @@ function requiresBridgeExecution(stepType: StepTypeEnum | undefined): boolean {
   if (!stepType) return false;
 
   return ![StepTypeEnum.TRIGGER, StepTypeEnum.DIGEST, StepTypeEnum.DELAY, StepTypeEnum.HTTP_REQUEST].includes(stepType);
+}
+
+/**
+ * Secret env vars stay masked for channel message rendering (email, SMS, etc.)
+ * so plaintext never reaches subscribers or the activity UI. Only outbound
+ * server-side steps that authenticate with those secrets may resolve them.
+ */
+function shouldIncludeEnvironmentSecrets(stepType: StepTypeEnum | string | undefined): boolean {
+  return stepType === StepTypeEnum.HTTP_REQUEST || stepType === StepTypeEnum.CUSTOM;
 }

--- a/libs/application-generic/src/encryption/encrypt-environment-variable.spec.ts
+++ b/libs/application-generic/src/encryption/encrypt-environment-variable.spec.ts
@@ -1,0 +1,52 @@
+import { SECRET_MASK } from '@novu/shared';
+import { expect } from 'chai';
+
+import {
+  decryptEnvironmentVariableValue,
+  resolveEnvironmentVariables,
+} from './encrypt-environment-variable';
+
+describe('encrypt-environment-variable', () => {
+  describe('resolveEnvironmentVariables', () => {
+    it('masks secret variables by default', () => {
+      const variables = [
+        { key: 'PUBLIC_URL', value: 'https://example.com', isSecret: false },
+        { key: 'API_KEY', value: 'plain-secret-value', isSecret: true },
+      ];
+
+      const resolved = resolveEnvironmentVariables(variables);
+
+      expect(resolved.PUBLIC_URL).to.equal('https://example.com');
+      expect(resolved.API_KEY).to.equal(SECRET_MASK);
+    });
+
+    it('decrypts secret variables when includeSecrets is true', () => {
+      const variables = [
+        { key: 'PUBLIC_URL', value: 'https://example.com', isSecret: false },
+        { key: 'API_KEY', value: 'plain-secret-value', isSecret: true },
+      ];
+
+      const resolved = resolveEnvironmentVariables(variables, { includeSecrets: true });
+
+      expect(resolved.PUBLIC_URL).to.equal('https://example.com');
+      expect(resolved.API_KEY).to.equal('plain-secret-value');
+    });
+
+    it('never returns plaintext secrets when includeSecrets is omitted', () => {
+      const variables = [{ key: 'API_KEY', value: 'sk_live_super_secret', isSecret: true }];
+
+      const masked = resolveEnvironmentVariables(variables);
+      const full = resolveEnvironmentVariables(variables, { includeSecrets: true });
+
+      expect(masked.API_KEY).to.equal(SECRET_MASK);
+      expect(full.API_KEY).to.equal('sk_live_super_secret');
+      expect(JSON.stringify(masked)).to.not.include('sk_live_super_secret');
+    });
+  });
+
+  describe('decryptEnvironmentVariableValue', () => {
+    it('returns plaintext values unchanged', () => {
+      expect(decryptEnvironmentVariableValue('hello')).to.equal('hello');
+    });
+  });
+});

--- a/libs/application-generic/src/encryption/encrypt-environment-variable.ts
+++ b/libs/application-generic/src/encryption/encrypt-environment-variable.ts
@@ -1,10 +1,20 @@
 import { Logger } from '@nestjs/common';
 import { EnvironmentVariableForTemplate } from '@novu/dal';
-import { NOVU_ENCRYPTION_SUB_MASK } from '@novu/shared';
+import { NOVU_ENCRYPTION_SUB_MASK, SECRET_MASK } from '@novu/shared';
 
 import { decryptSecret } from './encrypt-provider';
 
 const LOG_CONTEXT = 'DecryptEnvironmentVariable';
+
+export type ResolveEnvironmentVariablesOptions = {
+  /**
+   * When false (default), `isSecret` variables resolve to `SECRET_MASK` so they
+   * cannot appear in preview/API responses or channel message content.
+   * Set true only for server-side outbound execution (HTTP request / custom bridge)
+   * that must send real credentials and does not return them to API callers.
+   */
+  includeSecrets?: boolean;
+};
 
 export function decryptEnvironmentVariableValue(value: string): string {
   if (value.startsWith(NOVU_ENCRYPTION_SUB_MASK)) {
@@ -20,11 +30,19 @@ export function decryptEnvironmentVariableValue(value: string): string {
   return value;
 }
 
-export function resolveEnvironmentVariables(variables: EnvironmentVariableForTemplate[]): Record<string, string> {
+export function resolveEnvironmentVariables(
+  variables: EnvironmentVariableForTemplate[],
+  options: ResolveEnvironmentVariablesOptions = {}
+): Record<string, string> {
+  const includeSecrets = options.includeSecrets === true;
   const resolved: Record<string, string> = {};
 
   for (const variable of variables) {
-    resolved[variable.key] = decryptEnvironmentVariableValue(variable.value);
+    if (variable.isSecret && !includeSecrets) {
+      resolved[variable.key] = SECRET_MASK;
+    } else {
+      resolved[variable.key] = decryptEnvironmentVariableValue(variable.value);
+    }
   }
 
   return resolved;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Fixes **VULN-082** / [NV-8614](https://linear.app/novu/issue/NV-8614): secret environment variables (`isSecret: true`) were decrypted into the template compile context and returned in plaintext via `POST /v2/workflows/:workflowId/step/:stepId/preview` to any caller with `WORKFLOW_READ`.

**Change:** `resolveEnvironmentVariables` now masks `isSecret` values with `SECRET_MASK` by default. Callers that need real credentials for outbound server-side execution must pass `{ includeSecrets: true }`.

- Preview + layout preview: masked (default)
- Channel delivery (email, SMS, in-app, etc.): masked so secrets never render in message content / activity UI
- HTTP request + custom bridge steps: `includeSecrets: true` so authenticated outbound requests still work

```mermaid
flowchart TD
  A[Template compile needs env vars] --> B{includeSecrets?}
  B -->|false default| C[isSecret → SECRET_MASK]
  B -->|true HTTP/CUSTOM only| D[Decrypt real values]
  C --> E[Preview / channel content]
  D --> F[Outbound HTTP / bridge]
  E --> G[Never returned as plaintext]
  F --> H[Not echoed to API callers]
```

### Test plan

- Unit: `encrypt-environment-variable.spec.ts` — 4/4 passing
- E2E preview: `should mask secret environment variables in preview output (VULN-082)` — passing
- E2E delivery: `should mask secret environment variables in delivered channel content` — passing

### Special notes for your reviewer

- Docs already state secrets must not appear in the UI while HTTP steps can still authenticate; this aligns code with that contract.
- Existing step-conditions execution-detail redaction remains as defense in depth for HTTP/CUSTOM paths that still resolve secrets.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-125c014c-b715-4cf3-a2a4-e9329382d856?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-125c014c-b715-4cf3-a2a4-e9329382d856&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents secret environment variables from being exposed through workflow previews or rendered channel content while retaining plaintext resolution for HTTP request and custom server-side execution.

- Makes environment-variable resolution masked by default with an explicit `includeSecrets` opt-in.
- Separates masked and plaintext worker cache entries and selects the appropriate mode by step type.
- Adds unit and end-to-end coverage for preview and delivered-content masking.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and closes the described secret-exposure path without breaking the identified credential-bearing execution flows.

Environment secrets are masked for previews and channel rendering, while persisted and stateless HTTP request/custom jobs retain matching step types and therefore explicitly resolve plaintext credentials in isolated cache entries.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/encryption/encrypt-environment-variable.ts | Changes secret resolution to mask by default while preserving an explicit plaintext opt-in for trusted server-side execution. |
| apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts | Selects masked versus plaintext resolution by step type and isolates both forms in separate cache entries. |
| apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts | Verifies preview responses retain public values while excluding plaintext secret values. |
| apps/api/src/app/events/e2e/trigger-event.e2e.ts | Verifies rendered in-app delivery content masks secret environment variables. |
| libs/application-generic/src/encryption/encrypt-environment-variable.spec.ts | Covers default masking, explicit plaintext resolution, and unchanged handling of non-encrypted values. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Resolve workflow environment variables] --> B{Step requires server-side credentials?}
  B -->|HTTP_REQUEST or CUSTOM| C[Resolve plaintext secrets]
  B -->|Preview or channel delivery| D[Replace secrets with SECRET_MASK]
  C --> E[Outbound request or custom bridge]
  D --> F[Compile preview or channel content]
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): mask secret env vars i..."](https://github.com/novuhq/novu/commit/762e7fb4229af522448a33ba47e5804f0134432d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54706398)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)
- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)
</details>

<!-- /greptile_comment -->