### PR TITLE
fix(dashboard,novu): improve novu connect dashboard commands fixes NV-8636

### DIFF
--- a/apps/dashboard/src/components/agents/agent-chat-setup-content.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-setup-content.tsx
@@ -3,6 +3,7 @@ export {
   APPLICATION_IDENTIFIER_PLACEHOLDER,
   buildAgentChatPrompt,
   buildAgentChatTuiCommand,
+  buildAgentChatTuiCommandForDisplay,
   NOVU_CONNECT_AGENT_CHAT_TUI_COMMAND,
   SUBSCRIBER_ID_PLACEHOLDER,
 } from '@novu/shared';

--- a/apps/dashboard/src/components/agents/agent-chat-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-setup-guide.tsx
@@ -43,6 +43,7 @@ export function AgentChatSetupGuide({
   const stepsColumn = (
     <AgentChatSetupSteps
       prompt={prompt}
+      agentIdentifier={agent.identifier}
       stepOffset={stepOffset}
       firstIncompleteStep={firstIncompleteStep}
       onOpenChat={() => openPreview(agent.identifier)}

--- a/apps/dashboard/src/components/agents/agent-chat-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-setup-steps.tsx
@@ -3,6 +3,7 @@ import {
   AGENT_CHAT_DOCS_URL,
   AgentChatEmbedResources,
   buildAgentChatTuiCommand,
+  buildAgentChatTuiCommandForDisplay,
 } from '@/components/agents/agent-chat-setup-content';
 import { CopyableTerminalBlock } from '@/components/primitives/copyable-terminal-block';
 import { ExternalLink } from '@/components/shared/external-link';
@@ -12,6 +13,7 @@ import { deriveStepStatus } from './setup-guide-step-utils';
 
 type AgentChatSetupStepsProps = {
   prompt: string;
+  agentIdentifier: string;
   stepOffset?: number;
   /** Omit to show all steps as completed (connected recap). */
   firstIncompleteStep?: number;
@@ -20,12 +22,19 @@ type AgentChatSetupStepsProps = {
 
 export function AgentChatSetupSteps({
   prompt,
+  agentIdentifier,
   stepOffset = 1,
   firstIncompleteStep,
   onOpenChat,
 }: AgentChatSetupStepsProps) {
   const base = stepOffset;
-  const tuiCommand = buildAgentChatTuiCommand(apiHostnameManager.getHostname());
+  const tuiCommandOptions = {
+    apiUrl: apiHostnameManager.getHostname(),
+    agentIdentifier,
+    connectDashboardUrl: window.location.origin,
+  };
+  const tuiDisplayCommand = buildAgentChatTuiCommandForDisplay(tuiCommandOptions);
+  const tuiCopyCommand = buildAgentChatTuiCommand(tuiCommandOptions);
 
   return (
     <>
@@ -66,7 +75,7 @@ export function AgentChatSetupSteps({
             </ExternalLink>
           </>
         }
-        extraContent={<CopyableTerminalBlock displayCommand={tuiCommand} copyCommand={tuiCommand} />}
+        extraContent={<CopyableTerminalBlock displayCommand={tuiDisplayCommand} copyCommand={tuiCopyCommand} />}
         rightContent={<AgentChatEmbedResources prompt={prompt} />}
       />
     </>

--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -44,16 +44,21 @@ function resolveConnectRuntime(connectorId: ConnectorId | undefined): ConnectRun
 function buildConnectScaffoldParts({
   secretKey,
   apiUrl,
+  connectDashboardUrl,
   runtime,
 }: {
   secretKey: string;
   apiUrl: string;
+  connectDashboardUrl: string;
   runtime: ConnectRuntimeFlag;
 }): string[] {
   return [
     `${getNovuConnectInvocation(apiUrl)} --runtime ${runtime}`,
     `--secret-key ${secretKey}`,
-    ...getNovuConnectTargetFlags(apiUrl),
+    ...getNovuConnectTargetFlags({
+      apiUrl,
+      connectDashboardUrl,
+    }),
     '--channel skip',
   ];
 }
@@ -61,29 +66,33 @@ function buildConnectScaffoldParts({
 function buildConnectScaffoldCommand({
   secretKey,
   apiUrl,
+  connectDashboardUrl,
   runtime,
   masked,
 }: {
   secretKey: string;
   apiUrl: string;
+  connectDashboardUrl: string;
   runtime: ConnectRuntimeFlag;
   masked: boolean;
 }): string {
   const key = masked ? maskSecretKey(secretKey) : secretKey;
 
-  return buildConnectScaffoldParts({ secretKey: key, apiUrl, runtime }).join(' \\\n  ');
+  return buildConnectScaffoldParts({ secretKey: key, apiUrl, connectDashboardUrl, runtime }).join(' \\\n  ');
 }
 
 function buildConnectScaffoldCopyCommand({
   secretKey,
   apiUrl,
+  connectDashboardUrl,
   runtime,
 }: {
   secretKey: string;
   apiUrl: string;
+  connectDashboardUrl: string;
   runtime: ConnectRuntimeFlag;
 }): string {
-  return buildConnectScaffoldParts({ secretKey, apiUrl, runtime }).join(' ');
+  return buildConnectScaffoldParts({ secretKey, apiUrl, connectDashboardUrl, runtime }).join(' ');
 }
 
 function getProviderSlackMessage(agentName: string): string {
@@ -361,6 +370,7 @@ export function AgentCodeSetupSection({
   const connectRuntime = resolveConnectRuntime(connectorId);
 
   const currentApiUrl = apiHostnameManager.getHostname();
+  const connectDashboardUrl = window.location.origin;
 
   const bridgeConnected = useBridgeConnectionPolling(agent, onBridgeConnected);
 
@@ -402,12 +412,14 @@ export function AgentCodeSetupSection({
               displayCommand={buildConnectScaffoldCommand({
                 secretKey,
                 apiUrl: currentApiUrl,
+                connectDashboardUrl,
                 runtime: connectRuntime,
                 masked: true,
               })}
               copyCommand={buildConnectScaffoldCopyCommand({
                 secretKey,
                 apiUrl: currentApiUrl,
+                connectDashboardUrl,
                 runtime: connectRuntime,
               })}
             />

--- a/apps/dashboard/src/components/agents/agent-integration-guides/agent-chat-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/agent-chat-agent-integration-guide.tsx
@@ -168,7 +168,7 @@ function AgentChatConnectedRecap({
 
       <SetupGuideCard label="Setup steps" persistKey={persistKey} defaultExpanded={false}>
         <SetupStepperRail className="gap-8 py-6 pb-3 pr-3 md:pr-6">
-          <AgentChatSetupSteps prompt={prompt} onOpenChat={handleOpenChat} />
+          <AgentChatSetupSteps prompt={prompt} agentIdentifier={agent.identifier} onOpenChat={handleOpenChat} />
         </SetupStepperRail>
       </SetupGuideCard>
     </div>

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.21.0-rc.0",
+  "version": "2.20.1",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.20.1",
+  "version": "2.21.0-rc.0",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/novu/src/commands/connect/pipeline/resolve-existing-agent.ts
+++ b/packages/novu/src/commands/connect/pipeline/resolve-existing-agent.ts
@@ -1,36 +1,40 @@
 import type { AgentRecord } from '../api/agents';
-import type { AgentConnectMode, AgentSummary, ChannelChoice, ConnectCommandOptions } from '../types';
+import type { AgentConnectMode, AgentSummary, ConnectCommandOptions } from '../types';
 
 export function shouldSkipAgentConnectModePicker(options: ConnectCommandOptions): boolean {
   return Boolean(options.agentIdentifier?.trim());
 }
 
-export function resolveConnectModeForExistingAgent(
-  agent: Pick<AgentRecord, 'runtime'>,
-  channel?: ChannelChoice
-): AgentConnectMode {
-  if (channel === 'agent-chat' && agent.runtime !== 'self-hosted') {
-    return 'demo';
-  }
-
-  if (agent.runtime === 'self-hosted') {
-    return 'custom-code';
-  }
-
-  return 'demo';
+export function resolveConnectModeForExistingAgent(agent: Pick<AgentRecord, 'runtime'>): AgentConnectMode {
+  return agent.runtime === 'self-hosted' ? 'custom-code' : 'demo';
 }
 
-export function resolveExistingAgentByIdentifier(existingAgents: AgentRecord[], agentIdentifier: string): AgentSummary {
-  const normalized = agentIdentifier.trim();
-  const match = existingAgents.find((agent) => agent.identifier === normalized);
+export type ExistingAgentContext = {
+  summary: AgentSummary;
+  connectMode: AgentConnectMode;
+};
 
-  if (!match) {
+export function resolveExistingAgentContext(
+  existingAgents: AgentRecord[],
+  agentIdentifier: string
+): ExistingAgentContext {
+  const normalized = agentIdentifier.trim();
+  const record = existingAgents.find((agent) => agent.identifier === normalized);
+
+  if (!record) {
     throw new Error(`No agent found with identifier "${normalized}" in this environment.`);
   }
 
   return {
-    id: match._id,
-    identifier: match.identifier,
-    name: match.name,
+    summary: {
+      id: record._id,
+      identifier: record.identifier,
+      name: record.name,
+    },
+    connectMode: resolveConnectModeForExistingAgent(record),
   };
+}
+
+export function resolveExistingAgentByIdentifier(existingAgents: AgentRecord[], agentIdentifier: string): AgentSummary {
+  return resolveExistingAgentContext(existingAgents, agentIdentifier).summary;
 }

--- a/packages/novu/src/commands/connect/pipeline/resolve-existing-agent.ts
+++ b/packages/novu/src/commands/connect/pipeline/resolve-existing-agent.ts
@@ -1,0 +1,36 @@
+import type { AgentRecord } from '../api/agents';
+import type { AgentConnectMode, AgentSummary, ChannelChoice, ConnectCommandOptions } from '../types';
+
+export function shouldSkipAgentConnectModePicker(options: ConnectCommandOptions): boolean {
+  return Boolean(options.agentIdentifier?.trim());
+}
+
+export function resolveConnectModeForExistingAgent(
+  agent: Pick<AgentRecord, 'runtime'>,
+  channel?: ChannelChoice
+): AgentConnectMode {
+  if (channel === 'agent-chat' && agent.runtime !== 'self-hosted') {
+    return 'demo';
+  }
+
+  if (agent.runtime === 'self-hosted') {
+    return 'custom-code';
+  }
+
+  return 'demo';
+}
+
+export function resolveExistingAgentByIdentifier(existingAgents: AgentRecord[], agentIdentifier: string): AgentSummary {
+  const normalized = agentIdentifier.trim();
+  const match = existingAgents.find((agent) => agent.identifier === normalized);
+
+  if (!match) {
+    throw new Error(`No agent found with identifier "${normalized}" in this environment.`);
+  }
+
+  return {
+    id: match._id,
+    identifier: match.identifier,
+    name: match.name,
+  };
+}

--- a/packages/novu/src/commands/connect/pipeline/runner.ts
+++ b/packages/novu/src/commands/connect/pipeline/runner.ts
@@ -54,6 +54,11 @@ import { maybeRunChatSdkTunnel, runChatSdkProjectSetup } from './chat-sdk';
 import { runCustomCodeProjectSetup } from './custom-code';
 import { maybeRunLangChainTunnel, runLangChainProjectSetup } from './langchain';
 import { resolveAgentRuntimeIntegration, resolveRuntimeFromOptions } from './resolve-agent-runtime-integration';
+import {
+  resolveConnectModeForExistingAgent,
+  resolveExistingAgentByIdentifier,
+  shouldSkipAgentConnectModePicker,
+} from './resolve-existing-agent';
 
 export interface ConnectPipelineInput {
   options: ConnectCommandOptions;
@@ -151,7 +156,7 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
       ...sessionProps,
     });
 
-    const connectMode = await resolveAgentConnectMode(ctx);
+    const connectMode = await resolveAgentConnectMode(ctx, existingAgents);
 
     // Bridge modes need the user's real environment up front, so a keyless
     // session is upgraded before the agent is created.
@@ -178,6 +183,13 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
         identifier: agent.identifier,
         connectMode,
         flow,
+        ...sessionProps,
+      });
+    } else if (options.agentIdentifier?.trim()) {
+      agent = resolveExistingAgentByIdentifier(existingAgents, options.agentIdentifier);
+      flow = 'reused';
+      track(CONNECT_EVENTS.AGENT_REUSED, {
+        identifier: agent.identifier,
         ...sessionProps,
       });
     } else if (existingAgents.length > 0 && !options.prompt) {
@@ -550,7 +562,7 @@ function resolveBridgeProject(outcomes: {
   return outcomes.chatSdkOutcome ?? outcomes.aiSdkOutcome ?? outcomes.langChainOutcome ?? outcomes.customCodeOutcome;
 }
 
-async function resolveAgentConnectMode(ctx: PipelineContext): Promise<AgentConnectMode> {
+async function resolveAgentConnectMode(ctx: PipelineContext, existingAgents: AgentRecord[]): Promise<AgentConnectMode> {
   const { options, ui, track, sessionProps } = ctx;
 
   if (options.runtime) {
@@ -560,6 +572,19 @@ async function resolveAgentConnectMode(ctx: PipelineContext): Promise<AgentConne
     });
 
     return options.runtime;
+  }
+
+  if (shouldSkipAgentConnectModePicker(options)) {
+    const agentRecord = resolveExistingAgentByIdentifier(existingAgents, options.agentIdentifier!);
+    const matched = existingAgents.find((agent) => agent.identifier === agentRecord.identifier);
+    const connectMode = resolveConnectModeForExistingAgent(matched ?? { runtime: 'managed' }, options.channel);
+    track(CONNECT_EVENTS.RUNTIME_SELECTED, {
+      connectMode,
+      skipped: true,
+      ...sessionProps,
+    });
+
+    return connectMode;
   }
 
   const picked = await ui.pickAgentConnectMode({

--- a/packages/novu/src/commands/connect/pipeline/runner.ts
+++ b/packages/novu/src/commands/connect/pipeline/runner.ts
@@ -55,8 +55,8 @@ import { runCustomCodeProjectSetup } from './custom-code';
 import { maybeRunLangChainTunnel, runLangChainProjectSetup } from './langchain';
 import { resolveAgentRuntimeIntegration, resolveRuntimeFromOptions } from './resolve-agent-runtime-integration';
 import {
-  resolveConnectModeForExistingAgent,
-  resolveExistingAgentByIdentifier,
+  type ExistingAgentContext,
+  resolveExistingAgentContext,
   shouldSkipAgentConnectModePicker,
 } from './resolve-existing-agent';
 
@@ -156,7 +156,11 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
       ...sessionProps,
     });
 
-    const connectMode = await resolveAgentConnectMode(ctx, existingAgents);
+    const preselectedAgent = options.agentIdentifier?.trim()
+      ? resolveExistingAgentContext(existingAgents, options.agentIdentifier)
+      : undefined;
+
+    const connectMode = await resolveAgentConnectMode(ctx, preselectedAgent);
 
     // Bridge modes need the user's real environment up front, so a keyless
     // session is upgraded before the agent is created.
@@ -185,8 +189,8 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
         flow,
         ...sessionProps,
       });
-    } else if (options.agentIdentifier?.trim()) {
-      agent = resolveExistingAgentByIdentifier(existingAgents, options.agentIdentifier);
+    } else if (preselectedAgent) {
+      agent = preselectedAgent.summary;
       flow = 'reused';
       track(CONNECT_EVENTS.AGENT_REUSED, {
         identifier: agent.identifier,
@@ -562,7 +566,10 @@ function resolveBridgeProject(outcomes: {
   return outcomes.chatSdkOutcome ?? outcomes.aiSdkOutcome ?? outcomes.langChainOutcome ?? outcomes.customCodeOutcome;
 }
 
-async function resolveAgentConnectMode(ctx: PipelineContext, existingAgents: AgentRecord[]): Promise<AgentConnectMode> {
+async function resolveAgentConnectMode(
+  ctx: PipelineContext,
+  preselectedAgent?: ExistingAgentContext
+): Promise<AgentConnectMode> {
   const { options, ui, track, sessionProps } = ctx;
 
   if (options.runtime) {
@@ -575,9 +582,7 @@ async function resolveAgentConnectMode(ctx: PipelineContext, existingAgents: Age
   }
 
   if (shouldSkipAgentConnectModePicker(options)) {
-    const agentRecord = resolveExistingAgentByIdentifier(existingAgents, options.agentIdentifier!);
-    const matched = existingAgents.find((agent) => agent.identifier === agentRecord.identifier);
-    const connectMode = resolveConnectModeForExistingAgent(matched ?? { runtime: 'managed' }, options.channel);
+    const connectMode = preselectedAgent!.connectMode;
     track(CONNECT_EVENTS.RUNTIME_SELECTED, {
       connectMode,
       skipped: true,

--- a/packages/novu/src/commands/connect/types.ts
+++ b/packages/novu/src/commands/connect/types.ts
@@ -144,6 +144,8 @@ export interface ConnectCommandOptions {
   runtime?: AgentConnectMode;
   /** Use an existing agent-runtime integration instead of creating one. */
   agentIntegrationId?: string;
+  /** Use an existing agent by identifier, skipping the agent picker. */
+  agentIdentifier?: string;
   /** Anthropic API key for `--runtime claude` non-interactive runs. */
   anthropicApiKey?: string;
   /** AWS Claude API key for `--runtime claude-aws` non-interactive runs. */

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -215,6 +215,7 @@ program
     '--agent-integration-id <id>',
     'Use an existing agent-runtime integration (skips credential setup for BYOK runtimes)'
   )
+  .option('--agent-identifier <identifier>', 'Use an existing agent by identifier (skips the agent picker)')
   .option('--anthropic-api-key <key>', 'Anthropic API key for --runtime claude non-interactive runs')
   .option(
     '--llm-auth <choice>',
@@ -276,9 +277,9 @@ program
       const channel = options.skipSlack ? 'skip' : options.channel;
       const connectMode = options.chatSdk ? 'chat-sdk' : options.brain === 'chat-sdk' ? 'chat-sdk' : options.runtime;
 
-      if (!prompt && (!connectMode || !isBridgeConnectMode(connectMode))) {
+      if (!prompt && !options.agentIdentifier?.trim() && (!connectMode || !isBridgeConnectMode(connectMode))) {
         console.error(
-          'Non-interactive mode requires a prompt (positional <prompt> or --prompt), unless --runtime is a bridge mode (ai-sdk, langchain, custom-code, chat-sdk).\n(run `novu connect --help` for the non-interactive contract and examples)'
+          'Non-interactive mode requires a prompt (positional <prompt> or --prompt), --agent-identifier, or --runtime as a bridge mode (ai-sdk, langchain, custom-code, chat-sdk).\n(run `novu connect --help` for the non-interactive contract and examples)'
         );
         process.exit(1);
       }

--- a/packages/shared/src/utils/agent-chat-connect-prompt.spec.ts
+++ b/packages/shared/src/utils/agent-chat-connect-prompt.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildAgentChatPrompt,
   buildAgentChatTuiCommand,
+  buildAgentChatTuiCommandForDisplay,
   buildOnboardingAgentPrompt,
 } from './agent-chat-connect-prompt';
 import { NOVU_STAGING_API_URL } from './novu-connect-cli';
@@ -22,7 +23,31 @@ describe('agent-chat-connect-prompt', () => {
       'npx novu@latest connect --channel agent-chat --api-url https://eu.api.novu.co'
     );
     expect(buildAgentChatTuiCommand('http://localhost:3000')).toBe(
-      'npx novu@latest connect --channel agent-chat --api-url http://localhost:3000'
+      'npx novu@rc connect --channel agent-chat --api-url http://localhost:3000'
+    );
+  });
+
+  it('includes agent identifier and local dashboard URLs when provided', () => {
+    expect(
+      buildAgentChatTuiCommand({
+        apiUrl: 'http://localhost:3000',
+        agentIdentifier: 'support-agent',
+        connectDashboardUrl: 'http://localhost:4201',
+      })
+    ).toBe(
+      'npx novu@rc connect --channel agent-chat --api-url http://localhost:3000 --connect-dashboard-url http://localhost:4201 --dashboard-url http://localhost:4201 --agent-identifier support-agent'
+    );
+  });
+
+  it('formats the TUI command for terminal display with line continuations', () => {
+    expect(
+      buildAgentChatTuiCommandForDisplay({
+        apiUrl: 'http://localhost:3000',
+        agentIdentifier: 'support-agent',
+        connectDashboardUrl: 'http://localhost:4201',
+      })
+    ).toBe(
+      'npx novu@rc connect --channel agent-chat \\\n  --api-url http://localhost:3000 \\\n  --connect-dashboard-url http://localhost:4201 \\\n  --dashboard-url http://localhost:4201 \\\n  --agent-identifier support-agent'
     );
   });
 

--- a/packages/shared/src/utils/agent-chat-connect-prompt.ts
+++ b/packages/shared/src/utils/agent-chat-connect-prompt.ts
@@ -1,17 +1,54 @@
 import {
   buildNovuConnectStagingHint,
+  formatNovuConnectCommandForDisplay,
   getNovuConnectInvocation,
   getNovuConnectTargetFlags,
   isNovuStagingApiUrl,
+  type NovuConnectTargetOptions,
 } from './novu-connect-cli';
 
 export const AGENT_CHAT_DOCS_URL = 'https://docs.novu.co/agents/channels/agent-chat';
 export const AGENT_ONBOARDING_PLAYBOOK_URL = 'https://novu.co/agents.md';
 
-export function buildAgentChatTuiCommand(apiUrl?: string | null): string {
-  const parts = [`${getNovuConnectInvocation(apiUrl)} --channel agent-chat`, ...getNovuConnectTargetFlags(apiUrl)];
+export type BuildAgentChatTuiCommandOptions = NovuConnectTargetOptions & {
+  agentIdentifier?: string | null;
+};
 
-  return parts.join(' ');
+function normalizeBuildAgentChatTuiCommandOptions(
+  apiUrlOrOptions?: string | null | BuildAgentChatTuiCommandOptions
+): BuildAgentChatTuiCommandOptions {
+  if (typeof apiUrlOrOptions === 'string' || apiUrlOrOptions == null) {
+    return { apiUrl: apiUrlOrOptions };
+  }
+
+  return apiUrlOrOptions;
+}
+
+export function buildAgentChatTuiCommandParts(
+  apiUrlOrOptions?: string | null | BuildAgentChatTuiCommandOptions
+): string[] {
+  const options = normalizeBuildAgentChatTuiCommandOptions(apiUrlOrOptions);
+  const parts = [
+    `${getNovuConnectInvocation(options.apiUrl)} --channel agent-chat`,
+    ...getNovuConnectTargetFlags(options),
+  ];
+  const agentIdentifier = options.agentIdentifier?.trim();
+
+  if (agentIdentifier) {
+    parts.push(`--agent-identifier ${agentIdentifier}`);
+  }
+
+  return parts;
+}
+
+export function buildAgentChatTuiCommand(apiUrlOrOptions?: string | null | BuildAgentChatTuiCommandOptions): string {
+  return buildAgentChatTuiCommandParts(apiUrlOrOptions).join(' ');
+}
+
+export function buildAgentChatTuiCommandForDisplay(
+  apiUrlOrOptions?: string | null | BuildAgentChatTuiCommandOptions
+): string {
+  return formatNovuConnectCommandForDisplay(buildAgentChatTuiCommandParts(apiUrlOrOptions));
 }
 
 /** Production TUI command. Prefer `buildAgentChatTuiCommand(apiUrl)` in the dashboard. */
@@ -33,7 +70,7 @@ function signedInDashboardLine(apiUrl?: string | null): string {
 /**
  * Dashboard Copy prompt / Open in Cursor text. Same shape as the onboarding
  * prompt: signed-in line + intent + agents.md. The playbook owns `--ci`,
- * questions, and flags. Staging adds `novu@rc` + `--region staging`.
+ * questions, and flags. Staging and local dev use `novu@rc` (staging also passes `--region staging`).
  */
 export function buildAgentChatPrompt(agentName: string, agentIdentifier: string, apiUrl?: string | null): string {
   const lines = [

--- a/packages/shared/src/utils/agent-chat-connect-prompt.ts
+++ b/packages/shared/src/utils/agent-chat-connect-prompt.ts
@@ -5,6 +5,7 @@ import {
   getNovuConnectTargetFlags,
   isNovuStagingApiUrl,
   type NovuConnectTargetOptions,
+  normalizeConnectTargetOptions,
 } from './novu-connect-cli';
 
 export const AGENT_CHAT_DOCS_URL = 'https://docs.novu.co/agents/channels/agent-chat';
@@ -14,20 +15,10 @@ export type BuildAgentChatTuiCommandOptions = NovuConnectTargetOptions & {
   agentIdentifier?: string | null;
 };
 
-function normalizeBuildAgentChatTuiCommandOptions(
-  apiUrlOrOptions?: string | null | BuildAgentChatTuiCommandOptions
-): BuildAgentChatTuiCommandOptions {
-  if (typeof apiUrlOrOptions === 'string' || apiUrlOrOptions == null) {
-    return { apiUrl: apiUrlOrOptions };
-  }
-
-  return apiUrlOrOptions;
-}
-
 export function buildAgentChatTuiCommandParts(
   apiUrlOrOptions?: string | null | BuildAgentChatTuiCommandOptions
 ): string[] {
-  const options = normalizeBuildAgentChatTuiCommandOptions(apiUrlOrOptions);
+  const options = normalizeConnectTargetOptions<BuildAgentChatTuiCommandOptions>(apiUrlOrOptions);
   const parts = [
     `${getNovuConnectInvocation(options.apiUrl)} --channel agent-chat`,
     ...getNovuConnectTargetFlags(options),

--- a/packages/shared/src/utils/novu-connect-cli.spec.ts
+++ b/packages/shared/src/utils/novu-connect-cli.spec.ts
@@ -28,4 +28,32 @@ describe('novu-connect-cli', () => {
     expect(getNovuConnectTargetFlags('https://eu.api.novu.co')).toEqual(['--api-url https://eu.api.novu.co']);
     expect(getNovuConnectTargetFlags('http://localhost:3000')).toEqual(['--api-url http://localhost:3000']);
   });
+
+  it('uses rc on local API hosts', () => {
+    expect(getNovuConnectPackageTag('http://localhost:3000')).toBe('rc');
+    expect(getNovuConnectPackageTag('http://127.0.0.1:3000')).toBe('rc');
+    expect(getNovuConnectInvocation('http://localhost:3000')).toBe('npx novu@rc connect');
+  });
+
+  it('adds dashboard URLs for local connect commands', () => {
+    expect(
+      getNovuConnectTargetFlags({
+        apiUrl: 'http://localhost:3000',
+        connectDashboardUrl: 'http://localhost:4201',
+      })
+    ).toEqual([
+      '--api-url http://localhost:3000',
+      '--connect-dashboard-url http://localhost:4201',
+      '--dashboard-url http://localhost:4201',
+    ]);
+  });
+
+  it('does not add dashboard URLs for cloud dashboards', () => {
+    expect(
+      getNovuConnectTargetFlags({
+        apiUrl: 'http://localhost:3000',
+        connectDashboardUrl: 'https://dashboard.novu.co',
+      })
+    ).toEqual(['--api-url http://localhost:3000']);
+  });
 });

--- a/packages/shared/src/utils/novu-connect-cli.ts
+++ b/packages/shared/src/utils/novu-connect-cli.ts
@@ -3,16 +3,58 @@ export const NOVU_STAGING_API_URL = 'https://api.novu-staging.co';
 
 export type NovuConnectPackageTag = 'latest' | 'rc';
 
+export type NovuConnectTargetOptions = {
+  apiUrl?: string | null;
+  connectDashboardUrl?: string | null;
+  dashboardUrl?: string | null;
+};
+
+const NOVU_CLOUD_DASHBOARD_URLS = new Set([
+  'https://dashboard.novu.co',
+  'https://eu.dashboard.novu.co',
+  'https://dashboard.novu-staging.co',
+  'https://dashboard.novu.localhost',
+]);
+
+function normalizeUrl(url: string | null | undefined): string {
+  return (url ?? '').replace(/\/$/, '');
+}
+
 function normalizeApiUrl(apiUrl: string | null | undefined): string {
-  return (apiUrl ?? '').replace(/\/$/, '');
+  return normalizeUrl(apiUrl);
+}
+
+function normalizeConnectTargetOptions(
+  apiUrlOrOptions?: string | null | NovuConnectTargetOptions
+): NovuConnectTargetOptions {
+  if (typeof apiUrlOrOptions === 'string' || apiUrlOrOptions == null) {
+    return { apiUrl: apiUrlOrOptions };
+  }
+
+  return apiUrlOrOptions;
 }
 
 export function isNovuStagingApiUrl(apiUrl: string | null | undefined): boolean {
   return normalizeApiUrl(apiUrl) === NOVU_STAGING_API_URL;
 }
 
+export function isNovuLocalApiUrl(apiUrl: string | null | undefined): boolean {
+  const normalized = normalizeApiUrl(apiUrl);
+  if (!normalized) {
+    return false;
+  }
+
+  try {
+    const hostname = new URL(normalized).hostname;
+
+    return hostname === 'localhost' || hostname === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}
+
 export function getNovuConnectPackageTag(apiUrl?: string | null): NovuConnectPackageTag {
-  return isNovuStagingApiUrl(apiUrl) ? 'rc' : 'latest';
+  return isNovuStagingApiUrl(apiUrl) || isNovuLocalApiUrl(apiUrl) ? 'rc' : 'latest';
 }
 
 export function getNovuConnectRegionFlag(apiUrl?: string | null): '--region staging' | undefined {
@@ -27,22 +69,48 @@ export function getNovuConnectInvocation(apiUrl?: string | null): string {
   return `npx novu@${getNovuConnectPackageTag(apiUrl)} connect`;
 }
 
+function shouldEmitConnectDashboardFlags(connectDashboardUrl?: string | null): boolean {
+  const normalized = normalizeUrl(connectDashboardUrl);
+
+  if (!normalized) {
+    return false;
+  }
+
+  return !NOVU_CLOUD_DASHBOARD_URLS.has(normalized);
+}
+
+export function formatNovuConnectCommandForDisplay(parts: readonly string[]): string {
+  return parts.join(' \\\n  ');
+}
+
 /**
  * Staging uses `--region staging` so OAuth hits dashboard.novu-staging.co.
- * Other non-US Cloud APIs keep `--api-url`.
+ * Other non-US Cloud APIs keep `--api-url`. Local dev also needs dashboard URLs
+ * so browser OAuth opens the same dashboard the user copied the command from.
  */
-export function getNovuConnectTargetFlags(apiUrl?: string | null): string[] {
-  const regionFlag = getNovuConnectRegionFlag(apiUrl);
+export function getNovuConnectTargetFlags(apiUrlOrOptions?: string | null | NovuConnectTargetOptions): string[] {
+  const options = normalizeConnectTargetOptions(apiUrlOrOptions);
+  const regionFlag = getNovuConnectRegionFlag(options.apiUrl);
   if (regionFlag) {
     return [regionFlag];
   }
 
-  const normalized = normalizeApiUrl(apiUrl);
-  if (normalized && normalized !== NOVU_CLOUD_API_URL) {
-    return [`--api-url ${normalized}`];
+  const flags: string[] = [];
+  const normalizedApiUrl = normalizeApiUrl(options.apiUrl);
+
+  if (normalizedApiUrl && normalizedApiUrl !== NOVU_CLOUD_API_URL) {
+    flags.push(`--api-url ${normalizedApiUrl}`);
   }
 
-  return [];
+  if (shouldEmitConnectDashboardFlags(options.connectDashboardUrl)) {
+    const connectDashboardUrl = normalizeUrl(options.connectDashboardUrl);
+    const dashboardUrl = normalizeUrl(options.dashboardUrl) || connectDashboardUrl;
+
+    flags.push(`--connect-dashboard-url ${connectDashboardUrl}`);
+    flags.push(`--dashboard-url ${dashboardUrl}`);
+  }
+
+  return flags;
 }
 
 export function buildNovuConnectStagingHint(apiUrl?: string | null): string | undefined {

--- a/packages/shared/src/utils/novu-connect-cli.ts
+++ b/packages/shared/src/utils/novu-connect-cli.ts
@@ -24,11 +24,11 @@ function normalizeApiUrl(apiUrl: string | null | undefined): string {
   return normalizeUrl(apiUrl);
 }
 
-function normalizeConnectTargetOptions(
-  apiUrlOrOptions?: string | null | NovuConnectTargetOptions
-): NovuConnectTargetOptions {
+export function normalizeConnectTargetOptions<T extends NovuConnectTargetOptions = NovuConnectTargetOptions>(
+  apiUrlOrOptions?: string | null | T
+): T {
   if (typeof apiUrlOrOptions === 'string' || apiUrlOrOptions == null) {
-    return { apiUrl: apiUrlOrOptions };
+    return { apiUrl: apiUrlOrOptions } as T;
   }
 
   return apiUrlOrOptions;


### PR DESCRIPTION
## Summary
- Add `--agent-identifier` to the Novu CLI so connect skips agent and runtime pickers when launched from a specific agent page
- Fix dashboard copy commands to include agent identifier, local dashboard OAuth URLs, and `novu@rc` for staging/local environments
- Apply the same local dashboard URL fix to self-hosted scaffold commands; simplify CLI agent resolution after code review

## Test plan
- [ ] Copy Agent Chat TUI command on local dashboard — includes `@rc`, `--api-url`, dashboard URLs, and `--agent-identifier`
- [ ] Run connect locally with copied command — skips pickers and OAuth opens `localhost:4201`
- [ ] Staging command uses `@rc` + `--region staging`
- [ ] EU prod command uses `--api-url https://eu.api.novu.co`
- [ ] Self-hosted scaffold local command includes dashboard URL flags
- [x] `pnpm exec vitest run` for `@novu/shared` connect CLI specs
- [x] `pnpm exec vitest run src/commands/connect` in `packages/novu`

Linear: https://linear.app/novu/issue/NV-8636

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds agent-specific `novu connect` commands that skip interactive agent selection and improves generated commands for local, staging, EU, and self-hosted environments.
- Adds the `--agent-identifier` CLI option and resolves the corresponding existing agent.
- Includes local dashboard OAuth targets and environment-appropriate CLI package tags in copied commands.
- Updates dashboard setup components and shared command-builder tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code-triggered failures identified.

Agent selection, runtime reuse, and generated environment target flags remain consistent with the reachable CLI and dashboard flows examined.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/pipeline/resolve-existing-agent.ts | Resolves a requested agent identifier and derives its existing connect mode without an actionable regression found. |
| packages/novu/src/commands/connect/pipeline/runner.ts | Integrates preselected-agent resolution into the connect pipeline and bypasses the picker for a valid identifier. |
| packages/novu/src/index.ts | Exposes the new CLI option and permits it to satisfy the non-interactive invocation contract. |
| packages/shared/src/utils/novu-connect-cli.ts | Adds local API detection, dashboard target flags, and reusable display formatting for generated commands. |
| packages/shared/src/utils/agent-chat-connect-prompt.ts | Generates copy and display variants of agent-specific TUI commands using validated agent identifiers. |
| apps/dashboard/src/components/agents/agent-chat-setup-steps.tsx | Supplies the current agent and dashboard origin to the shared command builders. |
| apps/dashboard/src/components/agents/agent-code-setup-section.tsx | Adds local dashboard targets to generated self-hosted scaffold commands. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Dashboard agent setup] --> B[Build novu connect command]
  B --> C[CLI parses agent identifier and target URLs]
  C --> D[Authenticate against selected dashboard]
  D --> E[Fetch existing agents]
  E --> F[Resolve identifier]
  F --> G[Reuse agent and skip picker]
```

<sub>Reviews (1): Last reviewed commit: ["refactor(agents): simplify connect agent..."](https://github.com/novuhq/novu/commit/a1c8e6b845e854da0f93bc7a565296356f82e0d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55506533)</sub>

<!-- /greptile_comment -->