### PR TITLE
fix(dashboard): use novu@rc and --region staging in connect snippets fixes NV-8620

### DIFF
--- a/apps/dashboard/src/components/agents/agent-chat-setup-content.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-setup-content.tsx
@@ -2,6 +2,7 @@ export {
   AGENT_CHAT_DOCS_URL,
   APPLICATION_IDENTIFIER_PLACEHOLDER,
   buildAgentChatPrompt,
+  buildAgentChatTuiCommand,
   NOVU_CONNECT_AGENT_CHAT_TUI_COMMAND,
   SUBSCRIBER_ID_PLACEHOLDER,
 } from '@novu/shared';

--- a/apps/dashboard/src/components/agents/agent-chat-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-setup-steps.tsx
@@ -2,10 +2,11 @@ import { RiArrowRightSLine } from 'react-icons/ri';
 import {
   AGENT_CHAT_DOCS_URL,
   AgentChatEmbedResources,
-  NOVU_CONNECT_AGENT_CHAT_TUI_COMMAND,
+  buildAgentChatTuiCommand,
 } from '@/components/agents/agent-chat-setup-content';
 import { CopyableTerminalBlock } from '@/components/primitives/copyable-terminal-block';
 import { ExternalLink } from '@/components/shared/external-link';
+import { apiHostnameManager } from '@/utils/api-hostname-manager';
 import { SetupStep } from './setup-guide-primitives';
 import { deriveStepStatus } from './setup-guide-step-utils';
 
@@ -24,6 +25,7 @@ export function AgentChatSetupSteps({
   onOpenChat,
 }: AgentChatSetupStepsProps) {
   const base = stepOffset;
+  const tuiCommand = buildAgentChatTuiCommand(apiHostnameManager.getHostname());
 
   return (
     <>
@@ -64,12 +66,7 @@ export function AgentChatSetupSteps({
             </ExternalLink>
           </>
         }
-        extraContent={
-          <CopyableTerminalBlock
-            displayCommand={NOVU_CONNECT_AGENT_CHAT_TUI_COMMAND}
-            copyCommand={NOVU_CONNECT_AGENT_CHAT_TUI_COMMAND}
-          />
-        }
+        extraContent={<CopyableTerminalBlock displayCommand={tuiCommand} copyCommand={tuiCommand} />}
         rightContent={<AgentChatEmbedResources prompt={prompt} />}
       />
     </>

--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -1,4 +1,9 @@
-import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
+import {
+  ChatProviderIdEnum,
+  EmailProviderIdEnum,
+  getNovuConnectInvocation,
+  getNovuConnectTargetFlags,
+} from '@novu/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { Loader } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -18,10 +23,7 @@ import { SetupStep } from './setup-guide-primitives';
 import { deriveStepStatus } from './setup-guide-step-utils';
 import { SharedInboundAddressField } from './shared-inbound-address-field';
 
-const CLI_DEFAULT_API_URL = 'https://api.novu.co';
 const BRIDGE_POLL_INTERVAL_MS = 2000;
-
-const CLI_PACKAGE_TAG = 'latest';
 
 function maskSecretKey(key: string): string {
   return `nv-${'•'.repeat(16)}${key.slice(-4)}`;
@@ -39,6 +41,23 @@ function resolveConnectRuntime(connectorId: ConnectorId | undefined): ConnectRun
   return DEFAULT_CONNECT_RUNTIME;
 }
 
+function buildConnectScaffoldParts({
+  secretKey,
+  apiUrl,
+  runtime,
+}: {
+  secretKey: string;
+  apiUrl: string;
+  runtime: ConnectRuntimeFlag;
+}): string[] {
+  return [
+    `${getNovuConnectInvocation(apiUrl)} --runtime ${runtime}`,
+    `--secret-key ${secretKey}`,
+    ...getNovuConnectTargetFlags(apiUrl),
+    '--channel skip',
+  ];
+}
+
 function buildConnectScaffoldCommand({
   secretKey,
   apiUrl,
@@ -46,20 +65,13 @@ function buildConnectScaffoldCommand({
   masked,
 }: {
   secretKey: string;
-  apiUrl: string | null;
+  apiUrl: string;
   runtime: ConnectRuntimeFlag;
   masked: boolean;
 }): string {
   const key = masked ? maskSecretKey(secretKey) : secretKey;
-  const parts = [`npx novu@${CLI_PACKAGE_TAG} connect --runtime ${runtime}`, `--secret-key ${key}`];
 
-  if (apiUrl) {
-    parts.push(`--api-url ${apiUrl}`);
-  }
-
-  parts.push('--channel skip');
-
-  return parts.join(' \\\n  ');
+  return buildConnectScaffoldParts({ secretKey: key, apiUrl, runtime }).join(' \\\n  ');
 }
 
 function buildConnectScaffoldCopyCommand({
@@ -68,18 +80,10 @@ function buildConnectScaffoldCopyCommand({
   runtime,
 }: {
   secretKey: string;
-  apiUrl: string | null;
+  apiUrl: string;
   runtime: ConnectRuntimeFlag;
 }): string {
-  const parts = [`npx novu@${CLI_PACKAGE_TAG} connect --runtime ${runtime}`, `--secret-key ${secretKey}`];
-
-  if (apiUrl) {
-    parts.push(`--api-url ${apiUrl}`);
-  }
-
-  parts.push('--channel skip');
-
-  return parts.join(' ');
+  return buildConnectScaffoldParts({ secretKey, apiUrl, runtime }).join(' ');
 }
 
 function getProviderSlackMessage(agentName: string): string {
@@ -357,7 +361,6 @@ export function AgentCodeSetupSection({
   const connectRuntime = resolveConnectRuntime(connectorId);
 
   const currentApiUrl = apiHostnameManager.getHostname();
-  const apiUrl = currentApiUrl !== CLI_DEFAULT_API_URL ? currentApiUrl : null;
 
   const bridgeConnected = useBridgeConnectionPolling(agent, onBridgeConnected);
 
@@ -398,13 +401,13 @@ export function AgentCodeSetupSection({
             <CopyableTerminalBlock
               displayCommand={buildConnectScaffoldCommand({
                 secretKey,
-                apiUrl,
+                apiUrl: currentApiUrl,
                 runtime: connectRuntime,
                 masked: true,
               })}
               copyCommand={buildConnectScaffoldCopyCommand({
                 secretKey,
-                apiUrl,
+                apiUrl: currentApiUrl,
                 runtime: connectRuntime,
               })}
             />

--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -1,13 +1,12 @@
+import { buildOnboardingAgentPrompt } from '@novu/shared';
 import { useMemo, useState } from 'react';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { apiHostnameManager } from '@/utils/api-hostname-manager';
 import { TelemetryEvent } from '@/utils/telemetry';
 
-/**
- * Starter prompt surfaced in the onboarding banner. Mirrors the demo support-agent the user can
- * spin up from the "What should your agent do?" step, so copying it (or opening it in Cursor)
- * gets them to a working agent description without typing anything.
- */
-const PREBUILT_AGENT_PROMPT = `I'm signed in to the Novu dashboard, so use dashboard login (not keyless mode). Add an agent to my app following instructions from this markdown file: https://novu.co/agents.md`;
+function getDefaultOnboardingPrompt(): string {
+  return buildOnboardingAgentPrompt(apiHostnameManager.getHostname());
+}
 
 function safeCursorEncode(text: string): string {
   return encodeURIComponent(text).replace(/[!'()*~]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
@@ -43,7 +42,7 @@ const outlineActionStyle = {
  * user can copy to their clipboard or open directly in Cursor via the prompt deep link.
  */
 export function CursorPromptActions({
-  prompt = PREBUILT_AGENT_PROMPT,
+  prompt = getDefaultOnboardingPrompt(),
   command,
   source = 'agents-onboarding',
   compact = false,
@@ -114,7 +113,7 @@ export function CursorPromptActions({
 }
 
 export function PrebuiltPromptBanner({
-  prompt = PREBUILT_AGENT_PROMPT,
+  prompt = getDefaultOnboardingPrompt(),
   command,
   source = 'agents-onboarding',
   message = 'Use this pre-built prompt to get started faster.',

--- a/apps/dashboard/src/hooks/use-agent-chat-prompt.ts
+++ b/apps/dashboard/src/hooks/use-agent-chat-prompt.ts
@@ -1,7 +1,13 @@
 import { useMemo } from 'react';
 import type { AgentResponse } from '@/api/agents';
 import { buildAgentChatPrompt } from '@/components/agents/agent-chat-setup-content';
+import { apiHostnameManager } from '@/utils/api-hostname-manager';
 
 export function useAgentChatPrompt(agent: AgentResponse): string {
-  return useMemo(() => buildAgentChatPrompt(agent.name, agent.identifier), [agent.name, agent.identifier]);
+  const apiUrl = apiHostnameManager.getHostname();
+
+  return useMemo(
+    () => buildAgentChatPrompt(agent.name, agent.identifier, apiUrl),
+    [agent.name, agent.identifier, apiUrl]
+  );
 }

--- a/packages/shared/src/utils/agent-chat-connect-prompt.spec.ts
+++ b/packages/shared/src/utils/agent-chat-connect-prompt.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAgentChatPrompt,
+  buildAgentChatTuiCommand,
+  buildOnboardingAgentPrompt,
+} from './agent-chat-connect-prompt';
+import { NOVU_STAGING_API_URL } from './novu-connect-cli';
+
+describe('agent-chat-connect-prompt', () => {
+  it('uses latest TUI command on US Cloud', () => {
+    expect(buildAgentChatTuiCommand('https://api.novu.co')).toBe('npx novu@latest connect --channel agent-chat');
+  });
+
+  it('uses rc and --region staging on staging', () => {
+    expect(buildAgentChatTuiCommand(NOVU_STAGING_API_URL)).toBe(
+      'npx novu@rc connect --channel agent-chat --region staging'
+    );
+  });
+
+  it('keeps --api-url for EU and local TUI commands', () => {
+    expect(buildAgentChatTuiCommand('https://eu.api.novu.co')).toBe(
+      'npx novu@latest connect --channel agent-chat --api-url https://eu.api.novu.co'
+    );
+    expect(buildAgentChatTuiCommand('http://localhost:3000')).toBe(
+      'npx novu@latest connect --channel agent-chat --api-url http://localhost:3000'
+    );
+  });
+
+  it('adds a staging hint to the copy prompt', () => {
+    const prompt = buildAgentChatPrompt('Fred', 'fred', NOVU_STAGING_API_URL);
+
+    expect(prompt).toContain('Novu staging dashboard');
+    expect(prompt).toContain('npx novu@rc');
+    expect(prompt).toContain('--region staging');
+  });
+
+  it('keeps the production copy prompt on US Cloud', () => {
+    const prompt = buildOnboardingAgentPrompt('https://api.novu.co');
+
+    expect(prompt).not.toContain('novu@rc');
+    expect(prompt).toContain('https://novu.co/agents.md');
+  });
+});

--- a/packages/shared/src/utils/agent-chat-connect-prompt.ts
+++ b/packages/shared/src/utils/agent-chat-connect-prompt.ts
@@ -1,22 +1,57 @@
+import {
+  buildNovuConnectStagingHint,
+  getNovuConnectInvocation,
+  getNovuConnectTargetFlags,
+  isNovuStagingApiUrl,
+} from './novu-connect-cli';
+
 export const AGENT_CHAT_DOCS_URL = 'https://docs.novu.co/agents/channels/agent-chat';
 export const AGENT_ONBOARDING_PLAYBOOK_URL = 'https://novu.co/agents.md';
-/** Interactive TUI — pick the existing dashboard agent, then embed or scaffold. */
-export const NOVU_CONNECT_AGENT_CHAT_TUI_COMMAND = 'npx novu@latest connect --channel agent-chat';
+
+export function buildAgentChatTuiCommand(apiUrl?: string | null): string {
+  const parts = [`${getNovuConnectInvocation(apiUrl)} --channel agent-chat`, ...getNovuConnectTargetFlags(apiUrl)];
+
+  return parts.join(' ');
+}
+
+/** Production TUI command. Prefer `buildAgentChatTuiCommand(apiUrl)` in the dashboard. */
+export const NOVU_CONNECT_AGENT_CHAT_TUI_COMMAND = buildAgentChatTuiCommand();
 
 export {
   APPLICATION_IDENTIFIER_PLACEHOLDER,
   SUBSCRIBER_ID_PLACEHOLDER,
 } from './connect-embed-prompt-constants';
 
+function signedInDashboardLine(apiUrl?: string | null): string {
+  if (isNovuStagingApiUrl(apiUrl)) {
+    return `I'm signed in to the Novu staging dashboard, so use dashboard login (not keyless mode).`;
+  }
+
+  return `I'm signed in to the Novu dashboard, so use dashboard login (not keyless mode).`;
+}
+
 /**
  * Dashboard Copy prompt / Open in Cursor text. Same shape as the onboarding
- * `PREBUILT_AGENT_PROMPT`: signed-in line + intent + agents.md. The playbook
- * owns `--ci`, questions, and flags.
+ * prompt: signed-in line + intent + agents.md. The playbook owns `--ci`,
+ * questions, and flags. Staging adds `novu@rc` + `--region staging`.
  */
-export function buildAgentChatPrompt(agentName: string, agentIdentifier: string): string {
-  return `I'm signed in to the Novu dashboard, so use dashboard login (not keyless mode). Add Agent Chat to my app following instructions from this markdown file: ${AGENT_ONBOARDING_PLAYBOOK_URL}
+export function buildAgentChatPrompt(agentName: string, agentIdentifier: string, apiUrl?: string | null): string {
+  const lines = [
+    `${signedInDashboardLine(apiUrl)} Add Agent Chat to my app following instructions from this markdown file: ${AGENT_ONBOARDING_PLAYBOOK_URL}`,
+    buildNovuConnectStagingHint(apiUrl),
+    `The dashboard already has "${agentName}" (id: ${agentIdentifier}) with Agent Chat linked for preview.`,
+  ].filter((line): line is string => Boolean(line));
 
-The dashboard already has "${agentName}" (id: ${agentIdentifier}) with Agent Chat linked for preview.`;
+  return lines.join('\n\n');
+}
+
+export function buildOnboardingAgentPrompt(apiUrl?: string | null): string {
+  const lines = [
+    `${signedInDashboardLine(apiUrl)} Add an agent to my app following instructions from this markdown file: ${AGENT_ONBOARDING_PLAYBOOK_URL}`,
+    buildNovuConnectStagingHint(apiUrl),
+  ].filter((line): line is string => Boolean(line));
+
+  return lines.join('\n\n');
 }
 
 export { buildAgentChatEmbedPromptForAuth } from './connect-embed-prompt';

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -16,6 +16,7 @@ export * from './issues';
 export * from './locales';
 export * from './managed-integration-credentials';
 export * from './normalizeEmail';
+export * from './novu-connect-cli';
 export { safeJsonStringify } from './safe-json-stringify';
 export { createMockObjectFromSchema } from './schema/create-mock-object-from-schema';
 export { slugify } from './slugify';

--- a/packages/shared/src/utils/novu-connect-cli.spec.ts
+++ b/packages/shared/src/utils/novu-connect-cli.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildNovuConnectStagingHint,
+  getNovuConnectInvocation,
+  getNovuConnectPackageTag,
+  getNovuConnectTargetFlags,
+  NOVU_STAGING_API_URL,
+} from './novu-connect-cli';
+
+describe('novu-connect-cli', () => {
+  it('uses latest and no extra flags on US Cloud', () => {
+    expect(getNovuConnectPackageTag('https://api.novu.co')).toBe('latest');
+    expect(getNovuConnectInvocation('https://api.novu.co')).toBe('npx novu@latest connect');
+    expect(getNovuConnectTargetFlags('https://api.novu.co')).toEqual([]);
+    expect(getNovuConnectTargetFlags(undefined)).toEqual([]);
+    expect(buildNovuConnectStagingHint('https://api.novu.co')).toBeUndefined();
+  });
+
+  it('uses rc and --region staging on staging', () => {
+    expect(getNovuConnectPackageTag(NOVU_STAGING_API_URL)).toBe('rc');
+    expect(getNovuConnectInvocation(`${NOVU_STAGING_API_URL}/`)).toBe('npx novu@rc connect');
+    expect(getNovuConnectTargetFlags(NOVU_STAGING_API_URL)).toEqual(['--region staging']);
+    expect(buildNovuConnectStagingHint(NOVU_STAGING_API_URL)).toBe('Use `npx novu@rc` and pass `--region staging`.');
+  });
+
+  it('keeps --api-url for EU and local', () => {
+    expect(getNovuConnectPackageTag('https://eu.api.novu.co')).toBe('latest');
+    expect(getNovuConnectTargetFlags('https://eu.api.novu.co')).toEqual(['--api-url https://eu.api.novu.co']);
+    expect(getNovuConnectTargetFlags('http://localhost:3000')).toEqual(['--api-url http://localhost:3000']);
+  });
+});

--- a/packages/shared/src/utils/novu-connect-cli.ts
+++ b/packages/shared/src/utils/novu-connect-cli.ts
@@ -1,0 +1,54 @@
+export const NOVU_CLOUD_API_URL = 'https://api.novu.co';
+export const NOVU_STAGING_API_URL = 'https://api.novu-staging.co';
+
+export type NovuConnectPackageTag = 'latest' | 'rc';
+
+function normalizeApiUrl(apiUrl: string | null | undefined): string {
+  return (apiUrl ?? '').replace(/\/$/, '');
+}
+
+export function isNovuStagingApiUrl(apiUrl: string | null | undefined): boolean {
+  return normalizeApiUrl(apiUrl) === NOVU_STAGING_API_URL;
+}
+
+export function getNovuConnectPackageTag(apiUrl?: string | null): NovuConnectPackageTag {
+  return isNovuStagingApiUrl(apiUrl) ? 'rc' : 'latest';
+}
+
+export function getNovuConnectRegionFlag(apiUrl?: string | null): '--region staging' | undefined {
+  if (!isNovuStagingApiUrl(apiUrl)) {
+    return undefined;
+  }
+
+  return '--region staging';
+}
+
+export function getNovuConnectInvocation(apiUrl?: string | null): string {
+  return `npx novu@${getNovuConnectPackageTag(apiUrl)} connect`;
+}
+
+/**
+ * Staging uses `--region staging` so OAuth hits dashboard.novu-staging.co.
+ * Other non-US Cloud APIs keep `--api-url`.
+ */
+export function getNovuConnectTargetFlags(apiUrl?: string | null): string[] {
+  const regionFlag = getNovuConnectRegionFlag(apiUrl);
+  if (regionFlag) {
+    return [regionFlag];
+  }
+
+  const normalized = normalizeApiUrl(apiUrl);
+  if (normalized && normalized !== NOVU_CLOUD_API_URL) {
+    return [`--api-url ${normalized}`];
+  }
+
+  return [];
+}
+
+export function buildNovuConnectStagingHint(apiUrl?: string | null): string | undefined {
+  if (!isNovuStagingApiUrl(apiUrl)) {
+    return undefined;
+  }
+
+  return 'Use `npx novu@rc` and pass `--region staging`.';
+}


### PR DESCRIPTION
## Summary
- On staging (`api.novu-staging.co`), dashboard `npx novu connect` copy commands and Copy prompts now use `novu@rc` and `--region staging` so testers hit staging npm + staging OAuth instead of production.
- Production stays `novu@latest` with no region flag. EU and local keep `--api-url`.
- Applies to Agent Chat TUI/Copy prompt, onboarding Copy prompt, and the bridge scaffold snippet.

## Test plan
- [ ] On production dashboard, Copy command is `npx novu@latest connect --channel agent-chat` (no `--region`).
- [ ] On staging dashboard, Copy command is `npx novu@rc connect --channel agent-chat --region staging`.
- [ ] Staging Copy prompt mentions `novu@rc` and `--region staging`.
- [ ] Self-hosted / custom API still appends `--api-url <host>` and keeps `novu@latest`.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes construction of `novu connect` commands and makes dashboard Agent Chat, onboarding prompts, and scaffold snippets target staging with `novu@rc` and `--region staging`.

- Adds shared helpers for selecting the CLI package tag and target flags from the API hostname.
- Updates Agent Chat TUI commands, generated prompts, and scaffold commands to use those helpers.
- Adds unit coverage for production, staging, EU, and local command generation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The staging command paths consistently select the release-candidate CLI and staging region, while production and custom API behavior remains aligned with the stated contract.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/novu-connect-cli.ts | Introduces centralized API-host classification and CLI package/target-flag generation. |
| packages/shared/src/utils/agent-chat-connect-prompt.ts | Makes Agent Chat and onboarding prompts hostname-aware and adds staging-specific guidance. |
| apps/dashboard/src/components/agents/agent-code-setup-section.tsx | Reuses the shared helpers when building masked and copied scaffold commands. |
| apps/dashboard/src/components/agents/agent-chat-setup-steps.tsx | Builds the displayed Agent Chat TUI command from the dashboard’s active API hostname. |
| apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx | Generates the default onboarding prompt using the dashboard API hostname. |
| packages/shared/src/utils/novu-connect-cli.spec.ts | Covers production, staging, EU, and local package and target-flag behavior. |
| packages/shared/src/utils/agent-chat-connect-prompt.spec.ts | Covers environment-sensitive TUI commands and staging prompt guidance. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard,shared): use novu@rc and -..."](https://github.com/novuhq/novu/commit/e73d599c787af4e8a964b33f99b1b816de5592f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55197030)</sub>

<!-- /greptile_comment -->