### PR TITLE
fix(agent-chat): await ingress processing and fix Agent Chat runtime bugs fixes NV-8593

### DIFF
--- a/packages/chat-adapter-agent-chat/src/adapter.ts
+++ b/packages/chat-adapter-agent-chat/src/adapter.ts
@@ -240,7 +240,7 @@ export class NovuAgentChatAdapterImpl implements Adapter<AgentChatThreadId, Agen
       contextKeys: session.contextKeys ?? [],
     });
 
-    this.chat!.processMessage(this, threadId, message, options);
+    await this.chat!.processMessage(this, threadId, message, options);
 
     // Public conversation identifier stays bare `conv_*`; chat-sdk thread ids are
     // `agent_chat:conv_*` so `chat.thread()` can resolve this adapter by prefix.
@@ -274,7 +274,7 @@ export class NovuAgentChatAdapterImpl implements Adapter<AgentChatThreadId, Agen
       isMe: false,
     };
 
-    this.chat!.processAction(
+    await this.chat!.processAction(
       {
         adapter: this,
         actionId: kind.actionId,

--- a/packages/js/src/agent-chat/apply-envelope.ts
+++ b/packages/js/src/agent-chat/apply-envelope.ts
@@ -348,8 +348,9 @@ function applyDurableMessageParts(
   const streamingIndex = findStreamingTextPartIndex(next);
 
   if ('markdown' in content) {
-    if (streamingIndex >= 0) {
-      next[streamingIndex] = { type: 'text', text: content.markdown, state: 'done' };
+    const textIndex = streamingIndex >= 0 ? streamingIndex : next.findIndex((part) => part.type === 'text');
+    if (textIndex >= 0) {
+      next[textIndex] = { type: 'text', text: content.markdown, state: 'done' };
     } else {
       next = [...next, { type: 'text', text: content.markdown, state: 'done' }];
     }

--- a/packages/js/src/ws/socket-factory.ts
+++ b/packages/js/src/ws/socket-factory.ts
@@ -13,6 +13,8 @@ const PARTY_SOCKET_URLS = [
   'wss://socket-worker-local.cli-shortener.workers.dev',
   'ws://127.0.0.1:8787',
   'http://127.0.0.1:8787',
+  'ws://localhost:8787',
+  'http://localhost:8787',
 ];
 
 const URL_TRANSFORMATIONS: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Await agent message processing in the Agent Chat adapter before returning HTTP 201 so first replies are durable when the client catch-up runs.
- Deduplicate durable text parts in `apply-envelope` to prevent duplicated user message text (for example `hellohello`).
- Treat `ws://localhost:8787` as a local PartySocket worker URL so local embeds connect to the correct socket endpoint.

## Stack

- Base: `next`
- Merge this PR before #12393.

## Test plan

- [x] `@novu/chat-adapter-agent-chat` adapter tests pass
- [x] `@novu/js` agent-chat tests pass
- [ ] Local embed: first message gets an agent reply without a second send when socket URL is configured

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Agent Chat ingress wait for message and action processing, reconciles durable markdown with existing text parts, and recognizes localhost worker URLs as PartySocket endpoints.
- Awaits message and action processing before returning ingress responses.
- Replaces an existing text part when applying durable markdown to avoid duplicated content.
- Adds localhost HTTP and WebSocket URLs to local PartySocket selection.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/chat-adapter-agent-chat/src/adapter.ts | Awaits message and action processing so ingress responses are not returned before processing completes. |
| packages/js/src/agent-chat/apply-envelope.ts | Reconciles durable markdown with an existing text part when no streaming part remains. |
| packages/js/src/ws/socket-factory.ts | Classifies the CLI-generated localhost worker URLs as PartySocket endpoints. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(js): treat localhost PartySocket URL..."](https://github.com/novuhq/novu/commit/5f548388da65811dc5f591db92dbb53b1c637fa5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54772862)</sub>

**Context used:**

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)

<!-- /greptile_comment -->