### PR TITLE
feat(docs): add Tool channel information in framework fixes DOC-434

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1001,7 +1001,8 @@
                   "framework/in-app-channel",
                   "framework/push-channel",
                   "framework/sms-channel",
-                  "framework/chat-channel"
+                  "framework/chat-channel",
+                  "framework/tool-channel"
                 ],
                 "icon": "radio"
               },
@@ -1040,7 +1041,8 @@
                       "framework/typescript/steps/inApp",
                       "framework/typescript/steps",
                       "framework/typescript/steps/push",
-                      "framework/typescript/steps/sms"
+                      "framework/typescript/steps/sms",
+                      "framework/typescript/steps/tool"
                     ]
                   },
                   "framework/schema/zod",

--- a/docs/framework/custom.mdx
+++ b/docs/framework/custom.mdx
@@ -12,6 +12,8 @@ A custom steps allows to execute any custom logic and persist in the durable exe
 - Execute a custom logic to transform data
 - Custom provider implementation
 
+To page on-call or POST to a webhook through a Novu integration, use the [Tool channel](/framework/tool-channel) (`step.tool`) instead of implementing that delivery in `step.custom`.
+
 ## Custom Step Interface
 
 ```tsx

--- a/docs/framework/introduction.mdx
+++ b/docs/framework/introduction.mdx
@@ -59,7 +59,7 @@ Workflow identifiers should be unique to your application and should be descript
 Channel Steps are the delivery methods of the notification. In our example, we have an email Channel Step that will send an email with the subject `Welcome to Novu` and the body `Hello, welcome to Novu!`.
 Novu's durable workflow execution engine will select the relevant delivery provider configured for this channel and send the notification with the specified content.
 
-Novu supports a variety of common notification channels out-of-the-box, including **email**, **SMS**, **push**, **inbox**, and **chat**.
+Novu supports a variety of common notification channels out-of-the-box, including **email**, **SMS**, **push**, **inbox**, **chat**, and **tool**.
 
 To read more about the full list of parameters, check out the [full SDK reference](/framework/typescript/overview).
 

--- a/docs/framework/tool-channel.mdx
+++ b/docs/framework/tool-channel.mdx
@@ -1,0 +1,295 @@
+---
+title: 'Tool'
+description: "Use the Tool channel in Novu Framework to page on-call, open incidents, or POST JSON to a webhook from a workflow step."
+---
+
+The Tool channel delivers a payload from a workflow to an operational system. Use it to page on-call, open an incident, or POST JSON to an endpoint you control.
+
+It is a **channel step**, like email or SMS. Novu sends through a Tool integration in the Integration Store. It is not a replacement for [`step.custom`](/framework/custom), which runs arbitrary code in your bridge and returns structured results to later steps.
+
+<Note>
+  Connect a Tool provider before triggering. PagerDuty, Opsgenie, and Grafana route per subscriber via [channel endpoints](/api-reference/channel-endpoints/create-a-channel-endpoint). Tool webhook can use a shared URL (static) or per-subscriber URLs (dynamic).
+</Note>
+
+## When to use `step.tool`
+
+| Use `step.tool` when | Use `step.custom` when |
+| --- | --- |
+| You want Novu to deliver to PagerDuty, Opsgenie, Grafana, or a webhook | You need to fetch or transform data in your bridge |
+| Delivery should use a configured integration and Activity feed | The result must be reused in later steps |
+| You need provider-specific fields (severity, tags, extra JSON keys) | You are calling an API that has no Tool provider |
+
+A common pattern is to fetch in `step.custom`, then page with `step.tool` using that result.
+
+## Providers
+
+| Provider | What `body` becomes | Setup |
+| --- | --- | --- |
+| [PagerDuty](/platform/integrations/tool/pagerduty) | Incident `payload.summary` | Per-subscriber Events API v2 routing key |
+| [Opsgenie](/platform/integrations/tool/opsgenie) | Alert `message` (truncated at 130 characters) | Per-subscriber API key |
+| [Grafana](/platform/integrations/tool/grafana) | Alert group `title` (truncated at 1024 characters) | Per-subscriber webhook URL |
+| [Tool webhook](/platform/integrations/tool/webhook) | Request JSON `content` | Static URL on the integration, or dynamic subscriber endpoints |
+
+If a subscriber has no channel endpoint for an endpoint-routed provider (or no dynamic webhook URLs), Novu marks the Tool step **skipped** for that subscriber. Other subscribers on the same trigger are unaffected.
+
+## Define a tool step
+
+The resolver must return a `body` string. That string is the default content sent to the provider.
+
+```tsx
+await step.tool('page-oncall', async () => {
+  return {
+    body: 'Payment failed for order ORD-12345',
+  };
+});
+```
+
+### Workflow with payload
+
+```tsx
+import { workflow } from '@novu/framework';
+import { z } from 'zod';
+
+export const orderFailed = workflow(
+  'order-failed',
+  async ({ step, payload, subscriber }) => {
+    await step.tool('page-oncall', async () => ({
+      body: `Payment failed for order ${payload.orderNumber} (${subscriber.subscriberId}): ${payload.reason}`,
+    }));
+  },
+  {
+    payloadSchema: z.object({
+      orderNumber: z.string(),
+      reason: z.string(),
+    }),
+  }
+);
+```
+
+Trigger the workflow as usual. Delivery uses the subscriber's Tool endpoints for that environment.
+
+```tsx
+await orderFailed.trigger({
+  to: 'user-123',
+  payload: {
+    orderNumber: 'ORD-12345',
+    reason: 'payment_declined',
+  },
+});
+```
+
+## Provider overrides
+
+Use the `providers` option to pass fields the shared `body` schema does not cover. Keys are Tool provider IDs: `pagerduty`, `opsgenie`, `grafana`, and `tool-webhook`.
+
+Only the override for the integration that actually sends is applied. You can define several; unused ones are ignored.
+
+<Tabs>
+  <Tab title="PagerDuty">
+```tsx
+await step.tool(
+  'page-oncall',
+  async () => ({
+    body: 'Payment failed for order ORD-12345',
+  }),
+  {
+    providers: {
+      pagerduty: async ({ outputs }) => ({
+        severity: 'error',
+        source: 'checkout',
+        summary: outputs.body,
+        custom_details: {
+          runbook: 'https://runbooks.example.com/payments',
+        },
+      }),
+    },
+  }
+);
+```
+
+PagerDuty defaults `severity` to `critical` and `source` to `novu` when you omit those fields. See [incident payload defaults](/platform/integrations/tool/pagerduty#incident-payload-defaults-and-overrides).
+  </Tab>
+  <Tab title="Opsgenie">
+```tsx
+await step.tool(
+  'page-oncall',
+  async () => ({
+    body: 'Payment failed for order ORD-12345',
+  }),
+  {
+    providers: {
+      opsgenie: async ({ outputs }) => ({
+        message: outputs.body,
+        description: 'Card declined after 3 retries. Customer is blocked at checkout.',
+        priority: 'P1',
+        tags: ['payments', 'checkout'],
+        source: 'novu',
+      }),
+    },
+  }
+);
+```
+
+Opsgenie truncates `message` at 130 characters. Put detail in `description` (up to 15,000 characters). See [alert payload defaults](/platform/integrations/tool/opsgenie#alert-payload-defaults-and-overrides).
+  </Tab>
+  <Tab title="Grafana">
+```tsx
+await step.tool(
+  'page-oncall',
+  async () => ({
+    body: 'Payment failed for order ORD-12345',
+  }),
+  {
+    providers: {
+      grafana: async ({ outputs }) => ({
+        title: outputs.body,
+        message: 'Card declined after 3 retries.',
+        state: 'alerting',
+        link_to_upstream_details: 'https://app.example.com/orders/ORD-12345',
+      }),
+    },
+  }
+);
+```
+
+Send `state: 'ok'` with the same `alert_uid` to auto-resolve. See [alert payload defaults](/platform/integrations/tool/grafana#alert-payload-defaults-and-overrides).
+  </Tab>
+  <Tab title="Tool webhook">
+```tsx
+await step.tool(
+  'notify-ops',
+  async () => ({
+    body: 'Payment failed for order ORD-12345',
+  }),
+  {
+    providers: {
+      'tool-webhook': async ({ outputs }) => ({
+        alert_type: 'incident',
+        title: outputs.body,
+      }),
+    },
+  }
+);
+```
+
+The rendered `body` is always sent as `content` on the JSON request. Extra keys from the override merge into that object. See [request shape](/platform/integrations/tool/webhook#request-shape).
+  </Tab>
+</Tabs>
+
+You can also use `_passthrough` to merge extra `body`, `headers`, or `query` into the underlying provider request. See [provider overrides](/framework/typescript/steps#providers-overrides-object).
+
+## Step controls
+
+Expose copy that non-developers can edit in the dashboard without changing code.
+
+```tsx
+import { z } from 'zod';
+
+await step.tool(
+  'page-oncall',
+  async (controls) => ({
+    body: controls.body,
+  }),
+  {
+    controlSchema: z.object({
+      body: z.string().default('An incident requires attention.'),
+    }),
+    providers: {
+      pagerduty: async ({ controls, outputs }) => ({
+        summary: outputs.body,
+        severity: 'error',
+        source: 'checkout',
+      }),
+    },
+  }
+);
+```
+
+After you sync the workflow, the dashboard renders a **body** field for this step. Payload data still comes from `novu.trigger`. Learn more about [controls](/framework/controls).
+
+## Skip the step
+
+Skip delivery from previous-step results, payload flags, or subscriber data.
+
+```tsx
+workflow('order-failed', async ({ step, payload }) => {
+  const order = await step.custom(
+    'load-order',
+    async () => {
+      const record = await db.orders.find(payload.orderNumber);
+
+      return {
+        orderNumber: record.id,
+        alreadyPaged: record.pagerDutyIncidentId != null,
+      };
+    },
+    {
+      outputSchema: {
+        type: 'object',
+        properties: {
+          orderNumber: { type: 'string' },
+          alreadyPaged: { type: 'boolean' },
+        },
+        required: ['orderNumber', 'alreadyPaged'],
+      },
+    }
+  );
+
+  await step.tool(
+    'page-oncall',
+    async () => ({
+      body: `Payment failed for order ${order.orderNumber}`,
+    }),
+    {
+      skip: () => order.alreadyPaged || payload.severity === 'low',
+    }
+  );
+});
+```
+
+`skip` runs at send time, not during dashboard preview. See [skip](/framework/skip).
+
+## Channel preferences
+
+Disable Tool for a workflow (or leave it subscriber-controlled) with `preferences.channels.tool`:
+
+```tsx
+workflow(
+  'order-failed',
+  async ({ step, payload }) => {
+    await step.tool('page-oncall', async () => ({
+      body: `Payment failed for order ${payload.orderNumber}`,
+    }));
+  },
+  {
+    preferences: {
+      channels: {
+        tool: { enabled: true },
+      },
+    },
+  }
+);
+```
+
+## Output
+
+The resolver returns `{ body: string }`. The step does not return a result, so you cannot branch later steps on whether the provider accepted the request.
+
+See the [Tool step reference](/framework/typescript/steps/tool).
+
+## Related
+
+<Columns cols={2}>
+  <Card icon="book-open" href="/framework/typescript/steps/tool" title="Tool step reference">
+    Output schema and SDK types.
+  </Card>
+  <Card icon="webhook" href="/platform/integrations/tool/webhook" title="Tool webhook">
+    Static vs dynamic routing, request body merge, and HMAC signatures.
+  </Card>
+  <Card icon="siren" href="/platform/integrations/tool/pagerduty" title="PagerDuty">
+    Per-subscriber routing keys and Events API v2 incident fields.
+  </Card>
+  <Card icon="code" href="/framework/custom" title="Custom step">
+    Fetch data in your bridge, then pass it into `step.tool`.
+  </Card>
+</Columns>

--- a/docs/framework/typescript/steps/tool.mdx
+++ b/docs/framework/typescript/steps/tool.mdx
@@ -1,0 +1,26 @@
+---
+title: 'Tool'
+description: "Use the tool step in Novu Framework to deliver a payload to PagerDuty, Opsgenie, Grafana, or a Tool webhook as part of a workflow."
+---
+
+The `tool` step delivers a `body` string through a Tool integration. For when to use it versus `step.custom`, provider mapping, overrides, skip, and controls, see the [Tool channel](/framework/tool-channel) guide.
+
+## Example Usage
+
+```tsx
+await step.tool('page-oncall', async () => {
+  return {
+    body: 'Payment failed for order ORD-12345',
+  };
+});
+```
+
+## Tool Step Output
+
+| Property | Type   | Required | Description                                      |
+| -------- | ------ | -------- | ------------------------------------------------ |
+| body     | string | Yes      | The payload sent to the Tool provider as content |
+
+## Tool Step Result
+
+The `tool` step does not return any result object.

--- a/docs/framework/typescript/workflow.mdx
+++ b/docs/framework/typescript/workflow.mdx
@@ -104,6 +104,7 @@ workflow(workflowId, handler, options);
   - `sms`: `{ enabled: boolean }` - SMS channel preferences
   - `chat`: `{ enabled: boolean }` - Chat channel preferences
   - `push`: `{ enabled: boolean }` - Push channel preferences
+  - `tool`: `{ enabled: boolean }` - Tool channel preferences
 
 ## Workflow Context
 

--- a/docs/platform/workflow/add-and-configure-steps/code-steps.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/code-steps.mdx
@@ -16,6 +16,20 @@ You can create both UI-managed steps and code-managed steps within the same work
 | Push | `subject`, `body` |
 | Chat | `body` |
 | In-App | `subject`, `body` (plus optional `avatar`, `primaryAction`, `secondaryAction`, `data`, `redirect`) |
+| Tool | `body` |
+
+Tool steps use the same handler shape as other channels. Return a `body` string; Novu delivers it through a [Tool integration](/platform/integrations/tool/webhook). See the [Tool channel](/framework/tool-channel) guide for provider overrides and skip.
+
+```typescript
+import { step } from '@novu/framework/step-resolver';
+
+export default step.tool(
+  'page-oncall',
+  async (controls, { payload }) => ({
+    body: `Payment failed for order ${payload.orderNumber}: ${payload.reason}`,
+  })
+);
+```
 
 ## Quick Start
 

--- a/packages/novu/src/commands/step/discovery/step-discovery.spec.ts
+++ b/packages/novu/src/commands/step/discovery/step-discovery.spec.ts
@@ -90,7 +90,7 @@ describe('step-discovery', () => {
   });
 
   it('accepts all supported channel step types', async () => {
-    for (const type of ['email', 'sms', 'chat', 'push']) {
+    for (const type of ['email', 'sms', 'chat', 'push', 'tool']) {
       writeStepFile(
         `onboarding/${type}-step.step.ts`,
         createStepFileContent({ stepId: `${type}-step`, type, useJsx: false })
@@ -105,7 +105,7 @@ describe('step-discovery', () => {
 
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
-    expect(result.steps).toHaveLength(5);
+    expect(result.steps).toHaveLength(6);
   });
 
   it('detects invalid step type', async () => {

--- a/packages/novu/src/commands/step/discovery/step-discovery.ts
+++ b/packages/novu/src/commands/step/discovery/step-discovery.ts
@@ -27,6 +27,7 @@ const METHOD_NAME_TO_TYPE: Record<string, string> = {
   chat: 'chat',
   push: 'push',
   inApp: 'in_app',
+  tool: 'tool',
   delay: 'delay',
   digest: 'digest',
   throttle: 'throttle',

--- a/packages/novu/src/commands/step/publish.ts
+++ b/packages/novu/src/commands/step/publish.ts
@@ -45,7 +45,7 @@ const RELEASE_ARTIFACT_BASENAME = 'step-resolver-release';
 
 type ScaffoldResult = { mode: 'react-email'; templatePath: string } | { mode: 'placeholder'; stepType: string };
 
-const KNOWN_STEP_TYPES = new Set(['email', 'sms', 'push', 'chat', 'in_app', 'delay', 'digest', 'throttle']);
+const KNOWN_STEP_TYPES = new Set(['email', 'sms', 'push', 'chat', 'in_app', 'tool', 'delay', 'digest', 'throttle']);
 
 export async function stepPublish(options: PublishOptions): Promise<void> {
   try {
@@ -218,6 +218,7 @@ async function promptForStepType(rootDir: string): Promise<ScaffoldResult | unde
         { title: 'Push         — mobile push notification', value: 'push' },
         { title: 'Chat         — chat message (Slack, MS Teams, etc.)', value: 'chat' },
         { title: 'In-App       — in-app notification', value: 'in_app' },
+        { title: 'Tool         — PagerDuty, Opsgenie, Grafana, or webhook', value: 'tool' },
         { title: 'Delay        — pause execution for a duration', value: 'delay' },
         { title: 'Digest       — batch events over a time window', value: 'digest' },
         { title: 'Throttle     — limit send frequency per subscriber', value: 'throttle' },

--- a/packages/novu/src/commands/step/templates/__snapshots__/step-file.spec.ts.snap
+++ b/packages/novu/src/commands/step/templates/__snapshots__/step-file.spec.ts.snap
@@ -369,3 +369,54 @@ export default step.sms(
 );
 "
 `;
+
+exports[`generateToolStepFile > should match snapshot with zod 1`] = `
+"import { step } from '@novu/framework/step-resolver';
+import { z } from 'zod';
+
+export default step.tool(
+  'page-oncall',
+  async (controls) => ({
+    body: controls.body,
+  }),
+  {
+    controlSchema: z.object({
+      body: z.string().default('An incident requires attention.'),
+    }),
+    // providers: {
+    //   'tool-webhook': async ({ outputs }) => ({
+    //     alert_type: 'incident',
+    //     title: outputs.body,
+    //   }),
+    // },
+  }
+);
+"
+`;
+
+exports[`generateToolStepFile > should match snapshot without zod 1`] = `
+"import { step } from '@novu/framework/step-resolver';
+
+export default step.tool(
+  'page-oncall',
+  async (controls) => ({
+    body: controls.body,
+  }),
+  {
+    controlSchema: {
+      type: 'object',
+      properties: {
+        body: { type: 'string', default: 'An incident requires attention.' },
+      },
+      additionalProperties: false,
+    } as const,
+    // providers: {
+    //   'tool-webhook': async ({ outputs }) => ({
+    //     alert_type: 'incident',
+    //     title: outputs.body,
+    //   }),
+    // },
+  }
+);
+"
+`;

--- a/packages/novu/src/commands/step/templates/index.ts
+++ b/packages/novu/src/commands/step/templates/index.ts
@@ -6,4 +6,5 @@ export {
   generateReactEmailStepFile,
   generateSmsStepFile,
   generateStepFileForType,
+  generateToolStepFile,
 } from './step-file';

--- a/packages/novu/src/commands/step/templates/step-file.spec.ts
+++ b/packages/novu/src/commands/step/templates/step-file.spec.ts
@@ -7,6 +7,7 @@ import {
   generateReactEmailStepFile,
   generateSmsStepFile,
   generateStepFileForType,
+  generateToolStepFile,
 } from './step-file';
 
 describe('generateReactEmailStepFile', () => {
@@ -115,6 +116,16 @@ describe('generateChatStepFile', () => {
   });
 });
 
+describe('generateToolStepFile', () => {
+  it('should match snapshot with zod', () => {
+    expect(generateToolStepFile('page-oncall', true)).toMatchSnapshot();
+  });
+
+  it('should match snapshot without zod', () => {
+    expect(generateToolStepFile('page-oncall', false)).toMatchSnapshot();
+  });
+});
+
 describe('generateInAppStepFile', () => {
   it('should match snapshot with zod', () => {
     expect(generateInAppStepFile('in-app-notify', true)).toMatchSnapshot();
@@ -144,5 +155,11 @@ describe('generateStepFileForType', () => {
     const result = generateStepFileForType('my-step', 'sms', false);
     expect(result).not.toContain("from 'zod'");
     expect(result).toContain('as const');
+  });
+
+  it('scaffolds a tool channel step', () => {
+    const result = generateStepFileForType('page-oncall', 'tool', false);
+    expect(result).toContain('step.tool(');
+    expect(result).toContain("'page-oncall'");
   });
 });

--- a/packages/novu/src/commands/step/templates/step-file.ts
+++ b/packages/novu/src/commands/step/templates/step-file.ts
@@ -166,6 +166,31 @@ export default step.chat(
 `;
 }
 
+const toolFields: ControlFields = {
+  body: { default: 'An incident requires attention.' },
+};
+
+export function generateToolStepFile(stepId: string, useZod: boolean): string {
+  return `${stepImports(useZod)}
+
+export default step.tool(
+  '${escapeString(stepId)}',
+  async (controls) => ({
+    body: controls.body,
+  }),
+  {
+    controlSchema: ${controlSchema(toolFields, useZod)},
+    // providers: {
+    //   'tool-webhook': async ({ outputs }) => ({
+    //     alert_type: 'incident',
+    //     title: outputs.body,
+    //   }),
+    // },
+  }
+);
+`;
+}
+
 const inAppFields: ControlFields = {
   subject: { default: 'New activity' },
   body: { default: 'You have a new notification.' },
@@ -283,6 +308,7 @@ const STEP_GENERATORS: Record<string, (stepId: string, useZod: boolean) => strin
   push: generatePushStepFile,
   chat: generateChatStepFile,
   in_app: generateInAppStepFile,
+  tool: generateToolStepFile,
   delay: generateDelayStepFile,
   digest: generateDigestStepFile,
   throttle: generateThrottleStepFile,


### PR DESCRIPTION
- Added Tool channel to documentation, detailing its use for paging on-call, opening incidents, and posting to webhooks.
- Updated existing documentation to include the Tool channel in the list of supported notification channels.
- Created new Tool channel and step files to facilitate integration with services like PagerDuty and Opsgenie.
- Enhanced step discovery to recognize the Tool step type and included it in scaffolding options.
- Updated relevant examples and schemas to reflect the new Tool step functionality.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR documents the Tool notification channel and adds Tool-step support to the step-resolver CLI.
- Adds Tool channel guides, reference material, examples, and documentation navigation.
- Recognizes `step.tool` during discovery and publishing.
- Adds Tool scaffolding with Zod and JSON Schema variants, plus tests and snapshots.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete defects identified.

The CLI additions align with the existing Framework Tool schemas and exports, while the new documentation accurately reflects the supported API and provider contracts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/step/discovery/step-discovery.ts | Maps `step.tool` to the supported `tool` channel type during static discovery. |
| packages/novu/src/commands/step/publish.ts | Adds Tool to known and interactively selectable scaffold step types. |
| packages/novu/src/commands/step/templates/step-file.ts | Generates a Tool resolver whose control and output shapes match the Framework Tool schema. |
| docs/framework/tool-channel.mdx | Adds comprehensive Tool channel guidance consistent with current Framework types and provider identifiers. |
| docs/platform/workflow/add-and-configure-steps/code-steps.mdx | Adds a standalone Tool-step example using the supported step-resolver signature. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(docs): add Tool channel information..."](https://github.com/novuhq/novu/commit/f9ac83d09ac7dc6307f27bbbe09875fe645974f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54784704)</sub>

<!-- /greptile_comment -->