### PR TITLE
feat(application-generic): add unary operators for empty and non-empty string fields in step condition fixes NV-8674

### DIFF
--- a/apps/dashboard/src/components/conditions-editor/field-type-editors.ts
+++ b/apps/dashboard/src/components/conditions-editor/field-type-editors.ts
@@ -1,9 +1,9 @@
 import type { ValueEditorType } from 'react-querybuilder';
 import type { EnhancedField } from '@/components/conditions-editor/conditions-editor';
-import { isRelativeDateOperator } from './field-type-operators';
+import { isRelativeDateOperator, isValuelessOperator } from './field-type-operators';
 
 export function getValueEditorTypeForField(fieldName: string, operator: string): ValueEditorType {
-  if (operator === 'null' || operator === 'notNull') {
+  if (isValuelessOperator(operator)) {
     return null;
   }
 

--- a/apps/dashboard/src/components/conditions-editor/field-type-operators.ts
+++ b/apps/dashboard/src/components/conditions-editor/field-type-operators.ts
@@ -5,6 +5,8 @@ const FIELD_TYPE_OPERATORS: Record<FieldDataType, Operator[]> = {
   string: [
     { name: '=', label: 'equals' },
     { name: '!=', label: 'does not equal' },
+    { name: 'isEmpty', label: 'is empty' },
+    { name: 'isNonEmpty', label: 'is not empty' },
     { name: 'contains', label: 'contains' },
     { name: 'beginsWith', label: 'begins with' },
     { name: 'endsWith', label: 'ends with' },
@@ -87,7 +89,17 @@ export function getOperatorsForFieldType(dataType: FieldDataType): Operator[] {
 }
 
 const RELATIVE_DATE_OPERATORS = ['moreThanXAgo', 'lessThanXAgo', 'withinLast', 'notWithinLast', 'exactlyXAgo'] as const;
+const UNARY_JSON_LOGIC_OPERATORS = ['isEmpty', 'isNonEmpty'] as const;
+const VALUELESS_OPERATORS = ['null', 'notNull', ...UNARY_JSON_LOGIC_OPERATORS] as const;
 
 export function isRelativeDateOperator(operator: string): boolean {
   return RELATIVE_DATE_OPERATORS.includes(operator as any);
+}
+
+export function isUnaryJsonLogicOperator(operator: string): boolean {
+  return UNARY_JSON_LOGIC_OPERATORS.some((candidate) => candidate === operator);
+}
+
+export function isValuelessOperator(operator: string): boolean {
+  return VALUELESS_OPERATORS.some((candidate) => candidate === operator);
 }

--- a/apps/dashboard/src/components/conditions-editor/value-editor.tsx
+++ b/apps/dashboard/src/components/conditions-editor/value-editor.tsx
@@ -2,6 +2,7 @@ import { useFormContext } from 'react-hook-form';
 import { useValueEditor, ValueEditorProps } from 'react-querybuilder';
 import type { HelpTextInfo } from '@/components/conditions-editor/field-type-editors';
 import { shouldUseRelativeDateEditor } from '@/components/conditions-editor/field-type-editors';
+import { isValuelessOperator } from '@/components/conditions-editor/field-type-operators';
 import { HelpIcon } from '@/components/conditions-editor/help-icon';
 import { InputRoot, InputWrapper } from '@/components/primitives/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/primitives/select';
@@ -51,7 +52,7 @@ export const ValueEditor = (props: ValueEditorProps) => {
   const stringValue = typeof value === 'string' ? value : `${value}`;
   const stringValueAsArray = valueAsArray.map((v) => (typeof v === 'string' ? v : `${v}`));
 
-  if (operator === 'null' || operator === 'notNull') {
+  if (isValuelessOperator(operator)) {
     return null;
   }
 

--- a/apps/dashboard/src/components/workflow-editor/steps/conditions/edit-step-conditions-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/conditions/edit-step-conditions-form.tsx
@@ -14,7 +14,11 @@ import { parseJsonLogic } from 'react-querybuilder/parseJsonLogic';
 import { z } from 'zod';
 
 import { ConditionsEditor } from '@/components/conditions-editor/conditions-editor';
-import { isRelativeDateOperator } from '@/components/conditions-editor/field-type-operators';
+import {
+  isRelativeDateOperator,
+  isUnaryJsonLogicOperator,
+  isValuelessOperator,
+} from '@/components/conditions-editor/field-type-operators';
 import { Form, FormField } from '@/components/primitives/form/form';
 import { updateStepInWorkflow } from '@/components/workflow-editor/step-utils';
 import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
@@ -44,6 +48,12 @@ function isContainsAnyOperator(operator: string): boolean {
 }
 
 const customRuleProcessor = (rule: RuleType, options: any) => {
+  if (isUnaryJsonLogicOperator(rule.operator)) {
+    return {
+      [rule.operator]: [{ var: rule.field }],
+    };
+  }
+
   if (isRelativeDateOperator(rule.operator)) {
     try {
       const parsedValue = JSON.parse(rule.value as string);
@@ -134,7 +144,7 @@ const getRuleSchema = (
               path: ['value'],
             });
           }
-        } else if (operator !== 'null' && operator !== 'notNull') {
+        } else if (!isValuelessOperator(operator)) {
           const trimmedValue = value?.trim();
 
           if (!trimmedValue || trimmedValue.length === 0) {

--- a/apps/dashboard/src/utils/conditions.ts
+++ b/apps/dashboard/src/utils/conditions.ts
@@ -36,6 +36,23 @@ function parseRelativeDateArgs(val: any, operator: string) {
   };
 }
 
+function parseUnaryOperatorArgs(val: unknown, operator: string) {
+  if (!val || !Array.isArray(val) || val.length !== 1) {
+    return false;
+  }
+
+  const [operand] = val;
+  if (!operand || typeof operand !== 'object' || !('var' in operand) || typeof operand.var !== 'string') {
+    return false;
+  }
+
+  return {
+    field: operand.var,
+    operator,
+    value: '',
+  };
+}
+
 const customJsonLogicOperations = {
   moreThanXAgo: (val: any) => parseRelativeDateArgs(val, 'moreThanXAgo'),
   lessThanXAgo: (val: any) => parseRelativeDateArgs(val, 'lessThanXAgo'),
@@ -44,6 +61,8 @@ const customJsonLogicOperations = {
   notWithinLast: (val: any) => parseRelativeDateArgs(val, 'notWithinLast'),
   containsAny: (val: any) => parseArrayOperatorArgs(val, 'containsAny'),
   doesNotContainAny: (val: any) => parseArrayOperatorArgs(val, 'doesNotContainAny'),
+  isEmpty: (val: unknown) => parseUnaryOperatorArgs(val, 'isEmpty'),
+  isNonEmpty: (val: unknown) => parseUnaryOperatorArgs(val, 'isNonEmpty'),
 };
 
 // Shared parse options for consistency

--- a/docs/platform/workflow/add-and-configure-steps/step-conditions.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/step-conditions.mdx
@@ -44,6 +44,8 @@ This structure allows you to model both simple checks and complex branching logi
     | --------------------- | --------------------------------------- | ----------------------------------------------- |
     | `=`                   | Equal to                                | `subscriber.locale = "en-US"`                   |
     | `!=`                  | Not equal to                            | `subscriber.isOnline != true`                   |
+    | `is empty`            | Is an empty string                      | `payload.marketingName is empty`                |
+    | `is not empty`        | Is a non-empty string                   | `payload.marketingName is not empty`            |
     | `<`                   | Less than                               | `payload.totalAmount < 100`                     |
     | `>`                   | Greater than                            | `payload.totalAmount > 100`                     |
     | `<=`                  | Less than or equal to                   | `payload.totalAmount <= 200`                    |
@@ -60,6 +62,13 @@ This structure allows you to model both simple checks and complex branching logi
     | `not in`              | Does not match any of the listed values | `subscriber.locale not in ["fr-FR", "de-DE"]`   |
     | `between`             | Within a range                          | `payload.totalAmount between [50, 200]`         |
     | `not between`         | Outside of a range                      | `payload.totalAmount not between [0, 50]`       |
+
+  **is empty** and **is not empty** are available only for string fields. They check the exact string value, so
+  whitespace-only strings are considered non-empty. Missing fields, `null`, arrays, objects, numbers, and booleans do
+  not match either operator.
+
+  Existing step conditions are unchanged. Saved `equals`, `is null`, and other operators keep the same result until
+  you add an **is empty** or **is not empty** rule.
 
 ## Data used for step conditions
 

--- a/libs/application-generic/src/services/query-parser/query-parser.service.spec.ts
+++ b/libs/application-generic/src/services/query-parser/query-parser.service.spec.ts
@@ -239,6 +239,88 @@ describe('QueryParserService', () => {
       });
     });
 
+    describe('isEmpty operator', () => {
+      it('should return true when the string is empty', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          isEmpty: [{ var: 'steps.http-step.marketingName' }],
+        };
+        const { result, error } = evaluateRules(rule, {
+          steps: { 'http-step': { marketingName: '' } },
+        });
+
+        expect(error).to.be.undefined;
+        expect(result).to.be.true;
+      });
+
+      it('should return false when the string is non-empty', () => {
+        const rule: RulesLogic<AdditionalOperation> = { isEmpty: [{ var: 'value' }] };
+        const { result, error } = evaluateRules(rule, { value: ' ' });
+
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+
+      it('should return false when the value is missing, null, or not a string', () => {
+        const rule: RulesLogic<AdditionalOperation> = { isEmpty: [{ var: 'value' }] };
+
+        expect(evaluateRules(rule, {}).result).to.be.false;
+        expect(evaluateRules(rule, { value: null }).result).to.be.false;
+        expect(evaluateRules(rule, { value: [] }).result).to.be.false;
+      });
+    });
+
+    describe('isNonEmpty operator', () => {
+      it('should return true when the string is non-empty', () => {
+        const rule: RulesLogic<AdditionalOperation> = { isNonEmpty: [{ var: 'value' }] };
+        const { result, error } = evaluateRules(rule, { value: ' ' });
+
+        expect(error).to.be.undefined;
+        expect(result).to.be.true;
+      });
+
+      it('should return false when the string is empty', () => {
+        const rule: RulesLogic<AdditionalOperation> = { isNonEmpty: [{ var: 'value' }] };
+        const { result, error } = evaluateRules(rule, { value: '' });
+
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+
+      it('should return false when the value is missing, null, or not a string', () => {
+        const rule: RulesLogic<AdditionalOperation> = { isNonEmpty: [{ var: 'value' }] };
+
+        expect(evaluateRules(rule, {}).result).to.be.false;
+        expect(evaluateRules(rule, { value: null }).result).to.be.false;
+        expect(evaluateRules(rule, { value: 1 }).result).to.be.false;
+      });
+    });
+
+    describe('existing skip rules', () => {
+      it('should keep stored equals rules matching the comparison value', () => {
+        const rule: RulesLogic<AdditionalOperation> = { '==': [{ var: 'payload.foo' }, 'high'] };
+
+        expect(evaluateRules(rule, { payload: { foo: 'high' } }).result).to.be.true;
+        expect(evaluateRules(rule, { payload: { foo: '' } }).result).to.be.false;
+        expect(evaluateRules(rule, { payload: { foo: 'low' } }).result).to.be.false;
+      });
+
+      it('should keep stored is-null comparison rules matching the same values as before', () => {
+        const rule: RulesLogic<AdditionalOperation> = { '==': [{ var: 'payload.foo' }, null] };
+
+        expect(evaluateRules(rule, { payload: { foo: null } }).result).to.be.true;
+        expect(evaluateRules(rule, { payload: { foo: '' } }).result).to.be.true;
+        expect(evaluateRules(rule, { payload: { foo: 'Acme' } }).result).to.be.false;
+      });
+
+      it('should keep stored is-not-null comparison rules matching the same values as before', () => {
+        const rule: RulesLogic<AdditionalOperation> = { '!=': [{ var: 'payload.foo' }, null] };
+
+        expect(evaluateRules(rule, { payload: { foo: 'Acme' } }).result).to.be.true;
+        expect(evaluateRules(rule, { payload: { foo: '' } }).result).to.be.false;
+        expect(evaluateRules(rule, { payload: { foo: null } }).result).to.be.false;
+      });
+    });
+
     describe('notIn operator', () => {
       it('should return true when value is not in array', () => {
         const rule: RulesLogic<AdditionalOperation> = { notIn: [{ var: 'value' }, ['a', 'b', 'c']] };

--- a/libs/application-generic/src/services/query-parser/query-parser.service.ts
+++ b/libs/application-generic/src/services/query-parser/query-parser.service.ts
@@ -235,6 +235,13 @@ const initializeCustomOperators = (): void => {
 
   jsonLogic.add_operation('notNull', (dataInput: unknown): boolean => dataInput !== null);
 
+  jsonLogic.add_operation('isEmpty', (dataInput: unknown): boolean => dataInput === '');
+
+  jsonLogic.add_operation(
+    'isNonEmpty',
+    (dataInput: unknown): boolean => typeof dataInput === 'string' && dataInput.length > 0
+  );
+
   jsonLogic.add_operation(
     'notIn',
     (dataInput: unknown, ruleValue: unknown[]): boolean => Array.isArray(ruleValue) && !ruleValue.includes(dataInput)

--- a/libs/application-generic/src/services/query-parser/query-validator.service.spec.ts
+++ b/libs/application-generic/src/services/query-parser/query-validator.service.spec.ts
@@ -80,6 +80,69 @@ describe('QueryValidatorService', () => {
       });
     });
 
+    describe('existing skip rules', () => {
+      it('should still accept stored equals and is-null comparison rules', () => {
+        const equalsRule: RulesLogic<AdditionalOperation> = {
+          '==': [{ var: 'payload.foo' }, 'high'],
+        };
+        const isNullRule: RulesLogic<AdditionalOperation> = {
+          '==': [{ var: 'payload.foo' }, null],
+        };
+
+        expect(queryValidatorService.validateQueryRules(equalsRule)).to.be.empty;
+        expect(queryValidatorService.validateQueryRules(isNullRule)).to.be.empty;
+      });
+
+      it('should still reject equals with an empty comparison value', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          '==': [{ var: 'payload.foo' }, ''],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].type).to.equal(QueryIssueTypeEnum.MISSING_VALUE);
+      });
+    });
+
+    describe('unary string operators', () => {
+      for (const operator of ['isEmpty', 'isNonEmpty']) {
+        it(`should validate a valid ${operator} operation`, () => {
+          const rule: RulesLogic<AdditionalOperation> = {
+            [operator]: [{ var: 'payload.foo' }],
+          };
+
+          const issues = queryValidatorService.validateQueryRules(rule);
+
+          expect(issues).to.be.empty;
+        });
+
+        it(`should reject an invalid ${operator} operation structure`, () => {
+          const rule: RulesLogic<AdditionalOperation> = {
+            [operator]: [{ var: 'payload.foo' }, 'unexpected'],
+          };
+
+          const issues = queryValidatorService.validateQueryRules(rule);
+
+          expect(issues).to.have.lengthOf(1);
+          expect(issues[0].message).to.include(`Invalid operation structure for operator "${operator}"`);
+          expect(issues[0].type).to.equal(QueryIssueTypeEnum.INVALID_STRUCTURE);
+        });
+
+        it(`should reject an invalid field reference for ${operator}`, () => {
+          const rule: RulesLogic<AdditionalOperation> = {
+            [operator]: [{ var: '' }],
+          };
+
+          const issues = queryValidatorService.validateQueryRules(rule);
+
+          expect(issues).to.have.lengthOf(1);
+          expect(issues[0].message).to.include('Value is not valid');
+          expect(issues[0].type).to.equal(QueryIssueTypeEnum.INVALID_FIELD_VALUE);
+        });
+      }
+    });
+
     describe('in operation', () => {
       it('should detect invalid array in operation', () => {
         const rule: any = {

--- a/libs/application-generic/src/services/query-parser/query-validator.service.ts
+++ b/libs/application-generic/src/services/query-parser/query-validator.service.ts
@@ -1,6 +1,12 @@
 import { AdditionalOperation, RulesLogic } from 'json-logic-js';
 
-import { COMPARISON_OPERATORS, JsonComparisonOperatorEnum, JsonLogicOperatorEnum } from './types';
+import type { UnaryStringOperator } from './types';
+import {
+  COMPARISON_OPERATORS,
+  isUnaryStringOperator,
+  JsonComparisonOperatorEnum,
+  JsonLogicOperatorEnum,
+} from './types';
 
 type QueryIssue = {
   message: string;
@@ -147,6 +153,16 @@ export class QueryValidatorService {
         continue;
       }
 
+      if (isUnaryStringOperator(key)) {
+        this.validateUnaryStringOperation({
+          operator: key,
+          value,
+          issues,
+          path,
+        });
+        continue;
+      }
+
       const isBetween =
         key === JsonComparisonOperatorEnum.LESS_THAN_OR_EQUAL && Array.isArray(value) && value.length === 3;
       if (isBetween) {
@@ -191,6 +207,26 @@ export class QueryValidatorService {
     if (lowerBoundIsUndefined || upperBoundIsUndefined) {
       issues.push(this.getValueIssue(path));
     }
+  }
+
+  private validateUnaryStringOperation({
+    operator,
+    value,
+    issues,
+    path,
+  }: {
+    operator: UnaryStringOperator;
+    value: unknown;
+    issues: QueryIssue[];
+    path: number[];
+  }) {
+    if (!Array.isArray(value) || value.length !== 1) {
+      issues.push(this.getOperationIssue(operator, path));
+
+      return;
+    }
+
+    this.validateFieldReference(value[0], issues, path);
   }
 
   private validateComparisonOperation({

--- a/libs/application-generic/src/services/query-parser/types.ts
+++ b/libs/application-generic/src/services/query-parser/types.ts
@@ -28,6 +28,14 @@ export const COMPARISON_OPERATORS = [
   JsonComparisonOperatorEnum.ENDS_WITH,
 ] as const;
 
+export const UNARY_STRING_OPERATORS = ['isEmpty', 'isNonEmpty'] as const;
+
+export type UnaryStringOperator = (typeof UNARY_STRING_OPERATORS)[number];
+
+export function isUnaryStringOperator(operator: string): operator is UnaryStringOperator {
+  return UNARY_STRING_OPERATORS.some((candidate) => candidate === operator);
+}
+
 export const LOGICAL_OPERATORS = [
   JsonLogicOperatorEnum.AND,
   JsonLogicOperatorEnum.OR,


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds string-only “is empty” and “is not empty” step-condition operators across dashboard authoring, JSON Logic parsing and serialization, backend validation and evaluation, tests, and documentation.
- Adds valueless unary operators to the conditions editor and preserves them when workflows are saved and reopened.
- Registers strict runtime semantics for empty and non-empty strings.
- Validates the new one-field operand structure and documents behavior for missing and non-string values.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the dashboard, validation, and runtime evaluation contracts aligned for the new unary operators.

The emitted unary JSON Logic shape round-trips through the dashboard parser, is accepted by backend validation, and reaches registered runtime operations whose tested behavior matches the documentation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/workflow-editor/steps/conditions/edit-step-conditions-form.tsx | Serializes unary operators without values, exempts them from value validation, and restores saved rules through shared parser options. |
| apps/dashboard/src/utils/conditions.ts | Adds strict parsing of single-variable unary JSON Logic expressions for editor, badge, and telemetry consumers. |
| libs/application-generic/src/services/query-parser/query-parser.service.ts | Registers strict string-only runtime evaluation for the two new operators. |
| libs/application-generic/src/services/query-parser/query-validator.service.ts | Recognizes unary string operators and enforces exactly one valid field-reference operand. |
| libs/application-generic/src/services/query-parser/types.ts | Defines the shared unary string operator set and type guard. |
| docs/platform/workflow/add-and-configure-steps/step-conditions.mdx | Documents exact string semantics, including whitespace, missing values, nulls, and non-string inputs. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Operator selected in dashboard] --> B[Rule serialized as unary JSON Logic]
  B --> C[Workflow condition saved]
  C --> D[Query validator checks one field operand]
  D --> E[Worker evaluates isEmpty or isNonEmpty]
  E --> F[Step runs or is skipped]
  B --> G[Dashboard parser restores the rule for editing]
```

<sub>Reviews (1): Last reviewed commit: ["feat(application-generic): add unary ope..."](https://github.com/novuhq/novu/commit/99ff654e2530f5987ae2c797d7a9474dad6a79b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56331457)</sub>

<!-- /greptile_comment -->