### PR TITLE
feat(connect): add OrcaRouter as a named LLM auth provider for ai-sdk and langchain scaffolds

### DIFF
--- a/packages/novu/src/commands/connect/help-text.ts
+++ b/packages/novu/src/commands/connect/help-text.ts
@@ -143,6 +143,7 @@ Non-interactive (agent / CI) contract:
   LLM wiring (fresh empty-dir scaffold for --runtime ai-sdk or --runtime langchain only):
     - --llm-auth openai --openai-api-key "$OPENAI_API_KEY"  → wire OpenAI; skips the Ink picker (no --ci required)
     - --llm-auth anthropic --anthropic-api-key "$ANTHROPIC_API_KEY"  → wire Anthropic; skips the Ink picker
+    - --llm-auth orcarouter --orcarouter-api-key "$ORCAROUTER_API_KEY"  → wire OrcaRouter (OpenAI-compatible gateway); skips the Ink picker
     - --llm-auth codex-subscription  → OAuth via codex login (ai-sdk) or langchainjs-codex-oauth (langchain)
     - --llm-auth claude-subscription  → ai-sdk only; requires prior claude auth login
     - --llm-auth skip  → demo echo agent (default when omitted)

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/README.md
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/README.md
@@ -30,9 +30,11 @@ Entry point: `bridge-adapter/engine.ts` calls `resolveLlmAuthChoice` before scaf
 
 ## CLI flags
 
-`--llm-auth` skips the Ink picker even without `--ci`. Pair API-key kinds with `--openai-api-key` or `--anthropic-api-key` in non-interactive mode.
+`--llm-auth` skips the Ink picker even without `--ci`. Pair API-key kinds with `--openai-api-key`, `--anthropic-api-key`, or `--orcarouter-api-key` in non-interactive mode.
 
 Subscription kinds run OAuth on the local machine; tokens are not stored in Novu cloud. Warn when `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` are set in the shell (may override subscription billing).
+
+OrcaRouter is OpenAI-compatible: the `orcarouter` scaffold reuses the `@ai-sdk/openai` / `@langchain/openai` packages and points them at `https://api.orcarouter.ai/v1` with the `ORCAROUTER_API_KEY`.
 
 ## Subscription OAuth trust boundary
 

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-support-agent.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-support-agent.ts
@@ -115,6 +115,12 @@ function buildOnMessageBody(input: GenerateSupportAgentInput): string {
   if (runtime === 'ai-sdk') {
     if (llmAuth.kind === 'openai-api-key') return buildAiSdkHandler(input, "openai('gpt-4o-mini')");
     if (llmAuth.kind === 'anthropic-api-key') return buildAiSdkHandler(input, "anthropic('claude-haiku-4-5')");
+    if (llmAuth.kind === 'orcarouter-api-key') {
+      return buildAiSdkHandler(
+        input,
+        "createOpenAI({ baseURL: 'https://api.orcarouter.ai/v1', apiKey: process.env.ORCAROUTER_API_KEY })('openai/gpt-4o-mini')"
+      );
+    }
     if (llmAuth.kind === 'codex-subscription') return buildAiSdkHandler(input, "codexCli('gpt-5.4-mini')");
     if (llmAuth.kind === 'claude-subscription') return buildAiSdkHandler(input, "claudeCode('haiku')");
   }
@@ -122,6 +128,11 @@ function buildOnMessageBody(input: GenerateSupportAgentInput): string {
   if (runtime === 'langchain') {
     if (llmAuth.kind === 'openai-api-key') return buildLangChainHandler("'openai:gpt-4o-mini'");
     if (llmAuth.kind === 'anthropic-api-key') return buildLangChainHandler("'anthropic:claude-haiku-4-5'");
+    if (llmAuth.kind === 'orcarouter-api-key') {
+      return buildLangChainHandler(
+        "new ChatOpenAI({ model: 'openai/gpt-4o-mini', apiKey: process.env.ORCAROUTER_API_KEY, configuration: { baseURL: 'https://api.orcarouter.ai/v1' } })"
+      );
+    }
     if (llmAuth.kind === 'codex-subscription') {
       return buildLangChainHandler("new ChatCodexOAuth({ model: 'gpt-5.4-mini' })");
     }
@@ -149,6 +160,11 @@ ${toolImports}`;
 import { openai } from '@ai-sdk/openai';`;
   }
 
+  if (kind === 'orcarouter-api-key') {
+    return `${base}
+import { createOpenAI } from '@ai-sdk/openai';`;
+  }
+
   if (kind === 'anthropic-api-key') {
     return `${base}
 import { anthropic } from '@ai-sdk/anthropic';`;
@@ -173,6 +189,11 @@ import { Actions, Button, Card, CardText } from '@novu/framework';
 import { agent } from '@novu/framework/langchain';
 import { tool } from '@langchain/core/tools';
 import { searchNovuDocsIndex, searchNovuDocsInputSchema } from './tools/search-novu-docs';`;
+
+  if (kind === 'orcarouter-api-key') {
+    return `${base}
+import { ChatOpenAI } from '@langchain/openai';`;
+  }
 
   if (kind === 'codex-subscription') {
     return `${base}

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/tool-support.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/tool-support.spec.ts
@@ -5,6 +5,7 @@ describe('tool-support', () => {
   it('enables tools for AI SDK API-key providers only', () => {
     expect(aiSdkCodegenSupportsTools('openai-api-key')).toBe(true);
     expect(aiSdkCodegenSupportsTools('anthropic-api-key')).toBe(true);
+    expect(aiSdkCodegenSupportsTools('orcarouter-api-key')).toBe(true);
     expect(aiSdkCodegenSupportsTools('codex-subscription')).toBe(false);
     expect(aiSdkCodegenSupportsTools('claude-subscription')).toBe(false);
     expect(aiSdkCodegenSupportsTools('skip')).toBe(false);

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/tool-support.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/tool-support.ts
@@ -1,7 +1,7 @@
 import type { GenerateSupportAgentInput, LlmAuthKind } from '../types';
 
 export function aiSdkCodegenSupportsTools(kind: LlmAuthKind): boolean {
-  return kind === 'openai-api-key' || kind === 'anthropic-api-key';
+  return kind === 'openai-api-key' || kind === 'anthropic-api-key' || kind === 'orcarouter-api-key';
 }
 
 export function codegenSupportsTools(input: GenerateSupportAgentInput): boolean {

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth-options.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth-options.ts
@@ -11,6 +11,12 @@ const ANTHROPIC_API_KEY_OPTION: LlmAuthPickerOption = {
   title: 'Anthropic API key',
 };
 
+const ORCAROUTER_API_KEY_OPTION: LlmAuthPickerOption = {
+  kind: 'orcarouter-api-key',
+  title: 'OrcaRouter API key',
+  detail: 'OpenAI-compatible gateway (routing, failover, guardrails)',
+};
+
 const CODEX_SUBSCRIPTION_OPTION: LlmAuthPickerOption = {
   kind: 'codex-subscription',
   title: 'ChatGPT subscription (Codex)',
@@ -33,13 +39,20 @@ export function getLlmAuthPickerOptions(connectMode: BridgeAdapterVariant): read
     return [
       OPENAI_API_KEY_OPTION,
       ANTHROPIC_API_KEY_OPTION,
+      ORCAROUTER_API_KEY_OPTION,
       CODEX_SUBSCRIPTION_OPTION,
       CLAUDE_SUBSCRIPTION_OPTION,
       SKIP_OPTION,
     ];
   }
 
-  return [OPENAI_API_KEY_OPTION, ANTHROPIC_API_KEY_OPTION, CODEX_SUBSCRIPTION_OPTION, SKIP_OPTION];
+  return [
+    OPENAI_API_KEY_OPTION,
+    ANTHROPIC_API_KEY_OPTION,
+    ORCAROUTER_API_KEY_OPTION,
+    CODEX_SUBSCRIPTION_OPTION,
+    SKIP_OPTION,
+  ];
 }
 
 export const LLM_AUTH_PICKER_TITLE = 'How do you want to power your agent?';
@@ -53,6 +66,8 @@ export function describeLlmAuthChoice(llmAuth: LlmAuthChoice): string {
       return 'OpenAI API key';
     case 'anthropic-api-key':
       return 'Anthropic API key';
+    case 'orcarouter-api-key':
+      return 'OrcaRouter API key';
     case 'codex-subscription':
       return 'ChatGPT subscription (Codex CLI)';
     case 'claude-subscription':

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth.spec.ts
@@ -22,6 +22,18 @@ describe('llm-auth registry', () => {
     expect(resolveLlmAuthEnvVars({ kind: 'skip' })).toEqual({});
   });
 
+  it('resolves OrcaRouter packages per runtime', () => {
+    expect(resolveLlmAuthPackages('ai-sdk', { kind: 'orcarouter-api-key', apiKey: 'or-test' })).toEqual([
+      '@ai-sdk/openai',
+    ]);
+    expect(resolveLlmAuthPackages('langchain', { kind: 'orcarouter-api-key', apiKey: 'or-test' })).toEqual([
+      '@langchain/openai',
+    ]);
+    expect(resolveLlmAuthEnvVars({ kind: 'orcarouter-api-key', apiKey: 'or-test' })).toEqual({
+      ORCAROUTER_API_KEY: 'or-test',
+    });
+  });
+
   it('pins subscription providers to zod v4-compatible releases', () => {
     expect(resolveLlmAuthPackageDependencies('ai-sdk', { kind: 'codex-subscription' })).toEqual({
       'ai-sdk-provider-codex-cli': '2.1.1',
@@ -88,6 +100,15 @@ describe('llm-auth picker options', () => {
     expect(langChainKinds).not.toContain('claude-subscription');
   });
 
+  it('includes OrcaRouter for both runtimes', () => {
+    const aiSdkKinds = getLlmAuthPickerOptions('ai-sdk').map((opt) => opt.kind);
+    const langChainKinds = getLlmAuthPickerOptions('langchain').map((opt) => opt.kind);
+
+    expect(aiSdkKinds).toContain('orcarouter-api-key');
+    expect(langChainKinds).toContain('orcarouter-api-key');
+    expect(describeLlmAuthChoice({ kind: 'orcarouter-api-key', apiKey: 'or-test' })).toContain('OrcaRouter');
+  });
+
   it('describes scaffold wiring choices for confirm screens', () => {
     expect(describeLlmAuthChoice({ kind: 'claude-subscription' })).toContain('Claude Code');
     expect(describeLlmAuthChoice({ kind: 'skip' })).toContain('echo');
@@ -135,6 +156,35 @@ describe('generateSupportAgentSource', () => {
     expect(source).toContain("toolCall.name === 'searchNovuDocs'");
     expect(source).toContain('export const myAgent');
     expect(source).not.toContain('ChatAnthropic');
+  });
+
+  it('generates wired AI SDK OrcaRouter handler with a custom base URL', () => {
+    const source = generateSupportAgentSource({
+      runtime: 'ai-sdk',
+      agentIdentifier: 'support-agent',
+      llmAuth: { kind: 'orcarouter-api-key', apiKey: 'or-test' },
+    });
+
+    expect(source).toContain("import { createOpenAI } from '@ai-sdk/openai'");
+    expect(source).toContain("baseURL: 'https://api.orcarouter.ai/v1'");
+    expect(source).toContain('process.env.ORCAROUTER_API_KEY');
+    expect(source).toContain("('openai/gpt-4o-mini')");
+    expect(source).toContain('tools: { searchNovuDocs }');
+    expect(source).toContain('needsApproval: true');
+  });
+
+  it('generates wired LangChain OrcaRouter handler with a custom base URL', () => {
+    const source = generateSupportAgentSource({
+      runtime: 'langchain',
+      agentIdentifier: 'support-agent',
+      llmAuth: { kind: 'orcarouter-api-key', apiKey: 'or-test' },
+    });
+
+    expect(source).toContain("import { ChatOpenAI } from '@langchain/openai'");
+    expect(source).toContain("model: 'openai/gpt-4o-mini'");
+    expect(source).toContain("baseURL: 'https://api.orcarouter.ai/v1'");
+    expect(source).toContain('process.env.ORCAROUTER_API_KEY');
+    expect(source).toContain('tools: [searchNovuDocs]');
   });
 
   it('generates wired LangChain Codex subscription handler with tools', () => {

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/registry.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/registry.ts
@@ -26,6 +26,15 @@ const REGISTRY: Record<Exclude<LlmAuthKind, 'skip'>, LlmAuthRegistryEntry> = {
       langchain: [{ name: '@langchain/anthropic', version: '^1.0.0' }],
     },
   },
+  // OrcaRouter is an OpenAI-compatible gateway, so scaffolds reuse the OpenAI
+  // provider packages but point them at the OrcaRouter base URL and API key.
+  'orcarouter-api-key': {
+    envKey: 'ORCAROUTER_API_KEY',
+    packages: {
+      'ai-sdk': [{ name: '@ai-sdk/openai', version: 'latest' }],
+      langchain: [{ name: '@langchain/openai', version: '^1.0.0' }],
+    },
+  },
   'codex-subscription': {
     packages: {
       'ai-sdk': [
@@ -78,6 +87,10 @@ export function resolveLlmAuthEnvVars(llmAuth: LlmAuthChoice): Record<string, st
 
   if (llmAuth.kind === 'anthropic-api-key') {
     return { ANTHROPIC_API_KEY: llmAuth.apiKey };
+  }
+
+  if (llmAuth.kind === 'orcarouter-api-key') {
+    return { ORCAROUTER_API_KEY: llmAuth.apiKey };
   }
 
   return {};

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.spec.ts
@@ -54,6 +54,35 @@ describe('resolveLlmAuthChoice', () => {
     expect(result).toEqual({ kind: 'openai-api-key', apiKey: 'sk-test' });
   });
 
+  it('resolves OrcaRouter API key from CI flags', async () => {
+    const result = await resolveLlmAuthChoice({
+      connectMode: 'ai-sdk',
+      options: {
+        ci: true,
+        llmAuth: 'orcarouter',
+        orcarouterApiKey: 'or-test',
+        ...baseOptions(),
+      },
+      ui: createUi(),
+    });
+
+    expect(result).toEqual({ kind: 'orcarouter-api-key', apiKey: 'or-test' });
+  });
+
+  it('throws when OrcaRouter key is missing in CI', async () => {
+    await expect(
+      resolveLlmAuthChoice({
+        connectMode: 'ai-sdk',
+        options: {
+          ci: true,
+          llmAuth: 'orcarouter',
+          ...baseOptions(),
+        },
+        ui: createUi(),
+      })
+    ).rejects.toThrow(/--orcarouter-api-key/);
+  });
+
   it('rejects Claude subscription for langchain runtime', async () => {
     await expect(
       resolveLlmAuthChoice({

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.ts
@@ -20,6 +20,8 @@ function mapCliChoiceToKind(choice: LlmAuthCliChoice, connectMode: BridgeAdapter
       return 'openai-api-key';
     case 'anthropic':
       return 'anthropic-api-key';
+    case 'orcarouter':
+      return 'orcarouter-api-key';
     case 'codex-subscription':
       return 'codex-subscription';
     case 'claude-subscription':
@@ -42,16 +44,26 @@ function resolveApiKeyFromOptions(kind: LlmAuthKind, options: ConnectCommandOpti
     return options.anthropicApiKey?.trim();
   }
 
+  if (kind === 'orcarouter-api-key') {
+    return options.orcarouterApiKey?.trim();
+  }
+
   return undefined;
 }
 
-async function promptForApiKey(ui: ConnectUI, kind: 'openai-api-key' | 'anthropic-api-key'): Promise<string> {
+async function promptForApiKey(
+  ui: ConnectUI,
+  kind: 'openai-api-key' | 'anthropic-api-key' | 'orcarouter-api-key'
+): Promise<string> {
   const isOpenAi = kind === 'openai-api-key';
+  const isOrcaRouter = kind === 'orcarouter-api-key';
+  const title = isOrcaRouter ? 'OrcaRouter API key' : isOpenAi ? 'OpenAI API key' : 'Anthropic API key';
+  const placeholder = isOrcaRouter ? 'or_...' : isOpenAi ? 'sk-...' : 'sk-ant-...';
 
   while (true) {
     const value = await ui.promptForSecretInput({
-      title: isOpenAi ? 'OpenAI API key' : 'Anthropic API key',
-      placeholder: isOpenAi ? 'sk-...' : 'sk-ant-...',
+      title,
+      placeholder,
       hint: 'Saved to .env.local in your scaffolded project.',
       secret: true,
     });
@@ -83,13 +95,14 @@ async function resolveFromCliFlags(input: ResolveLlmAuthInput): Promise<LlmAuthC
 
   const apiKey = resolveApiKeyFromOptions(kind, input.options);
   if (!apiKey) {
-    const flag = kind === 'openai-api-key' ? '--openai-api-key' : '--anthropic-api-key';
+    const flag =
+      kind === 'openai-api-key'
+        ? '--openai-api-key'
+        : kind === 'anthropic-api-key'
+          ? '--anthropic-api-key'
+          : '--orcarouter-api-key';
 
     throw new Error(`Non-interactive mode requires ${flag} when --llm-auth is "${cliChoice}".`);
-  }
-
-  if (kind === 'openai-api-key') {
-    return { kind, apiKey };
   }
 
   return { kind, apiKey };

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/types.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/types.ts
@@ -4,16 +4,24 @@ import type { BridgeAdapterVariant } from '../bridge-adapter/types';
 export type LlmAuthKind =
   | 'openai-api-key'
   | 'anthropic-api-key'
+  | 'orcarouter-api-key'
   | 'codex-subscription'
   | 'claude-subscription'
   | 'skip';
 
 /** Short names for `--llm-auth`; mapped to `LlmAuthKind` in `resolve-llm-auth.ts`. */
-export type LlmAuthCliChoice = 'openai' | 'anthropic' | 'codex-subscription' | 'claude-subscription' | 'skip';
+export type LlmAuthCliChoice =
+  | 'openai'
+  | 'anthropic'
+  | 'orcarouter'
+  | 'codex-subscription'
+  | 'claude-subscription'
+  | 'skip';
 
 export type LlmAuthChoice =
   | { kind: 'openai-api-key'; apiKey: string }
   | { kind: 'anthropic-api-key'; apiKey: string }
+  | { kind: 'orcarouter-api-key'; apiKey: string }
   | { kind: 'codex-subscription' }
   | { kind: 'claude-subscription' }
   | { kind: 'skip' };

--- a/packages/novu/src/commands/connect/types.ts
+++ b/packages/novu/src/commands/connect/types.ts
@@ -197,11 +197,13 @@ export interface ConnectCommandOptions {
   noScaffold?: boolean;
   /**
    * LLM provider for ai-sdk / langchain fresh scaffolds only.
-   * openai | anthropic | codex-subscription | claude-subscription | skip
+   * openai | anthropic | orcarouter | codex-subscription | claude-subscription | skip
    */
   llmAuth?: LlmAuthCliChoice;
   /** OpenAI API key for --llm-auth openai non-interactive scaffold runs. */
   openaiApiKey?: string;
+  /** OrcaRouter API key for --llm-auth orcarouter non-interactive scaffold runs. */
+  orcarouterApiKey?: string;
   /** Agent Chat post-connect setup for --ci: scaffold | embed | skip (auto-detect when omitted). */
   agentChatSetup?: AgentChatSetupMode;
 }

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -219,9 +219,10 @@ program
   .option('--anthropic-api-key <key>', 'Anthropic API key for --runtime claude non-interactive runs')
   .option(
     '--llm-auth <choice>',
-    'LLM provider for ai-sdk/langchain scaffold (openai | anthropic | codex-subscription | claude-subscription | skip)'
+    'LLM provider for ai-sdk/langchain scaffold (openai | anthropic | orcarouter | codex-subscription | claude-subscription | skip)'
   )
   .option('--openai-api-key <key>', 'OpenAI API key for --llm-auth openai non-interactive scaffold runs')
+  .option('--orcarouter-api-key <key>', 'OrcaRouter API key for --llm-auth orcarouter non-interactive scaffold runs')
   .option('--aws-claude-api-key <key>', 'AWS Claude API key for --runtime claude-aws non-interactive runs')
   .option('--aws-claude-region <region>', 'AWS Claude commercial region for --runtime claude-aws')
   .option('--aws-claude-workspace-id <id>', 'AWS Claude workspace ID for --runtime claude-aws')
@@ -318,6 +319,7 @@ program
     const LLM_AUTH_CHOICES: readonly LlmAuthCliChoice[] = [
       'openai',
       'anthropic',
+      'orcarouter',
       'codex-subscription',
       'claude-subscription',
       'skip',


### PR DESCRIPTION
### What changed? Why was the change needed?

`novu connect` already lets you scaffold a fresh ai-sdk or langchain agent with a first-class LLM provider: pick `--llm-auth openai` and it wires `@ai-sdk/openai`, `--llm-auth anthropic` and it wires `@ai-sdk/anthropic`. This PR adds **[OrcaRouter](https://www.orcarouter.ai)** as the same kind of named provider — `--llm-auth orcarouter` — so users of Novu's Agent Communication Infrastructure can wire a scaffolded agent to OrcaRouter without treating it as an anonymous custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

Because OrcaRouter speaks the OpenAI protocol, the scaffold reuses the same provider packages Novu already installs for OpenAI, pointing them at the OrcaRouter base URL with `ORCAROUTER_API_KEY`:

- **AI SDK**: `createOpenAI({ baseURL: 'https://api.orcarouter.ai/v1', apiKey: process.env.ORCAROUTER_API_KEY })('openai/gpt-4o-mini')`
- **LangChain**: `new ChatOpenAI({ model: 'openai/gpt-4o-mini', apiKey: process.env.ORCAROUTER_API_KEY, configuration: { baseURL: 'https://api.orcarouter.ai/v1' } })`

Changes:

- `registry.ts`: new `orcarouter-api-key` kind with per-runtime npm specs (`@ai-sdk/openai` / `@langchain/openai`) and `ORCAROUTER_API_KEY` env key
- `resolve-llm-auth.ts` / `types.ts`: CLI choice `orcarouter`, api-key resolution, and interactive prompt (title + placeholder)
- `llm-auth-options.ts`: picker option with a descriptive detail line for both ai-sdk and langchain runtimes
- `codegen/generate-support-agent.ts`: generated handler imports and model lines for both runtimes; tool support enabled (same as OpenAI/Anthropic)
- `index.ts` / `help-text.ts` / `README.md`: `--orcarouter-api-key` flag, help text, and docs

Verification:

- `vitest run` over the `llm-auth` pipeline: **47/47 tests pass** (registry, picker, resolver, codegen, tool-support)
- `biome check` on all changed files: clean (the single warning on `index.ts` is pre-existing)
- `tsc --noEmit` on the changed source: no errors introduced
- Live test through the exact generated AI SDK path (`createOpenAI` + OrcaRouter base URL) returned a real completion; same for the generated LangChain `ChatOpenAI` path.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds OrcaRouter as a named OpenAI-compatible authentication provider for fresh AI SDK and LangChain agent scaffolds.
- Extends CLI choices, flags, interactive picker metadata, credential resolution, and help documentation.
- Registers runtime-specific OpenAI provider packages and persists `ORCAROUTER_API_KEY`.
- Generates OrcaRouter-configured AI SDK and LangChain models with tool support.
- Adds focused coverage for registry resolution, CLI handling, generated source, and tool capability.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete blocking or independently actionable non-blocking defects were identified.

The new provider choice is carried through CLI resolution, credential persistence, dependency generation, and runtime-specific code generation with matching environment names and compatible framework model contracts.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-support-agent.ts | Generates runtime-specific OrcaRouter model clients using the OpenAI-compatible endpoint and existing agent handler contracts. |
| packages/novu/src/commands/connect/pipeline/llm-auth/registry.ts | Registers the OrcaRouter environment variable and appropriate OpenAI provider package for each supported runtime. |
| packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.ts | Maps the new CLI and picker choice to OrcaRouter credentials while preserving existing interactive and explicit-provider behavior. |
| packages/novu/src/index.ts | Exposes and validates the OrcaRouter provider choice and API-key command-line flag. |
| packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth.spec.ts | Covers OrcaRouter registry resolution, picker exposure, and generated handlers for both runtimes. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    CLI[novu connect --llm-auth orcarouter] --> Resolve[Resolve OrcaRouter API key]
    Resolve --> Registry[Select runtime package and env variable]
    Registry --> Runtime{Selected runtime}
    Runtime -->|AI SDK| AISDK[Install @ai-sdk/openai]
    Runtime -->|LangChain| LangChain[Install @langchain/openai]
    AISDK --> Generate[Generate provider with OrcaRouter base URL]
    LangChain --> Generate
    Generate --> Env[Write ORCAROUTER_API_KEY to .env.local]
    Env --> Agent[Run tool-enabled support agent]
```

<sub>Reviews (1): Last reviewed commit: ["feat(connect): add OrcaRouter as a named..."](https://github.com/novuhq/novu/commit/4f18478e8cece5f498d97be1712744f813ae12b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55968587)</sub>

<!-- /greptile_comment -->