### PR TITLE
feat(dashboard): showcase resume, retry, and tool details in web chat preview fixes NV-8678

### DIFF
--- a/apps/api/src/app/agents/managed-runtime/managed-agent-provider-factory.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-provider-factory.service.ts
@@ -185,12 +185,7 @@ export class ManagedAgentProviderFactory {
       throw new Error('THALAMUS_WEBHOOK_SECRET is required for managed agents');
     }
 
-    // Local wrangler cannot POST to the portless HTTPS hostname (untrusted CA).
-    // AGENT_API_HOSTNAME copied from main is :3000, which is a different process.
-    const localListenPort = process.env.NODE_ENV === 'local' ? process.env.PORT : undefined;
-    const webhookBaseUrl = localListenPort
-      ? `http://127.0.0.1:${localListenPort}`
-      : (process.env.AGENT_API_HOSTNAME ?? process.env.API_ROOT_URL);
+    const webhookBaseUrl = process.env.AGENT_API_HOSTNAME ?? process.env.API_ROOT_URL;
     if (!webhookBaseUrl) {
       throw new Error('AGENT_API_HOSTNAME or API_ROOT_URL is required for managed agents');
     }

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-provider-factory.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-provider-factory.service.ts
@@ -185,7 +185,12 @@ export class ManagedAgentProviderFactory {
       throw new Error('THALAMUS_WEBHOOK_SECRET is required for managed agents');
     }
 
-    const webhookBaseUrl = process.env.AGENT_API_HOSTNAME ?? process.env.API_ROOT_URL;
+    // Local wrangler cannot POST to the portless HTTPS hostname (untrusted CA).
+    // AGENT_API_HOSTNAME copied from main is :3000, which is a different process.
+    const localListenPort = process.env.NODE_ENV === 'local' ? process.env.PORT : undefined;
+    const webhookBaseUrl = localListenPort
+      ? `http://127.0.0.1:${localListenPort}`
+      : (process.env.AGENT_API_HOSTNAME ?? process.env.API_ROOT_URL);
     if (!webhookBaseUrl) {
       throw new Error('AGENT_API_HOSTNAME or API_ROOT_URL is required for managed agents');
     }

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-drawer.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-drawer.tsx
@@ -73,7 +73,7 @@ export function AgentChatDrawer({
           </SheetClose>
         </div>
 
-        <div className="flex min-h-0 flex-1 flex-col px-4 pt-4">
+        <div className="flex min-h-0 flex-1 flex-col gap-3 px-4 pt-4">
           {showAddToAppCallouts ? (
             <div className="bg-bg-weak flex min-h-9 shrink-0 flex-wrap items-center gap-2 rounded-lg py-1.5 pr-1.5 pl-2">
               <span className="bg-text-sub h-[22px] w-1 shrink-0 rounded-full" aria-hidden />
@@ -84,7 +84,9 @@ export function AgentChatDrawer({
             </div>
           ) : null}
 
-          <AgentChatPanel agent={agent} showAddToAppCallouts={showAddToAppCallouts} addToAppHref={addToAppHref} />
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+            <AgentChatPanel agent={agent} showAddToAppCallouts={showAddToAppCallouts} addToAppHref={addToAppHref} />
+          </div>
         </div>
       </SheetContent>
     </Sheet>

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-drawer.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-drawer.tsx
@@ -84,9 +84,7 @@ export function AgentChatDrawer({
             </div>
           ) : null}
 
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-            <AgentChatPanel agent={agent} showAddToAppCallouts={showAddToAppCallouts} addToAppHref={addToAppHref} />
-          </div>
+          <AgentChatPanel agent={agent} showAddToAppCallouts={showAddToAppCallouts} addToAppHref={addToAppHref} />
         </div>
       </SheetContent>
     </Sheet>

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-panel.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-panel.tsx
@@ -5,6 +5,8 @@ import { RiArrowUpLine, RiCloseFill, RiErrorWarningLine, RiLoader4Line } from 'r
 import { Link } from 'react-router-dom';
 import type { AgentResponse } from '@/api/agents';
 import { ChatEmptyState, ChatMessageRow, ChatTypingRow } from '@/components/agents/agent-chat-panel/agent-chat-parts';
+import { AgentChatSessionBar } from '@/components/agents/agent-chat-panel/agent-chat-session-bar';
+import { useAgentChatConversationList } from '@/components/agents/agent-chat-panel/use-agent-chat-conversation-list';
 import { Button } from '@/components/primitives/button';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
@@ -50,6 +52,9 @@ export function AgentChatPanel({ agent, showAddToAppCallouts = false, addToAppHr
     }),
     [testerSubscriberId, currentUser?.firstName, currentUser?.lastName, currentUser?.email, currentUser?.profilePicture]
   );
+  const [resumeId, setResumeId] = useState<string | undefined>();
+  const [sessionNonce, setSessionNonce] = useState(0);
+  const { items, reload } = useAgentChatConversationList(agent.identifier, testerSubscriberId);
 
   if (!isReady || !currentEnvironment) {
     return (
@@ -66,14 +71,24 @@ export function AgentChatPanel({ agent, showAddToAppCallouts = false, addToAppHr
       subscriber={subscriber}
       applicationIdentifier={currentEnvironment.identifier}
       apiUrl={apiHostnameManager.getHostname()}
-      socketUrl={apiHostnameManager.getWebSocketHostname()}
+      socketUrl={import.meta.env.VITE_SOCKET_WORKER_URL || apiHostnameManager.getWebSocketHostname()}
+      socketOptions={{ socketType: 'cloud' }}
     >
       <div className="flex min-h-0 flex-1 flex-col">
         <AgentChatSurface
+          key={sessionNonce}
           agentId={agent.identifier}
           agentName={agent.name}
+          conversationId={resumeId}
+          conversations={items}
           showAddToAppCallouts={showAddToAppCallouts}
           addToAppHref={addToAppHref}
+          onSelectConversation={setResumeId}
+          onNewChat={() => {
+            setResumeId(undefined);
+            setSessionNonce((nonce) => nonce + 1);
+          }}
+          onConversationActivity={reload}
         />
       </div>
     </NovuProvider>
@@ -83,22 +98,44 @@ export function AgentChatPanel({ agent, showAddToAppCallouts = false, addToAppHr
 function AgentChatSurface({
   agentId,
   agentName,
+  conversationId,
+  conversations,
   showAddToAppCallouts,
   addToAppHref,
+  onSelectConversation,
+  onNewChat,
+  onConversationActivity,
 }: {
   agentId: string;
   agentName: string;
+  conversationId?: string;
+  conversations: ReturnType<typeof useAgentChatConversationList>['items'];
   showAddToAppCallouts: boolean;
   addToAppHref?: string;
+  onSelectConversation: (identifier: string) => void;
+  onNewChat: () => void;
+  onConversationActivity: () => void;
 }) {
   const [draft, setDraft] = useState('');
   const [showChannelPromo, setShowChannelPromo] = useState(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { messages, pendingActions, sendMessage, sendAction, respondToAction, error, isRunning, isLoading, typing } =
-    useAgentChat({
-      agentId,
-    });
+  const {
+    messages,
+    pendingActions,
+    sendMessage,
+    sendAction,
+    respondToAction,
+    retryMessage,
+    conversationId: activeConversationId,
+    error,
+    isRunning,
+    isLoading,
+    typing,
+  } = useAgentChat({
+    agentId,
+    conversationId,
+  });
 
   const composerDisabled = isRunning || isLoading;
   const canSend = !composerDisabled && Boolean(draft.trim());
@@ -108,6 +145,7 @@ function AgentChatSurface({
   const lastMessageSignature = lastMessage
     ? `${lastMessage.id}:${lastMessage.parts.map((part) => (part.type === 'text' ? part.text : part.type)).join('\0')}`
     : '';
+  const canStartNew = Boolean(activeConversationId || conversationId || messages.length > 0);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure whenever the draft changes
   useLayoutEffect(() => {
@@ -131,12 +169,23 @@ function AgentChatSurface({
     if (!trimmed || composerDisabled) return;
 
     setDraft('');
-    void sendMessage(trimmed);
+    void sendMessage(trimmed).then((result) => {
+      if (result.data) {
+        onConversationActivity();
+      }
+    });
     textareaRef.current?.focus();
   };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
+      <AgentChatSessionBar
+        conversations={conversations}
+        activeConversationId={activeConversationId ?? conversationId}
+        onSelect={onSelectConversation}
+        onNewChat={onNewChat}
+        canStartNew={canStartNew}
+      />
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto" role="log" aria-live="polite">
         {isEmpty ? (
           <div className="flex h-full w-full flex-col">
@@ -152,6 +201,7 @@ function AgentChatSurface({
                 cardActionsDisabled={composerDisabled}
                 onCardAction={(action) => void sendAction(action)}
                 onRespondToAction={(action) => void respondToAction(action)}
+                onRetry={(messageId) => void retryMessage(messageId)}
               />
             ))}
             {showTypingRow ? <ChatTypingRow status={typing?.status} /> : null}

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-panel.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-panel.tsx
@@ -37,7 +37,13 @@ type AgentChatPanelProps = {
   addToAppHref?: string;
 };
 
-export function AgentChatPanel({ agent, showAddToAppCallouts = false, addToAppHref }: AgentChatPanelProps) {
+export function AgentChatPanel(props: AgentChatPanelProps) {
+  const { currentEnvironment } = useEnvironment();
+
+  return <AgentChatPanelInner key={`${props.agent.identifier}:${currentEnvironment?._id ?? ''}`} {...props} />;
+}
+
+function AgentChatPanelInner({ agent, showAddToAppCallouts = false, addToAppHref }: AgentChatPanelProps) {
   const { currentUser, isUserLoaded } = useAuth();
   const { currentEnvironment } = useEnvironment();
   const testerSubscriberId = currentUser?._id ? buildDashboardAgentChatSubscriberId(currentUser._id) : '';
@@ -203,7 +209,13 @@ function AgentChatSurface({
                 cardActionsDisabled={composerDisabled}
                 onCardAction={(action) => void sendAction(action)}
                 onRespondToAction={(action) => void respondToAction(action)}
-                onRetry={(messageId) => void retryMessage(messageId)}
+                onRetry={(messageId) => {
+                  void retryMessage(messageId).then((result) => {
+                    if (result.data) {
+                      onConversationActivity();
+                    }
+                  });
+                }}
               />
             ))}
             {showTypingRow ? <ChatTypingRow status={typing?.status} /> : null}

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-panel.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-panel.tsx
@@ -71,10 +71,9 @@ export function AgentChatPanel({ agent, showAddToAppCallouts = false, addToAppHr
       subscriber={subscriber}
       applicationIdentifier={currentEnvironment.identifier}
       apiUrl={apiHostnameManager.getHostname()}
-      socketUrl={import.meta.env.VITE_SOCKET_WORKER_URL || apiHostnameManager.getWebSocketHostname()}
-      socketOptions={{ socketType: 'cloud' }}
+      socketUrl={apiHostnameManager.getWebSocketHostname()}
     >
-      <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         <AgentChatSurface
           key={sessionNonce}
           agentId={agent.identifier}
@@ -83,7 +82,10 @@ export function AgentChatPanel({ agent, showAddToAppCallouts = false, addToAppHr
           conversations={items}
           showAddToAppCallouts={showAddToAppCallouts}
           addToAppHref={addToAppHref}
-          onSelectConversation={setResumeId}
+          onSelectConversation={(identifier) => {
+            setResumeId(identifier);
+            setSessionNonce((nonce) => nonce + 1);
+          }}
           onNewChat={() => {
             setResumeId(undefined);
             setSessionNonce((nonce) => nonce + 1);

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
@@ -1,4 +1,5 @@
 import type { AgentMessage } from '@novu/react';
+import { type ReactNode } from 'react';
 import {
   RiArrowRightSLine,
   RiChat3Fill,
@@ -493,6 +494,37 @@ function PayloadPeek({ label, value }: { label: string; value: string }) {
   );
 }
 
+function ExpandableRow({
+  id,
+  className,
+  summary,
+  children,
+}: {
+  id?: string;
+  className?: string;
+  summary: ReactNode;
+  children?: ReactNode;
+}) {
+  if (!children) {
+    return (
+      <span id={id} className={className}>
+        {summary}
+      </span>
+    );
+  }
+
+  return (
+    <details id={id} className={cn('group w-full min-w-0', className)}>
+      <summary className="flex cursor-pointer list-none items-center [&::-webkit-details-marker]:hidden">
+        {summary}
+      </summary>
+      <div className="border-stroke-soft mt-1 flex w-full min-w-0 flex-col gap-2 rounded-md border px-2.5 py-2">
+        {children}
+      </div>
+    </details>
+  );
+}
+
 function ToolChip({ tool }: { tool: ToolPart }) {
   const isRunning = tool.state === 'input-streaming' || tool.state === 'input-available';
   const isFailed = tool.state === 'output-error';
@@ -506,39 +538,33 @@ function ToolChip({ tool }: { tool: ToolPart }) {
 
   const inputPreview = tool.input && Object.keys(tool.input).length > 0 ? prettyJson(tool.input) : undefined;
   const outputPreview = formatToolOutput(tool.output);
-  const canExpand = Boolean(inputPreview || outputPreview);
-  const row = (
-    <span
-      className={cn(
-        'text-label-xs inline-flex min-w-0 items-center gap-1',
-        isFailed ? 'text-error-base' : 'text-text-soft',
-        canExpand && 'cursor-pointer'
-      )}
-    >
-      {isRunning ? (
-        <RiLoader4Line className="size-3.5 shrink-0 animate-spin" aria-hidden />
-      ) : (
-        <RiArrowRightSLine
-          className={cn('size-3.5 shrink-0', canExpand && 'transition-transform group-open:rotate-90')}
-          aria-hidden
-        />
-      )}
-      {statusLabel} <span className="font-mono">{tool.toolName}</span>
-    </span>
-  );
-
-  if (!canExpand) {
-    return row;
-  }
 
   return (
-    <details className="group w-full min-w-0">
-      <summary className="flex list-none items-center [&::-webkit-details-marker]:hidden">{row}</summary>
-      <div className="border-stroke-soft mt-1 flex w-full min-w-0 flex-col gap-2 rounded-md border px-2.5 py-2">
-        {inputPreview ? <PayloadPeek label="Input" value={inputPreview} /> : null}
-        {outputPreview ? <PayloadPeek label="Result" value={outputPreview} /> : null}
-      </div>
-    </details>
+    <ExpandableRow
+      summary={
+        <span
+          className={cn(
+            'text-label-xs inline-flex min-w-0 items-center gap-1',
+            isFailed ? 'text-error-base' : 'text-text-soft',
+            (inputPreview || outputPreview) && 'cursor-pointer'
+          )}
+        >
+          {isRunning ? (
+            <RiLoader4Line className="size-3.5 shrink-0 animate-spin" aria-hidden />
+          ) : (
+            <RiArrowRightSLine className="size-3.5 shrink-0 transition-transform group-open:rotate-90" aria-hidden />
+          )}
+          {statusLabel} <span className="font-mono">{tool.toolName}</span>
+        </span>
+      }
+    >
+      {inputPreview || outputPreview ? (
+        <>
+          {inputPreview ? <PayloadPeek label="Input" value={inputPreview} /> : null}
+          {outputPreview ? <PayloadPeek label="Result" value={outputPreview} /> : null}
+        </>
+      ) : null}
+    </ExpandableRow>
   );
 }
 
@@ -661,40 +687,29 @@ export function ChatToolApprovalCard({
 
   if (state !== 'pending') {
     const isApproved = state === 'approved';
-    const statusRow = (
-      <span className="text-label-xs inline-flex items-center gap-1">
-        <RiArrowRightSLine
-          className={cn(
-            'text-text-soft size-3.5 shrink-0',
-            inputPreview && 'transition-transform group-open:rotate-90'
-          )}
-          aria-hidden
-        />
-        <span className="text-text-soft font-mono">{toolName}</span>
-        <span className="text-text-soft" aria-hidden>
-          ·
-        </span>
-        <span className={isApproved ? 'text-text-sub' : 'text-error-base'}>{isApproved ? 'Approved' : 'Denied'}</span>
-      </span>
-    );
-
-    if (!inputPreview) {
-      return (
-        <span id={id} className={cn('text-label-xs inline-flex items-center gap-1', className)}>
-          {statusRow}
-        </span>
-      );
-    }
 
     return (
-      <details id={id} className={cn('group w-full min-w-0', className)}>
-        <summary className="flex list-none cursor-pointer items-center [&::-webkit-details-marker]:hidden">
-          {statusRow}
-        </summary>
-        <div className="border-stroke-soft mt-1 flex w-full min-w-0 flex-col gap-2 rounded-md border px-2.5 py-2">
-          <PayloadPeek label="Input" value={inputPreview} />
-        </div>
-      </details>
+      <ExpandableRow
+        id={id}
+        className={className}
+        summary={
+          <span className="text-label-xs inline-flex items-center gap-1">
+            <RiArrowRightSLine
+              className="text-text-soft size-3.5 shrink-0 transition-transform group-open:rotate-90"
+              aria-hidden
+            />
+            <span className="text-text-soft font-mono">{toolName}</span>
+            <span className="text-text-soft" aria-hidden>
+              ·
+            </span>
+            <span className={isApproved ? 'text-text-sub' : 'text-error-base'}>
+              {isApproved ? 'Approved' : 'Denied'}
+            </span>
+          </span>
+        }
+      >
+        {inputPreview ? <PayloadPeek label="Input" value={inputPreview} /> : null}
+      </ExpandableRow>
     );
   }
 

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
@@ -126,12 +126,14 @@ export function ChatMessageRow({
   onCardAction,
   cardActionsDisabled,
   onRespondToAction,
+  onRetry,
 }: {
   message: AgentMessage;
   showAvatar: boolean;
   onCardAction?: CardActionHandler;
   cardActionsDisabled?: boolean;
   onRespondToAction?: (args: { actionId: string; decision: ToolApprovalDecision }) => void;
+  onRetry?: (messageId: string) => void;
 }) {
   const isUser = message.role === 'user';
   const textParts = message.parts.filter((part): part is TextPart => part.type === 'text');
@@ -175,6 +177,15 @@ export function ChatMessageRow({
           <span className="text-error-base text-label-xs inline-flex items-center gap-1">
             <RiErrorWarningLine className="size-3" aria-hidden />
             Not sent
+            {onRetry ? (
+              <button
+                type="button"
+                className="text-error-base hover:opacity-80 underline decoration-from-font underline-offset-2"
+                onClick={() => onRetry(message.id)}
+              >
+                Retry
+              </button>
+            ) : null}
           </span>
         ) : null}
       </div>
@@ -210,7 +221,7 @@ export function ChatMessageRow({
           />
         ))}
         {visibleTools.length > 0 ? (
-          <div className="flex flex-wrap gap-1.5">
+          <div className="flex w-full flex-col items-start gap-1">
             {visibleTools.map((tool) => (
               <ToolChip key={tool.toolUseId} tool={tool} />
             ))}
@@ -222,6 +233,7 @@ export function ChatMessageRow({
             id={part.approvalId}
             toolName={part.toolName}
             source={part.source}
+            input={part.input}
             state={part.state}
             trustToolActionId={part.trustToolActionId}
             trustServerActionId={part.trustServerActionId}
@@ -439,6 +451,48 @@ function ChatCardPart({
   );
 }
 
+function prettyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatToolOutput(output: ToolPart['output']): string | undefined {
+  if (!output?.length) {
+    return undefined;
+  }
+
+  const chunks = output.map((part) => {
+    switch (part.type) {
+      case 'text':
+        return part.text;
+      case 'json':
+        return prettyJson(part.value);
+      case 'citation':
+        return part.title ? `${part.title}\n${part.url}` : part.url;
+      case 'media':
+        return part.name ?? part.mediaType;
+      default:
+        return prettyJson(part.data);
+    }
+  });
+
+  return chunks.filter(Boolean).join('\n\n') || undefined;
+}
+
+function PayloadPeek({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <span className="text-label-xs text-text-soft">{label}</span>
+      <pre className="text-paragraph-xs text-text-sub max-h-28 overflow-auto whitespace-pre-wrap break-all font-mono leading-4">
+        {value}
+      </pre>
+    </div>
+  );
+}
+
 function ToolChip({ tool }: { tool: ToolPart }) {
   const isRunning = tool.state === 'input-streaming' || tool.state === 'input-available';
   const isFailed = tool.state === 'output-error';
@@ -450,17 +504,41 @@ function ToolChip({ tool }: { tool: ToolPart }) {
     statusLabel = 'Failed';
   }
 
-  return (
+  const inputPreview = tool.input && Object.keys(tool.input).length > 0 ? prettyJson(tool.input) : undefined;
+  const outputPreview = formatToolOutput(tool.output);
+  const canExpand = Boolean(inputPreview || outputPreview);
+  const row = (
     <span
-      className={cn('text-label-xs inline-flex items-center gap-1', isFailed ? 'text-error-base' : 'text-text-soft')}
+      className={cn(
+        'text-label-xs inline-flex min-w-0 items-center gap-1',
+        isFailed ? 'text-error-base' : 'text-text-soft',
+        canExpand && 'cursor-pointer'
+      )}
     >
       {isRunning ? (
         <RiLoader4Line className="size-3.5 shrink-0 animate-spin" aria-hidden />
       ) : (
-        <RiArrowRightSLine className="size-3.5 shrink-0" aria-hidden />
+        <RiArrowRightSLine
+          className={cn('size-3.5 shrink-0', canExpand && 'transition-transform group-open:rotate-90')}
+          aria-hidden
+        />
       )}
       {statusLabel} <span className="font-mono">{tool.toolName}</span>
     </span>
+  );
+
+  if (!canExpand) {
+    return row;
+  }
+
+  return (
+    <details className="group w-full min-w-0">
+      <summary className="flex list-none items-center [&::-webkit-details-marker]:hidden">{row}</summary>
+      <div className="border-stroke-soft mt-1 flex w-full min-w-0 flex-col gap-2 rounded-md border px-2.5 py-2">
+        {inputPreview ? <PayloadPeek label="Input" value={inputPreview} /> : null}
+        {outputPreview ? <PayloadPeek label="Result" value={outputPreview} /> : null}
+      </div>
+    </details>
   );
 }
 
@@ -480,6 +558,7 @@ type ToolApprovalCardProps = {
   id?: string;
   toolName: string;
   source?: ApprovalPart['source'];
+  input?: ApprovalPart['input'];
   state: ApprovalPart['state'];
   trustToolActionId?: string;
   trustServerActionId?: string;
@@ -570,6 +649,7 @@ export function ChatToolApprovalCard({
   id,
   toolName,
   source,
+  input,
   state,
   trustToolActionId,
   trustServerActionId,
@@ -577,18 +657,44 @@ export function ChatToolApprovalCard({
   onRespond,
   className,
 }: ToolApprovalCardProps) {
+  const inputPreview = input && Object.keys(input).length > 0 ? prettyJson(input) : undefined;
+
   if (state !== 'pending') {
     const isApproved = state === 'approved';
-
-    return (
-      <span id={id} className={cn('text-label-xs inline-flex items-center gap-1', className)}>
-        <RiArrowRightSLine className="text-text-soft size-3.5 shrink-0" aria-hidden />
+    const statusRow = (
+      <span className="text-label-xs inline-flex items-center gap-1">
+        <RiArrowRightSLine
+          className={cn(
+            'text-text-soft size-3.5 shrink-0',
+            inputPreview && 'transition-transform group-open:rotate-90'
+          )}
+          aria-hidden
+        />
         <span className="text-text-soft font-mono">{toolName}</span>
         <span className="text-text-soft" aria-hidden>
           ·
         </span>
         <span className={isApproved ? 'text-text-sub' : 'text-error-base'}>{isApproved ? 'Approved' : 'Denied'}</span>
       </span>
+    );
+
+    if (!inputPreview) {
+      return (
+        <span id={id} className={cn('text-label-xs inline-flex items-center gap-1', className)}>
+          {statusRow}
+        </span>
+      );
+    }
+
+    return (
+      <details id={id} className={cn('group w-full min-w-0', className)}>
+        <summary className="flex list-none cursor-pointer items-center [&::-webkit-details-marker]:hidden">
+          {statusRow}
+        </summary>
+        <div className="border-stroke-soft mt-1 flex w-full min-w-0 flex-col gap-2 rounded-md border px-2.5 py-2">
+          <PayloadPeek label="Input" value={inputPreview} />
+        </div>
+      </details>
     );
   }
 
@@ -605,6 +711,17 @@ export function ChatToolApprovalCard({
           The agent is waiting for your approval.
         </p>
       </div>
+      {inputPreview ? (
+        <details className="group min-w-0">
+          <summary className="text-label-xs text-text-sub hover:text-text-strong flex cursor-pointer list-none items-center gap-1 [&::-webkit-details-marker]:hidden">
+            <RiArrowRightSLine className="size-3.5 shrink-0 transition-transform group-open:rotate-90" aria-hidden />
+            Arguments
+          </summary>
+          <div className="mt-1.5">
+            <PayloadPeek label="Input" value={inputPreview} />
+          </div>
+        </details>
+      ) : null}
       <ToolApprovalActions
         disabled={disabled}
         onRespond={onRespond}

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-session-bar.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-session-bar.tsx
@@ -1,0 +1,109 @@
+import { RiAddLine, RiArrowDownSLine, RiCheckLine } from 'react-icons/ri';
+import { CompactButton } from '@/components/primitives/button-compact';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/primitives/dropdown-menu';
+import { cn } from '@/utils/ui';
+import type { AgentChatSessionItem } from './use-agent-chat-conversation-list';
+
+function relativeTime(iso: string): string {
+  const deltaMs = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(deltaMs)) {
+    return '';
+  }
+
+  const minutes = Math.round(deltaMs / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+export function AgentChatSessionBar({
+  conversations,
+  activeConversationId,
+  onSelect,
+  onNewChat,
+  canStartNew,
+}: {
+  conversations: AgentChatSessionItem[];
+  activeConversationId?: string;
+  onSelect: (identifier: string) => void;
+  onNewChat: () => void;
+  canStartNew: boolean;
+}) {
+  const active = conversations.find((conversation) => conversation.identifier === activeConversationId);
+  const label = active?.title ?? (activeConversationId ? 'Current chat' : 'New chat');
+  const hasHistory = conversations.length > 0;
+
+  if (!hasHistory && !activeConversationId) {
+    return null;
+  }
+
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="hover:bg-bg-weak flex min-w-0 flex-1 items-center gap-1 rounded-md px-2 py-1.5 text-left"
+            aria-label="Switch conversation"
+          >
+            <span className="text-label-xs text-text-strong min-w-0 flex-1 truncate font-medium">{label}</span>
+            <RiArrowDownSLine className="text-text-soft size-3.5 shrink-0" aria-hidden />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-[min(20rem,calc(100vw-2rem))]" sideOffset={4}>
+          {hasHistory ? (
+            conversations.map((conversation) => {
+              const isActive = conversation.identifier === activeConversationId;
+
+              return (
+                <DropdownMenuItem
+                  key={conversation.identifier}
+                  className="items-start"
+                  onSelect={() => onSelect(conversation.identifier)}
+                >
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-label-xs text-text-strong truncate">{conversation.title}</span>
+                    <span className="text-paragraph-xs text-text-soft">
+                      {relativeTime(conversation.lastActivityAt)}
+                    </span>
+                  </span>
+                  <RiCheckLine className={cn('text-text-sub mt-0.5 size-3.5 shrink-0', !isActive && 'invisible')} />
+                </DropdownMenuItem>
+              );
+            })
+          ) : (
+            <p className="text-paragraph-xs text-text-soft px-2 py-1.5">No earlier chats</p>
+          )}
+          {canStartNew ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={onNewChat}>
+                <RiAddLine className="size-3.5" aria-hidden />
+                <span className="text-label-xs">New chat</span>
+              </DropdownMenuItem>
+            </>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <CompactButton
+        type="button"
+        size="md"
+        variant="ghost"
+        icon={RiAddLine}
+        disabled={!canStartNew}
+        aria-label="New chat"
+        onClick={onNewChat}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/agents/agent-chat-panel/use-agent-chat-conversation-list.ts
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/use-agent-chat-conversation-list.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { useFetchConversations } from '@/hooks/use-fetch-conversations';
+
+export type AgentChatSessionItem = {
+  identifier: string;
+  title: string;
+  lastActivityAt: string;
+};
+
+export function useAgentChatConversationList(agentIdentifier: string, subscriberId: string) {
+  const { conversations, refetch } = useFetchConversations(
+    {
+      filters: {
+        agentId: agentIdentifier,
+        subscriberId,
+      },
+      limit: 20,
+    },
+    { enabled: Boolean(agentIdentifier && subscriberId) }
+  );
+
+  const items = useMemo<AgentChatSessionItem[]>(
+    () =>
+      conversations.map((conversation) => ({
+        identifier: conversation.identifier,
+        title: conversation.title.trim() || 'Untitled conversation',
+        lastActivityAt: conversation.lastActivityAt,
+      })),
+    [conversations]
+  );
+
+  return { items, reload: refetch };
+}


### PR DESCRIPTION
## Summary

- Web chat preview can resume a recent tester conversation or start a new one (default is still a new chat).
- Failed user messages show Retry; tool rows and approval cards expand to Input / Result.
- Add-to-app banner and conversation selector are stacked with a gap so they no longer overlap.

```mermaid
flowchart TD
  drawer["AgentChatDrawer"] --> banner["Add Web Chat banner"]
  drawer --> panel["AgentChatPanel"]
  panel --> bar["Session bar: list + New chat"]
  bar -->|select conversationId| hook["useAgentChat"]
  bar -->|New chat| remount["Remount surface"]
  panel --> retry["retryMessage"]
  panel --> tools["ExpandableRow tool/approval payloads"]
```

## Test plan

- [ ] Open Web chat preview on an agent. Confirm it starts as a new chat.
- [ ] Send a message. Confirm the session bar appears. Open the dropdown and start New chat.
- [ ] Send a second chat, then switch back to the first. Confirm history loads and the composer is empty.
- [ ] Trigger a failed send and click Retry.
- [ ] Expand a tool row and a pending approval Arguments row. Confirm Input/Result are scrollable.
- [ ] With the add-to-app banner visible, confirm it does not overlap the conversation selector.


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enhances the dashboard’s Agent Chat preview with resumable conversations, retry support, expandable tool details, and improved layout spacing.
- Adds an environment- and agent-scoped session selector with explicit new-chat behavior.
- Refreshes conversation history after successful sends and retries.
- Displays expandable tool inputs, outputs, and approval arguments.
- Adds spacing between the add-to-app callout and chat panel.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-panel.tsx | Adds scope-safe remounting, conversation selection, new-chat behavior, retries, and post-activity session-list refreshes. |
| apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx | Adds retry controls and expandable rendering for tool inputs, outputs, and approval arguments. |
| apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-session-bar.tsx | Introduces the conversation selector and new-chat controls with active-session labeling. |
| apps/dashboard/src/components/agents/agent-chat-panel/use-agent-chat-conversation-list.ts | Adds the filtered conversation-list query adapter used by the chat session selector. |
| apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-drawer.tsx | Adds layout spacing to prevent the add-to-app callout from overlapping the chat controls. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Drawer[AgentChatDrawer] --> Panel[AgentChatPanel]
  Panel --> Scope[Agent and environment keyed inner panel]
  Scope --> List[Conversation list query]
  Scope --> Surface[AgentChatSurface]
  List --> SessionBar[Session selector]
  SessionBar -->|Select conversation| Resume[Remount with conversationId]
  SessionBar -->|New chat| New[Remount without conversationId]
  Surface -->|Successful send or retry| Reload[Refresh conversation list]
  Surface --> Details[Expandable tool and approval payloads]
```

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): reset web chat session o..."](https://github.com/novuhq/novu/commit/431289f1b9de3db6fbf349bb9913022e03795cba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56598661)</sub>

<!-- /greptile_comment -->