### PR TITLE
feat(react,js): rebuild useAgentChat on conversation runtime fixes NV-8641

### DIFF
--- a/packages/js/scripts/size-limit.mjs
+++ b/packages/js/scripts/size-limit.mjs
@@ -16,8 +16,8 @@ const modules = [
     name: 'UMD minified',
     filePath: umdPath,
     // Raised for agent conversation runtime (NV-8640), protocol validation (NV-8644),
-    // and agent-chat idempotency/retry (NV-8642).
-    limitInBytes: 238_000,
+    // agent-chat idempotency/retry (NV-8642), and publication meta (NV-8641).
+    limitInBytes: 240_000,
   },
   {
     name: 'UMD gzip',

--- a/packages/js/src/agent-chat/agent-conversation-runtime.test.ts
+++ b/packages/js/src/agent-chat/agent-conversation-runtime.test.ts
@@ -182,6 +182,7 @@ describe('AgentConversationRuntime', () => {
     expect(snapshot.run.typing?.status).toBe('Thinking…');
     expect(snapshot.conversationStatus).toBe('active');
     expect(snapshot.pagination.hasMore).toBe(false);
+    expect(snapshot.pagination.status).toBe('idle');
 
     created.data.dispose();
   });

--- a/packages/js/src/agent-chat/agent-conversation-runtime.ts
+++ b/packages/js/src/agent-chat/agent-conversation-runtime.ts
@@ -5,6 +5,7 @@ import { createLocalConversationKey } from './agent-chat-store';
 import type { AgentToolApprovalDecision } from './agent-message.types';
 import { derivePendingActions } from './agent-message.types';
 import type {
+  AgentConversationPaginationSnapshot,
   AgentConversationRunSnapshot,
   AgentConversationSessionStatus,
   AgentConversationSnapshot,
@@ -15,19 +16,6 @@ import type {
 import { runtimeCacheKey } from './runtime-cache-key';
 
 const EMPTY_RUN: AgentConversationRunSnapshot = Object.freeze({ isRunning: false });
-
-function cloneSnapshot(snapshot: AgentConversationSnapshot): AgentConversationSnapshot {
-  return {
-    ...snapshot,
-    run: {
-      ...snapshot.run,
-      typing: snapshot.run.typing ? { ...snapshot.run.typing } : undefined,
-    },
-    pagination: { ...snapshot.pagination },
-    messages: structuredClone(snapshot.messages),
-    pendingActions: structuredClone(snapshot.pendingActions),
-  };
-}
 
 function deepFreeze<T>(value: T): T {
   if (value === null || typeof value !== 'object') {
@@ -63,10 +51,26 @@ function createEmptySnapshot(key: string, conversationId?: string): AgentConvers
     status: conversationId ? 'loading' : 'ready',
     run: EMPTY_RUN,
     conversationStatus: 'active',
-    pagination: { hasMore: false },
+    pagination: { hasMore: false, status: 'idle' },
     messages: [],
     pendingActions: [],
+    isRecovering: false,
   });
+}
+
+const SERVER_SNAPSHOT = createEmptySnapshot('ssr');
+
+function cloneSnapshot(snapshot: AgentConversationSnapshot): AgentConversationSnapshot {
+  return {
+    ...snapshot,
+    run: {
+      ...snapshot.run,
+      typing: snapshot.run.typing ? { ...snapshot.run.typing } : undefined,
+    },
+    pagination: { ...snapshot.pagination },
+    messages: structuredClone(snapshot.messages),
+    pendingActions: structuredClone(snapshot.pendingActions),
+  };
 }
 
 function normalizeSendMessageInput(input: SendMessageInput): { text: string; metadata?: Record<string, unknown> } {
@@ -75,6 +79,10 @@ function normalizeSendMessageInput(input: SendMessageInput): { text: string; met
   }
 
   return { text: input.text, metadata: input.metadata };
+}
+
+function storePagination(hasMore: boolean, status: AgentConversationPaginationSnapshot['status'] = 'idle') {
+  return { hasMore, status };
 }
 
 /**
@@ -118,7 +126,9 @@ export class AgentConversationRuntime {
         isRunning: data.isRunning,
         typing: data.typing,
         status: data.status,
-        hasMore: data.hasMore,
+        pagination: data.pagination,
+        isRecovering: data.isRecovering,
+        catchUpError: data.catchUpError,
         conversationId: data.conversationId,
         sessionStatus:
           this.#snapshot.status === 'loading' || this.#snapshot.status === 'fetching' ? this.#snapshot.status : 'ready',
@@ -132,6 +142,10 @@ export class AgentConversationRuntime {
 
   getSnapshot(): AgentConversationSnapshot {
     return this.#snapshot;
+  }
+
+  getServerSnapshot(): AgentConversationSnapshot {
+    return SERVER_SNAPSHOT;
   }
 
   subscribe(listener: (snapshot: AgentConversationSnapshot) => void): () => void {
@@ -185,12 +199,20 @@ export class AgentConversationRuntime {
     }
 
     if (response.data) {
+      const store = this.#agentChat.getConversation({
+        agentId: this.agentId,
+        key: this.key,
+        conversationId: response.data.conversationId,
+      });
+
       this.#publishFromStore({
         messages: response.data.messages,
-        isRunning: this.#snapshot.run.isRunning,
-        typing: this.#snapshot.run.typing,
-        status: this.#snapshot.conversationStatus,
-        hasMore: response.data.hasMore,
+        isRunning: store?.isRunning ?? this.#snapshot.run.isRunning,
+        typing: store?.typing ?? this.#snapshot.run.typing,
+        status: store?.status ?? this.#snapshot.conversationStatus,
+        pagination: store?.pagination ?? storePagination(response.data.hasMore),
+        isRecovering: store?.isRecovering ?? false,
+        catchUpError: store?.catchUpError,
         conversationId: response.data.conversationId,
         sessionStatus: 'ready',
       });
@@ -230,7 +252,9 @@ export class AgentConversationRuntime {
         isRunning: store?.isRunning ?? this.#snapshot.run.isRunning,
         typing: store?.typing ?? this.#snapshot.run.typing,
         status: store?.status ?? this.#snapshot.conversationStatus,
-        hasMore: response.data.hasMore,
+        pagination: store?.pagination ?? storePagination(response.data.hasMore),
+        isRecovering: store?.isRecovering ?? this.#snapshot.isRecovering,
+        catchUpError: store?.catchUpError,
         conversationId: store?.conversationId ?? this.#conversationId,
         sessionStatus: 'ready',
       });
@@ -309,6 +333,24 @@ export class AgentConversationRuntime {
     return response;
   }
 
+  async retryMessage(
+    messageId: string
+  ): Promise<{ data?: { conversationId: string; messageId: string }; error?: NovuError | AgentChatPlanLimitError }> {
+    const response = await this.#agentChat.retryMessage({
+      agentId: this.agentId,
+      agentHash: this.#agentHash,
+      key: this.key,
+      conversationId: this.#conversationId,
+      messageId,
+    });
+
+    if (response.error) {
+      this.#publishError(response.error);
+    }
+
+    return response;
+  }
+
   cancelRun(): ConversationResult<void> {
     return {
       ok: false,
@@ -363,7 +405,9 @@ export class AgentConversationRuntime {
     isRunning: boolean;
     typing?: AgentConversationRunSnapshot['typing'];
     status: AgentConversationSnapshot['conversationStatus'];
-    hasMore: boolean;
+    pagination: AgentConversationPaginationSnapshot;
+    isRecovering: boolean;
+    catchUpError?: NovuError;
     conversationId?: string;
     sessionStatus: AgentConversationSessionStatus;
   }): void {
@@ -376,11 +420,11 @@ export class AgentConversationRuntime {
         typing: args.typing,
       },
       conversationStatus: args.status,
-      pagination: {
-        hasMore: args.hasMore,
-      },
+      pagination: args.pagination,
       messages: args.messages,
       pendingActions: derivePendingActions([...args.messages]),
+      isRecovering: args.isRecovering,
+      catchUpError: args.catchUpError,
       error: undefined,
     });
   }

--- a/packages/js/src/agent-chat/agent-conversation-runtime.ts
+++ b/packages/js/src/agent-chat/agent-conversation-runtime.ts
@@ -6,6 +6,7 @@ import type { AgentToolApprovalDecision } from './agent-message.types';
 import { derivePendingActions } from './agent-message.types';
 import type {
   AgentConversationPaginationSnapshot,
+  AgentConversationPublicationMeta,
   AgentConversationRunSnapshot,
   AgentConversationSessionStatus,
   AgentConversationSnapshot,
@@ -97,7 +98,7 @@ export class AgentConversationRuntime {
   #agentHash?: string;
   #conversationId?: string;
   #snapshot: AgentConversationSnapshot;
-  #listeners = new Set<(snapshot: AgentConversationSnapshot) => void>();
+  #listeners = new Set<(snapshot: AgentConversationSnapshot, meta?: AgentConversationPublicationMeta) => void>();
   #stopListening?: () => void;
   #disposed = false;
   #registeredConversationKey?: string;
@@ -121,18 +122,23 @@ export class AgentConversationRuntime {
         this.#registerByConversationId(data.conversationId);
       }
 
-      this.#publishFromStore({
-        messages: data.messages,
-        isRunning: data.isRunning,
-        typing: data.typing,
-        status: data.status,
-        pagination: data.pagination,
-        isRecovering: data.isRecovering,
-        catchUpError: data.catchUpError,
-        conversationId: data.conversationId,
-        sessionStatus:
-          this.#snapshot.status === 'loading' || this.#snapshot.status === 'fetching' ? this.#snapshot.status : 'ready',
-      });
+      this.#publishFromStore(
+        {
+          messages: data.messages,
+          isRunning: data.isRunning,
+          typing: data.typing,
+          status: data.status,
+          pagination: data.pagination,
+          isRecovering: data.isRecovering,
+          catchUpError: data.catchUpError,
+          conversationId: data.conversationId,
+          sessionStatus:
+            this.#snapshot.status === 'loading' || this.#snapshot.status === 'fetching'
+              ? this.#snapshot.status
+              : 'ready',
+        },
+        { change: data.change }
+      );
     });
 
     if (args.conversationId) {
@@ -148,7 +154,9 @@ export class AgentConversationRuntime {
     return SERVER_SNAPSHOT;
   }
 
-  subscribe(listener: (snapshot: AgentConversationSnapshot) => void): () => void {
+  subscribe(
+    listener: (snapshot: AgentConversationSnapshot, meta?: AgentConversationPublicationMeta) => void
+  ): () => void {
     this.#listeners.add(listener);
     listener(this.#snapshot);
 
@@ -205,17 +213,20 @@ export class AgentConversationRuntime {
         conversationId: response.data.conversationId,
       });
 
-      this.#publishFromStore({
-        messages: response.data.messages,
-        isRunning: store?.isRunning ?? this.#snapshot.run.isRunning,
-        typing: store?.typing ?? this.#snapshot.run.typing,
-        status: store?.status ?? this.#snapshot.conversationStatus,
-        pagination: store?.pagination ?? storePagination(response.data.hasMore),
-        isRecovering: store?.isRecovering ?? false,
-        catchUpError: store?.catchUpError,
-        conversationId: response.data.conversationId,
-        sessionStatus: 'ready',
-      });
+      this.#publishFromStore(
+        {
+          messages: response.data.messages,
+          isRunning: store?.isRunning ?? this.#snapshot.run.isRunning,
+          typing: store?.typing ?? this.#snapshot.run.typing,
+          status: store?.status ?? this.#snapshot.conversationStatus,
+          pagination: store?.pagination ?? storePagination(response.data.hasMore),
+          isRecovering: store?.isRecovering ?? false,
+          catchUpError: store?.catchUpError,
+          conversationId: response.data.conversationId,
+          sessionStatus: 'ready',
+        },
+        { historyLoaded: true }
+      );
     }
 
     return response;
@@ -400,36 +411,42 @@ export class AgentConversationRuntime {
     });
   }
 
-  #publishFromStore(args: {
-    messages: AgentConversationSnapshot['messages'];
-    isRunning: boolean;
-    typing?: AgentConversationRunSnapshot['typing'];
-    status: AgentConversationSnapshot['conversationStatus'];
-    pagination: AgentConversationPaginationSnapshot;
-    isRecovering: boolean;
-    catchUpError?: NovuError;
-    conversationId?: string;
-    sessionStatus: AgentConversationSessionStatus;
-  }): void {
-    this.#publish({
-      key: this.key,
-      conversationId: args.conversationId ?? this.#conversationId,
-      status: args.sessionStatus,
-      run: {
-        isRunning: args.isRunning,
-        typing: args.typing,
+  #publishFromStore(
+    args: {
+      messages: AgentConversationSnapshot['messages'];
+      isRunning: boolean;
+      typing?: AgentConversationRunSnapshot['typing'];
+      status: AgentConversationSnapshot['conversationStatus'];
+      pagination: AgentConversationPaginationSnapshot;
+      isRecovering: boolean;
+      catchUpError?: NovuError;
+      conversationId?: string;
+      sessionStatus: AgentConversationSessionStatus;
+    },
+    meta?: AgentConversationPublicationMeta
+  ): void {
+    this.#publish(
+      {
+        key: this.key,
+        conversationId: args.conversationId ?? this.#conversationId,
+        status: args.sessionStatus,
+        run: {
+          isRunning: args.isRunning,
+          typing: args.typing,
+        },
+        conversationStatus: args.status,
+        pagination: args.pagination,
+        messages: args.messages,
+        pendingActions: derivePendingActions([...args.messages]),
+        isRecovering: args.isRecovering,
+        catchUpError: args.catchUpError,
+        error: undefined,
       },
-      conversationStatus: args.status,
-      pagination: args.pagination,
-      messages: args.messages,
-      pendingActions: derivePendingActions([...args.messages]),
-      isRecovering: args.isRecovering,
-      catchUpError: args.catchUpError,
-      error: undefined,
-    });
+      meta
+    );
   }
 
-  #publish(next: AgentConversationSnapshot): void {
+  #publish(next: AgentConversationSnapshot, meta?: AgentConversationPublicationMeta): void {
     if (this.#disposed) {
       return;
     }
@@ -438,7 +455,7 @@ export class AgentConversationRuntime {
     this.#snapshot = frozen;
 
     for (const listener of this.#listeners) {
-      listener(frozen);
+      listener(frozen, meta);
     }
   }
 }

--- a/packages/js/src/agent-chat/conversation-runtime.types.ts
+++ b/packages/js/src/agent-chat/conversation-runtime.types.ts
@@ -9,6 +9,7 @@ import type {
   AgentToolApprovalDecision,
 } from './agent-message.types';
 import type {
+  AgentChatChange,
   AgentChatPaginationStatus,
   FetchMoreResult,
   LoadConversationResult,
@@ -29,6 +30,13 @@ export type AgentConversationRunSnapshot = {
 export type AgentConversationPaginationSnapshot = {
   hasMore: boolean;
   status: AgentChatPaginationStatus;
+};
+
+/** Extra context for one snapshot publication. Omitted on the initial subscribe replay. */
+export type AgentConversationPublicationMeta = {
+  change?: AgentChatChange;
+  /** Resume history finished loading for this runtime. */
+  historyLoaded?: boolean;
 };
 
 /**
@@ -68,7 +76,9 @@ export type SendMessageInput = string | { text: string; metadata?: Record<string
 export type AgentConversationRuntimeActions = {
   getSnapshot(): AgentConversationSnapshot;
   getServerSnapshot(): AgentConversationSnapshot;
-  subscribe(listener: (snapshot: AgentConversationSnapshot) => void): () => void;
+  subscribe(
+    listener: (snapshot: AgentConversationSnapshot, meta?: AgentConversationPublicationMeta) => void
+  ): () => void;
   dispose(): void;
   load(): Promise<{ data?: LoadConversationResult; error?: NovuError }>;
   fetchMore(): Promise<{ data?: FetchMoreResult; error?: NovuError }>;

--- a/packages/js/src/agent-chat/conversation-runtime.types.ts
+++ b/packages/js/src/agent-chat/conversation-runtime.types.ts
@@ -9,9 +9,11 @@ import type {
   AgentToolApprovalDecision,
 } from './agent-message.types';
 import type {
+  AgentChatPaginationStatus,
   FetchMoreResult,
   LoadConversationResult,
   RespondToActionResult,
+  RetryMessageResult,
   SendActionResult,
   SendMessageResult,
 } from './types';
@@ -26,6 +28,7 @@ export type AgentConversationRunSnapshot = {
 
 export type AgentConversationPaginationSnapshot = {
   hasMore: boolean;
+  status: AgentChatPaginationStatus;
 };
 
 /**
@@ -44,6 +47,10 @@ export type AgentConversationSnapshot = {
   messages: readonly AgentMessage[];
   pendingActions: readonly AgentPendingAction[];
   error?: NovuError | AgentChatPlanLimitError | AgentConversationError;
+  /** True while reconnect catch-up is in flight for this conversation. */
+  isRecovering: boolean;
+  /** Set when reconnect catch-up fails. Separate from send/fetch `error`. */
+  catchUpError?: NovuError;
 };
 
 export type ConversationOk<T> = { ok: true; data: T };
@@ -60,6 +67,7 @@ export type SendMessageInput = string | { text: string; metadata?: Record<string
 
 export type AgentConversationRuntimeActions = {
   getSnapshot(): AgentConversationSnapshot;
+  getServerSnapshot(): AgentConversationSnapshot;
   subscribe(listener: (snapshot: AgentConversationSnapshot) => void): () => void;
   dispose(): void;
   load(): Promise<{ data?: LoadConversationResult; error?: NovuError }>;
@@ -76,5 +84,6 @@ export type AgentConversationRuntimeActions = {
     sourceMessageId: string;
     value?: string;
   }): Promise<{ data?: SendActionResult; error?: NovuError | AgentChatPlanLimitError }>;
+  retryMessage(messageId: string): Promise<{ data?: RetryMessageResult; error?: NovuError | AgentChatPlanLimitError }>;
   cancelRun(): ConversationResult<void>;
 };

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -35,6 +35,7 @@ export type {
 export { derivePendingActions } from './agent-message.types';
 export type {
   AgentConversationPaginationSnapshot,
+  AgentConversationPublicationMeta,
   AgentConversationRunSnapshot,
   AgentConversationRuntimeActions,
   AgentConversationSessionStatus,

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -10,6 +10,7 @@ export type {
   AgentChatToolsDefinition,
   AgentConversationError,
   AgentConversationPaginationSnapshot,
+  AgentConversationPublicationMeta,
   AgentConversationRunSnapshot,
   AgentConversationRuntimeActions,
   AgentConversationSessionStatus,

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,8 +1,10 @@
 import type {
   AgentChatPagination,
   AgentChatPlanLimitError,
+  AgentConversationRunSnapshot,
+  AgentConversationRuntime,
+  AgentConversationSnapshot,
   AgentConversationStatus,
-  AgentConversationTyping,
   AgentEventEnvelope,
   AgentHashFields,
   AgentMessage,
@@ -14,19 +16,11 @@ import type {
   SendActionResult,
   SendMessageResult,
 } from '@novu/js';
-import { derivePendingActions } from '@novu/js';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
 
-export type UseAgentChatProps = AgentHashFields & {
-  agentId: string;
-  /**
-   * Resume this conversation. The hook loads history on mount.
-   * Omit this prop to start a new chat. The first send creates a conversation.
-   * Later sends pass the returned id. Remount or clear this prop to start another chat.
-   */
-  conversationId?: string;
+type UseAgentChatCallbacks = {
   onSuccess?: (data: LoadConversationResult) => void;
   onError?: (error: NovuError | AgentChatPlanLimitError) => void;
   /**
@@ -51,6 +45,28 @@ export type UseAgentChatProps = AgentHashFields & {
   onEvent?: (envelope: AgentEventEnvelope) => void;
 };
 
+export type UseAgentChatProps = UseAgentChatCallbacks &
+  AgentHashFields &
+  (
+    | {
+        agentId: string;
+        /**
+         * Resume this conversation. The hook loads history on mount.
+         * Omit this prop to start a new chat. The first send creates a conversation.
+         * Later sends pass the returned id. Remount or clear this prop to start another chat.
+         */
+        conversationId?: string;
+        conversation?: never;
+      }
+    | {
+        /** Share an existing conversation runtime across multiple hook instances. */
+        conversation: AgentConversationRuntime;
+        agentId?: never;
+        conversationId?: never;
+        agentHash?: never;
+      }
+  );
+
 export type UseAgentChatResult = {
   messages: AgentMessage[];
   pendingActions: AgentPendingAction[];
@@ -59,8 +75,13 @@ export type UseAgentChatResult = {
   /** True until the first history fetch completes. False when there is no `conversationId` prop. */
   isLoading: boolean;
   isRunning: boolean;
-  typing?: AgentConversationTyping;
+  typing?: AgentConversationRunSnapshot['typing'];
+  /** Conversation lifecycle status (`active`, etc.). */
   status: AgentConversationStatus;
+  /** Explicit alias for `status`. */
+  conversationStatus: AgentConversationStatus;
+  /** Current agent run snapshot. */
+  run: AgentConversationRunSnapshot;
   pagination: AgentChatPagination & {
     fetchMore: () => Promise<{
       data?: { messages: AgentMessage[]; hasMore: boolean };
@@ -84,102 +105,43 @@ export type UseAgentChatResult = {
     data?: SendActionResult;
     error?: NovuError | AgentChatPlanLimitError;
   }>;
+  retryMessage: (messageId: string) => Promise<{
+    data?: SendMessageResult;
+    error?: NovuError | AgentChatPlanLimitError;
+  }>;
 };
 
-function createLocalSessionKey(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return `local_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
-  }
-
-  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
-    const bytes = new Uint8Array(6);
-    crypto.getRandomValues(bytes);
-
-    return `local_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
-  }
-
-  return `local_${Date.now().toString(36)}`;
+function subscribeToRuntime(runtime: AgentConversationRuntime, onStoreChange: () => void): () => void {
+  return runtime.subscribe(() => {
+    onStoreChange();
+  });
 }
 
-type ConversationSnapshot = {
-  messages: AgentMessage[];
-  isRunning: boolean;
-  typing?: AgentConversationTyping;
-  status: AgentConversationStatus;
-  pagination: AgentChatPagination;
-  error?: NovuError | AgentChatPlanLimitError;
-};
-
-const EMPTY_CONVERSATION: ConversationSnapshot = {
+const EMPTY_SERVER_SNAPSHOT: AgentConversationSnapshot = {
+  key: 'ssr',
+  status: 'ready',
+  run: { isRunning: false },
+  conversationStatus: 'active',
+  pagination: { hasMore: false, status: 'idle' },
   messages: [],
-  isRunning: false,
-  typing: undefined,
-  status: 'active',
-  pagination: { status: 'idle', hasMore: false },
+  pendingActions: [],
+  isRecovering: false,
 };
-
-function applyConversationSnapshot(
-  snapshot: ConversationSnapshot,
-  setters: {
-    setMessages: (messages: AgentMessage[]) => void;
-    setIsRunning: (isRunning: boolean) => void;
-    setTyping: (typing?: AgentConversationTyping) => void;
-    setStatus: (status: AgentConversationStatus) => void;
-    setPagination: (pagination: AgentChatPagination) => void;
-    setError: (error?: NovuError | AgentChatPlanLimitError) => void;
-  }
-): void {
-  setters.setMessages(snapshot.messages);
-  setters.setIsRunning(snapshot.isRunning);
-  setters.setTyping(snapshot.typing);
-  setters.setStatus(snapshot.status);
-  setters.setPagination(snapshot.pagination);
-  setters.setError(snapshot.error);
-}
 
 export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
-  const { agentId, agentHash, conversationId: conversationIdProp } = props;
-  const propsRef = useDataRef(props);
   const novu = useNovu();
+  const propsRef = useDataRef(props);
 
-  // Resume: the prop is the key on the same render (no effect lag).
-  // Create: keep a `local_*` key until remount, prop clear, or agent change.
-  const [localSessionKey, setLocalSessionKey] = useState(createLocalSessionKey);
-  const sessionKey = conversationIdProp ?? localSessionKey;
-  const sessionKeyRef = useDataRef(sessionKey);
+  const sharedRuntime = 'conversation' in props ? props.conversation : undefined;
+  const agentId = sharedRuntime?.agentId ?? props.agentId!;
+  const conversationIdProp = sharedRuntime ? undefined : props.conversationId;
+  const agentHash = sharedRuntime ? undefined : props.agentHash;
+
+  const ownedRuntimeRef = useRef<AgentConversationRuntime | null>(null);
+  const ownsRuntimeRef = useRef(false);
   const prevAgentIdRef = useRef(agentId);
   const prevConversationIdPropRef = useRef(conversationIdProp);
-
-  const [assignedConversationId, setAssignedConversationId] = useState<string>();
-  const conversationId = conversationIdProp ?? assignedConversationId;
-  const conversationIdRef = useDataRef(conversationId);
-
-  const [messages, setMessages] = useState<AgentMessage[]>([]);
-  const [isRunning, setIsRunning] = useState(false);
-  const [typing, setTyping] = useState<AgentConversationTyping>();
-  const [status, setStatus] = useState<AgentConversationStatus>('active');
-  const [pagination, setPagination] = useState<AgentChatPagination>({ status: 'idle', hasMore: false });
-  const [error, setError] = useState<NovuError | AgentChatPlanLimitError>();
-  const [isLoading, setIsLoading] = useState(Boolean(conversationIdProp));
-  const [isRecovering, setIsRecovering] = useState(false);
-  const [catchUpError, setCatchUpError] = useState<NovuError | undefined>();
-  const fetchGenerationRef = useRef(0);
-  const notifiedCatchUpErrorRef = useRef<NovuError | undefined>();
-  const lastReportedErrorKeyRef = useRef<string>();
-
-  const pendingActions = useMemo(() => derivePendingActions(messages), [messages]);
-
-  const snapshotSetters = useMemo(
-    () => ({
-      setMessages,
-      setIsRunning,
-      setTyping,
-      setStatus,
-      setPagination,
-      setError,
-    }),
-    []
-  );
+  const [createSessionGeneration, setCreateSessionGeneration] = useState(0);
 
   useEffect(() => {
     const agentChanged = prevAgentIdRef.current !== agentId;
@@ -187,134 +149,121 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     prevAgentIdRef.current = agentId;
     prevConversationIdPropRef.current = conversationIdProp;
 
-    if (agentChanged) {
-      setAssignedConversationId(undefined);
-      setLocalSessionKey(createLocalSessionKey());
-      applyConversationSnapshot(EMPTY_CONVERSATION, snapshotSetters);
-      setError(undefined);
-      setIsLoading(Boolean(conversationIdProp));
-      lastReportedErrorKeyRef.current = undefined;
-
+    if (sharedRuntime) {
       return;
+    }
+
+    if (agentChanged || (prevConversationIdProp !== undefined && conversationIdProp === undefined)) {
+      if (ownsRuntimeRef.current && ownedRuntimeRef.current) {
+        ownedRuntimeRef.current.dispose();
+      }
+      ownedRuntimeRef.current = null;
+      ownsRuntimeRef.current = false;
+      setCreateSessionGeneration((generation) => generation + 1);
+    }
+
+    if (conversationIdProp && ownsRuntimeRef.current && ownedRuntimeRef.current) {
+      ownedRuntimeRef.current.dispose();
+      ownedRuntimeRef.current = null;
+      ownsRuntimeRef.current = false;
+    }
+  }, [agentId, conversationIdProp, sharedRuntime]);
+
+  const runtime = useMemo(() => {
+    if (sharedRuntime) {
+      return sharedRuntime;
     }
 
     if (conversationIdProp) {
-      setAssignedConversationId(undefined);
+      const result = novu.agentChat.conversation({
+        agentId,
+        conversationId: conversationIdProp,
+        agentHash,
+      });
 
+      return result.ok ? result.data : null;
+    }
+
+    if (!ownedRuntimeRef.current) {
+      const result = novu.agentChat.conversation({ agentId, agentHash });
+      if (result.ok) {
+        ownedRuntimeRef.current = result.data;
+        ownsRuntimeRef.current = true;
+      }
+    }
+
+    return ownedRuntimeRef.current;
+  }, [sharedRuntime, novu, agentId, conversationIdProp, agentHash, createSessionGeneration]);
+
+  useEffect(() => {
+    return () => {
+      if (ownsRuntimeRef.current && ownedRuntimeRef.current) {
+        ownedRuntimeRef.current.dispose();
+        ownedRuntimeRef.current = null;
+        ownsRuntimeRef.current = false;
+      }
+    };
+  }, []);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!runtime) {
+        return () => {};
+      }
+
+      return subscribeToRuntime(runtime, onStoreChange);
+    },
+    [runtime]
+  );
+
+  const getSnapshot = useCallback(() => {
+    return runtime?.getSnapshot() ?? EMPTY_SERVER_SNAPSHOT;
+  }, [runtime]);
+
+  const getServerSnapshot = useCallback(() => {
+    return runtime?.getServerSnapshot() ?? EMPTY_SERVER_SNAPSHOT;
+  }, [runtime]);
+
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const notifiedCatchUpErrorRef = useRef<NovuError | undefined>();
+  const lastReportedErrorKeyRef = useRef<string>();
+  const loadNotifiedRef = useRef(false);
+  const replayedActionsRef = useRef(false);
+
+  useEffect(() => {
+    loadNotifiedRef.current = false;
+    replayedActionsRef.current = false;
+    notifiedCatchUpErrorRef.current = undefined;
+    lastReportedErrorKeyRef.current = undefined;
+  }, [runtime]);
+
+  useEffect(() => {
+    if (!runtime) {
       return;
     }
 
-    setIsLoading(false);
-    if (prevConversationIdProp !== undefined) {
-      setAssignedConversationId(undefined);
-      setLocalSessionKey(createLocalSessionKey());
-      applyConversationSnapshot(EMPTY_CONVERSATION, snapshotSetters);
-    }
-  }, [agentId, conversationIdProp, snapshotSetters]);
-
-  const fetchConversation = useCallback(
-    async (targetConversationId: string) => {
-      const generation = ++fetchGenerationRef.current;
-      setError(undefined);
-      lastReportedErrorKeyRef.current = undefined;
-      setIsLoading(true);
-
-      const response = await novu.agentChat.loadConversation({
-        agentId,
-        conversationId: targetConversationId,
-      });
-
-      if (generation !== fetchGenerationRef.current) {
-        return;
-      }
-
-      if (response.error) {
-        setError(response.error);
-        propsRef.current.onError?.(response.error);
-      } else if (response.data) {
-        setMessages(response.data.messages);
-        const snapshot = novu.agentChat.getConversation({
-          agentId,
-          conversationId: targetConversationId,
-        });
-        if (snapshot) {
-          setPagination(snapshot.pagination);
-        } else {
-          setPagination({ status: 'idle', hasMore: response.data.hasMore });
-        }
-        propsRef.current.onSuccess?.(response.data);
-      }
-
-      setIsLoading(false);
-    },
-    [novu, agentId, propsRef]
-  );
-
-  useEffect(() => {
-    // Agent chat always subscribes for live WS events while mounted, regardless of
-    // `<NovuProvider realtime={false}>`. That flag only disables notification/count
-    // auto-sync (`useNotifications`, `useCounts`). To stop agent-chat live updates,
-    // unmount the hook or call `novu.agentChat.unsubscribe()` yourself.
-    novu.agentChat.subscribe();
-
-    const snapshot = novu.agentChat.getConversation({
-      agentId,
-      key: sessionKey,
-      conversationId: conversationIdProp,
-    });
-    if (snapshot) {
-      applyConversationSnapshot(
-        {
-          messages: snapshot.messages,
-          isRunning: snapshot.isRunning,
-          typing: snapshot.typing,
-          status: snapshot.status,
-          pagination: snapshot.pagination,
-          error: snapshot.error,
-        },
-        snapshotSetters
-      );
-      setIsRecovering(snapshot.isRecovering);
-      setCatchUpError(snapshot.catchUpError);
-      if (snapshot.catchUpError && snapshot.catchUpError !== notifiedCatchUpErrorRef.current) {
-        notifiedCatchUpErrorRef.current = snapshot.catchUpError;
-        propsRef.current.onError?.(snapshot.catchUpError);
-      }
-      if (snapshot.conversationId && !conversationIdProp) {
-        setAssignedConversationId(snapshot.conversationId);
-      }
-
-      // The store reports each action once per holder, and a holder outlives a mount.
-      // Replay from the snapshot so a remount still learns what the run is blocked on.
-      for (const action of derivePendingActions(snapshot.messages)) {
+    if (!replayedActionsRef.current) {
+      replayedActionsRef.current = true;
+      for (const action of runtime.getSnapshot().pendingActions) {
         propsRef.current.onActionRequested?.(action);
       }
-    } else if (!conversationIdProp) {
-      applyConversationSnapshot(EMPTY_CONVERSATION, snapshotSetters);
     }
 
-    const cleanup = novu.on('agent_chat.messages.updated', ({ data }) => {
-      if (data.key !== sessionKeyRef.current) {
+    return novu.agentChat.onMessagesUpdated((data) => {
+      if (data.key !== runtime.key) {
         return;
       }
 
-      applyConversationSnapshot(
-        {
+      if (data.change.kind === 'history' && !loadNotifiedRef.current && conversationIdProp) {
+        loadNotifiedRef.current = true;
+        propsRef.current.onSuccess?.({
+          conversationId: data.conversationId!,
           messages: data.messages,
-          isRunning: data.isRunning,
-          typing: data.typing,
-          status: data.status,
-          pagination: data.pagination,
-          error: data.error,
-        },
-        snapshotSetters
-      );
-      if (data.conversationId && !propsRef.current.conversationId) {
-        setAssignedConversationId(data.conversationId);
+          hasMore: data.hasMore,
+        });
       }
 
-      setIsRecovering(data.isRecovering);
-      setCatchUpError(data.catchUpError);
       if (data.catchUpError && data.catchUpError !== notifiedCatchUpErrorRef.current) {
         notifiedCatchUpErrorRef.current = data.catchUpError;
         propsRef.current.onError?.(data.catchUpError);
@@ -332,156 +281,149 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
         lastReportedErrorKeyRef.current = undefined;
       }
 
-      const { change } = data;
-      if (change.kind === 'live') {
-        propsRef.current.onEvent?.(change.envelope);
+      if (data.change.kind === 'live') {
+        propsRef.current.onEvent?.(data.change.envelope);
       }
 
-      if (change.kind !== 'history') {
-        for (const message of change.addedMessages) {
+      if (data.change.kind !== 'history') {
+        for (const message of data.change.addedMessages) {
           propsRef.current.onMessage?.(message);
         }
       }
 
-      for (const action of change.newActions) {
+      for (const action of data.change.newActions) {
         propsRef.current.onActionRequested?.(action);
       }
     });
-
-    if (conversationIdProp) {
-      void fetchConversation(conversationIdProp);
-    }
-
-    return () => {
-      cleanup();
-      novu.agentChat.unsubscribe();
-    };
-  }, [novu, agentId, conversationIdProp, sessionKey, sessionKeyRef, propsRef, fetchConversation, snapshotSetters]);
+  }, [novu, runtime, conversationIdProp, propsRef]);
 
   const refetch = useCallback(async () => {
-    const id = conversationIdRef.current;
-    if (!id) {
+    if (!runtime) {
       return;
     }
 
-    await fetchConversation(id);
-  }, [conversationIdRef, fetchConversation]);
+    const response = await runtime.load();
+    if (response.data) {
+      propsRef.current.onSuccess?.({
+        conversationId: response.data.conversationId,
+        messages: [...response.data.messages],
+        hasMore: response.data.hasMore,
+      });
+    }
+  }, [runtime, propsRef]);
 
   const fetchMore = useCallback(async () => {
-    const response = await novu.agentChat.fetchMore({
-      agentId,
-      key: sessionKeyRef.current,
-      conversationId: conversationIdRef.current,
-    });
-
-    if (response.error) {
-      setError(response.error);
-      propsRef.current.onError?.(response.error);
-    } else if (response.data) {
-      setMessages(response.data.messages);
-      setPagination((current: AgentChatPagination) => ({
-        ...current,
-        hasMore: response.data!.hasMore,
-      }));
+    if (!runtime) {
+      return { error: undefined };
     }
 
-    return response;
-  }, [novu, agentId, sessionKeyRef, conversationIdRef, propsRef]);
+    const response = await runtime.fetchMore();
+    if (response.error) {
+      propsRef.current.onError?.(response.error);
+    }
+
+    return {
+      ...response,
+      data: response.data
+        ? {
+            messages: [...response.data.messages],
+            hasMore: response.data.hasMore,
+          }
+        : undefined,
+    };
+  }, [runtime, propsRef]);
 
   const paginationWithFetch = useMemo(
     () => ({
-      ...pagination,
+      status: snapshot.pagination.status,
+      hasMore: snapshot.pagination.hasMore,
       fetchMore,
     }),
-    [pagination, fetchMore]
+    [snapshot.pagination.status, snapshot.pagination.hasMore, fetchMore]
   );
 
   const sendMessage = useCallback(
     async (text: string) => {
-      setError(undefined);
+      if (!runtime) {
+        return { error: undefined };
+      }
 
-      const response = await novu.agentChat.sendMessage({
-        agentId,
-        agentHash,
-        text,
-        key: sessionKeyRef.current,
-        conversationId: conversationIdRef.current,
-      });
-
+      const response = await runtime.sendMessage(text);
       if (response.error) {
-        setError(response.error);
         propsRef.current.onError?.(response.error);
-      } else if (response.data && !propsRef.current.conversationId) {
-        setAssignedConversationId(response.data.conversationId);
       }
 
       return response;
     },
-    [novu, agentId, agentHash, sessionKeyRef, conversationIdRef, propsRef]
+    [runtime, propsRef]
   );
 
   const respondToAction = useCallback(
     async (args: { actionId: string; decision: AgentToolApprovalDecision }) => {
-      setError(undefined);
+      if (!runtime) {
+        return { error: undefined };
+      }
 
-      const response = await novu.agentChat.respondToAction({
-        agentId,
-        agentHash,
-        key: sessionKeyRef.current,
-        conversationId: conversationIdRef.current,
-        actionId: args.actionId,
-        decision: args.decision,
-      });
-
+      const response = await runtime.respondToAction(args);
       if (response.error) {
-        setError(response.error);
         propsRef.current.onError?.(response.error);
       }
 
       return response;
     },
-    [novu, agentId, agentHash, sessionKeyRef, conversationIdRef, propsRef]
+    [runtime, propsRef]
   );
 
   const sendAction = useCallback(
     async (args: { actionId: string; sourceMessageId: string; value?: string }) => {
-      setError(undefined);
+      if (!runtime) {
+        return { error: undefined };
+      }
 
-      const response = await novu.agentChat.sendAction({
-        agentId,
-        agentHash,
-        key: sessionKeyRef.current,
-        conversationId: conversationIdRef.current,
-        actionId: args.actionId,
-        sourceMessageId: args.sourceMessageId,
-        value: args.value,
-      });
-
+      const response = await runtime.sendAction(args);
       if (response.error) {
-        setError(response.error);
         propsRef.current.onError?.(response.error);
       }
 
       return response;
     },
-    [novu, agentId, agentHash, sessionKeyRef, conversationIdRef, propsRef]
+    [runtime, propsRef]
+  );
+
+  const retryMessage = useCallback(
+    async (messageId: string) => {
+      if (!runtime) {
+        return { error: undefined };
+      }
+
+      const response = await runtime.retryMessage(messageId);
+      if (response.error) {
+        propsRef.current.onError?.(response.error);
+      }
+
+      return response;
+    },
+    [runtime, propsRef]
   );
 
   return {
-    messages,
-    pendingActions,
+    messages: [...snapshot.messages],
+    pendingActions: [...snapshot.pendingActions],
+    conversationId: snapshot.conversationId,
+    error: snapshot.error as UseAgentChatResult['error'],
+    isLoading: snapshot.status === 'loading',
+    isRunning: snapshot.run.isRunning,
+    typing: snapshot.run.typing,
+    status: snapshot.conversationStatus,
+    conversationStatus: snapshot.conversationStatus,
+    run: snapshot.run,
+    pagination: paginationWithFetch,
+    isRecovering: snapshot.isRecovering,
+    catchUpError: snapshot.catchUpError,
+    refetch,
     sendMessage,
     respondToAction,
     sendAction,
-    conversationId,
-    error,
-    isLoading,
-    isRunning,
-    typing,
-    status,
-    pagination: paginationWithFetch,
-    isRecovering,
-    catchUpError,
-    refetch,
+    retryMessage,
   };
 };

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,6 +1,7 @@
 import type {
   AgentChatPagination,
   AgentChatPlanLimitError,
+  AgentConversationPublicationMeta,
   AgentConversationRunSnapshot,
   AgentConversationRuntime,
   AgentConversationSnapshot,
@@ -16,7 +17,7 @@ import type {
   SendActionResult,
   SendMessageResult,
 } from '@novu/js';
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
 
@@ -111,12 +112,6 @@ export type UseAgentChatResult = {
   }>;
 };
 
-function subscribeToRuntime(runtime: AgentConversationRuntime, onStoreChange: () => void): () => void {
-  return runtime.subscribe(() => {
-    onStoreChange();
-  });
-}
-
 const EMPTY_SERVER_SNAPSHOT: AgentConversationSnapshot = {
   key: 'ssr',
   status: 'ready',
@@ -128,6 +123,77 @@ const EMPTY_SERVER_SNAPSHOT: AgentConversationSnapshot = {
   isRecovering: false,
 };
 
+type RuntimeActionResult<T> = {
+  data?: T;
+  error?: NovuError | AgentChatPlanLimitError;
+};
+
+function handlePublicationCallbacks(args: {
+  snapshot: AgentConversationSnapshot;
+  meta: AgentConversationPublicationMeta | undefined;
+  conversationIdProp: string | undefined;
+  propsRef: ReturnType<typeof useDataRef<UseAgentChatProps>>;
+  loadNotifiedRef: MutableRefObject<boolean>;
+  notifiedCatchUpErrorRef: MutableRefObject<NovuError | undefined>;
+  lastReportedErrorKeyRef: MutableRefObject<string | undefined>;
+}): void {
+  const {
+    snapshot,
+    meta,
+    conversationIdProp,
+    propsRef,
+    loadNotifiedRef,
+    notifiedCatchUpErrorRef,
+    lastReportedErrorKeyRef,
+  } = args;
+
+  if ((meta?.historyLoaded || meta?.change?.kind === 'history') && !loadNotifiedRef.current && conversationIdProp) {
+    if (snapshot.conversationId) {
+      loadNotifiedRef.current = true;
+      propsRef.current.onSuccess?.({
+        conversationId: snapshot.conversationId,
+        messages: [...snapshot.messages],
+        hasMore: snapshot.pagination.hasMore,
+      });
+    }
+  }
+
+  if (snapshot.catchUpError && snapshot.catchUpError !== notifiedCatchUpErrorRef.current) {
+    notifiedCatchUpErrorRef.current = snapshot.catchUpError;
+    propsRef.current.onError?.(snapshot.catchUpError);
+  } else if (!snapshot.catchUpError) {
+    notifiedCatchUpErrorRef.current = undefined;
+  }
+
+  if (snapshot.error) {
+    const originalMessage = 'originalError' in snapshot.error ? (snapshot.error.originalError?.message ?? '') : '';
+    const errorKey = `${snapshot.error.message}:${originalMessage}`;
+    if (lastReportedErrorKeyRef.current !== errorKey) {
+      lastReportedErrorKeyRef.current = errorKey;
+      propsRef.current.onError?.(snapshot.error as NovuError | AgentChatPlanLimitError);
+    }
+  } else {
+    lastReportedErrorKeyRef.current = undefined;
+  }
+
+  const change = meta?.change;
+  if (change?.kind === 'live') {
+    propsRef.current.onEvent?.(change.envelope);
+  }
+
+  if (change && change.kind !== 'history') {
+    for (const message of change.addedMessages) {
+      propsRef.current.onMessage?.(message);
+    }
+  }
+
+  if (change) {
+    for (const action of change.newActions) {
+      propsRef.current.onActionRequested?.(action);
+    }
+  }
+}
+
 export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const novu = useNovu();
   const propsRef = useDataRef(props);
@@ -137,73 +203,60 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const conversationIdProp = sharedRuntime ? undefined : props.conversationId;
   const agentHash = sharedRuntime ? undefined : props.agentHash;
 
-  const ownedRuntimeRef = useRef<AgentConversationRuntime | null>(null);
-  const ownsRuntimeRef = useRef(false);
-  const prevAgentIdRef = useRef(agentId);
-  const prevConversationIdPropRef = useRef(conversationIdProp);
-  const [createSessionGeneration, setCreateSessionGeneration] = useState(0);
+  const [ownedRuntime, setOwnedRuntime] = useState<AgentConversationRuntime | null>(null);
 
-  useEffect(() => {
-    const agentChanged = prevAgentIdRef.current !== agentId;
-    const prevConversationIdProp = prevConversationIdPropRef.current;
-    prevAgentIdRef.current = agentId;
-    prevConversationIdPropRef.current = conversationIdProp;
-
-    if (sharedRuntime) {
-      return;
-    }
-
-    if (agentChanged || (prevConversationIdProp !== undefined && conversationIdProp === undefined)) {
-      if (ownsRuntimeRef.current && ownedRuntimeRef.current) {
-        ownedRuntimeRef.current.dispose();
-      }
-      ownedRuntimeRef.current = null;
-      ownsRuntimeRef.current = false;
-      setCreateSessionGeneration((generation) => generation + 1);
-    }
-
-    if (conversationIdProp && ownsRuntimeRef.current && ownedRuntimeRef.current) {
-      ownedRuntimeRef.current.dispose();
-      ownedRuntimeRef.current = null;
-      ownsRuntimeRef.current = false;
-    }
-  }, [agentId, conversationIdProp, sharedRuntime]);
-
-  const runtime = useMemo(() => {
+  const cachedRuntime = useMemo(() => {
     if (sharedRuntime) {
       return sharedRuntime;
     }
 
-    if (conversationIdProp) {
-      const result = novu.agentChat.conversation({
-        agentId,
-        conversationId: conversationIdProp,
-        agentHash,
-      });
-
-      return result.ok ? result.data : null;
+    if (!conversationIdProp) {
+      return null;
     }
 
-    if (!ownedRuntimeRef.current) {
-      const result = novu.agentChat.conversation({ agentId, agentHash });
-      if (result.ok) {
-        ownedRuntimeRef.current = result.data;
-        ownsRuntimeRef.current = true;
-      }
-    }
+    const result = novu.agentChat.conversation({
+      agentId,
+      conversationId: conversationIdProp,
+      agentHash,
+    });
 
-    return ownedRuntimeRef.current;
-  }, [sharedRuntime, novu, agentId, conversationIdProp, agentHash, createSessionGeneration]);
+    return result.ok ? result.data : null;
+  }, [sharedRuntime, novu, agentId, conversationIdProp, agentHash]);
 
   useEffect(() => {
+    if (sharedRuntime || conversationIdProp) {
+      setOwnedRuntime(null);
+      return;
+    }
+
+    const result = novu.agentChat.conversation({ agentId, agentHash });
+    if (!result.ok) {
+      setOwnedRuntime(null);
+      return;
+    }
+
+    const runtime = result.data;
+    setOwnedRuntime(runtime);
+
     return () => {
-      if (ownsRuntimeRef.current && ownedRuntimeRef.current) {
-        ownedRuntimeRef.current.dispose();
-        ownedRuntimeRef.current = null;
-        ownsRuntimeRef.current = false;
-      }
+      runtime.dispose();
+      setOwnedRuntime(null);
     };
-  }, []);
+  }, [sharedRuntime, conversationIdProp, agentId, agentHash, novu]);
+
+  const runtime = sharedRuntime ?? cachedRuntime ?? ownedRuntime;
+
+  const loadNotifiedRef = useRef(false);
+  const replayedActionsRef = useRef(false);
+  const notifiedCatchUpErrorRef = useRef<NovuError | undefined>();
+  const lastReportedErrorKeyRef = useRef<string>();
+
+  useEffect(() => {
+    loadNotifiedRef.current = false;
+    replayedActionsRef.current = false;
+    notifiedCatchUpErrorRef.current = undefined;
+    lastReportedErrorKeyRef.current = undefined;
+  }, [runtime]);
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
@@ -211,9 +264,27 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
         return () => {};
       }
 
-      return subscribeToRuntime(runtime, onStoreChange);
+      if (!replayedActionsRef.current) {
+        replayedActionsRef.current = true;
+        for (const action of runtime.getSnapshot().pendingActions) {
+          propsRef.current.onActionRequested?.(action);
+        }
+      }
+
+      return runtime.subscribe((snapshot, meta) => {
+        onStoreChange();
+        handlePublicationCallbacks({
+          snapshot,
+          meta,
+          conversationIdProp,
+          propsRef,
+          loadNotifiedRef,
+          notifiedCatchUpErrorRef,
+          lastReportedErrorKeyRef,
+        });
+      });
     },
-    [runtime]
+    [runtime, conversationIdProp, propsRef]
   );
 
   const getSnapshot = useCallback(() => {
@@ -226,76 +297,21 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
 
   const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
-  const notifiedCatchUpErrorRef = useRef<NovuError | undefined>();
-  const lastReportedErrorKeyRef = useRef<string>();
-  const loadNotifiedRef = useRef(false);
-  const replayedActionsRef = useRef(false);
-
-  useEffect(() => {
-    loadNotifiedRef.current = false;
-    replayedActionsRef.current = false;
-    notifiedCatchUpErrorRef.current = undefined;
-    lastReportedErrorKeyRef.current = undefined;
-  }, [runtime]);
-
-  useEffect(() => {
-    if (!runtime) {
-      return;
-    }
-
-    if (!replayedActionsRef.current) {
-      replayedActionsRef.current = true;
-      for (const action of runtime.getSnapshot().pendingActions) {
-        propsRef.current.onActionRequested?.(action);
-      }
-    }
-
-    return novu.agentChat.onMessagesUpdated((data) => {
-      if (data.key !== runtime.key) {
-        return;
+  const callRuntime = useCallback(
+    async <T>(action: (target: AgentConversationRuntime) => Promise<RuntimeActionResult<T>>) => {
+      if (!runtime) {
+        return { error: undefined };
       }
 
-      if (data.change.kind === 'history' && !loadNotifiedRef.current && conversationIdProp) {
-        loadNotifiedRef.current = true;
-        propsRef.current.onSuccess?.({
-          conversationId: data.conversationId!,
-          messages: data.messages,
-          hasMore: data.hasMore,
-        });
+      const response = await action(runtime);
+      if (response.error) {
+        propsRef.current.onError?.(response.error);
       }
 
-      if (data.catchUpError && data.catchUpError !== notifiedCatchUpErrorRef.current) {
-        notifiedCatchUpErrorRef.current = data.catchUpError;
-        propsRef.current.onError?.(data.catchUpError);
-      } else if (data.catchUpError === undefined) {
-        notifiedCatchUpErrorRef.current = undefined;
-      }
-
-      if (data.error) {
-        const errorKey = `${data.error.message}:${data.error.originalError?.message ?? ''}`;
-        if (lastReportedErrorKeyRef.current !== errorKey) {
-          lastReportedErrorKeyRef.current = errorKey;
-          propsRef.current.onError?.(data.error);
-        }
-      } else {
-        lastReportedErrorKeyRef.current = undefined;
-      }
-
-      if (data.change.kind === 'live') {
-        propsRef.current.onEvent?.(data.change.envelope);
-      }
-
-      if (data.change.kind !== 'history') {
-        for (const message of data.change.addedMessages) {
-          propsRef.current.onMessage?.(message);
-        }
-      }
-
-      for (const action of data.change.newActions) {
-        propsRef.current.onActionRequested?.(action);
-      }
-    });
-  }, [novu, runtime, conversationIdProp, propsRef]);
+      return response;
+    },
+    [runtime, propsRef]
+  );
 
   const refetch = useCallback(async () => {
     if (!runtime) {
@@ -313,17 +329,11 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   }, [runtime, propsRef]);
 
   const fetchMore = useCallback(async () => {
-    if (!runtime) {
-      return { error: undefined };
-    }
-
-    const response = await runtime.fetchMore();
-    if (response.error) {
-      propsRef.current.onError?.(response.error);
-    }
+    const response = await callRuntime((target) => target.fetchMore());
 
     return {
       ...response,
+      error: response.error as NovuError | undefined,
       data: response.data
         ? {
             messages: [...response.data.messages],
@@ -331,7 +341,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
           }
         : undefined,
     };
-  }, [runtime, propsRef]);
+  }, [callRuntime]);
 
   const paginationWithFetch = useMemo(
     () => ({
@@ -342,68 +352,20 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     [snapshot.pagination.status, snapshot.pagination.hasMore, fetchMore]
   );
 
-  const sendMessage = useCallback(
-    async (text: string) => {
-      if (!runtime) {
-        return { error: undefined };
-      }
-
-      const response = await runtime.sendMessage(text);
-      if (response.error) {
-        propsRef.current.onError?.(response.error);
-      }
-
-      return response;
-    },
-    [runtime, propsRef]
-  );
-
+  const sendMessage = useCallback((text: string) => callRuntime((target) => target.sendMessage(text)), [callRuntime]);
   const respondToAction = useCallback(
-    async (args: { actionId: string; decision: AgentToolApprovalDecision }) => {
-      if (!runtime) {
-        return { error: undefined };
-      }
-
-      const response = await runtime.respondToAction(args);
-      if (response.error) {
-        propsRef.current.onError?.(response.error);
-      }
-
-      return response;
-    },
-    [runtime, propsRef]
+    (args: { actionId: string; decision: AgentToolApprovalDecision }) =>
+      callRuntime((target) => target.respondToAction(args)),
+    [callRuntime]
   );
-
   const sendAction = useCallback(
-    async (args: { actionId: string; sourceMessageId: string; value?: string }) => {
-      if (!runtime) {
-        return { error: undefined };
-      }
-
-      const response = await runtime.sendAction(args);
-      if (response.error) {
-        propsRef.current.onError?.(response.error);
-      }
-
-      return response;
-    },
-    [runtime, propsRef]
+    (args: { actionId: string; sourceMessageId: string; value?: string }) =>
+      callRuntime((target) => target.sendAction(args)),
+    [callRuntime]
   );
-
   const retryMessage = useCallback(
-    async (messageId: string) => {
-      if (!runtime) {
-        return { error: undefined };
-      }
-
-      const response = await runtime.retryMessage(messageId);
-      if (response.error) {
-        propsRef.current.onError?.(response.error);
-      }
-
-      return response;
-    },
-    [runtime, propsRef]
+    (messageId: string) => callRuntime((target) => target.retryMessage(messageId)),
+    [callRuntime]
   );
 
   return {

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -17,7 +17,7 @@ import type {
   SendActionResult,
   SendMessageResult,
 } from '@novu/js';
-import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
 
@@ -194,6 +194,40 @@ function handlePublicationCallbacks(args: {
   }
 }
 
+type OwnedRuntimeEntry = {
+  key: string;
+  runtime: AgentConversationRuntime;
+};
+
+function getCreateFlowKey(agentId: string, agentHash?: string): string {
+  return `${agentId}\0${agentHash ?? ''}`;
+}
+
+function resolveOwnedRuntime(args: {
+  novu: ReturnType<typeof useNovu>;
+  agentId: string;
+  agentHash?: string;
+  ownedRuntimeRef: MutableRefObject<OwnedRuntimeEntry | null>;
+}): AgentConversationRuntime | null {
+  const key = getCreateFlowKey(args.agentId, args.agentHash);
+  const current = args.ownedRuntimeRef.current;
+
+  if (current?.key === key) {
+    return current.runtime;
+  }
+
+  current?.runtime.dispose();
+
+  const result = args.novu.agentChat.conversation({ agentId: args.agentId, agentHash: args.agentHash });
+  if (!result.ok) {
+    args.ownedRuntimeRef.current = null;
+    return null;
+  }
+
+  args.ownedRuntimeRef.current = { key, runtime: result.data };
+  return result.data;
+}
+
 export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const novu = useNovu();
   const propsRef = useDataRef(props);
@@ -203,7 +237,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const conversationIdProp = sharedRuntime ? undefined : props.conversationId;
   const agentHash = sharedRuntime ? undefined : props.agentHash;
 
-  const [ownedRuntime, setOwnedRuntime] = useState<AgentConversationRuntime | null>(null);
+  const ownedRuntimeRef = useRef<OwnedRuntimeEntry | null>(null);
 
   const cachedRuntime = useMemo(() => {
     if (sharedRuntime) {
@@ -223,28 +257,22 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     return result.ok ? result.data : null;
   }, [sharedRuntime, novu, agentId, conversationIdProp, agentHash]);
 
-  useEffect(() => {
-    if (sharedRuntime || conversationIdProp) {
-      setOwnedRuntime(null);
-      return;
-    }
+  if (sharedRuntime || conversationIdProp) {
+    ownedRuntimeRef.current?.runtime.dispose();
+    ownedRuntimeRef.current = null;
+  }
 
-    const result = novu.agentChat.conversation({ agentId, agentHash });
-    if (!result.ok) {
-      setOwnedRuntime(null);
-      return;
-    }
-
-    const runtime = result.data;
-    setOwnedRuntime(runtime);
-
-    return () => {
-      runtime.dispose();
-      setOwnedRuntime(null);
-    };
-  }, [sharedRuntime, conversationIdProp, agentId, agentHash, novu]);
+  const ownedRuntime =
+    sharedRuntime || conversationIdProp ? null : resolveOwnedRuntime({ novu, agentId, agentHash, ownedRuntimeRef });
 
   const runtime = sharedRuntime ?? cachedRuntime ?? ownedRuntime;
+
+  useEffect(() => {
+    return () => {
+      ownedRuntimeRef.current?.runtime.dispose();
+      ownedRuntimeRef.current = null;
+    };
+  }, []);
 
   const loadNotifiedRef = useRef(false);
   const replayedActionsRef = useRef(false);

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -85,6 +85,8 @@ export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
     isRunning: false,
     typing: undefined,
     status: 'active',
+    conversationStatus: 'active',
+    run: { isRunning: false },
     pagination: {
       status: 'idle',
       hasMore: false,
@@ -96,6 +98,7 @@ export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
     sendMessage: () => Promise.resolve({ data: undefined, error: undefined }),
     respondToAction: () => Promise.resolve({ data: undefined, error: undefined }),
     sendAction: () => Promise.resolve({ data: undefined, error: undefined }),
+    retryMessage: () => Promise.resolve({ data: undefined, error: undefined }),
   };
 }
 


### PR DESCRIPTION
## Summary
- Rebuild `useAgentChat` to bind to `AgentConversationRuntime` via `useSyncExternalStore`, removing mirrored React state for messages, run, pagination, and errors.
- Extend the conversation runtime snapshot with recovery/pagination metadata, `getServerSnapshot()`, and `retryMessage()`, plus publication meta for hook callbacks.
- Simplify hook lifecycle (effect-owned create-flow runtime, single runtime subscription, deduped action wrappers) to avoid Strict Mode dispose bugs and duplicate store listeners.

## Test plan
- [x] `pnpm test -- agent-conversation-runtime.test.ts` in `packages/js`
- [x] `pnpm exec tsc --noEmit` in `packages/react`
- [x] Typecheck `playground/agent-chat` and `apps/dashboard` consumers
- [ ] Manual smoke: `playground/agent-chat` — send message, resume conversation, pagination
- [ ] Strict Mode sanity check in dashboard agent chat panel (create + remount)

## Notes
- No new `@novu/react` unit tests added — consistent with existing hook coverage in this package; behavior is covered by `@novu/js` runtime/store tests plus consumer typechecks.
- Linear: https://linear.app/novu/issue/NV-8641


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR rebuilds `useAgentChat` around `AgentConversationRuntime` snapshots and `useSyncExternalStore`, removing mirrored React state and synchronizing runtime metadata, callbacks, retries, pagination, and server rendering.
- Creates the create-flow runtime synchronously so actions are available during the initial commit.
- Extends runtime snapshots with recovery, pagination, publication, and retry data.
- Supports externally shared conversation runtimes and adds matching server-hook defaults.
- Updates runtime tests and the JavaScript bundle-size allowance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/hooks/useAgentChat.ts | Replaces mirrored hook state with a synchronously available conversation runtime and `useSyncExternalStore`, addressing the previously reported initial-action gap. |
| packages/js/src/agent-chat/agent-conversation-runtime.ts | Expands immutable runtime snapshots and publication metadata while adding retry support and server snapshots. |
| packages/js/src/agent-chat/conversation-runtime.types.ts | Extends the public conversation runtime contract with pagination status, recovery state, publication metadata, and retry actions. |
| packages/react/src/server/index.tsx | Keeps the server-safe hook result aligned with the expanded client hook contract. |
| packages/js/src/agent-chat/agent-conversation-runtime.test.ts | Updates runtime snapshot coverage for the newly explicit pagination status. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Consumer[React consumer] --> Hook[useAgentChat]
  Hook -->|useSyncExternalStore| Runtime[AgentConversationRuntime]
  Runtime --> Store[Agent Chat store]
  Store --> Runtime
  Runtime -->|immutable snapshot| Hook
  Hook --> View[Messages, run, pagination, recovery]
  Consumer -->|actions| Hook
  Hook -->|send, retry, fetch, respond| Runtime
```

<sub>Reviews (2): Last reviewed commit: ["fix(react,js): create runtime synchronou..."](https://github.com/novuhq/novu/commit/91877793902207063afe4f85ef334e3d4c8587d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56245873)</sub>

<!-- /greptile_comment -->