### PR TITLE
feat(docs): enhance Databricks integration guide to include workflow events and clarify sync processes fixes DOC-435

### DIFF
--- a/docs/guides/analytics/databricks.mdx
+++ b/docs/guides/analytics/databricks.mdx
@@ -1,18 +1,19 @@
 ---
 title: 'Databricks'
-description: 'Sync subscriber profiles and cohort membership from Databricks to Novu with the REST API. Includes incremental processing, retries, and rate-limit handling.'
+description: 'Sync subscriber profiles, cohort membership, and workflow events from Databricks to Novu with the REST API. Includes incremental processing, retries, and rate-limit handling.'
 ---
 
 Novu does not provide a native Databricks connector. You can sync data from Databricks by calling the [Novu REST API](/api-reference) from a Databricks job.
 
-This guide covers two warehouse syncs:
+This guide covers three warehouse syncs:
 
 - [Subscriber](/platform/concepts/subscribers) profiles, such as email address, locale, and plan
 - Cohort membership, represented by [topic subscriptions](/platform/subscription/manage-topic-subscriptions)
+- Notification [events](/platform/concepts/trigger), which trigger workflows
 
-Do not use a scheduled warehouse job for real-time notification events. If your application already publishes events to Kafka or another event stream, [trigger](/platform/concepts/trigger) Novu workflows from that stream. Use Databricks for subscriber data and cohorts that are computed in the warehouse.
+Use Databricks for data that is computed or stored in the warehouse. If an event must notify a user within seconds of happening in your product, [trigger](/platform/concepts/trigger) Novu from Kafka or another event stream instead of waiting for a warehouse job.
 
-If you already run reverse ETL, use the [Hightouch](/guides/analytics/hightouch) guide instead of a custom notebook. For product analytics events, use the [Segment](/guides/analytics/segment) guide.
+If you already run reverse ETL, use the [Hightouch](/guides/analytics/hightouch) guide instead of a custom notebook. For product analytics identify/track streams, use the [Segment](/guides/analytics/segment) guide. The REST pattern below is the same if you call Novu from your own reverse ETL service.
 
 ## How the sync works
 
@@ -20,8 +21,9 @@ If you already run reverse ETL, use the [Hightouch](/guides/analytics/hightouch)
 | --- | --- | --- |
 | Subscriber profiles | [Subscribers](/platform/concepts/subscribers) | [`POST /v1/subscribers/bulk`](/api-reference/subscribers/bulk-create-subscribers) |
 | Cohort membership | [Topic subscriptions](/platform/concepts/topics) | [`POST`](/api-reference/topics/create-topic-subscriptions) and [`DELETE`](/api-reference/topics/delete-topic-subscriptions) `/v2/topics/{topicKey}/subscriptions` |
+| Notification events | [Workflow triggers](/platform/concepts/trigger) | [`POST /v1/events/trigger/bulk`](/api-reference/events/bulk-trigger-event) |
 
-The subscriber job processes at most 500 subscribers per request. The cohort job processes at most 100 topic subscriptions per request.
+The subscriber job processes at most 500 subscribers per request. The cohort job processes at most 100 topic subscriptions per request. The event job processes at most 100 events per request.
 
 The cohort job also calls [`POST /v2/topics`](/api-reference/topics/create-a-topic) to create the topic and [`GET /v2/topics/{topicKey}/subscriptions`](/api-reference/topics/list-topic-subscriptions) to read current membership.
 
@@ -29,7 +31,7 @@ The cohort job also calls [`POST /v2/topics`](/api-reference/topics/create-a-top
   Before you start, you need:
 
   - A Databricks workspace with permission to create jobs, secret scopes, and a checkpoint Volume
-  - A Unity Catalog Delta table with one row per subscriber
+  - Unity Catalog Delta tables for subscribers, and optionally for cohorts and events
   - A Novu [secret key](/platform/developer/api-keys) from **Developer** > **API Keys** in the Novu Dashboard. Keys are [environment-specific](/platform/developer/environments).
 </Info>
 
@@ -61,9 +63,10 @@ Use `https://eu.api.novu.co` for an EU Novu environment. See [API keys](/platfor
   <Step>
 ## Add the HTTP and batching helpers
 
-Add this cell once. Both syncs use it.
+Add this cell once. All three syncs use it.
 
 ```python
+import hashlib
 import random
 import time
 from urllib.parse import quote
@@ -71,15 +74,18 @@ from urllib.parse import quote
 import requests
 
 
-# The Configuration limit for the Free plan is 20 request tokens per second.
-# Change this value to the limit for your Novu plan.
+# Free plan: Configuration 20 tokens/sec, Events 60 tokens/sec.
+# Change these values to the limits for your Novu plan.
 CONFIGURATION_TOKENS_PER_SECOND = 20
+EVENT_TOKENS_PER_SECOND = 60
 
-# Reserve half of the bucket for other traffic that uses the same Novu key.
+# Reserve half of each bucket for other traffic that uses the same Novu key.
 RATE_LIMIT_SHARE = 0.5
 
 SUBSCRIBER_BATCH_SIZE = 500
 TOPIC_BATCH_SIZE = 100
+EVENT_BATCH_SIZE = 100
+PROCESSED_TRIGGER_STATUS = "processed"
 
 session = requests.Session()
 session.headers.update(
@@ -90,12 +96,12 @@ session.headers.update(
 )
 
 
-def wait_for_budget(token_cost):
-    usable_tokens_per_second = CONFIGURATION_TOKENS_PER_SECOND * RATE_LIMIT_SHARE
+def wait_for_budget(token_cost, tokens_per_second):
+    usable_tokens_per_second = tokens_per_second * RATE_LIMIT_SHARE
     time.sleep(token_cost / usable_tokens_per_second)
 
 
-def novu_request(method, path, body=None, params=None, max_attempts=5):
+def novu_request(method, path, body=None, params=None, headers=None, max_attempts=5):
     response = None
 
     for attempt in range(max_attempts):
@@ -104,10 +110,11 @@ def novu_request(method, path, body=None, params=None, max_attempts=5):
             url=f"{NOVU_API_URL}{path}",
             json=body,
             params=params,
+            headers=headers,
             timeout=60,
         )
 
-        if response.status_code not in {429, 500, 502, 503, 504}:
+        if response.status_code not in {409, 429, 500, 502, 503, 504}:
             response.raise_for_status()
 
             return response
@@ -127,19 +134,72 @@ def chunks(values, size):
         yield values[start : start + size]
 
 
+def batched(rows, to_item, size):
+    batch = []
+    for row in rows:
+        batch.append(to_item(row))
+        if len(batch) == size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def send_batch(method, path, body, token_cost, tokens_per_second, assert_ok, extra_headers=None):
+    wait_for_budget(token_cost, tokens_per_second)
+    response = novu_request(method, path, body, headers=extra_headers)
+    assert_ok(response)
+
+    return response
+
+
 def assert_no_item_failures(response, operation):
     result = response.json()
+    if not isinstance(result, dict):
+        raise RuntimeError(f"{operation} returned unexpected body: {result}")
+
     failures = result.get("failed", [])
     failed_count = result.get("meta", {}).get("failed", 0)
 
     if failures or failed_count:
         details = failures or result.get("errors", [])
         raise RuntimeError(f"{operation} returned item failures: {details}")
+
+
+def assert_no_trigger_failures(response, operation):
+    result = response.json()
+    if isinstance(result, list):
+        items = result
+    elif isinstance(result, dict) and isinstance(result.get("data"), list):
+        items = result["data"]
+    else:
+        raise RuntimeError(f"{operation} returned unexpected body: {result}")
+
+    failures = [item for item in items if item.get("status") != PROCESSED_TRIGGER_STATUS]
+    if failures:
+        raise RuntimeError(f"{operation} returned item failures: {failures}")
+
+
+def run_change_feed(table_name, checkpoint_path, on_batch, starting_timestamp=None):
+    reader = spark.readStream.option("readChangeFeed", "true")
+    if starting_timestamp:
+        reader = reader.option("startingTimestamp", starting_timestamp)
+
+    query = (
+        reader.table(table_name)
+        .writeStream.foreachBatch(on_batch)
+        .option("checkpointLocation", checkpoint_path)
+        .trigger(availableNow=True)
+        .start()
+    )
+    query.awaitTermination()
 ```
 
-The helper retries `429` and temporary server errors. It uses the `Retry-After` response header when Novu provides one.
+`novu_request` retries `429`, `409`, and temporary server errors. `409` is returned when [idempotency](/api-reference/idempotency) is enabled and the same `Idempotency-Key` is still in flight. The helper uses the `Retry-After` header when Novu provides one.
 
-The default pacing uses half of the Free plan's Configuration limit. Update `CONFIGURATION_TOKENS_PER_SECOND` for your plan, but keep spare capacity if production traffic uses the same secret key. See [Rate limiting](/api-reference/rate-limiting) for current limits and token costs.
+`wait_for_budget` sleeps **before** each write so the first request in a job is paced. It is a simple delay, not a shared token bucket across notebooks.
+
+The default pacing uses half of the Free plan's Configuration and Event limits. Update `CONFIGURATION_TOKENS_PER_SECOND` and `EVENT_TOKENS_PER_SECOND` for your plan, but keep spare capacity if production traffic uses the same secret key. See [Rate limiting](/api-reference/rate-limiting) for current limits and token costs.
   </Step>
 
   <Step>
@@ -182,8 +242,6 @@ def subscriber_payload(row):
 
 
 def sync_subscribers(dataframe):
-    batch = []
-
     rows = (
         dataframe.select(
             "subscriber_id",
@@ -197,27 +255,15 @@ def sync_subscribers(dataframe):
         .toLocalIterator()
     )
 
-    for row in rows:
-        batch.append(subscriber_payload(row))
-
-        if len(batch) == SUBSCRIBER_BATCH_SIZE:
-            response = novu_request(
-                "POST",
-                "/v1/subscribers/bulk",
-                {"subscribers": batch},
-            )
-            assert_no_item_failures(response, "Subscriber sync")
-            wait_for_budget(token_cost=100)
-            batch = []
-
-    if batch:
-        response = novu_request(
+    for batch in batched(rows, subscriber_payload, SUBSCRIBER_BATCH_SIZE):
+        send_batch(
             "POST",
             "/v1/subscribers/bulk",
             {"subscribers": batch},
+            100,
+            CONFIGURATION_TOKENS_PER_SECOND,
+            lambda response: assert_no_item_failures(response, "Subscriber sync"),
         )
-        assert_no_item_failures(response, "Subscriber sync")
-        wait_for_budget(token_cost=100)
 
 
 subscribers = spark.table("main.crm.novu_subscribers")
@@ -268,16 +314,11 @@ def sync_subscriber_changes(batch_dataframe, batch_id):
     sync_subscribers(current_values)
 
 
-query = (
-    spark.readStream.option("readChangeFeed", "true")
-    .table("main.crm.novu_subscribers")
-    .writeStream.foreachBatch(sync_subscriber_changes)
-    .option("checkpointLocation", CHECKPOINT_PATH)
-    .trigger(availableNow=True)
-    .start()
+run_change_feed(
+    table_name="main.crm.novu_subscribers",
+    checkpoint_path=CHECKPOINT_PATH,
+    on_batch=sync_subscriber_changes,
 )
-
-query.awaitTermination()
 ```
 
 On the first run, Databricks returns the current table snapshot as inserts. Later runs resume from the checkpoint. If a Novu request fails, `sync_subscribers` raises an error and Databricks does not commit that micro-batch to the checkpoint. The next run retries the batch.
@@ -313,6 +354,7 @@ def list_topic_members(topic_key):
         if cursor:
             params["after"] = cursor
 
+        wait_for_budget(1, CONFIGURATION_TOKENS_PER_SECOND)
         response = novu_request(
             "GET",
             f"/v2/topics/{encoded_topic_key}/subscriptions",
@@ -323,7 +365,6 @@ def list_topic_members(topic_key):
         for subscription in result["data"]:
             members.add(subscription["subscriber"]["subscriberId"])
 
-        wait_for_budget(token_cost=1)
         cursor = result.get("next")
         if not cursor:
             return members
@@ -332,12 +373,14 @@ def list_topic_members(topic_key):
 def sync_topic(topic_key, topic_name, dataframe):
     encoded_topic_key = quote(topic_key, safe="")
 
-    novu_request(
+    send_batch(
         "POST",
         "/v2/topics",
         {"key": topic_key, "name": topic_name},
+        1,
+        CONFIGURATION_TOKENS_PER_SECOND,
+        lambda response: None,
     )
-    wait_for_budget(token_cost=1)
 
     desired_members = {
         str(row["subscriber_id"])
@@ -352,22 +395,24 @@ def sync_topic(topic_key, topic_name, dataframe):
     members_to_remove = sorted(existing_members - desired_members)
 
     for batch in chunks(members_to_add, TOPIC_BATCH_SIZE):
-        response = novu_request(
+        send_batch(
             "POST",
             f"/v2/topics/{encoded_topic_key}/subscriptions",
             {"subscriptions": batch},
+            1,
+            CONFIGURATION_TOKENS_PER_SECOND,
+            lambda response: assert_no_item_failures(response, "Topic subscription create"),
         )
-        assert_no_item_failures(response, "Topic subscription create")
-        wait_for_budget(token_cost=1)
 
     for batch in chunks(members_to_remove, TOPIC_BATCH_SIZE):
-        response = novu_request(
+        send_batch(
             "DELETE",
             f"/v2/topics/{encoded_topic_key}/subscriptions",
             {"subscriptions": batch},
+            1,
+            CONFIGURATION_TOKENS_PER_SECOND,
+            lambda response: assert_no_item_failures(response, "Topic subscription delete"),
         )
-        assert_no_item_failures(response, "Topic subscription delete")
-        wait_for_budget(token_cost=1)
 
     print(
         f"Topic {topic_key}: added {len(members_to_add)}, "
@@ -389,46 +434,148 @@ Both the desired and existing membership sets are held in driver memory. For coh
   </Step>
 
   <Step>
+## Trigger workflows from warehouse events
+
+A Databricks events table maps to Novu [workflow triggers](/platform/concepts/trigger). Use this path for notifications that are computed in the warehouse, such as a daily digest or a trial-ending campaign. Do not use it for product actions that must notify within seconds.
+
+Keep this job separate from the subscriber sync so you can backfill profiles without sending historical notifications.
+
+The source must contain one row per notification to send. Use a stable `event_id` so retries do not send the same notification twice.
+
+| `event_id` | `subscriber_id` | `workflow_id` | `plan` | `account_type` |
+| --- | --- | --- | --- | --- |
+| `evt_9c01` | `usr_8f21` | `trial-ending` | pro | team |
+
+[`POST /v1/events/trigger/bulk`](/api-reference/events/bulk-trigger-event) accepts at most 100 events per request.
+
+Use both of these on every bulk trigger:
+
+- `Idempotency-Key` on the HTTP request, derived from the event ids in that batch. This is the API-layer retry lock. See [Idempotency](/api-reference/idempotency). It is not enabled for every organization; contact [support](mailto:support@novu.co) to turn it on.
+- `transactionId` set to the warehouse `event_id`. Use it to trace and [cancel](/api-reference/events/cancel-triggered-event) a run. It is **not** the same as an idempotency key. Concurrent retries can still enqueue twice if you rely on `transactionId` alone.
+
+Novu can [create a subscriber at trigger time](/platform/concepts/subscribers#just-in-time) from the `to` object. A prior subscriber sync is still useful so preferences and profile fields exist before the first notification.
+
+Do not call `sync_events` on the full table. The Change Data Feed job below is the production path.
+
+```python
+def event_payload(row):
+    return {
+        "name": str(row["workflow_id"]),
+        "to": {"subscriberId": str(row["subscriber_id"])},
+        "payload": {
+            "plan": row["plan"],
+            "accountType": row["account_type"],
+        },
+        "transactionId": str(row["event_id"]),
+    }
+
+
+def trigger_idempotency_key(batch):
+    joined = ",".join(sorted(item["transactionId"] for item in batch))
+
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def sync_events(dataframe):
+    rows = (
+        dataframe.select("event_id", "subscriber_id", "workflow_id", "plan", "account_type")
+        .filter(F.col("event_id").isNotNull() & F.col("subscriber_id").isNotNull())
+        .toLocalIterator()
+    )
+
+    for batch in batched(rows, event_payload, EVENT_BATCH_SIZE):
+        send_batch(
+            "POST",
+            "/v1/events/trigger/bulk",
+            {"events": batch},
+            100,
+            EVENT_TOKENS_PER_SECOND,
+            lambda response: assert_no_trigger_failures(response, "Event trigger"),
+            extra_headers={"Idempotency-Key": trigger_idempotency_key(batch)},
+        )
+```
+
+`name` is the workflow identifier in Novu. `payload` fields are available in templates as `{{payload.plan}}`.
+
+Enable Change Data Feed on the events table, then process **inserts only**. Set `EVENT_START_TIMESTAMP` before the first run so the snapshot of historical rows is not sent.
+
+```sql
+ALTER TABLE main.crm.novu_events
+SET TBLPROPERTIES (delta.enableChangeDataFeed = true);
+```
+
+```python
+EVENT_CHECKPOINT_PATH = "/Volumes/main/ops/novu_checkpoints/event-sync"
+# Inclusive lower bound for the first run. Change this before you start the stream.
+EVENT_START_TIMESTAMP = "2026-08-25T00:00:00.000Z"
+
+
+def sync_event_changes(batch_dataframe, batch_id):
+    inserts = batch_dataframe.filter(F.col("_change_type") == "insert")
+    if "occurred_at" in inserts.columns:
+        inserts = inserts.filter(F.col("occurred_at") >= F.lit(EVENT_START_TIMESTAMP))
+    sync_events(inserts)
+
+
+run_change_feed(
+    table_name="main.crm.novu_events",
+    checkpoint_path=EVENT_CHECKPOINT_PATH,
+    on_batch=sync_event_changes,
+    starting_timestamp=EVENT_START_TIMESTAMP,
+)
+```
+
+`startingTimestamp` is applied only when the checkpoint is empty. After the first successful run, Databricks resumes from the checkpoint and ignores `startingTimestamp`. If you need a new start bound, use a new checkpoint path.
+
+<Warning>
+  Do not replay the full events table. A replay consumes Event-bucket tokens even when Novu later ignores a duplicate `transactionId`.
+</Warning>
+  </Step>
+
+  <Step>
 ## Check the rate-limit settings
 
-Novu uses separate token buckets for Configuration and Event endpoints. Subscriber and topic requests use the Configuration bucket.
+Novu uses separate token buckets for Configuration and Event endpoints. Subscriber and topic requests use the Configuration bucket. Workflow triggers use the Event bucket.
 
 The requests in this guide have these costs:
 
-| Request | Token cost | Maximum items |
-| --- | --- | --- |
-| `POST /v1/subscribers/bulk` | 100 | 500 subscribers |
-| Topic create, list, subscribe, or unsubscribe | 1 | 100 subscriptions for write requests |
+| Request | Bucket | Token cost | Maximum items |
+| --- | --- | --- | --- |
+| `POST /v1/subscribers/bulk` | Configuration | 100 | 500 subscribers |
+| Topic create, list, subscribe, or unsubscribe | Configuration | 1 | 100 subscriptions for write requests |
+| `POST /v1/events/trigger/bulk` | Events | 100 | 100 events |
 
-The default helper uses 10 tokens per second, which is half of the Free plan's 20-token Configuration limit. At that setting, it sends one full subscriber batch every 10 seconds. This leaves capacity for other API traffic.
+The default helper uses half of the Free plan limits: 10 Configuration tokens per second and 30 Event tokens per second. At those settings, it sends one full subscriber batch every 10 seconds and one full event batch about every 3 seconds.
 
 Before increasing the rate:
 
-1. Check the Configuration limit for your Novu plan in [Rate limiting](/api-reference/rate-limiting).
-2. Set `CONFIGURATION_TOKENS_PER_SECOND` to that limit.
+1. Check the Configuration and Events limits for your Novu plan in [Rate limiting](/api-reference/rate-limiting).
+2. Set `CONFIGURATION_TOKENS_PER_SECOND` and `EVENT_TOKENS_PER_SECOND` to those limits.
 3. Keep `RATE_LIMIT_SHARE` below `1.0` when other services use the same secret key.
 4. Monitor `429` responses and the `RateLimit-Remaining` response header.
 
-Do not calculate throughput from request count alone. A bulk subscriber request costs 100 tokens even when the request contains fewer than 500 subscribers.
+Do not calculate throughput from request count alone. A bulk subscriber or bulk trigger request costs 100 tokens even when the request contains fewer than the maximum number of items.
   </Step>
 
   <Step>
 ## Schedule and verify the jobs
 
-Create two Databricks job tasks:
+Create three Databricks job tasks:
 
 1. Run the subscriber sync.
 2. Run the cohort sync after the subscriber task succeeds.
+3. Run the event trigger sync after the subscriber task succeeds. Cohort and event tasks can run in parallel.
 
-For the first production run, filter each source to a small known set of subscribers. Verify the results before removing the filter.
+For the first production run, filter each source to a small known set of subscribers. Verify the results before removing the filter. For events, start with rows added after a known timestamp so you do not notify on historical warehouse data.
 
 In the Novu Dashboard:
 
 1. Open **Subscribers** and confirm that profile fields match the source table.
 2. Open the topic and confirm that its subscriber count matches the cohort query.
-3. Check the Databricks task output for partial item failures or exhausted retries.
+3. Open **Activity Feed** and confirm that warehouse events triggered the expected workflows.
+4. Check the Databricks task output for partial item failures or exhausted retries.
 
-Set a job timeout and enable task retries. The subscriber bulk endpoint is an upsert, and the cohort job compares against Novu before writing, so rerunning either task is safe.
+Set a job timeout and enable task retries. Subscriber bulk upserts by `subscriberId`. The cohort job diffs against Novu before writing. Event retries are safe when each bulk request sends a stable `Idempotency-Key` (and `transactionId` for tracing).
   </Step>
 </Steps>
 
@@ -437,7 +584,10 @@ Set a job timeout and enable task retries. The subscriber bulk endpoint is an up
 - **401 Unauthorized**: Confirm the `Authorization` header uses `ApiKey`, and confirm the secret key matches the Novu environment and API region.
 - **400 from the subscriber bulk endpoint**: Confirm the body contains `{"subscribers": [...]}`, the array has no more than 500 items, and every `subscriberId` is a non-empty string.
 - **Topic subscription failures**: Run the subscriber sync first. Topic subscriptions require existing Novu subscribers.
-- **429 Too Many Requests**: Lower `RATE_LIMIT_SHARE` or `CONFIGURATION_TOKENS_PER_SECOND`. Confirm the latter matches your plan.
+- **Workflow not triggering**: Confirm `name` matches an active workflow identifier in the same Novu environment as the secret key, and confirm `to.subscriberId` is present.
+- **Duplicate notifications**: Send an `Idempotency-Key` per bulk request. Set `transactionId` to the warehouse `event_id` for tracing. Process Change Data Feed inserts only, and set `EVENT_START_TIMESTAMP` before the first run.
+- **409 Conflict**: The same `Idempotency-Key` is still in flight. The helper retries this. If it persists, wait and rerun the job.
+- **429 Too Many Requests**: Lower `RATE_LIMIT_SHARE`, `CONFIGURATION_TOKENS_PER_SECOND`, or `EVENT_TOKENS_PER_SECOND`. Confirm those values match your plan.
 - **Change Data Feed cannot find a version**: The checkpoint is older than the retained Delta history. Run a full sync and start again with a new checkpoint location.
 
 ## Related documentation
@@ -456,7 +606,16 @@ Set a job timeout and enable task retries. The subscriber bulk endpoint is an up
     Secret keys, environment isolation, and API hostnames.
   </Card>
   <Card title="Rate limiting" href="/api-reference/rate-limiting">
-    Configuration bucket limits, token costs, and `429` handling.
+    Configuration and Events bucket limits, token costs, and `429` handling.
+  </Card>
+  <Card title="Trigger event" href="/api-reference/events/trigger-event">
+    Single workflow trigger request shape, `transactionId`, and idempotency.
+  </Card>
+  <Card title="Bulk trigger event" href="/api-reference/events/bulk-trigger-event">
+    `POST /v1/events/trigger/bulk` request shape and 100-event cap.
+  </Card>
+  <Card title="Idempotency" href="/api-reference/idempotency">
+    `Idempotency-Key` for safe retries of POST requests.
   </Card>
   <Card title="Hightouch" href="/guides/analytics/hightouch">
     Reverse ETL when you do not want to run a custom Databricks notebook.

--- a/docs/guides/analytics/databricks.mdx
+++ b/docs/guides/analytics/databricks.mdx
@@ -471,7 +471,7 @@ def event_payload(row):
 
 
 def trigger_idempotency_key(batch):
-    joined = ",".join(sorted(item["transactionId"] for item in batch))
+    joined = ",".join(item["transactionId"] for item in batch)
 
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()
 
@@ -480,6 +480,7 @@ def sync_events(dataframe):
     rows = (
         dataframe.select("event_id", "subscriber_id", "workflow_id", "plan", "account_type")
         .filter(F.col("event_id").isNotNull() & F.col("subscriber_id").isNotNull())
+        .orderBy("event_id")
         .toLocalIterator()
     )
 
@@ -496,6 +497,8 @@ def sync_events(dataframe):
 ```
 
 `name` is the workflow identifier in Novu. `payload` fields are available in templates as `{{payload.plan}}`.
+
+`orderBy("event_id")` keeps bulk groups stable. If a micro-batch fails after some POSTs succeed, Databricks retries the same rows. An unordered `toLocalIterator()` can split those rows into different groups of 100, which would mint new `Idempotency-Key` values and send already-accepted events again. `event_id` must be unique so the sort order does not depend on Spark's partition layout.
 
 Enable Change Data Feed on the events table, then process **inserts only**. Set `EVENT_START_TIMESTAMP` before the first run so the snapshot of historical rows is not sent.
 


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the Databricks integration guide to cover warehouse-driven workflow events and refactors the shared request, batching, pacing, and Change Data Feed helpers.
- Adds bulk workflow triggering with stable event ordering and request idempotency keys.
- Documents separate Configuration and Event rate-limit buckets.
- Clarifies checkpointing, historical-event filtering, retries, scheduling, and troubleshooting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the event rows are now ordered before batching, addressing the previously reported unstable retry-idempotency keys under the guide's explicit unique-event-ID contract.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/guides/analytics/databricks.mdx | Adds the event-trigger synchronization guide and stabilizes retry batching by ordering rows using the documented unique event identifier. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Delta[Databricks Delta event table] --> CDF[Change Data Feed inserts]
  CDF --> Sort[Order by unique event_id]
  Sort --> Batch[Batch up to 100 events]
  Batch --> Key[Derive Idempotency-Key]
  Key --> API[Novu bulk trigger API]
  API --> Workflow[Workflow execution]
```

<sub>Reviews (2): Last reviewed commit: ["fix(docs): improve Databricks integratio..."](https://github.com/novuhq/novu/commit/fe06c77db0f6e530d8e6aa9861f28c2c31ce3245) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56367171)</sub>

<!-- /greptile_comment -->