### PR TITLE
fix(root): harden release-packages.yml against shell injection

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -82,14 +82,17 @@ jobs:
 
       - name: Set version for nightly or rc
         if: github.event.inputs.release_type != 'stable'
+        env:
+          INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           COMMIT_SHA=$(git rev-parse --short HEAD)
-          if [ "${{ github.event.inputs.release_type }}" = "nightly" ]; then
+          if [ "$INPUT_RELEASE_TYPE" = "nightly" ]; then
             DATE=$(date +'%Y%m%d')
-            echo "RELEASE_VERSION=${{ github.event.inputs.version }}-nightly.${DATE}.${COMMIT_SHA}" >> $GITHUB_ENV
+            echo "RELEASE_VERSION=${INPUT_VERSION}-nightly.${DATE}.${COMMIT_SHA}" >> $GITHUB_ENV
             echo "Using nightly version: $RELEASE_VERSION"
-          elif [ "${{ github.event.inputs.release_type }}" = "rc" ]; then
-            echo "RELEASE_VERSION=${{ github.event.inputs.version }}-rc.${COMMIT_SHA}" >> $GITHUB_ENV
+          elif [ "$INPUT_RELEASE_TYPE" = "rc" ]; then
+            echo "RELEASE_VERSION=${INPUT_VERSION}-rc.${COMMIT_SHA}" >> $GITHUB_ENV
             echo "Using rc version: $RELEASE_VERSION"
           fi
 
@@ -99,31 +102,41 @@ jobs:
           git config --global user.name "github-actions[bot]"
 
       - name: Release version (without commit)
+        env:
+          INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
         run: |
-          if [ "${{ github.event.inputs.release_type }}" = "nightly" ]; then
-            echo "Running nightly release with version: ${{ env.RELEASE_VERSION }}"
-            pnpm nx release version ${{ env.RELEASE_VERSION }} --projects=${{ github.event.inputs.packages }} --preid nightly --git-commit=false --verbose
-          elif [ "${{ github.event.inputs.release_type }}" = "rc" ]; then
-            echo "Running rc release with version: ${{ env.RELEASE_VERSION }}"
-            pnpm nx release version ${{ env.RELEASE_VERSION }} --projects=${{ github.event.inputs.packages }} --preid rc --git-commit=false --verbose
+          if [ "$INPUT_RELEASE_TYPE" = "nightly" ]; then
+            echo "Running nightly release with version: $RELEASE_VERSION"
+            pnpm nx release version "$RELEASE_VERSION" --projects="$INPUT_PACKAGES" --preid nightly --git-commit=false --verbose
+          elif [ "$INPUT_RELEASE_TYPE" = "rc" ]; then
+            echo "Running rc release with version: $RELEASE_VERSION"
+            pnpm nx release version "$RELEASE_VERSION" --projects="$INPUT_PACKAGES" --preid rc --git-commit=false --verbose
           else
-            echo "Running stable release with version: ${{ github.event.inputs.version }}"
-            pnpm nx release version ${{ github.event.inputs.version }} --projects=${{ github.event.inputs.packages }} --git-commit=false --verbose
+            echo "Running stable release with version: $INPUT_VERSION"
+            pnpm nx release version "$INPUT_VERSION" --projects="$INPUT_PACKAGES" --git-commit=false --verbose
           fi
 
       - name: Generate changelog (without commit)
+        env:
+          INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
+          INPUT_PREVIOUS_TAG: ${{ github.event.inputs.previous_tag }}
         run: |
-          if [ "${{ github.event.inputs.release_type }}" = "stable" ]; then
-            pnpm nx release changelog ${{ github.event.inputs.version }} --projects=${{ github.event.inputs.packages }} --from=${{ github.event.inputs.previous_tag }} --git-commit=false
+          if [ "$INPUT_RELEASE_TYPE" = "stable" ]; then
+            pnpm nx release changelog "$INPUT_VERSION" --projects="$INPUT_PACKAGES" --from="$INPUT_PREVIOUS_TAG" --git-commit=false
           else
-            pnpm nx release changelog ${{ env.RELEASE_VERSION }} --projects=${{ github.event.inputs.packages }} --from=${{ github.event.inputs.previous_tag }} --git-commit=false
+            pnpm nx release changelog "$RELEASE_VERSION" --projects="$INPUT_PACKAGES" --from="$INPUT_PREVIOUS_TAG" --git-commit=false
           fi
 
       - name: Build packages
         env:
           NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
+          INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
         run: |
-          if [ "${{ github.event.inputs.release_type }}" != "stable" ]; then
+          if [ "$INPUT_RELEASE_TYPE" != "stable" ]; then
             pnpm run build:packages
           else
             echo "Skipping build for stable release (will be built after PR merge)"
@@ -131,13 +144,16 @@ jobs:
 
       - name: Publish packages (nightly and rc only)
         if: github.event.inputs.release_type != 'stable'
+        env:
+          INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
         run: |
-          if [ "${{ github.event.inputs.release_type }}" = "nightly" ]; then
+          if [ "$INPUT_RELEASE_TYPE" = "nightly" ]; then
             echo "📦 Publishing nightly release with OIDC trusted publishing..."
-            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=nightly --provenance
-          elif [ "${{ github.event.inputs.release_type }}" = "rc" ]; then
+            pnpm nx run-many -t nx-release-publish --projects="$INPUT_PACKAGES" -- --tag=nightly --provenance
+          elif [ "$INPUT_RELEASE_TYPE" = "rc" ]; then
             echo "📦 Publishing RC release with OIDC trusted publishing..."
-            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=next --provenance
+            pnpm nx run-many -t nx-release-publish --projects="$INPUT_PACKAGES" -- --tag=next --provenance
           fi
       - name: Create Pull Request
         if: github.event.inputs.release_type == 'stable'
@@ -187,9 +203,9 @@ jobs:
 
       - name: Extract version and packages from PR
         id: extract-info
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE='${{ github.event.pull_request.title }}'
-
           echo "=== PR Title ==="
           echo "$PR_TITLE"
           echo ""
@@ -243,20 +259,25 @@ jobs:
         run: pnpm run build:packages
 
       - name: Publish packages to NPM
+        env:
+          RELEASE_PACKAGES: ${{ steps.extract-info.outputs.packages }}
         run: |
           echo "📦 Publishing stable release with OIDC trusted publishing..."
-          pnpm nx run-many -t nx-release-publish --projects=${{ steps.extract-info.outputs.packages }} -- --tag=latest --provenance
+          pnpm nx run-many -t nx-release-publish --projects="$RELEASE_PACKAGES" -- --tag=latest --provenance
 
       - name: Create and push tags
+        env:
+          RELEASE_PACKAGES: ${{ steps.extract-info.outputs.packages }}
+          RELEASE_VERSION: ${{ steps.extract-info.outputs.version }}
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-          echo "Creating tags for packages: ${{ steps.extract-info.outputs.packages }}"
-          IFS=',' read -ra PACKAGES <<< "${{ steps.extract-info.outputs.packages }}"
+          echo "Creating tags for packages: $RELEASE_PACKAGES"
+          IFS=',' read -ra PACKAGES <<< "$RELEASE_PACKAGES"
           for package in "${PACKAGES[@]}"; do
             package=$(echo "$package" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-            tag_name="${package}@${{ steps.extract-info.outputs.version }}"
+            tag_name="${package}@${RELEASE_VERSION}"
             echo "Creating tag: $tag_name"
             git tag "$tag_name"
             echo "Pushing tag: $tag_name"
@@ -266,18 +287,21 @@ jobs:
       - name: Create GitHub Releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PACKAGES: ${{ steps.extract-info.outputs.packages }}
+          RELEASE_VERSION: ${{ steps.extract-info.outputs.version }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          echo "Creating GitHub releases for packages: ${{ steps.extract-info.outputs.packages }}"
+          echo "Creating GitHub releases for packages: $RELEASE_PACKAGES"
 
-          IFS=',' read -ra PACKAGES <<< "${{ steps.extract-info.outputs.packages }}"
+          IFS=',' read -ra PACKAGES <<< "$RELEASE_PACKAGES"
           for package in "${PACKAGES[@]}"; do
             package=$(echo "$package" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-            tag_name="${package}@${{ steps.extract-info.outputs.version }}"
+            tag_name="${package}@${RELEASE_VERSION}"
             
             echo "Creating GitHub release for $package with tag: $tag_name"
             
             package_name=$(echo $package | sed 's/@novu\///')
-            release_body="Release of ${package} version ${{ steps.extract-info.outputs.version }}"
+            release_body="Release of ${package} version ${RELEASE_VERSION}"
             
             possible_paths=(
               "packages/${package_name}/CHANGELOG.md"
@@ -288,7 +312,7 @@ jobs:
             for changelog_path in "${possible_paths[@]}"; do
               if [ -f "$changelog_path" ]; then
                 echo "Found changelog at: $changelog_path"
-                changelog_content=$(awk -v version="${{ steps.extract-info.outputs.version }}" '
+                changelog_content=$(awk -v version="$RELEASE_VERSION" '
                   BEGIN { capture=0 }
                   /^## / || /^# / || /^v[0-9]+\./ {
                     if (capture) exit
@@ -310,7 +334,7 @@ jobs:
             gh release create "$tag_name" \
               --title "$tag_name" \
               --notes "$release_body" \
-              --target ${{ github.event.pull_request.base.ref }}
+              --target "$PR_BASE_REF"
 
             echo "✅ Created GitHub release for $tag_name"
           done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Hardened `.github/workflows/release-packages.yml` against shell injection by moving all `${{ }}` expression interpolations out of `run:` script bodies and into step-level `env:` blocks.

**Primary fix (reported vulnerability):** The `publish-stable` job interpolated `github.event.pull_request.title` directly into a single-quoted shell assignment on line 191:

```yaml
PR_TITLE='${{ github.event.pull_request.title }}'
```

A PR title containing a single quote (e.g. `Release v1.0.0 - don't skip @novu/react`) would terminate the string and the remainder would be parsed as shell code. While the job's `if:` guard makes external exploitation unlikely (requires a merged release branch with the `automated-npm-release` label), the blast radius of this job is high: it has `id-token: write` permission and publishes to npm with Trusted Publishing.

**Fix:** Move the PR title to an `env:` block so the shell treats it as data:

```yaml
env:
  PR_TITLE: ${{ github.event.pull_request.title }}
run: |
  echo "$PR_TITLE"
```

**Defense in depth:** Also moved all `workflow_dispatch` inputs and step outputs in both jobs (`release` and `publish-stable`) to `env:` blocks following the same pattern. This eliminated all 22 script-injection warnings from this file in the repo's own security linter (`check-workflow-security.py`).

No behavioral changes. All downstream references already used `"$VAR"` correctly.

### Screenshots

N/A (workflow YAML change only)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- The repo's workflow security linter (`python3 .github/workflows/scripts/check-workflow-security.py`) now reports zero warnings for `release-packages.yml` (previously 22).
- The `${{ }}` expressions in `with:` blocks (action inputs), `if:` conditions, and `run-name:` are safe and were not changed.
- The `release` job's `workflow_dispatch` inputs are lower risk (require write access), but were hardened for consistency and defense in depth.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06NABQRFQU/p1787129944297719?thread_ts=1787129944.297719&cid=C06NABQRFQU)

<div><a href="https://cursor.com/agents/bc-b2f19f74-737e-53e7-9841-893e0a5949ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2f19f74-737e-53e7-9841-893e0a5949ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the package-release workflow by moving GitHub expressions out of shell script bodies and passing their values through step-level environment variables.
- Protects the stable publishing path from shell injection through pull-request titles.
- Applies the same environment-variable pattern to workflow-dispatch inputs and step outputs.
- Quotes values passed to Nx, Git, and GitHub CLI commands.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no changed-code-triggered defects identified.

The workflow retains its expected release semantics while preventing pull-request titles, dispatch inputs, and step outputs from being interpreted as shell source.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-packages.yml | Safely migrates expression interpolation to step-level environment variables without breaking the workflow's documented input formats or release behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden release-packages.yml against..."](https://github.com/novuhq/novu/commit/32ced459c362e26d28404797d414c731ea47d114) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55083801)</sub>

<!-- /greptile_comment -->