### PR TITLE
fix(dashboard): silence Sanity changelog fetch error toasts fixes NV-8615

### DIFF
--- a/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
+++ b/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
@@ -141,10 +141,16 @@ export function ChangelogStack() {
       }
     `;
 
-    const sanityPosts = await fetchSanity<SanityChangelogPost[]>(query);
+    try {
+      const sanityPosts = await fetchSanity<SanityChangelogPost[]>(query);
+      const transformedData = transformSanityData(sanityPosts ?? []);
 
-    const transformedData = transformSanityData(sanityPosts ?? []);
-    return filterChangelogs(transformedData, getDismissedChangelogs());
+      return filterChangelogs(transformedData, getDismissedChangelogs());
+    } catch (error) {
+      console.error('Failed to fetch changelogs from Sanity', error);
+
+      return [];
+    }
   };
 
   const { data: changelogs = [] } = useQuery({
@@ -152,6 +158,8 @@ export function ChangelogStack() {
     queryFn: fetchChangelogs,
     // Refetch every hour to ensure users see new changelogs
     staleTime: 60 * 60 * 1000,
+    // Non-critical marketing content — never surface Sanity outages to users
+    meta: { showError: false },
   });
 
   const handleChangelogClick = async (changelog: Changelog) => {

--- a/apps/dashboard/src/hooks/use-agent-templates.ts
+++ b/apps/dashboard/src/hooks/use-agent-templates.ts
@@ -59,12 +59,20 @@ export function useAgentTemplates() {
   const { data, isLoading } = useQuery({
     queryKey: QUERY_KEY,
     queryFn: async ({ signal }) => {
-      const result = await fetchSanity<SanityAgentTemplate[]>(agentTemplatesQuery, { signal });
+      try {
+        const result = await fetchSanity<SanityAgentTemplate[]>(agentTemplatesQuery, { signal });
 
-      return (result ?? []).map(mapSanityTemplate).filter((template): template is AgentTemplate => template !== null);
+        return (result ?? []).map(mapSanityTemplate).filter((template): template is AgentTemplate => template !== null);
+      } catch (error) {
+        console.error('Failed to fetch agent templates from Sanity', error);
+
+        return [];
+      }
     },
     // Templates rarely change — keep them fresh for an hour like the changelog query.
     staleTime: 60 * 60 * 1000,
+    // Non-critical Sanity content — never surface fetch failures as toasts
+    meta: { showError: false },
   });
 
   const templates = data && data.length > 0 ? data : AGENT_TEMPLATES;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Customers were seeing intermittent error toasts when the dashboard failed to reach Sanity for changelog posts (network issues, intermittent CDN failures, etc.). Changelog is non-critical marketing content and should never surface a user-facing error.

- Catch Sanity fetch failures in the side-nav changelog query, `console.error`, and return empty data (no cards)
- Set `meta: { showError: false }` so the global React Query `QueryCache` handler in `root.tsx` does not toast
- Apply the same pattern to agent-template Sanity fetches (same non-critical content class)

Linear: [NV-8615](https://linear.app/novu/issue/NV-8615/dashboard-silence-sanity-changelog-fetch-error-toasts)

### Screenshots

Forced Sanity failure (invalid project ID) with ChangelogStack mounted:

![Console logs Failed to fetch changelogs from Sanity](https://cursor.com/artifacts/c/art-4b1b601b-b05a-42fb-acca-84caab2db479)
![Dashboard with no error toast](https://cursor.com/artifacts/c/art-b170e91c-8cc8-4656-aa1c-00a3b2d7a235)

<a href="https://cursor.com/agents/bc-2dd0672c-2eca-5b2a-b5d5-ac1dad20fbcd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsanity_fail_no_toast_demo.mp4"><img src="https://cursor.com/artifacts/c/art-a5b473e3-3483-4349-8a36-f77641cfd197" alt="sanity_fail_no_toast_demo.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

The global toast path is `QueryCache.onError` gated by `query.meta?.showError !== false`. Returning `[]` from the catch means the query succeeds, so the toast would not fire even without `meta`; both defenses are intentional.

Changelog cards are cloud-only (`BottomSection` early-returns when `IS_SELF_HOSTED`), which matches production for this customer report.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1787221285715149?thread_ts=1787221285.715149&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-2dd0672c-2eca-5b2a-b5d5-ac1dad20fbcd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dd0672c-2eca-5b2a-b5d5-ac1dad20fbcd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR suppresses user-facing errors for non-critical Sanity content while retaining console diagnostics.
- Changelog fetch failures now resolve to an empty list and opt out of global query-error toasts.
- Agent-template fetch failures now use the same suppression behavior, allowing the existing bundled-template fallback to render.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the changed failure-handling paths.

The changes consistently treat unavailable non-critical Sanity content as empty data, suppress the global toast path, and preserve the existing bundled fallback for agent templates.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/side-navigation/changelog-cards.tsx | Catches Sanity changelog failures, logs them, returns no cards, and disables global query-error toasts without an identified actionable defect. |
| apps/dashboard/src/hooks/use-agent-templates.ts | Converts Sanity template-fetch failures to empty data so the existing bundled templates are used, while suppressing global error toasts. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): silence Sanity changelog..."](https://github.com/novuhq/novu/commit/9da0067360ffc43417232271c0abebc27b6b97d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55111625)</sub>

**Context used:**

- Knowledge Base — [Dashboard App (apps/dashboard)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dashboard-app.md)

<!-- /greptile_comment -->