### PR TITLE
fix(dashboard): unblock saving payload schemas with array enum items fixes NV-8676

### DIFF
--- a/apps/dashboard/src/components/schema-editor/components/array-section.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/array-section.tsx
@@ -14,6 +14,7 @@ import type { VariableUsageInfo } from '../utils/check-variable-usage';
 import { newProperty } from '../utils/json-helpers';
 import { getMarginClassPx } from '../utils/ui-helpers';
 import type { PropertyListItem, SchemaEditorFormValues } from '../utils/validation-schema';
+import { EnumSection } from './enum-section';
 import { PropertyTypeSelector } from './property-type-selector';
 
 interface ArrayItemPropertyProps {
@@ -94,6 +95,7 @@ export const ArraySection = memo<ArraySectionProps>(function ArraySection({
   const itemSchemaObject = useWatch({ control, name: itemSchemaObjectPath }) as JSONSchema7 | undefined;
   const itemType = useSchemaPropertyType(itemSchemaObject);
   const itemIsObject = itemType === 'object';
+  const itemIsEnum = itemType === 'enum';
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -134,6 +136,15 @@ export const ArraySection = memo<ArraySectionProps>(function ArraySection({
           isDisabled={readOnly}
         />
       </div>
+
+      {itemIsEnum && (
+        <EnumSection
+          enumArrayPath={`${itemSchemaObjectPath}.enum` as Path<SchemaEditorFormValues>}
+          control={control}
+          indentationLevel={0}
+          readOnly={readOnly}
+        />
+      )}
 
       {itemIsObject && (
         <div className={cn('flex flex-col gap-1.5 pt-1.5', getMarginClassPx(1))}>

--- a/apps/dashboard/src/components/schema-editor/components/enum-section.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/enum-section.tsx
@@ -15,9 +15,16 @@ interface EnumChoiceProps {
   enumIndex: number;
   control: Control<any>;
   onRemove: () => void;
+  readOnly?: boolean;
 }
 
-const EnumChoice = memo<EnumChoiceProps>(function EnumChoice({ enumChoicePath, enumIndex, control, onRemove }) {
+const EnumChoice = memo<EnumChoiceProps>(function EnumChoice({
+  enumChoicePath,
+  enumIndex,
+  control,
+  onRemove,
+  readOnly = false,
+}) {
   return (
     <div className="flex items-center space-x-2">
       <Controller
@@ -25,7 +32,12 @@ const EnumChoice = memo<EnumChoiceProps>(function EnumChoice({ enumChoicePath, e
         control={control}
         render={({ field: choiceField, fieldState: choiceFieldState }) => (
           <InputRoot hasError={!!choiceFieldState.error} size="2xs" className="flex-1">
-            <InputPure {...choiceField} placeholder={`Choice ${enumIndex + 1}`} className="pl-2 text-xs" />
+            <InputPure
+              {...choiceField}
+              placeholder={`Choice ${enumIndex + 1}`}
+              className="pl-2 text-xs"
+              disabled={readOnly}
+            />
             {choiceFieldState.error && (
               <TooltipProvider delayDuration={0}>
                 <Tooltip>
@@ -52,6 +64,7 @@ const EnumChoice = memo<EnumChoiceProps>(function EnumChoice({ enumChoicePath, e
         onClick={onRemove}
         aria-label="Delete property"
         className={cn('border ml-1.5! h-7 w-7 border-neutral-200')}
+        disabled={readOnly}
       />
     </div>
   );
@@ -61,9 +74,15 @@ interface EnumSectionProps {
   enumArrayPath: Path<SchemaEditorFormValues>;
   control: Control<any>;
   indentationLevel: number;
+  readOnly?: boolean;
 }
 
-export const EnumSection = memo<EnumSectionProps>(function EnumSection({ enumArrayPath, control, indentationLevel }) {
+export const EnumSection = memo<EnumSectionProps>(function EnumSection({
+  enumArrayPath,
+  control,
+  indentationLevel,
+  readOnly = false,
+}) {
   const { fields, append, remove } = useFieldArray({
     control,
     name: enumArrayPath,
@@ -83,6 +102,7 @@ export const EnumSection = memo<EnumSectionProps>(function EnumSection({ enumArr
           enumIndex={enumIndex}
           control={control}
           onRemove={() => remove(enumIndex)}
+          readOnly={readOnly}
         />
       ))}
       <Button
@@ -92,6 +112,7 @@ export const EnumSection = memo<EnumSectionProps>(function EnumSection({ enumArr
         onClick={handleAddChoice}
         leadingIcon={RiAddLine}
         className="mt-1"
+        disabled={readOnly}
       >
         Add Choice
       </Button>

--- a/apps/dashboard/src/components/schema-editor/components/enum-section.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/enum-section.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { type Control, Controller, Path, useFieldArray } from 'react-hook-form';
 import { RiAddLine, RiDeleteBin2Line, RiDeleteBinLine, RiErrorWarningLine } from 'react-icons/ri';
 
@@ -16,6 +16,7 @@ interface EnumChoiceProps {
   control: Control<any>;
   onRemove: () => void;
   readOnly?: boolean;
+  isRemoveDisabled?: boolean;
 }
 
 const EnumChoice = memo<EnumChoiceProps>(function EnumChoice({
@@ -24,6 +25,7 @@ const EnumChoice = memo<EnumChoiceProps>(function EnumChoice({
   control,
   onRemove,
   readOnly = false,
+  isRemoveDisabled = false,
 }) {
   return (
     <div className="flex items-center space-x-2">
@@ -62,9 +64,9 @@ const EnumChoice = memo<EnumChoiceProps>(function EnumChoice({
         size="2xs"
         leadingIcon={RiDeleteBin2Line}
         onClick={onRemove}
-        aria-label="Delete property"
+        aria-label="Delete choice"
         className={cn('border ml-1.5! h-7 w-7 border-neutral-200')}
-        disabled={readOnly}
+        disabled={readOnly || isRemoveDisabled}
       />
     </div>
   );
@@ -93,6 +95,20 @@ export const EnumSection = memo<EnumSectionProps>(function EnumSection({
     append('', { shouldFocus: true });
   }, [append]);
 
+  // An enum with no choices matches nothing, so the editor always offers at
+  // least one row. The latch keeps StrictMode's double-invoked effect from
+  // seeding two rows.
+  const hasSeededFirstChoice = useRef(false);
+
+  useEffect(() => {
+    if (readOnly || hasSeededFirstChoice.current || fields.length > 0) {
+      return;
+    }
+
+    hasSeededFirstChoice.current = true;
+    append('', { shouldFocus: false });
+  }, [readOnly, fields.length, append]);
+
   return (
     <div className={cn('mt-1 space-y-1', getMarginClassPx(indentationLevel + 1))}>
       {fields.map((enumField, enumIndex) => (
@@ -103,6 +119,7 @@ export const EnumSection = memo<EnumSectionProps>(function EnumSection({
           control={control}
           onRemove={() => remove(enumIndex)}
           readOnly={readOnly}
+          isRemoveDisabled={fields.length <= 1}
         />
       ))}
       <Button

--- a/apps/dashboard/src/components/schema-editor/schema-property-row.tsx
+++ b/apps/dashboard/src/components/schema-editor/schema-property-row.tsx
@@ -131,7 +131,12 @@ export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPro
 
       {/* Type-specific sections */}
       {currentType === 'enum' && (
-        <EnumSection enumArrayPath={paths.enum} control={control} indentationLevel={indentationLevel} />
+        <EnumSection
+          enumArrayPath={paths.enum}
+          control={control}
+          indentationLevel={indentationLevel}
+          readOnly={readOnly}
+        />
       )}
 
       {currentType === 'object' && (

--- a/apps/dashboard/src/components/schema-editor/utils/json-helpers.ts
+++ b/apps/dashboard/src/components/schema-editor/utils/json-helpers.ts
@@ -153,10 +153,13 @@ export function ensureEnum(schema: JSONSchema7): JSONSchema7 {
   const newSchema: Partial<JSONSchema7> = { type: 'string' };
   carryOverCommonKeywords(schema, newSchema);
 
+  // Empty choices are never seeded here: react-hook-form field arrays drop falsy
+  // entries, so an empty choice would live in the form values without a row to
+  // edit it. `EnumSection` seeds the first editable choice instead.
   if (Array.isArray(schema.enum) && schema.enum.every((val): val is string => typeof val === 'string')) {
-    newSchema.enum = schema.enum.length > 0 ? schema.enum : [''];
+    newSchema.enum = schema.enum.filter((val) => val !== '');
   } else {
-    newSchema.enum = [''];
+    newSchema.enum = [];
   }
 
   if (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Fixes [NV-8676](https://linear.app/novu/issue/NV-8676): in a workflow's payload schema, adding a property of type **array** and choosing **Enum** as the array item type disabled **Add Property** and made **Save Changes** do nothing, with no on-screen explanation.

Two defects combined to produce that dead end:

1. **The array item editor never rendered the enum choices editor.** `ArraySection` only rendered nested controls when the item type was `object`, so picking `Enum` showed nothing at all — while `ensureEnum` had already written `items.enum = ['']` into the form. The empty choice fails the `Enum choice value cannot be empty.` rule, so `formState.isValid` stayed `false` forever. `SchemaEditor` disables **Add property** on `!formState.isValid`, and `PayloadSchemaDrawer` disables **Save Changes** on it too.

2. **The seeded empty choice was invisible even where the editor did render.** react-hook-form's `_getFieldArray` runs values through `compact` (`value.filter(Boolean)`), so a seeded `''` is dropped from the rendered field array while still living in `_formValues`. Selecting **Enum** therefore showed only an `+ Add Choice` button and no input, with an unreachable validation error attached to a row that was never drawn. This also affected plain top-level `Enum` properties, where the only way out was to guess and click `+ Add Choice`.

Changes:

- `ArraySection` renders `EnumSection` for `items.enum` when the array item type is `enum`.
- `ensureEnum` no longer seeds an empty choice (and drops empty ones when carrying choices over between types), since a falsy entry can never be rendered.
- `EnumSection` seeds the first editable choice itself when there are none, so the enum editor always shows one row. A ref latch keeps StrictMode's double-invoked effect from seeding two.
- The delete button on the last remaining choice is disabled, so an enum can't be reduced to zero choices (`enum: []` matches nothing).
- `EnumSection` now honours `readOnly`, which `ArraySection` and `SchemaPropertyRow` already receive but previously did not forward to enum inputs.

```mermaid
flowchart TD
    A["Property type = Array"] --> B["Array Item Type = Enum"]
    B --> C["ensureEnum writes items.enum"]
    C --> D{"Enum editor rendered?"}
    D -->|"before: no"| E["empty choice hidden in form values<br/>form invalid, no row to fix<br/>Add Property + Save Changes dead"]
    D -->|"after: yes"| F["EnumSection seeds Choice 1 row"]
    F --> G["user fills choices<br/>form valid, Save Changes works"]
```

### Screenshots

Before — array item type `Enum` renders no choices editor, and **+ Add property** is greyed out with **Save Changes** inert:

![Before: array of enum renders no enum choices editor and blocks saving](https://cursor.com/artifacts/c/art-66752e7e-2a35-47de-ba77-f71133730e35)

After — selecting `Enum` immediately shows an editable `Choice 1` row (its delete button disabled as the only choice), and the form becomes valid once filled:

![After: selecting Enum as array item type seeds an editable Choice 1 row](https://cursor.com/artifacts/c/art-cf40928b-e7a8-466a-94ae-c0b62deee1a0)

End-to-end: name a property, set type `Array`, set item type `Enum`, fill two choices, save, and reopen to confirm the schema persisted.

<a href="https://cursor.com/agents/bc-c883be36-88d1-43ea-85ca-b998b7b5db5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farray_item_enum_choices_editor_and_save_changes_working.mp4"><img src="https://cursor.com/artifacts/c/art-16e9a22a-2a01-40ad-a311-c9dcc2293c37" alt="array_item_enum_choices_editor_and_save_changes_working.mp4" /></a>

Array-of-enum and top-level enum properties both saving and persisting together:

![Persisted array-of-enum and top-level enum properties](https://cursor.com/artifacts/c/art-3d6b996a-104d-47d3-9360-9262da6954d5)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

Verified manually in the dashboard (reproduced the bug on `next`, then confirmed the fix for both array-item enums and top-level enums, including persistence across drawer reopen) plus a throwaway script over the pure helpers asserting that `ensureEnum` seeds nothing react-hook-form would hide, that empty choices are still rejected, and that `{ type: 'array', items: { type: 'string', enum: [...] } }` survives the `convertPropertyListToSchema` / `convertSchemaToPropertyList` round trip.

Worth a look during review: disabling delete on the last remaining choice is a small behaviour change for existing single-choice enums. It is what keeps the form from reaching `enum: []`, which would be a schema that matches nothing; editing the text in place is still possible.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8676](https://linear.app/novu/issue/NV-8676/array-enum-payload-schema-blocks-saving-changes)

<div><a href="https://cursor.com/agents/bc-c883be36-88d1-43ea-85ca-b998b7b5db5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c883be36-88d1-43ea-85ca-b998b7b5db5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes payload-schema editing for top-level and array-item enums while preserving read-only behavior.
- Renders enum choices for array item schemas.
- Moves initial-choice seeding into the visible enum editor and prevents deleting the last choice.
- Filters unusable empty choices during type conversion.
- Propagates read-only state through enum inputs and actions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the enum editing and read-only paths remaining internally consistent.

The new array-item editor uses the established form path, enum values survive schema conversion, and every newly introduced mutation path is suppressed for read-only workflows; no concrete regression remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/schema-editor/components/array-section.tsx | Adds the enum editor at the correct array-item schema path and forwards read-only state. |
| apps/dashboard/src/components/schema-editor/components/enum-section.tsx | Seeds a visible initial choice, protects the final row, and disables all mutations in read-only mode. |
| apps/dashboard/src/components/schema-editor/schema-property-row.tsx | Propagates the existing read-only contract to top-level enum editors. |
| apps/dashboard/src/components/schema-editor/utils/json-helpers.ts | Stops creating hidden empty enum values and removes unusable empty choices during enum conversion. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Select array property] --> B[Select enum item type]
  B --> C[ensureEnum creates enum array]
  C --> D[EnumSection renders]
  D --> E[Seed first editable choice]
  E --> F[User enters choices]
  F --> G[Schema conversion preserves items.enum]
  G --> H[Save payload schema]
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): stop seeding hidden empt..."](https://github.com/novuhq/novu/commit/65cd9ffe7fa242a737c9ffacd69d4bcb76575d77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56531505)</sub>

<!-- /greptile_comment -->