### PR TITLE
fix(root): normalize version input in release-packages.yml to prevent invalid semver

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -56,6 +56,18 @@ jobs:
           fetch-tags: true
           ref: ${{ github.ref_name }}
 
+      - name: Normalize and validate version
+        env:
+          RAW_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          SEMVER=$(echo "$RAW_VERSION" | sed 's/^[vV]\.*//')
+          if ! [[ "$SEMVER" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "❌ ERROR: Invalid version '$RAW_VERSION'. Must be semver (e.g. v3.1.0 or 3.1.0), got cleaned: '$SEMVER'"
+            exit 1
+          fi
+          echo "RELEASE_SEMVER=$SEMVER" >> "$GITHUB_ENV"
+          echo "✅ Normalized version: v$SEMVER (from input: $RAW_VERSION)"
+
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
@@ -84,16 +96,15 @@ jobs:
         if: github.event.inputs.release_type != 'stable'
         env:
           INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
-          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           COMMIT_SHA=$(git rev-parse --short HEAD)
           if [ "$INPUT_RELEASE_TYPE" = "nightly" ]; then
             DATE=$(date +'%Y%m%d')
-            echo "RELEASE_VERSION=${INPUT_VERSION}-nightly.${DATE}.${COMMIT_SHA}" >> $GITHUB_ENV
-            echo "Using nightly version: $RELEASE_VERSION"
+            echo "RELEASE_VERSION=v${RELEASE_SEMVER}-nightly.${DATE}.${COMMIT_SHA}" >> $GITHUB_ENV
+            echo "Using nightly version: v${RELEASE_SEMVER}-nightly.${DATE}.${COMMIT_SHA}"
           elif [ "$INPUT_RELEASE_TYPE" = "rc" ]; then
-            echo "RELEASE_VERSION=${INPUT_VERSION}-rc.${COMMIT_SHA}" >> $GITHUB_ENV
-            echo "Using rc version: $RELEASE_VERSION"
+            echo "RELEASE_VERSION=v${RELEASE_SEMVER}-rc.${COMMIT_SHA}" >> $GITHUB_ENV
+            echo "Using rc version: v${RELEASE_SEMVER}-rc.${COMMIT_SHA}"
           fi
 
       - name: Configure Git
@@ -104,7 +115,6 @@ jobs:
       - name: Release version (without commit)
         env:
           INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
-          INPUT_VERSION: ${{ github.event.inputs.version }}
           INPUT_PACKAGES: ${{ github.event.inputs.packages }}
         run: |
           if [ "$INPUT_RELEASE_TYPE" = "nightly" ]; then
@@ -114,19 +124,18 @@ jobs:
             echo "Running rc release with version: $RELEASE_VERSION"
             pnpm nx release version "$RELEASE_VERSION" --projects="$INPUT_PACKAGES" --preid rc --git-commit=false --verbose
           else
-            echo "Running stable release with version: $INPUT_VERSION"
-            pnpm nx release version "$INPUT_VERSION" --projects="$INPUT_PACKAGES" --git-commit=false --verbose
+            echo "Running stable release with version: v$RELEASE_SEMVER"
+            pnpm nx release version "v$RELEASE_SEMVER" --projects="$INPUT_PACKAGES" --git-commit=false --verbose
           fi
 
       - name: Generate changelog (without commit)
         env:
           INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
-          INPUT_VERSION: ${{ github.event.inputs.version }}
           INPUT_PACKAGES: ${{ github.event.inputs.packages }}
           INPUT_PREVIOUS_TAG: ${{ github.event.inputs.previous_tag }}
         run: |
           if [ "$INPUT_RELEASE_TYPE" = "stable" ]; then
-            pnpm nx release changelog "$INPUT_VERSION" --projects="$INPUT_PACKAGES" --from="$INPUT_PREVIOUS_TAG" --git-commit=false
+            pnpm nx release changelog "v$RELEASE_SEMVER" --projects="$INPUT_PACKAGES" --from="$INPUT_PREVIOUS_TAG" --git-commit=false
           else
             pnpm nx release changelog "$RELEASE_VERSION" --projects="$INPUT_PACKAGES" --from="$INPUT_PREVIOUS_TAG" --git-commit=false
           fi
@@ -161,12 +170,12 @@ jobs:
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: release ${{ github.event.inputs.version }} (${{ github.event.inputs.packages }})"
-          title: "🚀 Release ${{ github.event.inputs.version }} - ${{ github.event.inputs.packages }}"
+          commit-message: "chore: release v${{ env.RELEASE_SEMVER }} (${{ github.event.inputs.packages }})"
+          title: "🚀 Release v${{ env.RELEASE_SEMVER }} - ${{ github.event.inputs.packages }}"
           body: |
-            ## 🚀 Release ${{ github.event.inputs.version }}
+            ## 🚀 Release v${{ env.RELEASE_SEMVER }}
 
-            This PR contains the release changes for version **${{ github.event.inputs.version }}**
+            This PR contains the release changes for version **v${{ env.RELEASE_SEMVER }}**
 
             ### 📦 Packages Released:
             ```
@@ -174,7 +183,7 @@ jobs:
             ```
 
             ### 🔄 Changes:
-            - Updated package versions to ${{ github.event.inputs.version }}
+            - Updated package versions to v${{ env.RELEASE_SEMVER }}
             - Generated changelogs from ${{ github.event.inputs.previous_tag }}
 
             **After merging this PR:**
@@ -183,7 +192,7 @@ jobs:
             - GitHub releases will be created
 
             **Please review the changes and merge when ready.**
-          branch: release-${{ github.event.inputs.version }}
+          branch: release-v${{ env.RELEASE_SEMVER }}
           base: ${{ github.ref_name }}
           delete-branch: false
           labels: automated-npm-release
@@ -211,10 +220,10 @@ jobs:
           echo ""
           echo "=== Extraction ==="
 
-          VERSION=$(echo "$PR_TITLE" | sed -n 's/.*Release \([v0-9\.]*\).*/\1/p')
+          RAW_VERSION=$(echo "$PR_TITLE" | sed -n 's/.*Release \([v0-9\.]*\).*/\1/p')
           PACKAGES=$(echo "$PR_TITLE" | sed -n 's/.*- \(@novu.*\)/\1/p')
 
-          if [ -z "$VERSION" ]; then
+          if [ -z "$RAW_VERSION" ]; then
             echo "❌ ERROR: Failed to extract version from PR title"
             echo "Expected format: '🚀 Release vX.Y.Z - @novu/package1,@novu/package2'"
             exit 1
@@ -224,6 +233,11 @@ jobs:
             echo "❌ ERROR: Failed to extract packages from PR title"
             echo "Expected format: '🚀 Release vX.Y.Z - @novu/package1,@novu/package2'"
             exit 1
+          fi
+
+          VERSION=$(echo "$RAW_VERSION" | sed 's/^[vV]\.*/v/')
+          if [ "$VERSION" = "v" ]; then
+            VERSION="$RAW_VERSION"
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -61,7 +61,10 @@ jobs:
           RAW_VERSION: ${{ github.event.inputs.version }}
         run: |
           SEMVER=$(echo "$RAW_VERSION" | sed 's/^[vV]\.*//')
-          if ! [[ "$SEMVER" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+          # Numeric identifiers must not have leading zeros; prerelease ids must be
+          # non-empty and dot-separated (rejects 3.1.0-rc., 3.1.0-rc..1, 3.1.0-01).
+          semver_re='^[0-9]+\.[0-9]+\.[0-9]+(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?$'
+          if ! [[ "$SEMVER" =~ $semver_re ]]; then
             echo "❌ ERROR: Invalid version '$RAW_VERSION'. Must be semver (e.g. v3.1.0 or 3.1.0), got cleaned: '$SEMVER'"
             exit 1
           fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The `release-packages.yml` workflow was failing when the version input contained an extra dot after the `v` prefix (e.g. `v.3.19.1` instead of `v3.19.1`). This caused `nx release version` to reject the specifier as invalid semver, which meant the changelog was never generated.

**Failed run:** [#32387115598](https://github.com/novuhq/novu/actions/runs/32387115598) — `Release v.3.19.1 (rc)`

Error:
```
The given version specifier "v.3.19.1-rc.4d8d2628c7" is not valid.
You provide an exact version or a valid semver keyword such as "major", "minor", "patch", etc.
```

## Fix

Added a **"Normalize and validate version"** step early in the `release` job that:
1. Strips the leading `v`/`V` prefix and any immediately following dots (handles `v.3.19.1`, `v..3.19.1`, `V.3.19.1`, etc.)
2. Validates the cleaned version against SemVer, including prerelease identifier rules (non-empty ids, no consecutive dots, no leading zeros on numeric ids)
3. Sets `RELEASE_SEMVER` env var used consistently throughout the workflow

Also added defensive normalization in the `publish-stable` job's version extraction from PR titles.

This mirrors the normalization approach already used in `prepare-enterprise-self-hosted-release.yml`.

## Tested normalization logic

| Input | Normalized | Valid |
|-------|-----------|-------|
| `v.3.19.1` | `3.19.1` → `v3.19.1` | ✅ |
| `v3.19.1` | `3.19.1` → `v3.19.1` | ✅ |
| `3.19.1` | `3.19.1` → `v3.19.1` | ✅ |
| `v..3.19.1` | `3.19.1` → `v3.19.1` | ✅ |
| `V.3.19.1` | `3.19.1` → `v3.19.1` | ✅ |
| `v3.1.0-rc.1` | `3.1.0-rc.1` → `v3.1.0-rc.1` | ✅ |
| `3.1.0-rc.` | invalid prerelease | ❌ (fails fast) |
| `3.1.0-rc..1` | empty identifier | ❌ (fails fast) |
| `3.1.0-01` | leading zero | ❌ (fails fast) |
| `invalid` | `invalid` | ❌ (fails fast) |
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNSZEF/p1787240661065689?thread_ts=1787240661.065689&cid=D0919LNSZEF)

<div><a href="https://cursor.com/agents/bc-3520cb5a-38f9-50b7-9ab7-78d0aa40d5e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3520cb5a-38f9-50b7-9ab7-78d0aa40d5e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The workflow now normalizes manually supplied release versions before reuse and applies stricter validation to prerelease identifiers.
- Removes leading `v`/`V` prefixes and adjacent dots.
- Uses the normalized version for release commands, changelog generation, and release PR metadata.
- Correctly rejects the malformed prerelease identifiers identified in the previous review.
- Defensively normalizes versions extracted from stable-release PR titles.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-packages.yml | Adds centralized version normalization and stricter prerelease validation, resolving the previously reported acceptance of empty and leading-zero prerelease identifiers. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(root): reject invalid SemVer prerele..."](https://github.com/novuhq/novu/commit/39b92a3206fedd516b9112bedb1cbae805621bea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55218101)</sub>

<!-- /greptile_comment -->