### PR TITLE
chore(dashboard): chat editor full height fix when provider overrides ff is off

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-editor.tsx
@@ -85,14 +85,16 @@ export const ChatEditor = (props: ChatEditorProps) => {
 
   if (defaultContentActions) {
     return (
-      <TabsSection className="flex min-h-0 flex-1 flex-col p-3">
-        <div className="flex min-h-0 flex-1 flex-col gap-2">
-          <div className="flex shrink-0 items-center justify-end">{defaultContentActions}</div>
-          <div className="rounded-12 bg-bg-weak flex min-h-0 flex-1 flex-col gap-2 border border-neutral-100 p-2">
-            {defaultContent}
+      <div className="-mx-3 -mt-3 flex h-full min-h-0 flex-col">
+        <TabsSection className="flex min-h-0 flex-1 flex-col p-3">
+          <div className="flex min-h-0 flex-1 flex-col gap-2">
+            <div className="flex shrink-0 items-center justify-end">{defaultContentActions}</div>
+            <div className="rounded-12 bg-bg-weak flex min-h-0 flex-1 flex-col gap-2 border border-neutral-100 p-2">
+              {defaultContent}
+            </div>
           </div>
-        </div>
-      </TabsSection>
+        </TabsSection>
+      </div>
     );
   }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Dashboard - when provider overrides ff is off the chat blocks editor should take full available height

### Screenshots

<img width="1527" height="997" alt="Screenshot 2026-08-19 at 16 43 43" src="https://github.com/user-attachments/assets/9d03b09d-9b43-407e-86bd-7bb7a3fbedaf" />
<img width="1528" height="995" alt="Screenshot 2026-08-19 at 16 43 32" src="https://github.com/user-attachments/assets/c09d9c99-c878-4da3-876e-1f12ca899267" />
<img width="1533" height="1003" alt="Screenshot 2026-08-19 at 16 42 47" src="https://github.com/user-attachments/assets/9359096c-caf4-430d-8fa9-4f762d260543" />
<img width="1528" height="999" alt="Screenshot 2026-08-19 at 16 42 35" src="https://github.com/user-attachments/assets/4dc18e27-526b-4dd7-af0e-8f9798541b83" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the chat block editor consume the full available height when provider overrides are disabled.

- Wraps the standard chat editor branch in the same full-height, negative-margin layout used by the provider-overrides panel.
- Preserves the existing action selector and editable-content structure.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The changed branch reuses the established full-height chat editor wrapper pattern while leaving editor selection and content rendering behavior unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/workflow-editor/steps/chat/chat-editor.tsx | Aligns the non-provider-overrides chat editor layout with the existing full-height provider-overrides layout; no actionable defect identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(dashboard): chat editor full heigh..."](https://github.com/novuhq/novu/commit/60844d38e56ee80000013fa5aad43667e8c4b9b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54788902)</sub>

**Context used:**

- Knowledge Base — [Dashboard App (apps/dashboard)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dashboard-app.md)

<!-- /greptile_comment -->