### PR TITLE
fix(docs): supporting codesteps in EU region

### DIFF
--- a/docs/platform/workflow/add-and-configure-steps/code-steps.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/code-steps.mdx
@@ -7,10 +7,6 @@ Novu allows you to write step handlers as TypeScript code in your project and pu
 
 You can create both UI-managed steps and code-managed steps within the same workflow.
 
-<Note>
-  Code steps are only supported in the US region. We are working on supporting this in EU region.
-</Note>
-
 ## Supported channels
 
 | Channel | Required Output |

--- a/docs/platform/workflow/advanced-features/translations.mdx
+++ b/docs/platform/workflow/advanced-features/translations.mdx
@@ -5,10 +5,6 @@ description: "Translate Novu workflow step content into multiple languages with 
 
 Novu supports multi-language translations for workflows, allowing notifications to dynamically adapt to each of your subscriber's preferred language. You can enable, configure, and manage translations across your notification workflows from the Novu dashboard.
 
-<Note>
-  The translations feature is in `beta` and available on `Team` and `Enterprise` [plans](https://novu.co/pricing).
-</Note>
-
 Each workflow can support multiple locales. Novu automatically selects the correct translation based on the subscriber’s locale.
 
 <Warning>


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates workflow documentation to reflect broader code-step availability and removes obsolete beta and plan restrictions from the translations guide.
- Removes the US-only code-step limitation notice.
- Removes the translations beta and Team/Enterprise availability notice.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/workflow/add-and-configure-steps/code-steps.mdx | Removes the obsolete notice that code steps are supported only in the US region. |
| docs/platform/workflow/advanced-features/translations.mdx | Removes the translations beta and plan-availability notice. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docs): remove beta note for translat..."](https://github.com/novuhq/novu/commit/10de76582861059d1ebf55ea01e6890e05a4abc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54721721)</sub>

<!-- /greptile_comment -->