### PR TITLE
fix(shared): strip observability trace headers from outbound requests fixes NV-8509

### DIFF
--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -278,10 +278,29 @@ const SENSITIVE_HEADER_PATTERNS = [
   /-hmac/i,
 ];
 
+const TRACE_PROPAGATION_HEADER_PATTERNS = [
+  /^traceparent$/i,
+  /^tracestate$/i,
+  /^baggage$/i,
+  /^b3$/i,
+  /^x-b3-/i,
+  /^newrelic$/i,
+  /^x-newrelic-/i,
+  /^sentry-trace$/i,
+];
+
 function stripSensitiveHeaders(headers: Record<string, string | undefined>): void {
   for (const key of Object.keys(headers)) {
     if (SENSITIVE_HEADER_PATTERNS.some((re) => re.test(key))) {
       delete headers[key];
+    }
+  }
+}
+
+function stripTracePropagationHeaders(request: http.ClientRequest): void {
+  for (const header of request.getHeaderNames()) {
+    if (TRACE_PROPAGATION_HEADER_PATTERNS.some((re) => re.test(header))) {
+      request.removeHeader(header);
     }
   }
 }
@@ -407,6 +426,8 @@ function performPinnedRequest(params: PinnedRequestParams): Promise<SafeOutbound
 
       res.on('error', reject);
     });
+
+    stripTracePropagationHeaders(req);
 
     req.on('timeout', () => {
       const timeoutError: NodeJS.ErrnoException = new Error(

--- a/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
@@ -2,8 +2,12 @@
 // runtime so the TypeScript build does not traverse into libs/application-generic
 // and emit stray artifacts there. Vitest runs in Node and resolves the path
 // against the spec's __dirname.
+import * as dns from 'node:dns';
+import { readFileSync } from 'node:fs';
+import * as http from 'node:http';
 import { join } from 'node:path';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetOutboundSsrfAllowListCacheForTests } from './outbound-ssrf-allow-list';
 import { SsrfBlockedError as SharedSsrfBlockedError, isPrivateIp as sharedIsPrivateIp } from './ssrf-url-validation';
 
 const inlinedPath = join(
@@ -19,6 +23,8 @@ const inlinedPath = join(
   'ssrf-url-validation.ts'
 );
 
+const sharedSafeOutboundHttpPath = join(__dirname, 'safe-outbound-http.ts');
+
 type InlinedSsrfModule = {
   isPrivateIp: (ip: string) => boolean;
   normalizeHostnameForLookup: (hostname: string) => string;
@@ -31,17 +37,44 @@ type InlinedSsrfModule = {
     hostname?: string;
     resolvedAddress?: string;
   };
+  safeOutboundRequest: (options: {
+    url: string | URL;
+    method?: string;
+    headers?: Record<string, string | undefined>;
+    body?: unknown;
+  }) => Promise<{
+    statusCode: number;
+    headers: http.IncomingHttpHeaders;
+    body: Buffer;
+  }>;
 };
 
 let inlinedIsPrivateIp: InlinedSsrfModule['isPrivateIp'];
 let inlinedNormalizeHostnameForLookup: InlinedSsrfModule['normalizeHostnameForLookup'];
 let InlinedSsrfBlockedError: InlinedSsrfModule['SsrfBlockedError'];
+let inlinedSafeOutboundRequest: InlinedSsrfModule['safeOutboundRequest'];
+
+const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
 
 beforeAll(async () => {
+  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+  resetOutboundSsrfAllowListCacheForTests();
+
   const inlined = (await import(inlinedPath)) as InlinedSsrfModule;
   inlinedIsPrivateIp = inlined.isPrivateIp;
   inlinedNormalizeHostnameForLookup = inlined.normalizeHostnameForLookup;
   InlinedSsrfBlockedError = inlined.SsrfBlockedError;
+  inlinedSafeOutboundRequest = inlined.safeOutboundRequest;
+});
+
+afterAll(() => {
+  if (ORIGINAL_ALLOW === undefined) {
+    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+  } else {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
+  }
+
+  resetOutboundSsrfAllowListCacheForTests();
 });
 
 /**
@@ -82,5 +115,106 @@ describe('safe outbound HTTP — shared vs application-generic drift check', () 
       expect(inlinedErr.hostname).toBe(sharedErr.hostname);
       expect(inlinedErr.resolvedAddress).toBe(sharedErr.resolvedAddress);
     }
+  });
+
+  it('TRACE_PROPAGATION_HEADER_PATTERNS stay in lockstep with the inlined copy', () => {
+    const extract = (source: string, label: string) => {
+      const match = source.match(/const TRACE_PROPAGATION_HEADER_PATTERNS = \[[\s\S]*?\];/);
+      const block = match?.[0];
+
+      expect(block, `${label} is missing TRACE_PROPAGATION_HEADER_PATTERNS`).toBeTruthy();
+
+      return (block ?? '').replace(/\s+/g, '');
+    };
+
+    expect(extract(readFileSync(inlinedPath, 'utf8'), 'application-generic')).toBe(
+      extract(readFileSync(sharedSafeOutboundHttpPath, 'utf8'), 'shared')
+    );
+  });
+
+  describe('inlined safeOutboundRequest strips observability propagation headers', () => {
+    let upstream: http.Server;
+    let upstreamUrl: string;
+    let upstreamHits: Array<{ headers: http.IncomingHttpHeaders }> = [];
+
+    beforeEach(async () => {
+      upstreamHits = [];
+
+      upstream = http.createServer((req, res) => {
+        req.on('data', () => {
+          /* drain */
+        });
+        req.on('end', () => {
+          upstreamHits.push({ headers: req.headers });
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+        });
+      });
+
+      await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', () => resolve()));
+      const address = upstream.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Test upstream did not bind to a port');
+      }
+      upstreamUrl = `http://test-upstream.invalid:${address.port}`;
+    });
+
+    afterEach(async () => {
+      vi.restoreAllMocks();
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    });
+
+    it('drops trace-context headers while keeping application headers', async () => {
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+
+      await inlinedSafeOutboundRequest({
+        url: `${upstreamUrl}/webhook`,
+        method: 'POST',
+        headers: {
+          traceparent: '00-trace-span-01',
+          tracestate: 'vendor=value',
+          baggage: 'tenant=secret',
+          b3: 'trace-span-1',
+          'x-b3-traceid': 'trace',
+          'x-b3-spanid': 'span',
+          'x-b3-parentspanid': 'parent',
+          'x-b3-sampled': '1',
+          'x-b3-flags': '1',
+          newrelic: 'new-relic-payload',
+          'x-newrelic-id': 'legacy-new-relic-id',
+          'x-newrelic-transaction': 'legacy-new-relic-transaction',
+          'sentry-trace': 'sentry-payload',
+          'x-trace-id': 'application-trace-id',
+          'x-request-id': 'application-request-id',
+          authorization: 'Bearer application-token',
+        },
+        body: { ok: true },
+      });
+
+      expect(upstreamHits).toHaveLength(1);
+      const hit = upstreamHits[0];
+      expect(hit).toBeDefined();
+      if (!hit) {
+
+        return;
+      }
+
+      expect(hit.headers.traceparent).toBeUndefined();
+      expect(hit.headers.tracestate).toBeUndefined();
+      expect(hit.headers.baggage).toBeUndefined();
+      expect(hit.headers.b3).toBeUndefined();
+      expect(hit.headers['x-b3-traceid']).toBeUndefined();
+      expect(hit.headers['x-b3-spanid']).toBeUndefined();
+      expect(hit.headers['x-b3-parentspanid']).toBeUndefined();
+      expect(hit.headers['x-b3-sampled']).toBeUndefined();
+      expect(hit.headers['x-b3-flags']).toBeUndefined();
+      expect(hit.headers.newrelic).toBeUndefined();
+      expect(hit.headers['x-newrelic-id']).toBeUndefined();
+      expect(hit.headers['x-newrelic-transaction']).toBeUndefined();
+      expect(hit.headers['sentry-trace']).toBeUndefined();
+      expect(hit.headers['x-trace-id']).toBe('application-trace-id');
+      expect(hit.headers['x-request-id']).toBe('application-request-id');
+      expect(hit.headers.authorization).toBe('Bearer application-token');
+    });
   });
 });

--- a/packages/shared/src/utils/safe-outbound-http.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http.spec.ts
@@ -245,6 +245,54 @@ describe('safe-outbound-http', () => {
     });
   });
 
+  it('strips observability propagation headers while keeping application headers', async () => {
+    dnsLocalhost();
+
+    await safeOutboundRequest({
+      url: `${upstreamUrl}/webhook`,
+      method: 'POST',
+      headers: {
+        traceparent: '00-trace-span-01',
+        tracestate: 'vendor=value',
+        baggage: 'tenant=secret',
+        b3: 'trace-span-1',
+        'x-b3-traceid': 'trace',
+        'x-b3-spanid': 'span',
+        'x-b3-parentspanid': 'parent',
+        'x-b3-sampled': '1',
+        'x-b3-flags': '1',
+        newrelic: 'new-relic-payload',
+        'x-newrelic-id': 'legacy-new-relic-id',
+        'x-newrelic-transaction': 'legacy-new-relic-transaction',
+        'sentry-trace': 'sentry-payload',
+        'x-trace-id': 'application-trace-id',
+        'x-request-id': 'application-request-id',
+        authorization: 'Bearer application-token',
+      },
+      body: { ok: true },
+    });
+
+    expect(upstreamHits).toHaveLength(1);
+    const hit = upstreamHits[0]!;
+
+    expect(hit.headers.traceparent).toBeUndefined();
+    expect(hit.headers.tracestate).toBeUndefined();
+    expect(hit.headers.baggage).toBeUndefined();
+    expect(hit.headers.b3).toBeUndefined();
+    expect(hit.headers['x-b3-traceid']).toBeUndefined();
+    expect(hit.headers['x-b3-spanid']).toBeUndefined();
+    expect(hit.headers['x-b3-parentspanid']).toBeUndefined();
+    expect(hit.headers['x-b3-sampled']).toBeUndefined();
+    expect(hit.headers['x-b3-flags']).toBeUndefined();
+    expect(hit.headers.newrelic).toBeUndefined();
+    expect(hit.headers['x-newrelic-id']).toBeUndefined();
+    expect(hit.headers['x-newrelic-transaction']).toBeUndefined();
+    expect(hit.headers['sentry-trace']).toBeUndefined();
+    expect(hit.headers['x-trace-id']).toBe('application-trace-id');
+    expect(hit.headers['x-request-id']).toBe('application-request-id');
+    expect(hit.headers.authorization).toBe('Bearer application-token');
+  });
+
   describe('redirect handling', () => {
     it('re-runs the SSRF policy on every Location target', async () => {
       // Upstream returns a redirect to a publicly-validated host whose DNS now

--- a/packages/shared/src/utils/safe-outbound-http.ts
+++ b/packages/shared/src/utils/safe-outbound-http.ts
@@ -270,6 +270,8 @@ function performPinnedRequest(params: PinnedRequestParams): Promise<SafeOutbound
       res.on('error', reject);
     });
 
+    stripTracePropagationHeaders(req);
+
     req.on('timeout', () => {
       const timeoutError: NodeJS.ErrnoException = new Error(
         `Request to ${parsed.hostname} timed out after ${timeoutMs}ms.`
@@ -351,10 +353,29 @@ const SENSITIVE_HEADER_PATTERNS = [
   /-hmac/i,
 ];
 
+const TRACE_PROPAGATION_HEADER_PATTERNS = [
+  /^traceparent$/i,
+  /^tracestate$/i,
+  /^baggage$/i,
+  /^b3$/i,
+  /^x-b3-/i,
+  /^newrelic$/i,
+  /^x-newrelic-/i,
+  /^sentry-trace$/i,
+];
+
 function stripSensitiveHeaders(headers: Record<string, string | undefined>): void {
   for (const key of Object.keys(headers)) {
     if (SENSITIVE_HEADER_PATTERNS.some((re) => re.test(key))) {
       delete headers[key];
+    }
+  }
+}
+
+function stripTracePropagationHeaders(request: http.ClientRequest): void {
+  for (const header of request.getHeaderNames()) {
+    if (TRACE_PROPAGATION_HEADER_PATTERNS.some((re) => re.test(header))) {
+      request.removeHeader(header);
     }
   }
 }


### PR DESCRIPTION
## What changed? Why was the change needed?

Webhook and other customer-controlled outbound HTTP calls were forwarding OpenTelemetry / Sentry / New Relic / B3 propagation headers (`baggage`, `sentry-trace`, `traceparent`, `newrelic`, etc.). Those headers can leak tenant and internal tracing context to third-party endpoints.

This strips known trace-propagation headers from the **actual** `http.ClientRequest` after it is created in `safeOutboundRequest` (and the duplicated SSRF helper in `application-generic`). Stripping on the live request is required because instrumentation injects these headers at request-construction time, so removing them from the caller-supplied header map is not enough.

Application headers such as `x-request-id`, `x-trace-id`, and `Authorization` are left intact.

Linear: [NV-8509](https://linear.app/novu/issue/NV-8509/remove-baggage-and-sentry-trace-newrelic-fields-should-not-be)

```mermaid
sequenceDiagram
  participant Worker
  participant SafeOutbound as safeOutboundRequest
  participant OTel as Trace instrumentation
  participant Customer as Customer webhook

  Worker->>SafeOutbound: POST webhook URL
  SafeOutbound->>OTel: http.request()
  OTel-->>SafeOutbound: injects baggage, sentry-trace, newrelic, …
  SafeOutbound->>SafeOutbound: stripTracePropagationHeaders(req)
  SafeOutbound->>Customer: request without propagation headers
```

## Test plan

- [x] `packages/shared` unit spec asserts propagation headers are removed while `x-request-id`, `x-trace-id`, and `authorization` remain
- [ ] Trigger a chat/webhook channel delivery and confirm outbound request headers do not include `baggage`, `sentry-trace`, or `newrelic`
- [ ] Confirm customer-supplied webhook headers (auth, request id) still arrive

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

The same strip logic is duplicated in `libs/application-generic/src/utils/ssrf-url-validation.ts` to match the existing duplicated outbound HTTP path.

</details>

Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes observability propagation headers from both outbound HTTP implementations and adds shared and drift regression coverage.
- Filters W3C, B3, New Relic, and Sentry propagation headers from live `ClientRequest` objects.
- Preserves application headers such as authorization and request identifiers.
- Adds on-wire tests for both the shared implementation and the application-generic mirror, but the mirror test currently depends on prebuilt shared artifacts.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the new application-generic regression coverage can prevent the shared package’s standalone test suite from loading in a clean checkout.

The drift spec imports a module that requires compiled shared-package exports, while the package’s test command runs Vitest without producing those artifacts first.

**Files Needing Attention:** packages/shared/src/utils/safe-outbound-http-drift.spec.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/application-generic/src/utils/ssrf-url-validation.ts | Adds trace-propagation filtering to the duplicated pinned-request implementation. |
| packages/shared/src/utils/safe-outbound-http.ts | Removes known observability propagation headers from the live outbound request. |
| packages/shared/src/utils/safe-outbound-http.spec.ts | Verifies filtered and preserved headers against an on-wire request. |
| packages/shared/src/utils/safe-outbound-http-drift.spec.ts | Adds direct coverage for the application-generic mirror, but its dynamic import breaks standalone shared-package tests when dist has not already been built. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312435%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12435&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fshared%2Fsrc%2Futils%2Fsafe-outbound-http-drift.spec.ts%3A63%0A**Standalone%20test%20import%20fails**%0A%0AWhen%20the%20shared%20package's%20standalone%20%60test%60%20script%20runs%20in%20a%20clean%20checkout%2C%20this%20dynamic%20import%20loads%20a%20module%20whose%20%60%40novu%2Fshared%2Futils%2F*%60%20dependencies%20resolve%20to%20unbuilt%20%60dist%2Fcjs%60%20files%2C%20causing%20the%20suite%20to%20fail%20during%20initialization%20before%20the%20new%20regression%20coverage%20runs.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12435&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/utils/safe-outbound-http-drift.spec.ts:63
**Standalone test import fails**

When the shared package's standalone `test` script runs in a clean checkout, this dynamic import loads a module whose `@novu/shared/utils/*` dependencies resolve to unbuilt `dist/cjs` files, causing the suite to fail during initialization before the new regression coverage runs.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(shared): cover inlined outbound tra..."](https://github.com/novuhq/novu/commit/4abd34564a5849287f1388ad314a3a1d897869be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56201870)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->