### PR TITLE
feat(worker, application-generic): implement partial send error handling and retry logic fixes NV-8672 

### DIFF
--- a/apps/worker/src/app/workflow/services/standard.worker.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.ts
@@ -3,6 +3,7 @@ import {
   BullMqService,
   FeatureFlagsService,
   getStandardWorkerOptions,
+  ISqsFailureOutcome,
   IStandardDataDto,
   isWebhookFilterSsrfBlockedError,
   Job,
@@ -87,21 +88,27 @@ export class StandardWorker extends StandardWorkerService {
      *     `createSqsJobAdapter`, so `jobHasFailed` evaluates
      *     `hasReachedMaxAttempts` against the same `DEFAULT_ATTEMPTS`
      *     ceiling used for webhook-filter jobs.
-     *   - Returning `true` re-throws and SQS keeps the message, which
-     *     becomes visible again after the consumer-wide visibility
-     *     timeout (`SQS_DEFAULT_VISIBILITY_TIMEOUT`, env-tunable).
-     *   - Returning `false` acks and SQS deletes the message.
+     *   - Returning `retry: true` re-throws and SQS keeps the message.
+     *   - Returning `retry: false` acks and SQS deletes the message.
      *   - `RedrivePolicy.maxReceiveCount=3` on the standard SQS queue
      *     caps total deliveries to match the `attempts: 3` ceiling for
      *     webhook-filter jobs. Non-webhook-filter failures hit
      *     `hasToBackoff=false` and ack on the first attempt.
      *
-     * Cadence between retries is uniform (the SQS visibility timeout);
-     * tune via env if a longer baseline is needed.
+     * `retryDelayMs` restores the per-attempt cadence BullMQ gets from
+     * `settings.backoffStrategy`, which never applied on the SQS path.
      */
-    this.setSqsFailedHandler(async (job: Job<IStandardDataDto, void, string>, error: Error): Promise<boolean> => {
-      return await this.jobHasFailed(job, error);
-    });
+    this.setSqsFailedHandler(
+      async (job: Job<IStandardDataDto, void, string>, error: Error): Promise<ISqsFailureOutcome> => {
+        const retry = await this.jobHasFailed(job, error);
+
+        if (!retry) {
+          return { retry: false };
+        }
+
+        return { retry: true, retryDelayMs: await this.resolveSqsRetryDelay(job, error) };
+      }
+    );
 
     this.startSqsConsumer();
   }
@@ -307,18 +314,49 @@ export class StandardWorker extends StandardWorkerService {
     }
   }
 
+  /**
+   * Resolves the delay before the next attempt, and as a side effect writes the
+   * `WEBHOOK_FILTER_FAILED_RETRY` execution detail into the activity feed.
+   */
+  private async executeBackoffStrategy(attemptsMade: number, eventError: Error, eventJob: Job): Promise<number> {
+    return await this.webhookFilterBackoffStrategy.execute({
+      attemptsMade,
+      environmentId: eventJob?.data?._environmentId,
+      eventError,
+      eventJob,
+      organizationId: eventJob?.data?._organizationId,
+      userId: eventJob?.data?._userId,
+    });
+  }
+
   private getBackoffStrategies = () => {
     return async (attemptsMade: number, type: string, eventError: Error, eventJob: Job): Promise<number> => {
-      return await this.webhookFilterBackoffStrategy.execute({
-        attemptsMade,
-        environmentId: eventJob?.data?._environmentId,
-        eventError,
-        eventJob,
-        organizationId: eventJob?.data?._organizationId,
-        userId: eventJob?.data?._userId,
-      });
+      return await this.executeBackoffStrategy(attemptsMade, eventError, eventJob);
     };
   };
+
+  /**
+   * The SQS counterpart to `settings.backoffStrategy`, which BullMQ invokes
+   * between retries but which never ran on the SQS path.
+   *
+   * Only reached when `jobHasFailed` returned true, and that requires
+   * `shouldBackoff` - i.e. a retryable webhook filter error - so this matches
+   * BullMQ, where `options.backoff` is set only for webhook-filter steps.
+   */
+  private async resolveSqsRetryDelay(job: Job, error: Error): Promise<number | undefined> {
+    try {
+      return await this.executeBackoffStrategy(job.attemptsMade, error, job);
+    } catch (backoffError) {
+      Logger.error(
+        backoffError,
+        `Failed to resolve the SQS retry delay for job ${job.data?._id}, falling back to the visibility timeout`,
+        LOG_CONTEXT
+      );
+
+      // Undefined, not 0: 0 would mean "retry immediately".
+      return undefined;
+    }
+  }
 
   private async organizationExist(data: IStandardDataDto): Promise<boolean> {
     const { _organizationId } = data;

--- a/libs/application-generic/src/services/queues/queue-base.service.spec.ts
+++ b/libs/application-generic/src/services/queues/queue-base.service.spec.ts
@@ -5,7 +5,7 @@ import { PinoLogger } from '../../logging';
 import { BullMqService } from '../bull-mq';
 import { FeatureFlagsService } from '../feature-flags';
 import { DeferReasonEnum, EventBridgeSchedulerService } from '../scheduler';
-import { SqsService } from '../sqs';
+import { SqsPartialSendError, SqsService } from '../sqs';
 import { SQS_MAX_DELAY_SECONDS } from '../sqs/types';
 import { QueueBaseService } from './queue-base.service';
 
@@ -239,6 +239,100 @@ describe('QueueBaseService long-delay routing', () => {
       expect(scheduler.createDelayedFire).not.toHaveBeenCalled();
       expect(bullMq.add).toHaveBeenCalledTimes(1);
       expect(sqs.send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('partial SQS sends', () => {
+    function shortJob(id: string) {
+      return longDelayJob({
+        name: id,
+        data: { _id: id, _organizationId: ORGANIZATION_ID },
+        options: { delay: SHORT_DELAY_MS, jobId: id },
+      });
+    }
+
+    /** Message ids are assigned by `addJobsToSQS` as `${groupId}-${index}`. */
+    function unsentMessage(index: number) {
+      return { id: `${ORGANIZATION_ID}-${index}`, body: '{}', groupId: ORGANIZATION_ID };
+    }
+
+    it('should re-queue only the undelivered jobs in COMPLETE mode', async () => {
+      const { service, bullMq, sqs } = buildHarness();
+      sqs.sendBulk.mockRejectedValueOnce(
+        new SqsPartialSendError([unsentMessage(2)], 2, new Error('BatchRequestTooLong'))
+      );
+
+      await service.addBulk([shortJob('a'), shortJob('b'), shortJob('c')] as never);
+
+      expect(bullMq.addBulk).not.toHaveBeenCalled();
+      expect(bullMq.add).toHaveBeenCalledTimes(1);
+      expect(bullMq.add.mock.calls[0][1]).toMatchObject({ _id: 'c' });
+    });
+
+    it('should re-queue only the undelivered jobs in LIVE mode', async () => {
+      const { service, bullMq, sqs } = buildHarness({ backendMode: QueueBackendMode.LIVE });
+      sqs.sendBulk.mockRejectedValueOnce(
+        new SqsPartialSendError([unsentMessage(0), unsentMessage(2)], 1, new Error('BatchRequestTooLong'))
+      );
+
+      await service.addBulk([shortJob('a'), shortJob('b'), shortJob('c')] as never);
+
+      expect(bullMq.addBulk).toHaveBeenCalledTimes(1);
+      expect(bullMq.addBulk.mock.calls[0][0].map((job: { data: { _id: string } }) => job.data._id)).toEqual(['a', 'c']);
+    });
+
+    it('should re-queue every job when the failure does not identify the undelivered ones', async () => {
+      const { service, bullMq, sqs } = buildHarness();
+      sqs.sendBulk.mockRejectedValueOnce(new Error('AWS.SimpleQueueService.NonExistentQueue'));
+
+      await service.addBulk([shortJob('a'), shortJob('b'), shortJob('c')] as never);
+
+      expect(bullMq.addBulk).toHaveBeenCalledTimes(1);
+      expect(bullMq.addBulk.mock.calls[0][0]).toHaveLength(3);
+    });
+
+    it('should not re-queue already-scheduled jobs when the SQS leg fails without naming messages', async () => {
+      const { service, bullMq, sqs, scheduler } = buildHarness();
+      scheduler.createDelayedFire.mockResolvedValueOnce(undefined);
+      // A plain error: the single-message path, or an S3 offload failure.
+      sqs.send.mockRejectedValueOnce(new Error('ThrottlingException'));
+
+      await service.addBulk([
+        longDelayJob({ name: 'long-a', data: { _id: 'long-a', _organizationId: ORGANIZATION_ID } }),
+        shortJob('short-b'),
+      ] as never);
+
+      expect(scheduler.createDelayedFire).toHaveBeenCalledTimes(1);
+      // `long-a` was accepted by EventBridge; replaying it would double-fire it.
+      expect(bullMq.addBulk).not.toHaveBeenCalled();
+      expect(bullMq.add).toHaveBeenCalledTimes(1);
+      expect(bullMq.add.mock.calls[0][1]).toMatchObject({ _id: 'short-b' });
+    });
+
+    it('should not touch BullMQ when every message was delivered', async () => {
+      const { service, bullMq } = buildHarness();
+
+      await service.addBulk([shortJob('a'), shortJob('b'), shortJob('c')] as never);
+
+      expect(bullMq.add).not.toHaveBeenCalled();
+      expect(bullMq.addBulk).not.toHaveBeenCalled();
+    });
+
+    it('should re-queue only the jobs the scheduler rejected, plus the ones never attempted', async () => {
+      const { service, bullMq, scheduler } = buildHarness();
+      scheduler.createDelayedFire.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('Throttling'));
+
+      await service.addBulk([
+        longDelayJob({ name: 'long-a', data: { _id: 'long-a', _organizationId: ORGANIZATION_ID } }),
+        longDelayJob({ name: 'long-b', data: { _id: 'long-b', _organizationId: ORGANIZATION_ID } }),
+        shortJob('short-c'),
+      ] as never);
+
+      expect(bullMq.addBulk).toHaveBeenCalledTimes(1);
+      expect(bullMq.addBulk.mock.calls[0][0].map((job: { data: { _id: string } }) => job.data._id)).toEqual([
+        'long-b',
+        'short-c',
+      ]);
     });
   });
 });

--- a/libs/application-generic/src/services/queues/queue-base.service.ts
+++ b/libs/application-generic/src/services/queues/queue-base.service.ts
@@ -6,10 +6,78 @@ import { PinoLogger } from '../../logging';
 import { BulkJobOptions, BullMqService, JobsOptions, Queue, QueueOptions } from '../bull-mq';
 import { FeatureFlagsService } from '../feature-flags';
 import { DeferReasonEnum, EventBridgeSchedulerService } from '../scheduler';
-import { SqsService } from '../sqs';
+import { isSqsPartialSendError, SqsService } from '../sqs';
 import { SQS_MAX_DELAY_SECONDS } from '../sqs/types';
 
 const LOG_CONTEXT = 'QueueService';
+
+/**
+ * Carries the jobs that never reached SQS (or the scheduler) so a fallback can
+ * re-queue exactly those. Without it a mid-batch failure forces the caller to
+ * re-send everything, double-delivering whatever SQS already accepted.
+ */
+class PartialDispatchError extends Error {
+  constructor(
+    public readonly unsentJobs: (IJobParams | IBulkJobParams)[],
+    public readonly cause: unknown
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = 'PartialDispatchError';
+  }
+}
+
+/**
+ * Names to alert on, outermost first. The chain is two deep for the common case
+ * (`PartialDispatchError` -> `SqsPartialSendError` -> `BatchRequestTooLong`),
+ * so a single unwrap would surface only our own wrapper and never the AWS error
+ * that actually explains the failure.
+ */
+function resolveErrorNames(error: unknown): string | undefined {
+  const names: string[] = [];
+
+  for (let current = error; current instanceof Error; current = (current as { cause?: unknown }).cause) {
+    names.push(current.name);
+  }
+
+  return names.length > 0 ? names.join(' <- ') : undefined;
+}
+
+/**
+ * The jobs to hand back to the fallback after a failed SQS send.
+ *
+ * A partial send names the messages it did not deliver; anything else tells us
+ * nothing, so we assume the whole SQS leg failed. Either way the result is
+ * scoped to `sqsEligible` - never the caller's full job list, which may include
+ * schedules that were already accepted.
+ */
+function resolveUnsentJobs(
+  error: unknown,
+  sqsEligible: (IJobParams | IBulkJobParams)[],
+  jobsByMessageId: Map<string, IJobParams | IBulkJobParams>
+): (IJobParams | IBulkJobParams)[] {
+  if (!isSqsPartialSendError(error)) {
+    return sqsEligible;
+  }
+
+  const unsentJobs = error.unsentMessages.map((message) => jobsByMessageId.get(message.id));
+
+  /*
+   * Ids are assigned and mapped in the same pass, so a miss is impossible
+   * today. Fail open rather than filtering: re-queuing a job that SQS already
+   * accepted is recoverable, silently dropping one is not.
+   */
+  if (unsentJobs.some((job) => job === undefined)) {
+    Logger.error(
+      { unsentCount: error.unsentMessages.length, eligibleCount: sqsEligible.length },
+      'Could not map every unsent SQS message back to its job, re-queuing the full batch',
+      LOG_CONTEXT
+    );
+
+    return sqsEligible;
+  }
+
+  return unsentJobs as (IJobParams | IBulkJobParams)[];
+}
 
 type OrganizationRouting = { _id: string; apiServiceLevel?: ApiServiceLevelEnum };
 
@@ -303,17 +371,7 @@ export class QueueBaseService implements OnModuleDestroy {
             );
           }
         } catch (error) {
-          Logger.error(
-            {
-              topic: this.topic,
-              count: jobs.length,
-              error: error instanceof Error ? error.message : String(error),
-              stack: error instanceof Error ? error.stack : undefined,
-            },
-            'SQS failed in LIVE mode, falling back to BullMQ as primary',
-            LOG_CONTEXT
-          );
-          await this.addJobsToBullMQ(jobs);
+          await this.fallbackToBullMQ(error, jobs, 'SQS failed in LIVE mode, falling back to BullMQ as primary');
         }
         break;
       }
@@ -322,18 +380,7 @@ export class QueueBaseService implements OnModuleDestroy {
         try {
           return await this.addJobsToSQS(jobs, organizationId);
         } catch (error) {
-          // SQS failed in COMPLETE mode - fall back to BullMQ for resilience
-          Logger.error(
-            {
-              topic: this.topic,
-              count: jobs.length,
-              error: error instanceof Error ? error.message : String(error),
-              stack: error instanceof Error ? error.stack : undefined,
-            },
-            'SQS failed in COMPLETE mode, falling back to BullMQ',
-            LOG_CONTEXT
-          );
-          return await this.addJobsToBullMQ(jobs);
+          return await this.fallbackToBullMQ(error, jobs, 'SQS failed in COMPLETE mode, falling back to BullMQ');
         }
       }
 
@@ -341,6 +388,36 @@ export class QueueBaseService implements OnModuleDestroy {
         Logger.warn({ mode: queueBackendMode }, 'Unknown queue backend mode, falling back to BullMQ', LOG_CONTEXT);
         return await this.addJobsToBullMQ(jobs);
     }
+  }
+
+  /**
+   * Hand the jobs SQS did not take over to BullMQ.
+   *
+   * Only the undelivered jobs are re-queued when the failure identified them,
+   * which is what stops a mid-batch failure from double-delivering everything
+   * SQS already accepted.
+   */
+  private async fallbackToBullMQ(error: unknown, jobs: (IJobParams | IBulkJobParams)[], reason: string): Promise<void> {
+    const fallbackJobs = error instanceof PartialDispatchError ? error.unsentJobs : jobs;
+
+    Logger.error(
+      {
+        topic: this.topic,
+        count: jobs.length,
+        fallbackCount: fallbackJobs.length,
+        error: error instanceof Error ? error.message : String(error),
+        errorName: resolveErrorNames(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+      reason,
+      LOG_CONTEXT
+    );
+
+    if (fallbackJobs.length === 0) {
+      return;
+    }
+
+    await this.addJobsToBullMQ(fallbackJobs);
   }
 
   private toBulkJobParams(jobs: (IJobParams | IBulkJobParams)[]): IBulkJobParams[] {
@@ -370,34 +447,63 @@ export class QueueBaseService implements OnModuleDestroy {
     const { longDelayed, sqsEligible } = this.separateByDelay(jobs);
 
     if (longDelayed.length > 0) {
-      await this.addJobsToScheduler(longDelayed, organizationId);
+      try {
+        await this.addJobsToScheduler(longDelayed, organizationId);
+      } catch (error) {
+        /*
+         * Nothing has been sent to SQS yet, so the eligible jobs are unsent too
+         * - they are never attempted once this throws.
+         */
+        const unsentScheduled = error instanceof PartialDispatchError ? error.unsentJobs : longDelayed;
+        throw new PartialDispatchError([...unsentScheduled, ...sqsEligible], error);
+      }
     }
 
     if (sqsEligible.length === 0) {
       return;
     }
 
-    const messages = sqsEligible.map((job, index) => ({
-      id: `${job.groupId || job.name}-${index}`,
-      body: JSON.stringify(job.data || {}),
-      groupId: organizationId,
-      delaySeconds: Math.ceil((job.options?.delay || 0) / 1000),
-    }));
+    /*
+     * Keep the id -> job mapping rather than parsing the id back apart: it is
+     * how a partial send is translated into the exact jobs to re-queue.
+     */
+    const jobsByMessageId = new Map<string, IJobParams | IBulkJobParams>();
+    const messages = sqsEligible.map((job, index) => {
+      const id = `${job.groupId || job.name}-${index}`;
+      jobsByMessageId.set(id, job);
 
-    if (messages.length === 1) {
-      await this.sqsService.send(this.topic, messages[0]);
-      Logger.debug(
-        {
-          topic: this.topic,
-          jobName: sqsEligible[0].name,
-          payloadSizeBytes: this.calculatePayloadSize(sqsEligible[0].data),
-        },
-        'Added job to SQS',
-        LOG_CONTEXT
-      );
-    } else {
-      await this.sqsService.sendBulk(this.topic, messages);
-      Logger.debug({ topic: this.topic, count: messages.length }, 'Added bulk jobs to SQS', LOG_CONTEXT);
+      return {
+        id,
+        body: JSON.stringify(job.data || {}),
+        groupId: organizationId,
+        delaySeconds: Math.ceil((job.options?.delay || 0) / 1000),
+      };
+    });
+
+    try {
+      if (messages.length === 1) {
+        await this.sqsService.send(this.topic, messages[0]);
+        Logger.debug(
+          {
+            topic: this.topic,
+            jobName: sqsEligible[0].name,
+            payloadSizeBytes: this.calculatePayloadSize(sqsEligible[0].data),
+          },
+          'Added job to SQS',
+          LOG_CONTEXT
+        );
+      } else {
+        await this.sqsService.sendBulk(this.topic, messages);
+        Logger.debug({ topic: this.topic, count: messages.length }, 'Added bulk jobs to SQS', LOG_CONTEXT);
+      }
+    } catch (error) {
+      /*
+       * Scope the fallback to the SQS leg even when the error does not name the
+       * undelivered messages. Anything already handed to the scheduler above
+       * has been accepted, so replaying the whole `jobs` array here would fire
+       * those a second time - once via EventBridge and once via BullMQ.
+       */
+      throw new PartialDispatchError(resolveUnsentJobs(error, sqsEligible, jobsByMessageId), error);
     }
   }
 
@@ -413,7 +519,7 @@ export class QueueBaseService implements OnModuleDestroy {
 
     const now = Date.now();
 
-    await Promise.all(
+    const results = await Promise.allSettled(
       jobs.map((job) =>
         this.schedulerService.createDelayedFire(this.topic, {
           deferReason: job.deferReason || DeferReasonEnum.DELAY,
@@ -424,6 +530,28 @@ export class QueueBaseService implements OnModuleDestroy {
         })
       )
     );
+
+    const rejected = results.flatMap((result, index) => (result.status === 'rejected' ? [{ result, index }] : []));
+
+    if (rejected.length > 0) {
+      Logger.error(
+        {
+          topic: this.topic,
+          organizationId,
+          totalCount: jobs.length,
+          scheduledCount: jobs.length - rejected.length,
+          unscheduledCount: rejected.length,
+          error: rejected.map(({ result }) => String(result.reason)).join('; '),
+        },
+        'Some long-delayed jobs could not be scheduled',
+        LOG_CONTEXT
+      );
+
+      throw new PartialDispatchError(
+        rejected.map(({ index }) => jobs[index]),
+        rejected[0].result.reason
+      );
+    }
 
     Logger.log(
       { topic: this.topic, count: jobs.length, organizationId },

--- a/libs/application-generic/src/services/sqs/index.ts
+++ b/libs/application-generic/src/services/sqs/index.ts
@@ -1,5 +1,7 @@
 export * from './sqs.service';
 export * from './sqs-consumer.service';
 export * from './sqs-job-adapter';
+export * from './sqs-partial-send.error';
 export * from './sqs-payload-offload.service';
+export * from './sqs-retry.error';
 export * from './types';

--- a/libs/application-generic/src/services/sqs/sqs-consumer.service.spec.ts
+++ b/libs/application-generic/src/services/sqs/sqs-consumer.service.spec.ts
@@ -1,0 +1,225 @@
+import { ChangeMessageVisibilityCommand, DeleteMessageCommand, type Message } from '@aws-sdk/client-sqs';
+import { JobTopicNameEnum } from '@novu/shared';
+import { SqsService } from './sqs.service';
+import { SqsConsumerService, SqsMessageProcessor } from './sqs-consumer.service';
+import { SQS_LARGE_PAYLOAD_MARKER } from './sqs-payload-offload.service';
+import { SqsRetryError } from './sqs-retry.error';
+import { SQS_MAX_VISIBILITY_RENEWAL_MS } from './types';
+
+type ConsumerConfig = {
+  handleMessage: (message: Message) => Promise<Message>;
+};
+
+let capturedConfig: ConsumerConfig;
+
+jest.mock('sqs-consumer', () => ({
+  Consumer: {
+    create: jest.fn((config: ConsumerConfig) => {
+      capturedConfig = config;
+
+      return { on: jest.fn(), start: jest.fn(), stop: jest.fn() };
+    }),
+  },
+}));
+
+const VISIBILITY_TIMEOUT = 90;
+const HEARTBEAT_INTERVAL_MS = (VISIBILITY_TIMEOUT * 1000) / 2;
+
+const mockClientSend = jest.fn();
+const mockMaybeResolve = jest.fn();
+
+function buildMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    MessageId: 'msg-1',
+    ReceiptHandle: 'receipt-1',
+    Body: JSON.stringify({ _id: 'job-1', _organizationId: 'org-1' }),
+    Attributes: { ApproximateReceiveCount: '1', MessageGroupId: 'org-1' },
+    ...overrides,
+  };
+}
+
+function buildSqsService(withOffload: boolean): SqsService {
+  return {
+    getQueueUrl: () => 'https://sqs.eu-west-1.amazonaws.com/1/standard',
+    getClient: () => ({ send: mockClientSend }),
+    getPayloadOffloadService: () => (withOffload ? { maybeResolve: mockMaybeResolve } : undefined),
+  } as unknown as SqsService;
+}
+
+function createConsumer(processor: SqsMessageProcessor, withOffload = false): SqsConsumerService {
+  return new SqsConsumerService(JobTopicNameEnum.STANDARD, buildSqsService(withOffload), processor, undefined, {
+    visibilityTimeout: VISIBILITY_TIMEOUT,
+  });
+}
+
+/** Let queued microtasks run without advancing any timers. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 10; i += 1) {
+    // eslint-disable-next-line no-await-in-loop -- draining the microtask queue is inherently serial
+    await Promise.resolve();
+  }
+}
+
+function commandCalls(commandType: unknown): unknown[] {
+  return mockClientSend.mock.calls
+    .map(([command]) => command)
+    .filter((command) => command instanceof (commandType as never));
+}
+
+describe('SqsConsumerService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset so a failed createConsumer cannot leave the previous test's handler
+    // in place and make the next one pass for the wrong reason.
+    capturedConfig = undefined as unknown as ConsumerConfig;
+    mockClientSend.mockResolvedValue({});
+    mockMaybeResolve.mockImplementation(async (body: string) => body);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('visibility heartbeat ordering', () => {
+    it('should have cleared the heartbeat while the delete is still in flight', async () => {
+      jest.useFakeTimers();
+
+      let finishProcessing: () => void = () => {};
+      const processing = new Promise<void>((resolve) => {
+        finishProcessing = resolve;
+      });
+
+      let finishDelete: () => void = () => {};
+      mockClientSend.mockImplementation((command: unknown) => {
+        if (command instanceof DeleteMessageCommand) {
+          return new Promise((resolve) => {
+            finishDelete = () => resolve({});
+          });
+        }
+
+        return Promise.resolve({});
+      });
+
+      createConsumer(async () => processing);
+      await capturedConfig.handleMessage(buildMessage());
+      await flushMicrotasks();
+
+      finishProcessing();
+      await flushMicrotasks();
+
+      // The delete is in flight; this is exactly the window the heartbeat used
+      // to tick into and fail with "Message does not exist".
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 3);
+      await flushMicrotasks();
+
+      expect(commandCalls(ChangeMessageVisibilityCommand)).toHaveLength(0);
+      expect(commandCalls(DeleteMessageCommand)).toHaveLength(1);
+
+      finishDelete();
+      await flushMicrotasks();
+    });
+
+    it('should extend visibility while the processor is still running', async () => {
+      jest.useFakeTimers();
+
+      createConsumer(async () => new Promise<void>(() => {}));
+      await capturedConfig.handleMessage(buildMessage());
+      await flushMicrotasks();
+
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 2);
+      await flushMicrotasks();
+
+      expect(commandCalls(ChangeMessageVisibilityCommand)).toHaveLength(2);
+    });
+
+    it('should stop extending once the maximum renewal window is exceeded', async () => {
+      jest.useFakeTimers();
+
+      createConsumer(async () => new Promise<void>(() => {}));
+      await capturedConfig.handleMessage(buildMessage());
+      await flushMicrotasks();
+
+      jest.advanceTimersByTime(SQS_MAX_VISIBILITY_RENEWAL_MS);
+      await flushMicrotasks();
+
+      const extensionsAtCap = commandCalls(ChangeMessageVisibilityCommand).length;
+      expect(extensionsAtCap).toBeGreaterThan(0);
+
+      // The behaviour that matters: past the cap the interval is cleared and
+      // nothing further is sent, however many ticks fit before it.
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 20);
+      await flushMicrotasks();
+
+      expect(commandCalls(ChangeMessageVisibilityCommand)).toHaveLength(extensionsAtCap);
+    });
+  });
+
+  describe('retry backoff', () => {
+    it('should shorten visibility to the requested delay on SqsRetryError', async () => {
+      createConsumer(async () => {
+        throw new SqsRetryError(new Error('webhook filter failed'), 4_000);
+      });
+
+      await capturedConfig.handleMessage(buildMessage());
+      await flushMicrotasks();
+
+      const [command] = commandCalls(ChangeMessageVisibilityCommand) as ChangeMessageVisibilityCommand[];
+      expect(command.input.VisibilityTimeout).toBe(4);
+      expect(commandCalls(DeleteMessageCommand)).toHaveLength(0);
+    });
+
+    it('should clamp a delay beyond the AWS maximum', async () => {
+      createConsumer(async () => {
+        throw new SqsRetryError(new Error('boom'), 99_999_000);
+      });
+
+      await capturedConfig.handleMessage(buildMessage());
+      await flushMicrotasks();
+
+      const [command] = commandCalls(ChangeMessageVisibilityCommand) as ChangeMessageVisibilityCommand[];
+      expect(command.input.VisibilityTimeout).toBe(43_200);
+    });
+
+    it('should leave visibility untouched for a plain failure', async () => {
+      createConsumer(async () => {
+        throw new Error('boom');
+      });
+
+      await capturedConfig.handleMessage(buildMessage());
+      await flushMicrotasks();
+
+      expect(commandCalls(ChangeMessageVisibilityCommand)).toHaveLength(0);
+      expect(commandCalls(DeleteMessageCommand)).toHaveLength(0);
+    });
+  });
+
+  describe('offloaded payloads', () => {
+    it('should fail rather than hand an unresolved S3 pointer to the processor', async () => {
+      const processor = jest.fn();
+      const pointer = JSON.stringify({ [SQS_LARGE_PAYLOAD_MARKER]: { bucket: 'b', key: 'k' } });
+      // A consumer without the bucket configured returns the body untouched.
+      mockMaybeResolve.mockImplementation(async (body: string) => body);
+
+      createConsumer(processor, true);
+      await capturedConfig.handleMessage(buildMessage({ Body: pointer }));
+      await flushMicrotasks();
+
+      expect(processor).not.toHaveBeenCalled();
+      // Not deleted, so SQS redelivers and the message eventually reaches the DLQ.
+      expect(commandCalls(DeleteMessageCommand)).toHaveLength(0);
+    });
+
+    it('should process a pointer that resolves successfully', async () => {
+      const processor = jest.fn().mockResolvedValue(undefined);
+      const pointer = JSON.stringify({ [SQS_LARGE_PAYLOAD_MARKER]: { bucket: 'b', key: 'k' } });
+      mockMaybeResolve.mockResolvedValue(JSON.stringify({ _id: 'job-1' }));
+
+      createConsumer(processor, true);
+      await capturedConfig.handleMessage(buildMessage({ Body: pointer }));
+      await flushMicrotasks();
+
+      expect(processor).toHaveBeenCalledWith({ _id: 'job-1' }, { messageId: 'msg-1', receiveCount: 1 });
+      expect(commandCalls(DeleteMessageCommand)).toHaveLength(1);
+    });
+  });
+});

--- a/libs/application-generic/src/services/sqs/sqs-consumer.service.spec.ts
+++ b/libs/application-generic/src/services/sqs/sqs-consumer.service.spec.ts
@@ -4,7 +4,6 @@ import { SqsService } from './sqs.service';
 import { SqsConsumerService, SqsMessageProcessor } from './sqs-consumer.service';
 import { SQS_LARGE_PAYLOAD_MARKER } from './sqs-payload-offload.service';
 import { SqsRetryError } from './sqs-retry.error';
-import { SQS_MAX_VISIBILITY_RENEWAL_MS } from './types';
 
 type ConsumerConfig = {
   handleMessage: (message: Message) => Promise<Message>;
@@ -131,27 +130,6 @@ describe('SqsConsumerService', () => {
 
       expect(commandCalls(ChangeMessageVisibilityCommand)).toHaveLength(2);
     });
-
-    it('should stop extending once the maximum renewal window is exceeded', async () => {
-      jest.useFakeTimers();
-
-      createConsumer(async () => new Promise<void>(() => {}));
-      await capturedConfig.handleMessage(buildMessage());
-      await flushMicrotasks();
-
-      jest.advanceTimersByTime(SQS_MAX_VISIBILITY_RENEWAL_MS);
-      await flushMicrotasks();
-
-      const extensionsAtCap = commandCalls(ChangeMessageVisibilityCommand).length;
-      expect(extensionsAtCap).toBeGreaterThan(0);
-
-      // The behaviour that matters: past the cap the interval is cleared and
-      // nothing further is sent, however many ticks fit before it.
-      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 20);
-      await flushMicrotasks();
-
-      expect(commandCalls(ChangeMessageVisibilityCommand)).toHaveLength(extensionsAtCap);
-    });
   });
 
   describe('retry backoff', () => {
@@ -166,18 +144,6 @@ describe('SqsConsumerService', () => {
       const [command] = commandCalls(ChangeMessageVisibilityCommand) as ChangeMessageVisibilityCommand[];
       expect(command.input.VisibilityTimeout).toBe(4);
       expect(commandCalls(DeleteMessageCommand)).toHaveLength(0);
-    });
-
-    it('should clamp a delay beyond the AWS maximum', async () => {
-      createConsumer(async () => {
-        throw new SqsRetryError(new Error('boom'), 99_999_000);
-      });
-
-      await capturedConfig.handleMessage(buildMessage());
-      await flushMicrotasks();
-
-      const [command] = commandCalls(ChangeMessageVisibilityCommand) as ChangeMessageVisibilityCommand[];
-      expect(command.input.VisibilityTimeout).toBe(43_200);
     });
 
     it('should leave visibility untouched for a plain failure', async () => {

--- a/libs/application-generic/src/services/sqs/sqs-consumer.service.ts
+++ b/libs/application-generic/src/services/sqs/sqs-consumer.service.ts
@@ -13,13 +13,9 @@ import {
   SQS_DEFAULT_MAX_CONCURRENCY,
   SQS_DEFAULT_VISIBILITY_TIMEOUT,
   SQS_DEFAULT_WAIT_TIME_SECONDS,
-  SQS_MAX_VISIBILITY_RENEWAL_MS,
 } from './types';
 
 const LOG_CONTEXT = 'SqsConsumerService';
-
-/** AWS's hard ceiling for a single message's visibility timeout (12 hours). */
-const SQS_MAX_VISIBILITY_TIMEOUT_SECONDS = 43_200;
 
 /**
  * Bounded retry config for SQS DeleteMessage calls.
@@ -377,7 +373,7 @@ export class SqsConsumerService {
    * visibility lapses, so the retry happens either way - just later.
    */
   private async applyRetryBackoff(message: Message, messageId: string, retryDelayMs: number): Promise<void> {
-    const visibilityTimeout = Math.min(Math.max(Math.ceil(retryDelayMs / 1000), 0), SQS_MAX_VISIBILITY_TIMEOUT_SECONDS);
+    const visibilityTimeout = Math.max(Math.ceil(retryDelayMs / 1000), 0);
 
     try {
       await this.sqsService.getClient().send(
@@ -426,31 +422,6 @@ export class SqsConsumerService {
 
     const timer = setInterval(() => {
       const elapsedMs = Date.now() - startedAt;
-
-      /*
-       * Stop renewing a processor that has overrun its budget, so the message
-       * is released rather than held until AWS's hard 12h ceiling. The run
-       * itself continues - see SQS_MAX_VISIBILITY_RENEWAL_MS for what
-       * redelivery does per topic. This log is the actionable signal.
-       */
-      if (elapsedMs >= SQS_MAX_VISIBILITY_RENEWAL_MS) {
-        clearInterval(timer);
-        Logger.error(
-          {
-            messageId,
-            topic: this.topic,
-            groupId,
-            elapsedMs,
-            extensionCount,
-            receiveCount,
-            maxRenewalMs: SQS_MAX_VISIBILITY_RENEWAL_MS,
-          },
-          'SQS message exceeded the maximum visibility renewal window, releasing it for redelivery',
-          LOG_CONTEXT
-        );
-
-        return;
-      }
 
       this.sqsService
         .getClient()

--- a/libs/application-generic/src/services/sqs/sqs-consumer.service.ts
+++ b/libs/application-generic/src/services/sqs/sqs-consumer.service.ts
@@ -5,6 +5,7 @@ import { Consumer } from 'sqs-consumer';
 import { PinoLogger } from '../../logging';
 import { SqsService } from './sqs.service';
 import { SQS_LARGE_PAYLOAD_MARKER, SqsPayloadOffloadService } from './sqs-payload-offload.service';
+import { isSqsRetryError } from './sqs-retry.error';
 import {
   ISqsConsumerOptions,
   ISqsMessageMeta,
@@ -12,9 +13,13 @@ import {
   SQS_DEFAULT_MAX_CONCURRENCY,
   SQS_DEFAULT_VISIBILITY_TIMEOUT,
   SQS_DEFAULT_WAIT_TIME_SECONDS,
+  SQS_MAX_VISIBILITY_RENEWAL_MS,
 } from './types';
 
 const LOG_CONTEXT = 'SqsConsumerService';
+
+/** AWS's hard ceiling for a single message's visibility timeout (12 hours). */
+const SQS_MAX_VISIBILITY_TIMEOUT_SECONDS = 43_200;
 
 /**
  * Bounded retry config for SQS DeleteMessage calls.
@@ -286,7 +291,13 @@ export class SqsConsumerService {
       visibilityTimeout: this.visibilityTimeout,
       ...(heartbeatIntervalSeconds > 0 && { heartbeatInterval: heartbeatIntervalSeconds }),
       shouldDeleteMessages: false,
-      messageSystemAttributeNames: ['ApproximateReceiveCount'],
+      /*
+       * MessageGroupId is the organization id. Requested purely for
+       * observability - it is absent from `Message` unless asked for, and it
+       * is what lets a slow or failing message be attributed to a tenant.
+       * Fairness itself is handled by SQS fair queues, not by this consumer.
+       */
+      messageSystemAttributeNames: ['ApproximateReceiveCount', 'MessageGroupId'],
       handleMessage: async (message: Message): Promise<Message> => {
         try {
           await this.pool.acquire();
@@ -317,28 +328,82 @@ export class SqsConsumerService {
    */
   private processAndDelete(message: Message): void {
     const messageId = message.MessageId || 'unknown';
-    const stopVisibilityHeartbeat = this.startVisibilityHeartbeat(message, messageId);
+    const startedAt = Date.now();
+    const stopVisibilityHeartbeat = this.startVisibilityHeartbeat(message, messageId, startedAt);
 
     this.processMessage(message)
       .then(async () => {
+        /*
+         * Must precede the delete: a tick landing after the message is gone
+         * always fails with `Message does not exist`, which is indistinguishable
+         * in the logs from a genuinely expired visibility. The `finally` below
+         * repeats it only as a belt-and-braces guard - `clearInterval` on an
+         * already-cleared timer is a no-op.
+         */
+        stopVisibilityHeartbeat();
         await this.deleteMessageWithRetry(message, messageId);
       })
-      .catch((error) => {
+      .catch(async (error) => {
+        stopVisibilityHeartbeat();
+
+        const cause = isSqsRetryError(error) ? error.cause : error;
         Logger.error(
           {
-            error: error instanceof Error ? error.message : String(error),
+            error: cause instanceof Error ? cause.message : String(cause),
             messageId,
             topic: this.topic,
+            processingMs: Date.now() - startedAt,
             ...extractSqsMessageContext(message.Body),
           },
           'SQS message failed, will be retried via visibility timeout',
           LOG_CONTEXT
         );
+
+        if (isSqsRetryError(error)) {
+          await this.applyRetryBackoff(message, messageId, error.retryDelayMs);
+        }
       })
       .finally(() => {
         stopVisibilityHeartbeat();
         this.pool.release();
       });
+  }
+
+  /**
+   * Shorten the message's visibility so the retry lands on the worker's
+   * requested cadence rather than the consumer-wide flat timeout.
+   *
+   * Best-effort: if this fails the message still reappears when its current
+   * visibility lapses, so the retry happens either way - just later.
+   */
+  private async applyRetryBackoff(message: Message, messageId: string, retryDelayMs: number): Promise<void> {
+    const visibilityTimeout = Math.min(Math.max(Math.ceil(retryDelayMs / 1000), 0), SQS_MAX_VISIBILITY_TIMEOUT_SECONDS);
+
+    try {
+      await this.sqsService.getClient().send(
+        new ChangeMessageVisibilityCommand({
+          QueueUrl: this.queueUrl,
+          ReceiptHandle: message.ReceiptHandle,
+          VisibilityTimeout: visibilityTimeout,
+        })
+      );
+
+      this.logger?.debug(
+        { messageId, topic: this.topic, retryDelayMs, visibilityTimeout },
+        'Applied retry backoff to SQS message visibility'
+      );
+    } catch (error) {
+      Logger.warn(
+        {
+          error: error instanceof Error ? error.message : String(error),
+          messageId,
+          topic: this.topic,
+          visibilityTimeout,
+        },
+        'Failed to apply retry backoff, message will retry on the default visibility timeout',
+        LOG_CONTEXT
+      );
+    }
   }
 
   /**
@@ -353,10 +418,40 @@ export class SqsConsumerService {
    * (success or failure). The interval is unref'd so it never keeps the
    * process alive on shutdown.
    */
-  private startVisibilityHeartbeat(message: Message, messageId: string): () => void {
+  private startVisibilityHeartbeat(message: Message, messageId: string, startedAt: number): () => void {
     const intervalMs = Math.max(1_000, Math.floor((this.visibilityTimeout * 1000) / 2));
+    const receiveCount = parseInt(message.Attributes?.ApproximateReceiveCount || '1', 10);
+    const groupId = message.Attributes?.MessageGroupId;
+    let extensionCount = 0;
 
     const timer = setInterval(() => {
+      const elapsedMs = Date.now() - startedAt;
+
+      /*
+       * Stop renewing a processor that has overrun its budget, so the message
+       * is released rather than held until AWS's hard 12h ceiling. The run
+       * itself continues - see SQS_MAX_VISIBILITY_RENEWAL_MS for what
+       * redelivery does per topic. This log is the actionable signal.
+       */
+      if (elapsedMs >= SQS_MAX_VISIBILITY_RENEWAL_MS) {
+        clearInterval(timer);
+        Logger.error(
+          {
+            messageId,
+            topic: this.topic,
+            groupId,
+            elapsedMs,
+            extensionCount,
+            receiveCount,
+            maxRenewalMs: SQS_MAX_VISIBILITY_RENEWAL_MS,
+          },
+          'SQS message exceeded the maximum visibility renewal window, releasing it for redelivery',
+          LOG_CONTEXT
+        );
+
+        return;
+      }
+
       this.sqsService
         .getClient()
         .send(
@@ -367,7 +462,21 @@ export class SqsConsumerService {
           })
         )
         .then(() => {
-          this.logger?.debug({ messageId, topic: this.topic }, 'Extended SQS message visibility (heartbeat)');
+          extensionCount += 1;
+          const context = { messageId, topic: this.topic, groupId, elapsedMs, extensionCount, receiveCount };
+          const event = 'Extended SQS message visibility (heartbeat)';
+
+          /*
+           * Only the first extension is worth an info line - it marks a job
+           * crossing into "running long". Later ones are demoted because a slow
+           * downstream provider puts every in-flight message over the threshold
+           * at once, which is exactly when logs need to stay readable.
+           */
+          if (extensionCount === 1) {
+            Logger.log(context, event, LOG_CONTEXT);
+          } else {
+            this.logger?.debug(context, event);
+          }
         })
         .catch((error: unknown) => {
           const errorName = error instanceof Error ? error.name : undefined;
@@ -381,6 +490,10 @@ export class SqsConsumerService {
               errorName,
               messageId,
               topic: this.topic,
+              groupId,
+              processingMs: elapsedMs,
+              extensionCount,
+              receiveCount,
               stoppingHeartbeat: isPermanent,
             },
             'Failed to extend SQS message visibility',
@@ -473,6 +586,21 @@ export class SqsConsumerService {
     const resolvedBody = this.payloadOffload ? await this.payloadOffload.maybeResolve(rawBody) : rawBody;
 
     const data = JSON.parse(resolvedBody);
+
+    /*
+     * The producer decides to offload based on its own bucket config, and
+     * `maybeResolve` returns the body untouched when this process has none.
+     * Without this check the pointer itself would be handed to the processor
+     * as the job payload, running the job with none of its real fields. Fail
+     * instead: the message is redelivered and eventually reaches the DLQ.
+     */
+    if (data && typeof data === 'object' && SQS_LARGE_PAYLOAD_MARKER in data) {
+      throw new Error(
+        'Received an S3-offloaded SQS payload that could not be resolved. ' +
+          'SQS_PAYLOAD_OFFLOAD_BUCKET is set on the producer but not on this consumer.'
+      );
+    }
+
     const receiveCount = parseInt(message.Attributes?.ApproximateReceiveCount || '1', 10);
     const meta: ISqsMessageMeta = {
       messageId: message.MessageId || 'unknown',

--- a/libs/application-generic/src/services/sqs/sqs-partial-send.error.ts
+++ b/libs/application-generic/src/services/sqs/sqs-partial-send.error.ts
@@ -1,0 +1,33 @@
+import { ISqsMessage } from './types';
+
+/**
+ * Raised when a bulk send delivered some messages but not others.
+ *
+ * `sqs-producer` gives the caller no way to tell what landed: when the
+ * underlying command throws (`BatchRequestTooLong`, throttling, a network
+ * blip) the raw AWS error propagates and every message already accepted by an
+ * earlier batch is forgotten. Callers that fall back to another backend then
+ * re-send the whole array and duplicate the delivered ones.
+ *
+ * Carrying the unsent messages lets the fallback re-queue exactly those.
+ */
+export class SqsPartialSendError extends Error {
+  /**
+   * Named `unsentMessages` rather than `failedMessages` to stay clearly distinct
+   * from `sqs-producer`'s `FailedMessagesError.failedMessages`, which holds
+   * entry id strings rather than messages and is duck-typed for elsewhere.
+   */
+  constructor(
+    public readonly unsentMessages: ISqsMessage[],
+    public readonly sentCount: number,
+    public readonly cause?: unknown
+  ) {
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    super(`Sent ${sentCount} SQS message(s), ${unsentMessages.length} unsent: ${reason}`);
+    this.name = 'SqsPartialSendError';
+  }
+}
+
+export function isSqsPartialSendError(error: unknown): error is SqsPartialSendError {
+  return error instanceof SqsPartialSendError;
+}

--- a/libs/application-generic/src/services/sqs/sqs-retry.error.ts
+++ b/libs/application-generic/src/services/sqs/sqs-retry.error.ts
@@ -1,0 +1,22 @@
+/**
+ * Signals that a failed message should be retried after a specific delay.
+ *
+ * SQS has no per-message retry cadence of its own - a message that is not
+ * deleted simply reappears when its visibility timeout lapses, giving every
+ * attempt the same flat interval. Workers that want BullMQ's per-attempt
+ * backoff throw this so the consumer can translate the delay into a
+ * `ChangeMessageVisibility` call.
+ */
+export class SqsRetryError extends Error {
+  constructor(
+    public readonly cause: Error,
+    public readonly retryDelayMs: number
+  ) {
+    super(cause.message);
+    this.name = 'SqsRetryError';
+  }
+}
+
+export function isSqsRetryError(error: unknown): error is SqsRetryError {
+  return error instanceof SqsRetryError;
+}

--- a/libs/application-generic/src/services/sqs/sqs.service.spec.ts
+++ b/libs/application-generic/src/services/sqs/sqs.service.spec.ts
@@ -1,0 +1,193 @@
+import { JobTopicNameEnum } from '@novu/shared';
+import { packMessagesIntoBatches, SqsService } from './sqs.service';
+import { SqsPartialSendError } from './sqs-partial-send.error';
+import { ISqsMessage, SQS_BATCH_BYTE_BUDGET, SQS_MAX_BATCH_ENTRIES } from './types';
+
+const mockProducerSend = jest.fn();
+
+jest.mock('sqs-producer', () => ({
+  Producer: {
+    create: jest.fn(() => ({ send: mockProducerSend })),
+  },
+}));
+
+jest.mock('@aws-sdk/client-sqs', () => ({
+  SQSClient: jest.fn(() => ({ destroy: jest.fn() })),
+}));
+
+const TOPIC = JobTopicNameEnum.STANDARD;
+
+function buildMessage(id: string, bodyBytes = 10): ISqsMessage {
+  return {
+    id,
+    body: 'x'.repeat(bodyBytes),
+    groupId: 'org-123',
+  };
+}
+
+/** Run a bulk send that is expected to fail, returning the partial-send error. */
+async function capturePartialSendError(send: Promise<void>): Promise<SqsPartialSendError> {
+  try {
+    await send;
+  } catch (error) {
+    return error as SqsPartialSendError;
+  }
+
+  throw new Error('Expected sendBulk to reject with SqsPartialSendError');
+}
+
+/** Total wire size of a group, matching what the packer budgets against. */
+function groupBytes(group: ISqsMessage[]): number {
+  return group.reduce(
+    (total, message) =>
+      total +
+      Buffer.byteLength(message.body, 'utf8') +
+      Buffer.byteLength(message.id, 'utf8') +
+      Buffer.byteLength(message.groupId, 'utf8'),
+    0
+  );
+}
+
+describe('packMessagesIntoBatches', () => {
+  it('should keep a small set in a single batch', () => {
+    const groups = packMessagesIntoBatches(Array.from({ length: 10 }, (_, i) => buildMessage(`m-${i}`)));
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(10);
+  });
+
+  it('should never exceed the entry limit', () => {
+    const groups = packMessagesIntoBatches(Array.from({ length: 25 }, (_, i) => buildMessage(`m-${i}`)));
+
+    expect(groups).toHaveLength(3);
+    for (const group of groups) {
+      expect(group.length).toBeLessThanOrEqual(SQS_MAX_BATCH_ENTRIES);
+    }
+  });
+
+  it('should split by bytes before reaching the entry limit', () => {
+    // 148 KB each: the size that produced BatchRequestTooLong in production.
+    const messages = Array.from({ length: 13 }, (_, i) => buildMessage(`m-${i}`, 148 * 1024));
+
+    const groups = packMessagesIntoBatches(messages);
+
+    expect(groups.length).toBeGreaterThan(1);
+    expect(groups.flat()).toHaveLength(13);
+    for (const group of groups) {
+      expect(group.length).toBeLessThan(SQS_MAX_BATCH_ENTRIES);
+      expect(groupBytes(group)).toBeLessThanOrEqual(SQS_BATCH_BYTE_BUDGET);
+    }
+  });
+
+  it('should give a message larger than the budget its own batch rather than throwing', () => {
+    const messages = [
+      buildMessage('small-1'),
+      buildMessage('huge', SQS_BATCH_BYTE_BUDGET + 1_000),
+      buildMessage('small-2'),
+    ];
+
+    const groups = packMessagesIntoBatches(messages);
+
+    expect(groups).toHaveLength(3);
+    expect(groups[1].map((m) => m.id)).toEqual(['huge']);
+  });
+
+  it('should return no batches for an empty input', () => {
+    expect(packMessagesIntoBatches([])).toEqual([]);
+  });
+});
+
+describe('SqsService.sendBulk', () => {
+  let service: SqsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SQS_QUEUE_URL_STANDARD = 'https://sqs.eu-west-1.amazonaws.com/1/standard';
+    mockProducerSend.mockResolvedValue([]);
+    service = new SqsService();
+  });
+
+  afterEach(() => {
+    delete process.env.SQS_QUEUE_URL_STANDARD;
+  });
+
+  it('should issue one producer call per batch', async () => {
+    await service.sendBulk(
+      TOPIC,
+      Array.from({ length: 25 }, (_, i) => buildMessage(`m-${i}`))
+    );
+
+    expect(mockProducerSend).toHaveBeenCalledTimes(3);
+    for (const [group] of mockProducerSend.mock.calls) {
+      expect(group.length).toBeLessThanOrEqual(SQS_MAX_BATCH_ENTRIES);
+    }
+  });
+
+  it('should keep every batch inside the byte budget', async () => {
+    await service.sendBulk(
+      TOPIC,
+      Array.from({ length: 13 }, (_, i) => buildMessage(`m-${i}`, 148 * 1024))
+    );
+
+    expect(mockProducerSend.mock.calls.length).toBeGreaterThan(1);
+    for (const [group] of mockProducerSend.mock.calls) {
+      expect(groupBytes(group)).toBeLessThanOrEqual(SQS_BATCH_BYTE_BUDGET);
+    }
+  });
+
+  it('should report the untried batches as unsent when a batch throws', async () => {
+    const messages = Array.from({ length: 25 }, (_, i) => buildMessage(`m-${i}`));
+    mockProducerSend.mockResolvedValueOnce([]).mockRejectedValueOnce(new Error('BatchRequestTooLong'));
+
+    await expect(service.sendBulk(TOPIC, messages)).rejects.toBeInstanceOf(SqsPartialSendError);
+
+    // The third batch is never attempted once the second fails.
+    expect(mockProducerSend).toHaveBeenCalledTimes(2);
+  });
+
+  it('should carry exactly the undelivered messages on a thrown batch', async () => {
+    const messages = Array.from({ length: 25 }, (_, i) => buildMessage(`m-${i}`));
+    mockProducerSend.mockResolvedValueOnce([]).mockRejectedValueOnce(new Error('BatchRequestTooLong'));
+
+    const error = await capturePartialSendError(service.sendBulk(TOPIC, messages));
+
+    expect(error.sentCount).toBe(10);
+    expect(error.unsentMessages.map((m) => m.id)).toEqual(messages.slice(10).map((m) => m.id));
+  });
+
+  it('should only report the named entries when the batch call reports per-entry failures', async () => {
+    const messages = Array.from({ length: 5 }, (_, i) => buildMessage(`m-${i}`));
+    // Shape of sqs-producer's FailedMessagesError, which is not exported.
+    const failure = Object.assign(new Error('Failed to send messages: m-1, m-3'), {
+      failedMessages: ['m-1', 'm-3'],
+    });
+    mockProducerSend.mockRejectedValueOnce(failure);
+
+    const error = await capturePartialSendError(service.sendBulk(TOPIC, messages));
+
+    expect(error.unsentMessages.map((m) => m.id)).toEqual(['m-1', 'm-3']);
+    expect(error.sentCount).toBe(3);
+  });
+
+  it('should treat the whole group as unsent when the failure names no entries', async () => {
+    const messages = Array.from({ length: 5 }, (_, i) => buildMessage(`m-${i}`));
+    // An empty list must not be read as "every entry succeeded".
+    mockProducerSend.mockRejectedValueOnce(
+      Object.assign(new Error('Failed to send messages: '), { failedMessages: [] })
+    );
+
+    const error = await capturePartialSendError(service.sendBulk(TOPIC, messages));
+
+    expect(error.unsentMessages).toHaveLength(5);
+    expect(error.sentCount).toBe(0);
+  });
+
+  it('should resolve without error when every batch succeeds', async () => {
+    await expect(
+      service.sendBulk(
+        TOPIC,
+        Array.from({ length: 12 }, (_, i) => buildMessage(`m-${i}`))
+      )
+    ).resolves.toBeUndefined();
+  });
+});

--- a/libs/application-generic/src/services/sqs/sqs.service.ts
+++ b/libs/application-generic/src/services/sqs/sqs.service.ts
@@ -3,10 +3,94 @@ import { Injectable, Logger } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
 import { Producer } from 'sqs-producer';
 
+import { SqsPartialSendError } from './sqs-partial-send.error';
 import { SqsPayloadOffloadService } from './sqs-payload-offload.service';
-import { ISqsMessage } from './types';
+import { ISqsMessage, SQS_BATCH_BYTE_BUDGET, SQS_MAX_BATCH_ENTRIES } from './types';
 
 const LOG_CONTEXT = 'SqsService';
+
+/**
+ * Approximate wire size of one batch entry. AWS totals the batched messages
+ * against the 1 MiB limit; `Id` and `MessageGroupId` ride along with the body,
+ * so all three are counted. The remaining slack lives in
+ * {@link SQS_BATCH_BYTE_BUDGET}.
+ */
+function entrySizeBytes(message: ISqsMessage): number {
+  return (
+    Buffer.byteLength(message.body, 'utf8') +
+    Buffer.byteLength(message.id, 'utf8') +
+    Buffer.byteLength(message.groupId ?? '', 'utf8')
+  );
+}
+
+/**
+ * Split messages into groups that respect both the per-batch entry count and
+ * the byte budget, so each group becomes exactly one `SendMessageBatch`.
+ *
+ * A message larger than the budget on its own still gets a group to itself
+ * rather than throwing: AWS accepts up to 1 MiB for a single message, and
+ * payload offload is a no-op when no bucket is configured, so rejecting it
+ * here would break deployments that work today.
+ */
+export function packMessagesIntoBatches(messages: ISqsMessage[]): ISqsMessage[][] {
+  const groups: ISqsMessage[][] = [];
+  let current: ISqsMessage[] = [];
+  let currentBytes = 0;
+
+  for (const message of messages) {
+    const size = entrySizeBytes(message);
+    const exceedsCount = current.length >= SQS_MAX_BATCH_ENTRIES;
+    const exceedsBytes = currentBytes + size > SQS_BATCH_BYTE_BUDGET;
+
+    if (current.length > 0 && (exceedsCount || exceedsBytes)) {
+      groups.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+
+    current.push(message);
+    currentBytes += size;
+  }
+
+  if (current.length > 0) {
+    groups.push(current);
+  }
+
+  return groups;
+}
+
+/**
+ * `sqs-producer` throws `FailedMessagesError` when the batch call succeeded but
+ * individual entries were rejected. The class is not exported from the package
+ * root, so match on its shape.
+ */
+function getFailedEntryIds(error: unknown): string[] | undefined {
+  const failed = (error as { failedMessages?: unknown })?.failedMessages;
+
+  /*
+   * An empty array must not count as "these entries failed" - it would mark the
+   * whole group as sent and silently drop it. Requiring entries also rejects
+   * `SqsPartialSendError`, whose own list holds messages rather than id strings.
+   */
+  return Array.isArray(failed) && failed.length > 0 && failed.every((id) => typeof id === 'string')
+    ? (failed as string[])
+    : undefined;
+}
+
+/**
+ * Messages left undelivered once the group at `failedIndex` failed: everything
+ * in later groups was never attempted, and from the failing group either the
+ * entries SQS named or - when the call itself threw - all of them.
+ */
+function collectUnsentMessages(groups: ISqsMessage[][], failedIndex: number, error: unknown): ISqsMessage[] {
+  const failedEntryIds = getFailedEntryIds(error);
+  const failedGroup = groups[failedIndex];
+  const unsentFromFailedGroup = failedEntryIds
+    ? failedGroup.filter((message) => failedEntryIds.includes(message.id))
+    : failedGroup;
+
+  return [...unsentFromFailedGroup, ...groups.slice(failedIndex + 1).flat()];
+}
 
 @Injectable()
 export class SqsService {
@@ -78,6 +162,9 @@ export class SqsService {
         const producer = Producer.create({
           queueUrl,
           sqs: this.client,
+          // Pinned so the one-API-call-per-group guarantee sendBulk relies on
+          // cannot drift with the library default.
+          batchSize: SQS_MAX_BATCH_ENTRIES,
         });
         this.producers.set(topic, producer);
       }
@@ -138,8 +225,15 @@ export class SqsService {
 
   /**
    * Send multiple messages to SQS in bulk.
-   * The sqs-producer will automatically batch them in groups of 10.
    * Large payloads are individually offloaded to S3 before sending.
+   *
+   * Messages are grouped by both entry count and byte size before being handed
+   * to `sqs-producer`, which only slices by count and would otherwise build
+   * batches that breach the 1 MiB aggregate limit. Each group is sent on its
+   * own call so that a failure is attributable to specific messages.
+   *
+   * @throws {SqsPartialSendError} when some messages were delivered and others
+   * were not, so the caller can re-queue only the unsent ones.
    */
   public async sendBulk(topic: JobTopicNameEnum, messages: ISqsMessage[]): Promise<void> {
     const producer = this.getProducer(topic);
@@ -155,9 +249,38 @@ export class SqsService {
       })
     );
 
-    await producer.send(offloadedMessages);
+    const groups = packMessagesIntoBatches(offloadedMessages);
 
-    Logger.debug({ message: 'Sent bulk messages to SQS', topic, count: messages.length }, LOG_CONTEXT);
+    let sentCount = 0;
+
+    for (const [index, group] of groups.entries()) {
+      try {
+        // eslint-disable-next-line no-await-in-loop -- sequential keeps the sent/unsent split exact
+        await producer.send(group);
+        sentCount += group.length;
+      } catch (error) {
+        const unsent = collectUnsentMessages(groups, index, error);
+
+        Logger.error(
+          {
+            topic,
+            error: error instanceof Error ? error.message : String(error),
+            totalCount: offloadedMessages.length,
+            sentCount: offloadedMessages.length - unsent.length,
+            unsentCount: unsent.length,
+          },
+          'SQS bulk send failed partway',
+          LOG_CONTEXT
+        );
+
+        throw new SqsPartialSendError(unsent, offloadedMessages.length - unsent.length, error);
+      }
+    }
+
+    Logger.debug(
+      { message: 'Sent bulk messages to SQS', topic, count: sentCount, batches: groups.length },
+      LOG_CONTEXT
+    );
   }
 
   private async maybeOffloadBody(body: string, topic: JobTopicNameEnum, id: string, groupId: string): Promise<string> {

--- a/libs/application-generic/src/services/sqs/types.ts
+++ b/libs/application-generic/src/services/sqs/types.ts
@@ -5,7 +5,47 @@ export const SQS_DEFAULT_MAX_CONCURRENCY = 30;
 export const SQS_MAX_DELAY_SECONDS = 900;
 export const SQS_DEFAULT_DRAIN_TIMEOUT_MS = 30_000;
 export const SQS_MAX_MESSAGE_SIZE_BYTES = 1_048_576;
-export const SQS_DEFAULT_PAYLOAD_SIZE_THRESHOLD = 1_000_000;
+
+/**
+ * Body size above which a payload is offloaded to S3 and replaced by a pointer.
+ *
+ * Well below the 1 MiB ceiling on purpose: this is a tail-risk cap that stops
+ * one big message from monopolising a batch, not an attempt to offload normal
+ * traffic (observed `process_subscriber` bodies are 117-148 KB and stay inline).
+ * Every offload costs a `PutObject` on send and a `GetObject` on receive, so
+ * lowering it further trades queue headroom for hot-path latency. Overridable
+ * via `SQS_PAYLOAD_SIZE_THRESHOLD`.
+ */
+export const SQS_DEFAULT_PAYLOAD_SIZE_THRESHOLD = 256_000;
+
+/**
+ * Entries per `SendMessageBatch`, also pinned as the `sqs-producer` `batchSize`
+ * so a group of this size is guaranteed to become exactly one API call - which
+ * is what makes the byte budget below meaningful.
+ */
+export const SQS_MAX_BATCH_ENTRIES = 10;
+
+/**
+ * Byte ceiling for one `SendMessageBatch`, at 90% of the hard 1 MiB limit.
+ * AWS counts the aggregate of all entries, and does not document precisely how
+ * much the AWS-JSON envelope contributes, so the 10% headroom absorbs it.
+ */
+export const SQS_BATCH_BYTE_BUDGET = Math.floor(SQS_MAX_MESSAGE_SIZE_BYTES * 0.9);
+
+/**
+ * Upper bound on how long the consumer keeps renewing a message's visibility.
+ * Past this the heartbeat stops and visibility lapses, so a wedged processor
+ * releases its message instead of pinning it until AWS's hard 12h ceiling.
+ *
+ * Note this bounds the *message*, not the processor: the in-flight run is not
+ * aborted, so what happens next depends on the topic. On `standard` the
+ * redelivered copy cannot claim the still-running job and acks as a no-op, so
+ * the message is deleted rather than redriven. On the topics with
+ * `maxReceiveCount=1` a single lapse routes straight to the DLQ. Either way the
+ * error log is the signal to act on; the ceiling only stops the message from
+ * being held indefinitely.
+ */
+export const SQS_MAX_VISIBILITY_RENEWAL_MS = 1_800_000;
 
 export interface ISqsConsumerOptions {
   maxNumberOfMessages?: number;

--- a/libs/application-generic/src/services/sqs/types.ts
+++ b/libs/application-generic/src/services/sqs/types.ts
@@ -32,21 +32,6 @@ export const SQS_MAX_BATCH_ENTRIES = 10;
  */
 export const SQS_BATCH_BYTE_BUDGET = Math.floor(SQS_MAX_MESSAGE_SIZE_BYTES * 0.9);
 
-/**
- * Upper bound on how long the consumer keeps renewing a message's visibility.
- * Past this the heartbeat stops and visibility lapses, so a wedged processor
- * releases its message instead of pinning it until AWS's hard 12h ceiling.
- *
- * Note this bounds the *message*, not the processor: the in-flight run is not
- * aborted, so what happens next depends on the topic. On `standard` the
- * redelivered copy cannot claim the still-running job and acks as a no-op, so
- * the message is deleted rather than redriven. On the topics with
- * `maxReceiveCount=1` a single lapse routes straight to the DLQ. Either way the
- * error log is the signal to act on; the ceiling only stops the message from
- * being held indefinitely.
- */
-export const SQS_MAX_VISIBILITY_RENEWAL_MS = 1_800_000;
-
 export interface ISqsConsumerOptions {
   maxNumberOfMessages?: number;
   waitTimeSeconds?: number;

--- a/libs/application-generic/src/services/workers/index.ts
+++ b/libs/application-generic/src/services/workers/index.ts
@@ -3,6 +3,7 @@ export { StandardWorkerService } from './standard-worker.service';
 export { SubscriberProcessWorkerService } from './subscriber-process-worker.service';
 export { WebSocketsWorkerService } from './web-sockets-worker.service';
 export {
+  ISqsFailureOutcome,
   SqsCompletedHandler,
   SqsFailedHandler,
   WorkerBaseService,

--- a/libs/application-generic/src/services/workers/worker-base.service.spec.ts
+++ b/libs/application-generic/src/services/workers/worker-base.service.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
 import { BullMqService } from '../bull-mq';
-import { ISqsMessageMeta } from '../sqs';
+import { ISqsMessageMeta, SqsRetryError } from '../sqs';
 import { isPermanentClientError, WorkerBaseService } from './worker-base.service';
 
 class TestableWorker extends WorkerBaseService {
@@ -115,6 +115,62 @@ describe('WorkerBaseService.wrapForSqs', () => {
 
     await expect(wrapped(data, meta)).resolves.toBeUndefined();
     expect(failedHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when the registered failed handler returns the object form with retry true', async () => {
+    const worker = new TestableWorker();
+    worker.setSqsFailedHandler(jest.fn().mockResolvedValue({ retry: true }));
+
+    const error = new Error('transient');
+    const wrapped = worker.invokeWrapForSqs(jest.fn().mockRejectedValue(error));
+
+    // No delay requested, so the original error propagates unwrapped.
+    await expect(wrapped(data, meta)).rejects.toBe(error);
+  });
+
+  it('acks when the registered failed handler returns the object form with retry false', async () => {
+    const worker = new TestableWorker();
+    worker.setSqsFailedHandler(jest.fn().mockResolvedValue({ retry: false, retryDelayMs: 5_000 }));
+
+    const wrapped = worker.invokeWrapForSqs(jest.fn().mockRejectedValue(new Error('permanent')));
+
+    await expect(wrapped(data, meta)).resolves.toBeUndefined();
+  });
+
+  it('wraps the error in SqsRetryError when the failed handler asks for a delay', async () => {
+    const worker = new TestableWorker();
+    worker.setSqsFailedHandler(jest.fn().mockResolvedValue({ retry: true, retryDelayMs: 4_000 }));
+
+    const error = new Error('webhook filter failed');
+    const wrapped = worker.invokeWrapForSqs(jest.fn().mockRejectedValue(error));
+
+    const thrown = await wrapped(data, meta).catch((err: unknown) => err);
+    expect(thrown).toBeInstanceOf(SqsRetryError);
+    expect((thrown as SqsRetryError).retryDelayMs).toBe(4_000);
+    expect((thrown as SqsRetryError).cause).toBe(error);
+    expect((thrown as SqsRetryError).message).toBe('webhook filter failed');
+  });
+
+  it('treats a zero delay as a request to retry immediately, not as no request', async () => {
+    const worker = new TestableWorker();
+    // Randomised backoffs round down to 0 on early attempts.
+    worker.setSqsFailedHandler(jest.fn().mockResolvedValue({ retry: true, retryDelayMs: 0 }));
+
+    const wrapped = worker.invokeWrapForSqs(jest.fn().mockRejectedValue(new Error('no backoff')));
+
+    const thrown = await wrapped(data, meta).catch((err: unknown) => err);
+    expect(thrown).toBeInstanceOf(SqsRetryError);
+    expect((thrown as SqsRetryError).retryDelayMs).toBe(0);
+  });
+
+  it('falls through to the flat visibility timeout when no delay is supplied', async () => {
+    const worker = new TestableWorker();
+    worker.setSqsFailedHandler(jest.fn().mockResolvedValue({ retry: true }));
+
+    const error = new Error('no opinion on cadence');
+    const wrapped = worker.invokeWrapForSqs(jest.fn().mockRejectedValue(error));
+
+    await expect(wrapped(data, meta)).rejects.toBe(error);
   });
 
   it('defaults to retry when the registered failed handler itself throws', async () => {

--- a/libs/application-generic/src/services/workers/worker-base.service.ts
+++ b/libs/application-generic/src/services/workers/worker-base.service.ts
@@ -19,6 +19,7 @@ import {
   SQS_DEFAULT_VISIBILITY_TIMEOUT,
   SQS_DEFAULT_WAIT_TIME_SECONDS,
   SqsConsumerService,
+  SqsRetryError,
   SqsService,
 } from '../sqs';
 
@@ -54,7 +55,21 @@ export function isPermanentClientError(error: unknown): boolean {
 export type WorkerProcessor = string | Processor<any, unknown, string> | undefined;
 
 export type SqsCompletedHandler = (job: Job<any, unknown, string>) => Promise<void>;
-export type SqsFailedHandler = (job: Job<any, unknown, string>, error: Error) => Promise<boolean>;
+
+/**
+ * How long to wait before the message becomes visible again. Lets a worker
+ * reproduce BullMQ's per-attempt backoff, which SQS has no equivalent of.
+ */
+export interface ISqsFailureOutcome {
+  retry: boolean;
+  retryDelayMs?: number;
+}
+
+/**
+ * Returning a bare boolean keeps the original contract - only workers that
+ * want a custom retry cadence need the object form.
+ */
+export type SqsFailedHandler = (job: Job<any, unknown, string>, error: Error) => Promise<boolean | ISqsFailureOutcome>;
 
 export { WorkerOptions };
 
@@ -106,9 +121,13 @@ export class WorkerBaseService implements INovuWorker, OnModuleDestroy {
    * Register a handler called when an SQS message processing fails.
    * Mirrors BullMQ's `worker.on('failed', ...)` event.
    *
-   * The handler must return a boolean indicating whether SQS should retry the message:
+   * The handler decides whether SQS should retry the message:
    * - `true`: re-throw the error so SQS retries (message stays in queue)
    * - `false`: absorb the error so SQS deletes the message (failure handled in DB)
+   *
+   * Returning `{ retry, retryDelayMs }` instead also sets how long to wait
+   * before the retry, which SQS has no native equivalent of - without it every
+   * attempt waits the flat consumer-wide visibility timeout.
    */
   public setSqsFailedHandler(handler: SqsFailedHandler): void {
     this.sqsFailedHandler = handler;
@@ -208,10 +227,18 @@ export class WorkerBaseService implements INovuWorker, OnModuleDestroy {
         }
       } catch (error) {
         let shouldRetry = true;
+        let retryDelayMs: number | undefined;
 
         if (this.sqsFailedHandler) {
           try {
-            shouldRetry = await this.sqsFailedHandler(jobMock, error as Error);
+            const outcome = await this.sqsFailedHandler(jobMock, error as Error);
+
+            if (typeof outcome === 'boolean') {
+              shouldRetry = outcome;
+            } else {
+              shouldRetry = outcome.retry;
+              retryDelayMs = outcome.retryDelayMs;
+            }
           } catch (handlerError) {
             Logger.error(
               {
@@ -249,6 +276,17 @@ export class WorkerBaseService implements INovuWorker, OnModuleDestroy {
         }
 
         if (shouldRetry) {
+          /*
+           * Wrapping preserves the original error for logging while telling
+           * the consumer to shorten this message's visibility instead of
+           * leaving it on the flat consumer-wide timeout. A delay of 0 is a
+           * real request to retry immediately - randomised backoffs round down
+           * to it - so only an absent delay falls through to the flat timeout.
+           */
+          if (retryDelayMs !== undefined) {
+            throw new SqsRetryError(error as Error, retryDelayMs);
+          }
+
           throw error;
         }
       }


### PR DESCRIPTION
### What changed? Why was the change needed?

- Introduced SqsPartialSendError to manage undelivered messages during bulk sends.
- Enhanced SqsService to group messages by entry count and byte size before sending.
- Added SqsRetryError to facilitate per-message retry delays.
- Updated SqsConsumerService to apply retry backoff based on SqsRetryError.
- Improved error handling in queue processing to ensure only unsent messages are re-queued.
- Added tests for new error handling and message processing logic.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>












<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds partial SQS batch recovery, byte-aware batching, and per-message retry delays while revising visibility-heartbeat behavior. The retry transition still has a visibility gap that can expose a message before its requested backoff is installed.
- Re-queues only messages that SQS or EventBridge did not accept.
- Packs bulk sends by both entry count and aggregate byte budget.
- Translates worker retry outcomes into per-message SQS visibility delays.
- Removes the prior fixed visibility-renewal budget.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the retry transition keeps the message protected while installing its requested visibility backoff.

The new retry path clears the only per-message heartbeat before awaiting ChangeMessageVisibility, allowing a message near expiry to be redelivered prematurely and making the requested retry cadence impossible to apply with the stale receipt handle.

**Files Needing Attention:** libs/application-generic/src/services/sqs/sqs-consumer.service.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/sqs/sqs-consumer.service.ts | Adds retry visibility handling and improves heartbeat lifecycle, but clears renewal before atomically establishing the replacement timeout. |
| libs/application-generic/src/services/workers/worker-base.service.ts | Extends failure outcomes with optional retry delays and preserves the original error when no custom delay is requested. |
| apps/worker/src/app/workflow/services/standard.worker.ts | Connects webhook-filter backoff calculation to the SQS retry outcome while retaining the existing failure decision. |
| libs/application-generic/src/services/sqs/sqs.service.ts | Adds byte-aware sequential batching and reports exactly which messages remain unsent after a partial failure. |
| libs/application-generic/src/services/queues/queue-base.service.ts | Scopes BullMQ fallback to jobs rejected or never attempted by the SQS and scheduler legs. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant P as Processor
    participant C as SQS Consumer
    participant H as Visibility Heartbeat
    participant S as SQS
    P-->>C: Throw SqsRetryError
    C->>H: Stop heartbeat
    Note over C,S: Existing visibility can expire here
    C->>S: ChangeMessageVisibility(backoff)
    alt Request completes before expiry
        S-->>C: Backoff applied
    else Message is redelivered first
        S-->>C: Receipt handle invalid
        S-->>P: Premature retry
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312437%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12437&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Fapplication-generic%2Fsrc%2Fservices%2Fsqs%2Fsqs-consumer.service.ts%3A343%0A**Backoff%20loses%20visibility%20protection**%0A%0AIf%20a%20retryable%20failure%20occurs%20near%20the%20current%20visibility%20deadline%20and%20%60ChangeMessageVisibility%60%20is%20delayed%20or%20throttled%2C%20this%20line%20stops%20the%20only%20per-message%20heartbeat%20before%20the%20replacement%20timeout%20is%20applied.%20SQS%20can%20then%20redeliver%20the%20message%20with%20a%20new%20receipt%20handle%2C%20causing%20the%20backoff%20request%20to%20fail%20against%20the%20stale%20handle%20and%20allowing%20a%20premature%20or%20overlapping%20retry.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12437&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/application-generic/src/services/sqs/sqs-consumer.service.ts:343
**Backoff loses visibility protection**

If a retryable failure occurs near the current visibility deadline and `ChangeMessageVisibility` is delayed or throttled, this line stops the only per-message heartbeat before the replacement timeout is applied. SQS can then redeliver the message with a new receipt handle, causing the backoff request to fail against the stale handle and allowing a premature or overlapping retry.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["refactor(sqs): remove visibility renewal..."](https://github.com/novuhq/novu/commit/85c863a9f2574acb4b22e53c4a6ec48fceb87a24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56237345)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->