### PR TITLE
feat(providers): configurable HMAC secret key encoding for email webhook provider

### DIFF
--- a/libs/application-generic/src/dtos/credentials.dto.ts
+++ b/libs/application-generic/src/dtos/credentials.dto.ts
@@ -1,11 +1,14 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ICredentials } from '@novu/shared';
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsEmail, IsObject, IsOptional, IsString, Matches, ValidateIf } from 'class-validator';
+import { IsBoolean, IsEmail, IsIn, IsObject, IsOptional, IsString, Matches, ValidateIf } from 'class-validator';
 import { TransformToBoolean } from '../decorators/to-boolean';
 
 /** Lowercase letters, digits and dashes; 1-32 chars; no leading/trailing dash. */
 const AGENT_EMAIL_SLUG_PREFIX_REGEX = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+
+/** Allowed interpretations of the email webhook HMAC secret key when signing. */
+export const HMAC_SECRET_KEY_ENCODINGS = ['text', 'base64', 'hex'] as const;
 
 export class CredentialsDto implements ICredentials {
   @ApiPropertyOptional()
@@ -22,6 +25,17 @@ export class CredentialsDto implements ICredentials {
   @IsString()
   @IsOptional()
   secretKey?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Email webhook: how `secretKey` is interpreted when signing webhook calls. ' +
+      "`text` signs with the raw UTF-8 bytes; `base64`/`hex` decode it to binary first (e.g. for AWS KMS).",
+    enum: [...HMAC_SECRET_KEY_ENCODINGS],
+  })
+  @IsString()
+  @IsIn(HMAC_SECRET_KEY_ENCODINGS)
+  @IsOptional()
+  hmacSecretKeyEncoding?: (typeof HMAC_SECRET_KEY_ENCODINGS)[number];
 
   @ApiPropertyOptional()
   @IsString()

--- a/libs/application-generic/src/factories/mail/handlers/email-webhook.handler.ts
+++ b/libs/application-generic/src/factories/mail/handlers/email-webhook.handler.ts
@@ -12,10 +12,12 @@ export class EmailWebhookHandler extends BaseEmailHandler {
       from: string;
       webhookUrl: string;
       hmacSecretKey?: string;
+      hmacSecretKeyEncoding?: 'text' | 'base64' | 'hex';
     } = {
       from: credentials.from as string,
       webhookUrl: credentials.webhookUrl as string,
       hmacSecretKey: credentials.secretKey as string,
+      hmacSecretKeyEncoding: credentials.hmacSecretKeyEncoding ?? 'text',
     };
     this.provider = new EmailWebhookProvider(config);
   }

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -29,6 +29,7 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       apiKey: Schema.Types.String,
       user: Schema.Types.String,
       secretKey: Schema.Types.String,
+      hmacSecretKeyEncoding: Schema.Types.String,
       domain: Schema.Types.String,
       password: Schema.Types.String,
       host: Schema.Types.String,

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
@@ -259,4 +259,15 @@ describe('computeHmac secret key encodings', () => {
     expect(() => base64Provider.computeHmac(PAYLOAD)).toThrow(/not valid base64/);
     expect(() => missingKeyProvider.computeHmac(PAYLOAD)).toThrow(/requires a non-empty hmacSecretKey/);
   });
+
+  test('should reject unsupported encodings instead of signing with unintended key bytes', () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: 'https://example.com/webhook',
+      hmacSecretKey: 'super-secret-key',
+      // Runtime values are not constrained by the TypeScript union — the API persists raw strings.
+      hmacSecretKeyEncoding: 'latin1' as 'base64' | 'hex',
+    });
+
+    expect(() => provider.computeHmac(PAYLOAD)).toThrow(/Unsupported hmacSecretKeyEncoding: 'latin1'/);
+  });
 });

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
@@ -208,3 +208,55 @@ describe('without SSRF protection (self-hosted)', () => {
     expect(lastRequest?.method).toBe('POST');
   });
 });
+
+describe('computeHmac secret key encodings', () => {
+  const PAYLOAD =
+    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test","html":"<h1>test</h1>","text":"test"}';
+
+  // Signature produced by the legacy behavior: the raw UTF-8 bytes of 'super-secret-key'.
+  const TEXT_SIGNATURE = 'd1e94cd19eeceec2e0717e36f7edacaa93612b311bde8756ee35b89d4a994767';
+
+  test.each([
+    ['base64', Buffer.from('super-secret-key').toString('base64')],
+    ['hex', Buffer.from('super-secret-key').toString('hex')],
+  ])('should sign identically when a %s-encoded key decodes to the same binary material', (encoding, encodedKey) => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: 'https://example.com/webhook',
+      hmacSecretKey: encodedKey,
+      hmacSecretKeyEncoding: encoding as 'base64' | 'hex',
+    });
+
+    expect(provider.computeHmac(PAYLOAD)).toBe(TEXT_SIGNATURE);
+  });
+
+  test('should keep signing as plain text when no encoding is configured', () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: 'https://example.com/webhook',
+      hmacSecretKey: 'super-secret-key',
+    });
+    const explicitTextProvider = new EmailWebhookProvider({
+      webhookUrl: 'https://example.com/webhook',
+      hmacSecretKey: 'super-secret-key',
+      hmacSecretKeyEncoding: 'text',
+    });
+
+    expect(provider.computeHmac(PAYLOAD)).toBe(TEXT_SIGNATURE);
+    expect(explicitTextProvider.computeHmac(PAYLOAD)).toBe(provider.computeHmac(PAYLOAD));
+  });
+
+  test('should reject an empty decoded key for non-text encodings', () => {
+    // Node's decoders are lenient: only a value with zero valid digits yields an empty buffer.
+    const base64Provider = new EmailWebhookProvider({
+      webhookUrl: 'https://example.com/webhook',
+      hmacSecretKey: '!!!!',
+      hmacSecretKeyEncoding: 'base64',
+    });
+    const missingKeyProvider = new EmailWebhookProvider({
+      webhookUrl: 'https://example.com/webhook',
+      hmacSecretKeyEncoding: 'hex',
+    });
+
+    expect(() => base64Provider.computeHmac(PAYLOAD)).toThrow(/not valid base64/);
+    expect(() => missingKeyProvider.computeHmac(PAYLOAD)).toThrow(/requires a non-empty hmacSecretKey/);
+  });
+});

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -179,6 +179,10 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
       return this.config.hmacSecretKey as string;
     }
 
+    if (!['base64', 'hex'].includes(encoding)) {
+      throw new Error(`Unsupported hmacSecretKeyEncoding: '${encoding}'. Supported encodings: text, base64, hex`);
+    }
+
     if (!this.config.hmacSecretKey) {
       throw new Error(`hmacSecretKeyEncoding '${encoding}' requires a non-empty hmacSecretKey`);
     }

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -21,6 +21,14 @@ import { WithPassthrough } from '../../../utils/types';
 
 const PROTECTED_HEADER_NAMES = new Set(['content-type', 'x-novu-signature']);
 
+/**
+ * How the `hmacSecretKey` value is turned into signing bytes:
+ * - `text`: the raw UTF-8 bytes of the stored string (legacy/default behavior)
+ * - `base64` / `hex`: decode the stored string into its binary key material,
+ *   matching services (e.g. AWS KMS) that hold the HMAC key as binary
+ */
+export type EmailWebhookHmacSecretKeyEncoding = 'text' | 'base64' | 'hex';
+
 export class EmailWebhookUrlBlockedError extends Error {
   constructor(message: string) {
     super(message);
@@ -36,6 +44,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
   constructor(
     private config: {
       hmacSecretKey?: string;
+      hmacSecretKeyEncoding?: EmailWebhookHmacSecretKeyEncoding;
       webhookUrl: string;
       retryCount?: number;
       retryDelay?: number;
@@ -160,6 +169,26 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
   }
 
   computeHmac(payload: string): string {
-    return crypto.createHmac('sha256', this.config.hmacSecretKey).update(payload, 'utf-8').digest('hex');
+    return crypto.createHmac('sha256', this.resolveHmacSecret()).update(payload, 'utf-8').digest('hex');
+  }
+
+  private resolveHmacSecret(): Buffer | string {
+    const encoding = this.config.hmacSecretKeyEncoding ?? 'text';
+
+    if (encoding === 'text') {
+      return this.config.hmacSecretKey as string;
+    }
+
+    if (!this.config.hmacSecretKey) {
+      throw new Error(`hmacSecretKeyEncoding '${encoding}' requires a non-empty hmacSecretKey`);
+    }
+
+    const keyBuffer = Buffer.from(this.config.hmacSecretKey, encoding);
+
+    if (keyBuffer.length === 0) {
+      throw new Error(`hmacSecretKey is not valid ${encoding}: decoding produced no bytes`);
+    }
+
+    return keyBuffer;
   }
 }

--- a/packages/shared/src/consts/providers/channels/email.spec.ts
+++ b/packages/shared/src/consts/providers/channels/email.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { CredentialsKeyEnum } from '../../../types';
+import { emailWebhookConfig } from '../credentials';
+
+describe('emailProviders credentials', () => {
+  it('shapes emailWebhookConfig with an optional HMAC secret key encoding dropdown defaulting to text', () => {
+    expect(emailWebhookConfig.map((credential) => credential.key)).toEqual([
+      CredentialsKeyEnum.WebhookUrl,
+      CredentialsKeyEnum.SecretKey,
+      CredentialsKeyEnum.HmacSecretKeyEncoding,
+      CredentialsKeyEnum.From,
+      CredentialsKeyEnum.SenderName,
+    ]);
+
+    const encoding = emailWebhookConfig.find(
+      (credential) => credential.key === CredentialsKeyEnum.HmacSecretKeyEncoding
+    );
+
+    expect(encoding?.required).toBe(false);
+    expect(encoding?.value).toBe('text');
+    expect(encoding?.dropdown).toEqual([
+      { name: 'Text', value: 'text' },
+      { name: 'Base-64', value: 'base64' },
+      { name: 'HEX', value: 'hex' },
+    ]);
+  });
+});

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -1019,6 +1019,20 @@ export const emailWebhookConfig: IConfigCredential[] = [
     description: 'the secret used to sign webhooks calls',
     required: true,
   },
+  {
+    key: CredentialsKeyEnum.HmacSecretKeyEncoding,
+    displayName: 'Secret Hmac Key Encoding',
+    type: 'dropdown',
+    description:
+      'how the Secret Hmac Key is interpreted when signing webhook calls — Base-64/HEX for binary keys (e.g. AWS KMS)',
+    required: false,
+    value: 'text',
+    dropdown: [
+      { name: 'Text', value: 'text' },
+      { name: 'Base-64', value: 'base64' },
+      { name: 'HEX', value: 'hex' },
+    ],
+  },
   ...mailConfigBase,
 ];
 

--- a/packages/shared/src/entities/integration/credential.interface.ts
+++ b/packages/shared/src/entities/integration/credential.interface.ts
@@ -137,4 +137,11 @@ export interface ICredentials {
    * `'dynamic'` fans out to per-subscriber `tool_webhook` endpoints. Missing = static.
    */
   routingMode?: 'static' | 'dynamic';
+  /**
+   * Email webhook: how the `secretKey` value is interpreted when computing the
+   * `X-Novu-Signature` header. `'text'` (default) signs with the raw UTF-8 bytes of
+   * the stored secret; `'base64'` and `'hex'` decode it to binary first — required
+   * when the verification side (e.g. AWS KMS) holds the key as binary material.
+   */
+  hmacSecretKeyEncoding?: 'text' | 'base64' | 'hex';
 }

--- a/packages/shared/src/types/providers.ts
+++ b/packages/shared/src/types/providers.ts
@@ -68,6 +68,8 @@ export enum CredentialsKeyEnum {
   Body = 'body',
   /** Tool-webhook routing mode: static (integration URL) or dynamic (per-subscriber endpoints). */
   RoutingMode = 'routingMode',
+  /** Email webhook: how the HMAC secret key value is interpreted when signing webhook calls. */
+  HmacSecretKeyEncoding = 'hmacSecretKeyEncoding',
 }
 
 export type ConfigurationKey = keyof IConfigurations;


### PR DESCRIPTION
### What changed? Why was the change needed?

Adds a configurable encoding for the email webhook provider's HMAC secret key, requested in #4056.

The `X-Novu-Signature` header is currently computed by interpreting `secretKey` as plain text. Users whose verification side holds the key as binary material (e.g. AWS KMS imported keys) cannot produce matching signatures. This PR adds an optional `hmacSecretKeyEncoding` credential (`text` | `base64` | `hex`, defaulting to `text`) that decodes the stored secret into raw bytes before signing:

- `EmailWebhookProvider` resolves the signing key through a new `resolveHmacSecret()` helper; `text` keeps byte-for-byte identical legacy behavior, while `base64`/`hex` decode to binary and fail fast on empty decodes
- New optional dropdown credential in `emailWebhookConfig` (renders via the existing generic dropdown input — no dashboard changes needed)
- Threaded through `ICredentials` → `EmailWebhookHandler` → provider config, plus the integration Mongo schema

Closes #4056

### Special notes for your reviewer

- Fully backward compatible: integrations without the new credential keep signing exactly as before (covered by tests asserting identical signatures).
- The new spec proves that base64/hex-encoded keys decoding to the same binary material produce the same signature, which is the AWS KMS requirement from the issue.
- Node's base64/hex decoders are lenient (skip invalid digits), so validation rejects only values that decode to zero bytes rather than trying to re-implement strict validation.








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds configurable text, Base64, or hexadecimal decoding for email-webhook HMAC secrets while preserving text as the legacy default.
- Validates the encoding when integration credentials are created or updated.
- Persists and forwards the encoding through the email handler to the provider.
- Rejects unsupported encodings at runtime and covers equivalent decoded key material with provider tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/application-generic/src/dtos/credentials.dto.ts | Adds optional allowlisted validation and API documentation for the HMAC key encoding. |
| libs/application-generic/src/factories/mail/handlers/email-webhook.handler.ts | Passes the persisted encoding into the provider while defaulting legacy integrations to text. |
| libs/dal/src/repositories/integration/integration.schema.ts | Extends the integration credential schema to persist the selected encoding. |
| packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts | Resolves text or decoded binary key material and explicitly rejects unsupported or empty non-text keys. |
| packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts | Covers legacy compatibility, equivalent Base64 and hexadecimal key material, empty decoded keys, and unsupported encodings. |
| packages/shared/src/consts/providers/credentials/provider-credentials.ts | Adds the optional encoding dropdown to the email-webhook credential catalog. |
| packages/shared/src/entities/integration/credential.interface.ts | Adds the encoding union to the shared integration credential contract. |
| packages/shared/src/types/providers.ts | Adds the encoding field to the shared credential-key enum. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Integration credential input] --> B{Validate encoding}
  B -->|text, base64, hex| C[(Persist credentials)]
  C --> D[Email webhook handler]
  D --> E{Resolve HMAC key}
  E -->|text| F[UTF-8 secret bytes]
  E -->|base64 or hex| G[Decoded binary bytes]
  F --> H[Compute SHA-256 HMAC]
  G --> H
  H --> I[X-Novu-Signature header]
  B -->|unsupported| J[Reject integration request]
```

<sub>Reviews (4): Last reviewed commit: ["fix(api): validate email webhook hmac se..."](https://github.com/novuhq/novu/commit/d8a649b25d05a956d9ea836a7505fcdf086be8ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56128676)</sub>

**Context used:**

- Knowledge Base — [Delivery providers and channels](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/delivery-providers-and-channels.md)

<!-- /greptile_comment -->