### PR TITLE
feat(api-service): track agent assignment and origin hydration in Mixpanel fixes NV-8671

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts
@@ -55,7 +55,6 @@ describe('WorkflowOriginService', () => {
     };
     const analyticsService = {
       track: sinon.stub(),
-      mixpanelTrack: sinon.stub(),
     };
 
     const service = new WorkflowOriginService(
@@ -217,10 +216,6 @@ describe('WorkflowOriginService', () => {
         workflowIdentifier: 'order-alerts',
         platform: AgentPlatformEnum.SLACK,
       });
-      expect(analyticsService.mixpanelTrack.calledOnce).to.equal(true);
-      expect(analyticsService.mixpanelTrack.firstCall.args[0]).to.equal(
-        AGENTS_ORG_FUNNEL_EVENTS.WORKFLOW_ORIGIN_HYDRATED
-      );
     });
 
     it('keeps the origin re-derivable when the hydration marker write fails', async () => {
@@ -248,7 +243,6 @@ describe('WorkflowOriginService', () => {
       expect(conversationService.setNotificationId.calledOnce).to.equal(true);
       expect(target._notificationId).to.equal('notif1');
       expect(analyticsService.track.called).to.equal(false);
-      expect(analyticsService.mixpanelTrack.called).to.equal(false);
     });
   });
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts
@@ -1,4 +1,4 @@
-import { ChannelTypeEnum, ENDPOINT_TYPES } from '@novu/shared';
+import { AGENTS_ORG_FUNNEL_EVENTS, ChannelTypeEnum, ENDPOINT_TYPES } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
@@ -53,16 +53,29 @@ describe('WorkflowOriginService', () => {
       findOne: overrides.findOne ?? sinon.stub().resolves(null),
       find: overrides.find ?? sinon.stub().resolves([]),
     };
+    const analyticsService = {
+      track: sinon.stub(),
+      mixpanelTrack: sinon.stub(),
+    };
 
     const service = new WorkflowOriginService(
       logger as any,
       conversationService as any,
       subscriberRepository as any,
       notificationRepository as any,
-      messageRepository as any
+      messageRepository as any,
+      analyticsService as any
     );
 
-    return { service, logger, conversationService, subscriberRepository, notificationRepository, messageRepository };
+    return {
+      service,
+      logger,
+      conversationService,
+      subscriberRepository,
+      notificationRepository,
+      messageRepository,
+      analyticsService,
+    };
   }
 
   describe('Slack', () => {
@@ -158,7 +171,7 @@ describe('WorkflowOriginService', () => {
     });
 
     it('hydrates platform message id from the Slack identifier suffix', async () => {
-      const { service, conversationService, notificationRepository } = makeService({
+      const { service, conversationService, notificationRepository, analyticsService } = makeService({
         notificationFindOne: sinon.stub().resolves({ payload: { orderId: 'ORD-1' } }),
       });
 
@@ -192,10 +205,26 @@ describe('WorkflowOriginService', () => {
       expect(
         conversationService.setNotificationId.calledBefore(conversationService.persistWorkflowOriginHydration)
       ).to.equal(true);
+      expect(analyticsService.track.calledOnce).to.equal(true);
+      expect(analyticsService.track.firstCall.args[0]).to.equal(AGENTS_ORG_FUNNEL_EVENTS.WORKFLOW_ORIGIN_HYDRATED);
+      expect(analyticsService.track.firstCall.args[1]).to.equal('org1');
+      expect(analyticsService.track.firstCall.args[2]).to.include({
+        _organization: 'org1',
+        environmentId: 'env1',
+        agentId: 'agent1',
+        agentIdentifier: 'support-agent',
+        conversationId: 'conversation1',
+        workflowIdentifier: 'order-alerts',
+        platform: AgentPlatformEnum.SLACK,
+      });
+      expect(analyticsService.mixpanelTrack.calledOnce).to.equal(true);
+      expect(analyticsService.mixpanelTrack.firstCall.args[0]).to.equal(
+        AGENTS_ORG_FUNNEL_EVENTS.WORKFLOW_ORIGIN_HYDRATED
+      );
     });
 
     it('keeps the origin re-derivable when the hydration marker write fails', async () => {
-      const { service, conversationService } = makeService({
+      const { service, conversationService, analyticsService } = makeService({
         notificationFindOne: sinon.stub().resolves({ payload: { orderId: 'ORD-1' } }),
         persistWorkflowOriginHydration: sinon.stub().rejects(new Error('mongo timeout')),
       });
@@ -218,6 +247,8 @@ describe('WorkflowOriginService', () => {
       expect(snapshot).to.equal(null);
       expect(conversationService.setNotificationId.calledOnce).to.equal(true);
       expect(target._notificationId).to.equal('notif1');
+      expect(analyticsService.track.called).to.equal(false);
+      expect(analyticsService.mixpanelTrack.called).to.equal(false);
     });
   });
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { PinoLogger } from '@novu/application-generic';
+import { AnalyticsService, PinoLogger } from '@novu/application-generic';
 import {
   ConversationEntity,
   ConversationParticipantTypeEnum,
@@ -12,6 +12,7 @@ import { buildWorkflowOriginLine } from '@novu/framework/internal';
 import { ChannelTypeEnum, ENDPOINT_TYPES } from '@novu/shared';
 import type { Message } from 'chat';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
+import { trackWorkflowOriginHydrated } from '../../shared/analytics/agent-analytics';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
@@ -44,7 +45,8 @@ export class WorkflowOriginService {
     private readonly conversationService: AgentConversationService,
     private readonly subscriberRepository: SubscriberRepository,
     private readonly notificationRepository: NotificationRepository,
-    private readonly messageRepository: MessageRepository
+    private readonly messageRepository: MessageRepository,
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   async resolve(params: {
@@ -266,6 +268,17 @@ export class WorkflowOriginService {
           payload: data.payload,
         },
         ...(subscriberFirstName ? { subscriberFirstName } : {}),
+      });
+
+      trackWorkflowOriginHydrated(this.analyticsService, {
+        organizationId: config.organizationId,
+        environmentId: config.environmentId,
+        agentId,
+        agentIdentifier: config.agentIdentifier,
+        conversationId: conversation._id,
+        workflowIdentifier: data.workflowIdentifier,
+        platform: config.platform,
+        integrationIdentifier: config.integrationIdentifier,
       });
 
       return { data, source: 'hydrated' };

--- a/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts
@@ -9,10 +9,9 @@ import {
   SubscriberRepository,
 } from '@novu/dal';
 import { buildWorkflowOriginLine } from '@novu/framework/internal';
-import { ChannelTypeEnum, ENDPOINT_TYPES } from '@novu/shared';
+import { AGENTS_ORG_FUNNEL_EVENTS, ChannelTypeEnum, ENDPOINT_TYPES } from '@novu/shared';
 import type { Message } from 'chat';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
-import { trackWorkflowOriginHydrated } from '../../shared/analytics/agent-analytics';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
@@ -270,8 +269,8 @@ export class WorkflowOriginService {
         ...(subscriberFirstName ? { subscriberFirstName } : {}),
       });
 
-      trackWorkflowOriginHydrated(this.analyticsService, {
-        organizationId: config.organizationId,
+      this.analyticsService.track(AGENTS_ORG_FUNNEL_EVENTS.WORKFLOW_ORIGIN_HYDRATED, config.organizationId, {
+        _organization: config.organizationId,
         environmentId: config.environmentId,
         agentId,
         agentIdentifier: config.agentIdentifier,

--- a/apps/api/src/app/agents/shared/analytics/agent-analytics.ts
+++ b/apps/api/src/app/agents/shared/analytics/agent-analytics.ts
@@ -54,6 +54,34 @@ export function trackAgentCreated(
   });
 }
 
+export function trackWorkflowOriginHydrated(
+  analytics: AnalyticsService,
+  params: {
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    agentIdentifier: string;
+    conversationId: string;
+    workflowIdentifier: string;
+    platform: string;
+    integrationIdentifier?: string;
+  }
+): void {
+  const properties = {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    agentIdentifier: params.agentIdentifier,
+    conversationId: params.conversationId,
+    workflowIdentifier: params.workflowIdentifier,
+    platform: params.platform,
+    ...(params.integrationIdentifier ? { integrationIdentifier: params.integrationIdentifier } : {}),
+  };
+
+  analytics.track(AGENTS_ORG_FUNNEL_EVENTS.WORKFLOW_ORIGIN_HYDRATED, params.organizationId, properties);
+  analytics.mixpanelTrack(AGENTS_ORG_FUNNEL_EVENTS.WORKFLOW_ORIGIN_HYDRATED, params.organizationId, properties);
+}
+
 export function trackAgentIntegrationConnected(
   analytics: AnalyticsService,
   params: {

--- a/apps/api/src/app/agents/shared/analytics/agent-analytics.ts
+++ b/apps/api/src/app/agents/shared/analytics/agent-analytics.ts
@@ -54,34 +54,6 @@ export function trackAgentCreated(
   });
 }
 
-export function trackWorkflowOriginHydrated(
-  analytics: AnalyticsService,
-  params: {
-    organizationId: string;
-    environmentId: string;
-    agentId: string;
-    agentIdentifier: string;
-    conversationId: string;
-    workflowIdentifier: string;
-    platform: string;
-    integrationIdentifier?: string;
-  }
-): void {
-  const properties = {
-    _organization: params.organizationId,
-    environmentId: params.environmentId,
-    agentId: params.agentId,
-    agentIdentifier: params.agentIdentifier,
-    conversationId: params.conversationId,
-    workflowIdentifier: params.workflowIdentifier,
-    platform: params.platform,
-    ...(params.integrationIdentifier ? { integrationIdentifier: params.integrationIdentifier } : {}),
-  };
-
-  analytics.track(AGENTS_ORG_FUNNEL_EVENTS.WORKFLOW_ORIGIN_HYDRATED, params.organizationId, properties);
-  analytics.mixpanelTrack(AGENTS_ORG_FUNNEL_EVENTS.WORKFLOW_ORIGIN_HYDRATED, params.organizationId, properties);
-}
-
 export function trackAgentIntegrationConnected(
   analytics: AnalyticsService,
   params: {

--- a/apps/dashboard/src/components/workflow-editor/workflow-agent-assignment-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-agent-assignment-form.tsx
@@ -28,7 +28,9 @@ import { UpdateWorkflowFn } from '@/components/workflow-editor/workflow-provider
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useHasPermission } from '@/hooks/use-has-permission';
+import { useTelemetry } from '@/hooks/use-telemetry';
 import { buildRoute } from '@/utils/routes';
+import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
 
 const AGENT_TRIGGER_DOCS_URL = 'https://docs.novu.co/agents/get-started/mental-model';
@@ -45,6 +47,7 @@ type WorkflowAgentAssignmentFormProps = {
 export function WorkflowAgentAssignmentForm({ workflow, update, isReadOnly }: WorkflowAgentAssignmentFormProps) {
   const { currentEnvironment } = useEnvironment();
   const agentRoutes = useAgentRoutes();
+  const track = useTelemetry();
   const has = useHasPermission();
   const canReadAgents = has({ permission: PermissionsEnum.AGENT_READ });
   const canWriteWorkflow = has({ permission: PermissionsEnum.WORKFLOW_WRITE });
@@ -72,6 +75,15 @@ export function WorkflowAgentAssignmentForm({ workflow, update, isReadOnly }: Wo
   const hasNoAgents = !agentIdentifier && agentsPeekQuery.isSuccess && agentsPeekQuery.data.data.length === 0;
 
   const handleAgentChange = (nextIdentifier: string | null) => {
+    if (nextIdentifier && nextIdentifier !== agentIdentifier) {
+      track(TelemetryEvent.AGENT_ASSIGNED_TO_WORKFLOW, {
+        workflowId: workflow.workflowId,
+        workflowName: workflow.name,
+        agentIdentifier: nextIdentifier,
+        previousAgentIdentifier: agentIdentifier,
+      });
+    }
+
     update((current) => ({
       ...current,
       agent: nextIdentifier ? { identifier: nextIdentifier } : null,

--- a/apps/dashboard/src/utils/telemetry.ts
+++ b/apps/dashboard/src/utils/telemetry.ts
@@ -129,6 +129,7 @@ export enum TelemetryEvent {
   AGENTS_PAGE_VISITED = 'Agents page visited',
   AGENT_DETAILS_PAGE_VISITED = 'Agent details page visited',
   AGENT_CREATED_FROM_DASHBOARD = 'Agent created from dashboard',
+  AGENT_ASSIGNED_TO_WORKFLOW = 'Agent assigned to workflow',
   AGENT_DELETED_FROM_DASHBOARD = 'Agent deleted from dashboard',
   AGENT_INTEGRATION_LINKED_FROM_DASHBOARD = 'Agent integration linked from dashboard',
   AGENT_INTEGRATION_GUIDE_VIEWED = 'Agent integration setup guide viewed',

--- a/libs/application-generic/src/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -9,6 +9,7 @@ import {
   NotificationTemplateEntity,
 } from '@novu/dal';
 import {
+  AGENTS_ORG_FUNNEL_EVENTS,
   buildWorkflowPreferences,
   ControlValuesLevelEnum,
   ResourceOriginEnum,
@@ -116,6 +117,8 @@ export class UpsertWorkflowUseCase {
         skipPreferencesCache: true,
       })
     );
+
+    this.trackAgentAssignedToWorkflow(existingWorkflow, updatedWorkflow, resolvedCommand);
 
     if (existingWorkflow) {
       await this.sendWebhookMessage.execute({
@@ -678,5 +681,39 @@ export class UpsertWorkflowUseCase {
       origin: command.workflowDto.origin,
       source: command.workflowDto.__source,
     });
+  }
+
+  private trackAgentAssignedToWorkflow(
+    existingWorkflow: NotificationTemplateEntity | null,
+    updatedWorkflow: WorkflowResponseDto,
+    command: UpsertWorkflowCommand
+  ): void {
+    const nextAgentIdentifier = updatedWorkflow.agent?.identifier ?? null;
+    if (!nextAgentIdentifier) {
+      return;
+    }
+
+    const previousAgentIdentifier = existingWorkflow?.agent?.identifier ?? null;
+    if (nextAgentIdentifier === previousAgentIdentifier) {
+      return;
+    }
+
+    const userId = command.user?._id;
+    if (!userId) {
+      return;
+    }
+
+    const properties = {
+      _organization: command.user.organizationId,
+      environmentId: command.user.environmentId,
+      workflowId: updatedWorkflow.workflowId,
+      workflowName: updatedWorkflow.name,
+      agentIdentifier: nextAgentIdentifier,
+      previousAgentIdentifier,
+      source: command.workflowDto.__source,
+    };
+
+    this.analyticsService.track(AGENTS_ORG_FUNNEL_EVENTS.AGENT_ASSIGNED_TO_WORKFLOW, userId, properties);
+    this.analyticsService.mixpanelTrack(AGENTS_ORG_FUNNEL_EVENTS.AGENT_ASSIGNED_TO_WORKFLOW, userId, properties);
   }
 }

--- a/libs/application-generic/src/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -714,6 +714,5 @@ export class UpsertWorkflowUseCase {
     };
 
     this.analyticsService.track(AGENTS_ORG_FUNNEL_EVENTS.AGENT_ASSIGNED_TO_WORKFLOW, userId, properties);
-    this.analyticsService.mixpanelTrack(AGENTS_ORG_FUNNEL_EVENTS.AGENT_ASSIGNED_TO_WORKFLOW, userId, properties);
   }
 }

--- a/packages/shared/src/consts/agents-org-funnel.ts
+++ b/packages/shared/src/consts/agents-org-funnel.ts
@@ -2,11 +2,13 @@
  * Agents activation Mixpanel funnel (beginning of path). Identity is the acting
  * userId; `_organization` is attached for org-level filtering/breakdown.
  *
- * Create Organization → Agents Usecase Selected → Agent Created
+ * Create Organization → Agents Usecase Selected → Agent Created → Agent Assigned To Workflow → Workflow Origin Hydrated
  */
 export const AGENTS_ORG_FUNNEL_EVENTS = {
   USECASE_SELECTED: 'Agents Usecase Selected - [Agents]',
   AGENT_CREATED: 'Agent Created - [Agents]',
+  AGENT_ASSIGNED_TO_WORKFLOW: 'Agent Assigned To Workflow - [Agents]',
+  WORKFLOW_ORIGIN_HYDRATED: 'Workflow Origin Hydrated - [Agents]',
 } as const;
 
 export type AgentsOrgFunnelEvent = (typeof AGENTS_ORG_FUNNEL_EVENTS)[keyof typeof AGENTS_ORG_FUNNEL_EVENTS];


### PR DESCRIPTION
## Summary

- Extends the agents Mixpanel activation funnel with **Agent Assigned To Workflow** when a workflow's assigned agent actually changes (dashboard picker + persist path).
- Fires **Workflow Origin Hydrated** only after workflow-origin hydration persist succeeds, not on failed marker writes.
- Shared event names live in `AGENTS_ORG_FUNNEL_EVENTS` so dashboard, API, and Mixpanel stay aligned.

Linear: https://linear.app/novu/issue/NV-8671/track-mixpanel-events-for-agent-to-workflow-assignment-and-successful

```mermaid
flowchart LR
  A[Agent Created] --> B[Agent Assigned To Workflow]
  B --> C[Workflow Origin Hydrated]
```

## Test plan

- [ ] Assign an agent on a workflow in the dashboard and confirm Mixpanel receives `Agent assigned to workflow - [DASHBOARD]` plus `Agent Assigned To Workflow - [Agents]`
- [ ] Save the same workflow again without changing the agent and confirm assignment events do not fire
- [ ] Reply on a thread whose origin hydrates successfully and confirm `Workflow Origin Hydrated - [Agents]`
- [ ] Force a failed hydration persist and confirm the hydration event does not fire
- [ ] `apps/api` unit spec `workflow-origin.service.spec.ts` (run with `NODE_ENV=test` and mocha `--no-config`)


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends the agent activation funnel with workflow-assignment and successful origin-hydration events while centralizing the shared event names.
- Tracks changed agent assignments from the dashboard and persisted workflow upsert path.
- Emits origin-hydration telemetry only after its persistence marker succeeds.
- Adds API coverage for successful and failed hydration persistence.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.ts | Emits the shared origin-hydrated funnel event after successful hydration-marker persistence. |
| apps/api/src/app/agents/conversation-runtime/ingress/workflow-origin.service.spec.ts | Verifies telemetry emission after successful persistence and suppression after persistence failure. |
| apps/dashboard/src/components/workflow-editor/workflow-agent-assignment-form.tsx | Records dashboard telemetry when the selected agent changes to a non-null identifier. |
| libs/application-generic/src/usecases/upsert-workflow/upsert-workflow.usecase.ts | Records the shared assignment event after workflow persistence when the assigned agent actually changed. |
| packages/shared/src/consts/agents-org-funnel.ts | Adds shared names for workflow-assignment and origin-hydration funnel events. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Dashboard agent selection] --> B[Workflow update]
  B --> C[Persist assigned agent]
  C --> D[Agent Assigned To Workflow event]
  D --> E[Conversation origin hydration]
  E --> F[Persist hydration marker]
  F --> G[Workflow Origin Hydrated event]
```

<sub>Reviews (2): Last reviewed commit: ["Remove Mixpanel tracking from agent funn..."](https://github.com/novuhq/novu/commit/868206653acc19323f47cdea70baf21d33badf88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56230787)</sub>

<!-- /greptile_comment -->