### PR TITLE
docs(docs): rewrite Agent Chat channel docs for the shipped client fixes DOC-436

### DIFF
--- a/docs/agents/channels/agent-chat.mdx
+++ b/docs/agents/channels/agent-chat.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Chat"
-description: "Connect your agent to in-app Agent Chat: live typing, tool approval, thinking parts, and a headless React hook in your product UI."
+description: "Connect your agent to in-app Agent Chat: a headless React hook, live typing, tool approval, cards, and HMAC."
 sidebarTitle: Overview
 ---
 
@@ -10,52 +10,88 @@ sidebarTitle: Overview
 
 Agent Chat is an ACI channel. The messaging surface is your product UI.
 
-The agent brain, conversation history, tool approval, and dashboard observability match other ACI channels. The client is [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat) from `@novu/react`. You render the messages and the composer.
+The agent brain, conversation history, tool approval, and dashboard observability match other ACI channels. The React client is [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat) from `@novu/react`. You render the message list and the composer. There is no prebuilt `<AgentChat />` component.
 
-## Capabilities
+Agent Chat supports live typing, thinking parts, tool approval, MCP connect, cards, custom data parts, and file parts. HMAC is available on the integration.
 
-| Capability | Support |
-| --- | --- |
-| Full context history | Yes |
-| Threaded replies (one conversation per thread) | Yes |
-| Live typing indicator | Yes |
-| React with eyes on inbound messages | No |
-| Plan card (thinking parts) | Yes |
-| Rich text | Yes (your UI renders message parts) |
-| Tap-to-respond | Yes (tool approval and cards) |
-| Emoji reactions | No |
-| Message edits in place | Yes |
-| Action / MCP tool approval | Yes |
-| MCP connect card | Yes |
-| Resolve conversation | Yes |
-| File parts | Yes |
-| Streaming text parts | Yes (live socket) |
-
-Full matrix: [Channels overview](/agents/channels/overview).
-
-## Examples
-
-### In-app turn
-
-A subscriber sends a message in your UI. Novu loads conversation history, runs the agent brain, and streams the reply over the socket. Typing and thinking parts update while the turn runs.
-
-### Tool approval
-
-A gated tool pauses the turn. `pendingActions` includes a `tool-approval` item. Call `respondToAction` with `approved` or `denied`. The turn resumes after the decision.
+Full capability matrix: [Channels overview](/agents/channels/overview).
 
 ## Setup
 
 1. Create an agent and keep it **active**.
 2. In the Novu dashboard, open the agent and add **Agent Chat** as a channel. Novu creates the `novu-agent-chat` integration if it does not exist.
-3. Embed the chat in your app. Follow [Build the UI](/agents/channels/agent-chat/quickstart).
+
+You need:
+
+- Your **application identifier** from [API Keys](https://dashboard.novu.co/api-keys)
+- A [subscriber](/platform/additional-resources/glossary) id for the signed-in person
+- The public **agent identifier** from the agent page in the dashboard
+
+Then embed the chat in your app. For React, follow [Build the UI](/agents/channels/agent-chat/quickstart). For JavaScript, use [`conversation()`](/platform/sdks/javascript#agent-chat).
+
+## Security
+
+HMAC is off by default. Turn HMAC on before you ship. Agent Chat can require two hashes. Each hash has its own dashboard toggle.
+
+| Hash | Toggle | Input | Where the client passes it |
+| --- | --- | --- | --- |
+| `subscriberHash` | **Novu In-App** integration | `subscriberId` | `NovuProvider` |
+| `agentHash` | **Agent Chat** integration | agent identifier | `useAgentChat` |
+
+Both hashes use the same secret: the environment API secret from [API Keys](https://dashboard.novu.co/api-keys). Compute them on your server. Do not compute them in the browser.
+
+If only one toggle is on, pass only that hash. If both toggles are on, pass both hashes.
+
+### subscriberHash
+
+`subscriberHash` authenticates the signed-in subscriber. Without it, another person can guess a `subscriberId` and open that subscriber's session, including Agent Chat.
+
+If **Security HMAC encryption** is on for **Novu In-App**, pass `subscriberHash` to `NovuProvider`. The hash is `HMAC-SHA256(secretKey, subscriberId)` as a lowercase hex string.
+
+```tsx
+<NovuProvider
+  applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+  subscriber="YOUR_SUBSCRIBER_ID"
+  subscriberHash="YOUR_SUBSCRIBER_HASH"
+>
+  <Chat />
+</NovuProvider>
+```
+
+Generation recipes (Node.js, Python, and more): [Secure your Inbox with HMAC](/platform/inbox/prepare-for-production#secure-your-inbox-with-hmac-encryption).
+
+### agentHash
+
+`agentHash` authenticates which agent the subscriber can talk to. Without it, a client can send any public agent identifier that is linked to Agent Chat.
+
+If **Security HMAC encryption** is on for **Agent Chat**:
+
+1. Open [Integrations](https://dashboard.novu.co/integrations).
+2. Select the **Agent Chat** integration.
+3. Enable **Security HMAC encryption**.
+4. On your server, compute `HMAC-SHA256(secretKey, agentIdentifier)` as a lowercase hex string.
+5. Pass that value as `agentHash` to `useAgentChat`.
+
+```tsx
+useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  agentHash: 'YOUR_AGENT_HASH',
+});
+```
 
 ## Related
 
 <Columns cols={2}>
   <Card href="/agents/channels/agent-chat/quickstart" title="Build the UI" icon="rocket">
-    Install `@novu/react`, wrap `NovuProvider`, and send a message.
+    Install `@novu/react` and send the first message.
+  </Card>
+  <Card href="/agents/channels/agent-chat/chat-ui" title="Chat UI" icon="list">
+    Parts, retry, resume, cards, approvals, and reconnect.
   </Card>
   <Card href="/platform/sdks/react/hooks/use-agent-chat" title="useAgentChat" icon="code">
     Hook props, return value, and callbacks.
+  </Card>
+  <Card href="/platform/sdks/javascript#agent-chat" title="JavaScript SDK" icon="js">
+    `novu.agentChat.conversation()` in `@novu/js`.
   </Card>
 </Columns>

--- a/docs/agents/channels/agent-chat.mdx
+++ b/docs/agents/channels/agent-chat.mdx
@@ -21,13 +21,7 @@ Full capability matrix: [Channels overview](/agents/channels/overview).
 1. Create an agent and keep it **active**.
 2. In the Novu dashboard, open the agent and add **Agent Chat** as a channel. Novu creates the `novu-agent-chat` integration if it does not exist.
 
-You need:
-
-- Your **application identifier** from [API Keys](https://dashboard.novu.co/api-keys)
-- A [subscriber](/platform/additional-resources/glossary) id for the signed-in person
-- The public **agent identifier** from the agent page in the dashboard
-
-Then embed the chat in your app. For React, follow [Build the UI](/agents/channels/agent-chat/quickstart). For JavaScript, use [`conversation()`](/platform/sdks/javascript#agent-chat).
+Then embed the chat in your app. For React, follow [Quickstart](/agents/channels/agent-chat/quickstart). For JavaScript, use [`conversation()`](/platform/sdks/javascript#agent-chat).
 
 ## Security
 
@@ -82,7 +76,7 @@ useAgentChat({
 ## Related
 
 <Columns cols={2}>
-  <Card href="/agents/channels/agent-chat/quickstart" title="Build the UI" icon="rocket">
+  <Card href="/agents/channels/agent-chat/quickstart" title="Quickstart" icon="rocket">
     Install `@novu/react` and send the first message.
   </Card>
   <Card href="/agents/channels/agent-chat/chat-ui" title="Chat UI" icon="list">
@@ -91,7 +85,7 @@ useAgentChat({
   <Card href="/platform/sdks/react/hooks/use-agent-chat" title="useAgentChat" icon="code">
     Hook props, return value, and callbacks.
   </Card>
-  <Card href="/platform/sdks/javascript#agent-chat" title="JavaScript SDK" icon="js">
+  <Card href="/platform/sdks/javascript#agent-chat" title="JavaScript SDK" icon="code">
     `novu.agentChat.conversation()` in `@novu/js`.
   </Card>
 </Columns>

--- a/docs/agents/channels/agent-chat/chat-ui.mdx
+++ b/docs/agents/channels/agent-chat/chat-ui.mdx
@@ -8,41 +8,27 @@ sidebarTitle: Chat UI
   Agent Chat is in closed beta. Contact us at support@novu.co to get access.
 </Note>
 
-Start from [Send a message](/agents/channels/agent-chat/quickstart#send-a-message). This page is the rest of the client.
+Start from [Send a message](/agents/channels/agent-chat/quickstart#send-a-message). This page covers everything after the first message.
 
 `messages` is the ordered timeline. Each message has `role` (`user` or `assistant`) and `parts`.
 
 ## State
 
-Use these fields to drive the UI. Exact types: [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat).
+Use these fields to drive the UI. See [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat) for types.
 
 | Field | What you do |
 | --- | --- |
 | `isLoading` | First history fetch. False when there is no `conversationId`. Show a spinner. |
 | `isRunning` | Agent turn in progress. Disable the composer. `typing` is optional status text. |
-| `status` | Conversation lifecycle: `active` or `resolved`. Same value as `conversationStatus`. The agent sets `resolved` with `ctx.resolve()`. Not a loading flag. Do not use it to disable the composer. |
-| `error` | Last load, send, retry, action, or run error. Show the message. Not `catchUpError`. |
+| `status` | Conversation is `active` or `resolved`. Do not use it to disable the composer. |
+| `error` | Last load, send, retry, action, or run error. Show the message. |
 | `message.status` | `sending`, `sent`, or `failed`. If `failed`, call `retryMessage`. See [Retry](#retry-a-failed-send). |
 
-Reconnect: [Reconnect](#reconnect) (`isRecovering`, `catchUpError`). Older pages: [Older messages](#older-messages) (`pagination`).
-
-A turn is not the conversation. `isRunning` follows the agent run. `status` follows the conversation.
+See [Reconnect](#reconnect) (`isRecovering`, `catchUpError`). See [Older messages](#older-messages) (`pagination`).
 
 ## Parts
 
-Start with `type === 'text'`. Then handle the other part types.
-
-| `type` | What to render |
-| --- | --- |
-| `text` | Visible body. `state` is `streaming` or `done`. |
-| `thinking` | Plan text while the agent reasons. |
-| `tool` | Tool call and result. |
-| `approval` | Gated tool. Use `pendingActions` and `respondToAction`. |
-| `mcp-connection` | MCP connect card. Open `authorizeUrl`. |
-| `card` | Structured Card tree. Draw `part.card`. Button clicks call `sendAction`. See [Cards](#cards). |
-| `data` | Custom payload. `name` plus `data`. See [Custom data parts](#custom-data-parts). |
-| `file` | File attachment metadata. |
-| `source` | Citation (`url` or `document`). |
+Start with `type === 'text'`. Then handle the other part types. See [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat) for part types.
 
 ```tsx
 const { messages } = useAgentChat({ agentId: 'YOUR_AGENT_IDENTIFIER' });
@@ -55,8 +41,6 @@ const { messages } = useAgentChat({ agentId: 'YOUR_AGENT_IDENTIFIER' });
   </li>
 ))}
 ```
-
-Full field tables: [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat).
 
 ## Thinking
 
@@ -86,7 +70,7 @@ const { messages, isRunning, typing } = useAgentChat({
 )}
 ```
 
-The first envelope of a turn can create an empty assistant message before any text is folded in. Keep that row in the list. Then fill it as parts arrive.
+The first event of a turn can create an empty assistant message before any text arrives. Keep that row in the list. Then fill it as parts arrive.
 
 ## Approvals
 
@@ -153,7 +137,7 @@ Agents create Cards with JSX or `Card({…})`. That authoring API is shared with
 
 The SDK does not type `part.card`. `card` is `Record<string, unknown>`. Read the fields that you support. Skip child types that you do not use.
 
-Draw `title` and the `children` that you support. If the subscriber clicks a button, call `sendAction`. The agent receives the click in `onAction`.
+Render `title` and the `children` that you support. If the subscriber clicks a button, call `sendAction`. The agent receives the click in `onAction`.
 
 ```tsx
 const { messages, sendAction } = useAgentChat({
@@ -210,20 +194,9 @@ Do not call `respondToAction`. That function is for tool approval only.
 
 ### Custom data parts
 
-Call `ctx.emit` in your agent handler. Agent Chat folds that event into a part with `type: 'data'`. The payload is `name` plus `data`. The shape of `data` is yours.
+The agent sends a named payload with [`ctx.emit`](/agents/custom-code-agent/building-blocks/emit). Agent Chat adds it to the in-flight assistant message as `part.type === 'data'`. The fields are `name` and `data`.
 
-```ts
-onMessage: async (message, ctx) => {
-  await ctx.emit({
-    name: 'order-progress',
-    data: { pct: 70 },
-  });
-
-  await ctx.reply('Updating your order…');
-},
-```
-
-The part lands on the in-flight assistant message. Render it in the UI:
+See [Emit custom events](/agents/custom-code-agent/building-blocks/emit) for the handler API, size limit, and other channels.
 
 ```tsx
 const { messages } = useAgentChat({
@@ -297,13 +270,19 @@ const { messages, retryMessage } = useAgentChat({
 Pass `conversationId` so the hook loads history on mount.
 
 ```tsx
-useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-  conversationId, // omit to start a new chat
-});
+function Chat({ conversationId }: { conversationId?: string }) {
+  const { sendMessage } = useAgentChat({
+    agentId: 'YOUR_AGENT_IDENTIFIER',
+    conversationId,
+  });
 
-const { data } = await sendMessage(text);
-// persist data.conversationId and pass it back as conversationId
+  async function onSend(text: string) {
+    const { data } = await sendMessage(text);
+    if (data?.conversationId) {
+      // persist data.conversationId and pass it back as conversationId
+    }
+  }
+}
 ```
 
 Store the `conversationId` that `sendMessage` returns, or the `conversationId` field on the hook result. On the next visit, pass that id back in.
@@ -338,23 +317,6 @@ const { pagination } = useAgentChat({
 ```
 
 Overlapping `fetchMore` calls do not run.
-
-`isLoading` is true until the first history fetch completes. If you omit `conversationId`, `isLoading` is false. There is no history to load yet.
-
-```tsx
-const { isLoading, error } = useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-  conversationId,
-});
-
-if (isLoading) {
-  return <p>Loading conversation…</p>;
-}
-
-if (error) {
-  return <p>{error.message}</p>;
-}
-```
 
 ## Reconnect
 

--- a/docs/agents/channels/agent-chat/chat-ui.mdx
+++ b/docs/agents/channels/agent-chat/chat-ui.mdx
@@ -1,0 +1,373 @@
+---
+title: "Chat UI"
+description: "Agent Chat client: state, parts, thinking, cards, approvals, custom data, retry, resume, older history, and reconnect."
+sidebarTitle: Chat UI
+---
+
+<Note>
+  Agent Chat is in closed beta. Contact us at support@novu.co to get access.
+</Note>
+
+Start from [Send a message](/agents/channels/agent-chat/quickstart#send-a-message). This page is the rest of the client.
+
+`messages` is the ordered timeline. Each message has `role` (`user` or `assistant`) and `parts`.
+
+## State
+
+Use these fields to drive the UI. Exact types: [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat).
+
+| Field | What you do |
+| --- | --- |
+| `isLoading` | First history fetch. False when there is no `conversationId`. Show a spinner. |
+| `isRunning` | Agent turn in progress. Disable the composer. `typing` is optional status text. |
+| `status` | Conversation lifecycle: `active` or `resolved`. Same value as `conversationStatus`. The agent sets `resolved` with `ctx.resolve()`. Not a loading flag. Do not use it to disable the composer. |
+| `error` | Last load, send, retry, action, or run error. Show the message. Not `catchUpError`. |
+| `message.status` | `sending`, `sent`, or `failed`. If `failed`, call `retryMessage`. See [Retry](#retry-a-failed-send). |
+
+Reconnect: [Reconnect](#reconnect) (`isRecovering`, `catchUpError`). Older pages: [Older messages](#older-messages) (`pagination`).
+
+A turn is not the conversation. `isRunning` follows the agent run. `status` follows the conversation.
+
+## Parts
+
+Start with `type === 'text'`. Then handle the other part types.
+
+| `type` | What to render |
+| --- | --- |
+| `text` | Visible body. `state` is `streaming` or `done`. |
+| `thinking` | Plan text while the agent reasons. |
+| `tool` | Tool call and result. |
+| `approval` | Gated tool. Use `pendingActions` and `respondToAction`. |
+| `mcp-connection` | MCP connect card. Open `authorizeUrl`. |
+| `card` | Structured Card tree. Draw `part.card`. Button clicks call `sendAction`. See [Cards](#cards). |
+| `data` | Custom payload. `name` plus `data`. See [Custom data parts](#custom-data-parts). |
+| `file` | File attachment metadata. |
+| `source` | Citation (`url` or `document`). |
+
+```tsx
+const { messages } = useAgentChat({ agentId: 'YOUR_AGENT_IDENTIFIER' });
+
+{messages.map((message) => (
+  <li key={message.id}>
+    {message.parts.map((part, index) =>
+      part.type === 'text' ? <span key={index}>{part.text}</span> : null
+    )}
+  </li>
+))}
+```
+
+Full field tables: [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat).
+
+## Thinking
+
+While the agent turn is in progress, `isRunning` is true. `typing` is present when the agent is typing. Assistant messages can include `thinking` parts before text arrives.
+
+`run` is the same snapshot: `isRunning` is `run.isRunning`, and `typing` is `run.typing`.
+
+```tsx
+const { messages, isRunning, typing } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{isRunning ? <p>{typing?.status ?? 'Working…'}</p> : null}
+
+{messages.map((message) =>
+  message.parts.map((part, index) => {
+    if (part.type === 'thinking') {
+      return <em key={index}>{part.text}</em>;
+    }
+
+    if (part.type === 'text') {
+      return <span key={index}>{part.text}</span>;
+    }
+
+    return null;
+  })
+)}
+```
+
+The first envelope of a turn can create an empty assistant message before any text is folded in. Keep that row in the list. Then fill it as parts arrive.
+
+## Approvals
+
+`pendingActions` lists waits that block the turn. Do not mix the two action types.
+
+| `action.type` | What to do |
+| --- | --- |
+| `tool-approval` | Call `respondToAction` with `action.id` and `approved` or `denied`. |
+| `mcp-connection` | Open `action.authorizeUrl` in the browser. Do not call `respondToAction`. |
+
+### Tool approval
+
+```tsx
+const { pendingActions, respondToAction } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{pendingActions.map((action) => {
+  if (action.type !== 'tool-approval') {
+    return null;
+  }
+
+  return (
+    <button
+      key={action.id}
+      type="button"
+      onClick={() => void respondToAction({ actionId: action.id, decision: 'approved' })}
+    >
+      Approve {action.toolName}
+    </button>
+  );
+})}
+```
+
+Pass `action.id` from `pendingActions`. Do not invent approve or deny ids.
+
+### MCP connect
+
+```tsx
+const { pendingActions } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{pendingActions.map((action) => {
+  if (action.type !== 'mcp-connection') {
+    return null;
+  }
+
+  return (
+    <a key={action.id} href={action.authorizeUrl} target="_blank" rel="noreferrer">
+      Connect {action.displayName}
+    </a>
+  );
+})}
+```
+
+## Cards
+
+A Card is a structured reply. It can include a title, text, images, links, and buttons.
+
+When the agent sends a Card, the message includes a part with `type: 'card'`. The data is on `part.card`.
+
+Agents create Cards with JSX or `Card({…})`. That authoring API is shared with Slack and the other ACI channels: [Interactive cards](/agents/custom-code-agent/building-blocks/reply#interactive-cards). You can also post the JSON with [Send an agent reply](/api-reference/agents/send-an-agent-reply).
+
+The SDK does not type `part.card`. `card` is `Record<string, unknown>`. Read the fields that you support. Skip child types that you do not use.
+
+Draw `title` and the `children` that you support. If the subscriber clicks a button, call `sendAction`. The agent receives the click in `onAction`.
+
+```tsx
+const { messages, sendAction } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{messages.map((message) =>
+  message.parts.map((part, i) => {
+    if (part.type !== 'card') {
+      return null;
+    }
+
+    const title = typeof part.card.title === 'string' ? part.card.title : null;
+    const children = Array.isArray(part.card.children) ? part.card.children : [];
+
+    return (
+      <article key={i}>
+        {title ? <h3>{title}</h3> : null}
+        {children.map((child, j) => {
+          if (child?.type === 'text') {
+            return <p key={j}>{child.content}</p>;
+          }
+
+          if (child?.type !== 'actions') {
+            return null;
+          }
+
+          return child.children?.map((button) => (
+            <button
+              key={button.id}
+              type="button"
+              onClick={() =>
+                void sendAction({
+                  actionId: button.id,
+                  value: button.value,
+                  sourceMessageId: message.id,
+                })
+              }
+            >
+              {button.label}
+            </button>
+          ));
+        })}
+      </article>
+    );
+  })
+)}
+```
+
+Do not send the button label with `sendMessage`. That call creates a new chat message.
+Do not call `respondToAction`. That function is for tool approval only.
+
+## Data, file, source
+
+### Custom data parts
+
+Call `ctx.emit` in your agent handler. Agent Chat folds that event into a part with `type: 'data'`. The payload is `name` plus `data`. The shape of `data` is yours.
+
+```ts
+onMessage: async (message, ctx) => {
+  await ctx.emit({
+    name: 'order-progress',
+    data: { pct: 70 },
+  });
+
+  await ctx.reply('Updating your order…');
+},
+```
+
+The part lands on the in-flight assistant message. Render it in the UI:
+
+```tsx
+const { messages } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{messages.map((message) =>
+  message.parts.map((part, index) => {
+    if (part.type !== 'data') {
+      return null;
+    }
+
+    return (
+      <pre key={index}>
+        {part.name}: {JSON.stringify(part.data)}
+      </pre>
+    );
+  })
+)}
+```
+
+Skip `data` parts that your UI does not handle. The part stays on the message.
+
+### File and source
+
+```tsx
+{message.parts.map((part, index) => {
+  if (part.type === 'file') {
+    return <span key={index}>{part.name ?? part.fileId}</span>;
+  }
+
+  if (part.type === 'source' && part.url) {
+    return (
+      <a key={index} href={part.url}>
+        {part.title ?? part.url}
+      </a>
+    );
+  }
+
+  return null;
+})}
+```
+
+## Retry a failed send
+
+If `message.status` is `failed`, call `retryMessage` with that message id.
+
+Retry reuses the original idempotency key. It does not create a second message with the same text.
+
+```tsx
+const { messages, retryMessage } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{messages.map((message) => (
+  <li key={message.id}>
+    {message.parts.map((part, index) =>
+      part.type === 'text' ? <span key={index}>{part.text}</span> : null
+    )}
+    {message.status === 'failed' ? (
+      <button type="button" onClick={() => void retryMessage(message.id)}>
+        Retry
+      </button>
+    ) : null}
+  </li>
+))}
+```
+
+## Resume a conversation
+
+Pass `conversationId` so the hook loads history on mount.
+
+```tsx
+useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  conversationId, // omit to start a new chat
+});
+
+const { data } = await sendMessage(text);
+// persist data.conversationId and pass it back as conversationId
+```
+
+Store the `conversationId` that `sendMessage` returns, or the `conversationId` field on the hook result. On the next visit, pass that id back in.
+
+The hook has no list-conversations API. You store the ids that you want to reopen.
+
+To start another chat, remount the component without `conversationId`, or clear the prop.
+
+`agentId` selects the agent. If the identifier changes, remount with the new `agentId`.
+
+Omit `conversationId` unless that conversation belongs to the new agent. A conversation id from a different agent does not resume.
+
+## Older messages
+
+If `pagination.hasMore` is true, call `pagination.fetchMore()` to load an older page.
+
+```tsx
+const { pagination } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  conversationId,
+});
+
+{pagination.hasMore ? (
+  <button
+    type="button"
+    disabled={pagination.status === 'loading'}
+    onClick={() => void pagination.fetchMore()}
+  >
+    {pagination.status === 'loading' ? 'Loading…' : 'Load older messages'}
+  </button>
+) : null}
+```
+
+Overlapping `fetchMore` calls do not run.
+
+`isLoading` is true until the first history fetch completes. If you omit `conversationId`, `isLoading` is false. There is no history to load yet.
+
+```tsx
+const { isLoading, error } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  conversationId,
+});
+
+if (isLoading) {
+  return <p>Loading conversation…</p>;
+}
+
+if (error) {
+  return <p>{error.message}</p>;
+}
+```
+
+## Reconnect
+
+The hook reconnects and applies missed events on its own. Show a banner from these fields.
+
+```tsx
+const { isRecovering, catchUpError } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  conversationId,
+});
+
+{isRecovering ? <p>Reconnecting…</p> : null}
+{catchUpError ? <p>{catchUpError.message}</p> : null}
+```
+
+`catchUpError` is separate from send and fetch `error`. `status` does not become an error state when catch-up fails.

--- a/docs/agents/channels/agent-chat/quickstart.mdx
+++ b/docs/agents/channels/agent-chat/quickstart.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Build the Agent Chat UI"
-description: "Install @novu/react, wrap NovuProvider, and use useAgentChat to send, receive, and resume in-app agent conversations."
-sidebarTitle: Build the UI
+description: "Install @novu/react, wrap NovuProvider, and use useAgentChat to send, retry, and resume in-app agent conversations."
+sidebarTitle: Quickstart
 ---
 
 <Note>
   Agent Chat is in closed beta. Contact us at support@novu.co to get access.
 </Note>
 
-Build a two-way agent chat in your React app. You supply the UI. Novu supplies conversation state, delivery, and the live socket.
+Build a two-way support chat in your React app. You supply the UI. Novu supplies conversation state, delivery, and the live socket.
 
 ## Prerequisites
 
@@ -18,7 +18,9 @@ Complete [channel setup](/agents/channels/agent-chat#setup) first. Then you need
 - A [subscriber](/platform/additional-resources/glossary) id for the signed-in person
 - The public **agent identifier** from the agent page in the dashboard
 
-## Install and wrap NovuProvider
+HMAC: [Security](/agents/channels/agent-chat#security).
+
+## Install
 
 ```package-install
 npm install @novu/react
@@ -74,15 +76,27 @@ export function App() {
 
 Install `@novu/react`. Wrap the app in `NovuProvider`. Call `useAgentChat` and render your own message list and composer. There is no prebuilt `<AgentChat />` component.
 
-Latest docs: https://docs.novu.co/agents/channels/agent-chat/quickstart
+Canonical example: https://docs.novu.co/agents/channels/agent-chat/quickstart
 
-## Install
+ALWAYS:
 
-```bash
-npm install @novu/react
-```
+- Detect the project's package manager and use it for installation
+- Use `NovuProvider` from `@novu/react` (not a second Novu client)
+- Pass the dashboard agent identifier as `agentId`
+- Disable the composer while `isRunning` or `isLoading` is true
+- Use TypeScript, no comments, no empty props
 
-## Code
+NEVER:
+
+- Invent a `<AgentChat />` component from `@novu/react`. It does not exist.
+- Use `useChat` from `@ai-sdk/react`. Agent Chat uses `useAgentChat`.
+- Compute HMAC hashes in the browser
+- Hardcode real API keys
+</Prompt>
+
+## Send a message
+
+This example starts a new conversation on the first send.
 
 ```tsx
 'use client';
@@ -137,460 +151,23 @@ export default function App() {
 }
 ```
 
-## Rules
-
-ALWAYS:
-
-- Detect the project's package manager and use it for installation
-- Use `NovuProvider` from `@novu/react` (not a second Novu client)
-- Pass the dashboard agent identifier as `agentId`
-- Disable the composer while `isRunning` or `isLoading` is true
-- Use TypeScript, no comments, no empty props
-
-NEVER:
-
-- Invent a `<AgentChat />` component from `@novu/react`. It does not exist.
-- Use `useChat` from `@ai-sdk/react`. Agent Chat uses `useAgentChat`.
-- Compute HMAC hashes in the browser
-- Hardcode real API keys
-</Prompt>
-
-## Send a message
-
 Omit `conversationId` to start a new chat. The first successful send creates the conversation.
 
-<CodeGroup>
-```tsx title="HTML"
-const { sendMessage, isRunning, isLoading } = useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-});
-
-<form
-  onSubmit={(event) => {
-    event.preventDefault();
-    const input = event.currentTarget.elements.namedItem('text') as HTMLInputElement;
-    void sendMessage(input.value).then(({ data }) => {
-      // data.conversationId — store this to resume later
-    });
-    event.currentTarget.reset();
-  }}
->
-  <input name="text" disabled={isRunning || isLoading} />
-  <button type="submit" disabled={isRunning || isLoading}>
-    Send
-  </button>
-</form>
-```
-
-```tsx title="AI Elements"
-const { sendMessage, isRunning, isLoading } = useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-});
-
-<PromptInput
-  onSubmit={async (message) => {
-    if (!message.text.trim() || isRunning || isLoading) {
-      return;
-    }
-
-    const { data } = await sendMessage(message.text);
-    // data.conversationId — store this to resume later
-  }}
->
-  <PromptInputBody>
-    <PromptInputTextarea disabled={isRunning || isLoading} placeholder="Message" />
-  </PromptInputBody>
-  <PromptInputFooter>
-    <PromptInputSubmit
-      className="ml-auto"
-      disabled={isRunning || isLoading}
-      status={isRunning ? 'streaming' : 'ready'}
-    />
-  </PromptInputFooter>
-</PromptInput>
-```
-</CodeGroup>
-
-If `isRunning` or `isLoading` is true, disable the composer. The agent is still working on the turn.
-
-## Receive and render parts
-
-`messages` is the ordered timeline. Each message has `role` (`user` or `assistant`) and `parts`.
-
-Start with `type === 'text'`. Then handle the other part types as you need them.
-
-| `type` | What to render |
-| --- | --- |
-| `text` | Visible body. `state` is `streaming` or `done`. |
-| `thinking` | Plan text while the agent reasons. |
-| `tool` | Tool call and result. |
-| `approval` | Gated tool. Use `pendingActions` and `respondToAction`. |
-| `mcp-connection` | MCP connect card. Open `authorizeUrl`. |
-| `card` | Structured Card tree. Draw `part.card`. Button clicks call `sendAction`. See [Cards](#cards). |
-| `file` | File attachment metadata. |
-| `source` | Citation (`url` or `document`). |
-
-<CodeGroup>
-```tsx title="HTML"
-const { messages } = useAgentChat({ agentId: 'YOUR_AGENT_IDENTIFIER' });
-
-{messages.map((message) => (
-  <li key={message.id}>
-    {message.parts.map((part, index) =>
-      part.type === 'text' ? <span key={index}>{part.text}</span> : null
-    )}
-  </li>
-))}
-```
-
-```tsx title="AI Elements"
-const { messages } = useAgentChat({ agentId: 'YOUR_AGENT_IDENTIFIER' });
-
-<Conversation>
-  <ConversationContent>
-    {messages.map((message) => (
-      <Message key={message.id} from={message.role}>
-        <MessageContent>
-          {message.parts.map((part, index) =>
-            part.type === 'text' ? <MessageResponse key={index}>{part.text}</MessageResponse> : null
-          )}
-        </MessageContent>
-      </Message>
-    ))}
-  </ConversationContent>
-  <ConversationScrollButton />
-</Conversation>
-```
-</CodeGroup>
-
-Full field tables: [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat).
-
-## Cards
-
-A Card is a structured reply. It can include a title, text, images, links, and buttons.
-
-When the agent sends a Card, the message includes a part with `type: 'card'`. The data is on `part.card`.
-
-Agents create Cards with JSX or `Card({…})`. That authoring API is shared with Slack and the other ACI channels: [Interactive cards](/agents/custom-code-agent/building-blocks/reply#interactive-cards). You can also post the JSON with [Send an agent reply](/api-reference/agents/send-an-agent-reply).
-
-The SDK does not type `part.card`. Read the fields that you support. Skip child types that you do not use.
-
-An Order card arrives as this object on `part.card`:
-
-```json
-{
-  "type": "card",
-  "title": "Order #1234",
-  "children": [
-    { "type": "text", "content": "Your order is ready for pickup." },
-    {
-      "type": "actions",
-      "children": [
-        { "type": "button", "id": "ack", "label": "Acknowledge" },
-        { "type": "button", "id": "escalate", "label": "Escalate", "style": "danger" }
-      ]
-    }
-  ]
-}
-```
-
-| Field | What it is |
-| --- | --- |
-| `title` | Optional heading. |
-| `subtitle` | Optional secondary heading. |
-| `imageUrl` | Optional header image. |
-| `children` | Ordered nodes. See the table below. |
-
-| `child.type` | Fields |
-| --- | --- |
-| `text` | `content` |
-| `divider` | None |
-| `image` | `url`, `alt` |
-| `link` | `url`, `label` |
-| `actions` | `children` of `button` |
-| `button` | `id`, `label`, optional `value` and `style` |
-
-Draw `title` and the `children` that you support. If the subscriber clicks a button, call `sendAction`. The agent receives the click in `onAction`.
-
-```tsx
-const { messages, sendAction } = useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-});
-
-{messages.map((message) =>
-  message.parts.map((part, i) => {
-    if (part.type !== 'card') {
-      return null;
-    }
-
-    const title = typeof part.card.title === 'string' ? part.card.title : null;
-    const children = Array.isArray(part.card.children) ? part.card.children : [];
-
-    return (
-      <article key={i}>
-        {title ? <h3>{title}</h3> : null}
-        {children.map((child, j) => {
-          if (child?.type === 'text') {
-            return <p key={j}>{child.content}</p>;
-          }
-
-          if (child?.type !== 'actions') {
-            return null;
-          }
-
-          return child.children?.map((button) => (
-            <button
-              key={button.id}
-              type="button"
-              onClick={() =>
-                void sendAction({
-                  actionId: button.id,
-                  value: button.value,
-                  sourceMessageId: message.id,
-                })
-              }
-            >
-              {button.label}
-            </button>
-          ));
-        })}
-      </article>
-    );
-  })
-)}
-```
-
-Do not send the button label with `sendMessage`. That call creates a new chat message.
-Do not call `respondToAction`. That function is for tool approval only.
-
-## Thinking and running
-
-While the agent turn is in progress, `isRunning` is true. `typing` is present when the agent is typing. Assistant messages can include `thinking` parts before text arrives.
-
-<CodeGroup>
-```tsx title="HTML"
-const { messages, isRunning, typing } = useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-});
-
-{isRunning ? <p>{typing?.status ?? 'Working…'}</p> : null}
-
-{messages.map((message) =>
-  message.parts.map((part, index) => {
-    if (part.type === 'thinking') {
-      return <em key={index}>{part.text}</em>;
-    }
-
-    if (part.type === 'text') {
-      return <span key={index}>{part.text}</span>;
-    }
-
-    return null;
-  })
-)}
-```
-
-```tsx title="AI Elements"
-const { messages, isRunning, typing } = useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-});
-
-{isRunning ? <Shimmer>{typing?.status ?? 'Working…'}</Shimmer> : null}
-
-{messages.map((message) => (
-  <Message key={message.id} from={message.role}>
-    <MessageContent>
-      {message.parts.map((part, index) => {
-        if (part.type === 'thinking') {
-          return (
-            <ChainOfThought key={index} defaultOpen={part.state === 'streaming'}>
-              <ChainOfThoughtContent>
-                <ChainOfThoughtStep
-                  label={part.text}
-                  status={part.state === 'streaming' ? 'active' : 'complete'}
-                />
-              </ChainOfThoughtContent>
-            </ChainOfThought>
-          );
-        }
-
-        if (part.type === 'text') {
-          return <MessageResponse key={index}>{part.text}</MessageResponse>;
-        }
-
-        return null;
-      })}
-    </MessageContent>
-  </Message>
-))}
-```
-</CodeGroup>
-
-The first envelope of a turn can create an empty assistant message before any text is folded in. Keep that row in the list. Then fill it as parts arrive.
-
-## Tool approval and MCP connect
-
-`pendingActions` lists waits that block the turn. Do not mix the two action types.
-
-| `action.type` | What to do |
-| --- | --- |
-| `tool-approval` | Call `respondToAction` with `action.id` and `approved` or `denied`. |
-| `mcp-connection` | Open `action.authorizeUrl` in the browser. Do not call `respondToAction`. |
-
-<CodeGroup>
-```tsx title="HTML"
-const { pendingActions, respondToAction } = useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-});
-
-{pendingActions.map((action) => {
-  if (action.type === 'tool-approval') {
-    return (
-      <button
-        key={action.id}
-        type="button"
-        onClick={() => void respondToAction({ actionId: action.id, decision: 'approved' })}
-      >
-        Approve {action.toolName}
-      </button>
-    );
-  }
-
-  if (action.type === 'mcp-connection') {
-    return (
-      <a key={action.id} href={action.authorizeUrl} target="_blank" rel="noreferrer">
-        Connect {action.displayName}
-      </a>
-    );
-  }
-
-  return null;
-})}
-```
-
-```tsx title="AI Elements"
-const { pendingActions, respondToAction } = useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-});
-
-{pendingActions.map((action) => {
-  if (action.type === 'tool-approval') {
-    return (
-      <Message key={action.id} from="assistant">
-        <MessageContent>
-          <button
-            type="button"
-            onClick={() => void respondToAction({ actionId: action.id, decision: 'approved' })}
-          >
-            Approve {action.toolName}
-          </button>
-        </MessageContent>
-      </Message>
-    );
-  }
-
-  if (action.type === 'mcp-connection') {
-    return (
-      <Message key={action.id} from="assistant">
-        <MessageContent>
-          <a href={action.authorizeUrl} target="_blank" rel="noreferrer">
-            Connect {action.displayName}
-          </a>
-        </MessageContent>
-      </Message>
-    );
-  }
-
-  return null;
-})}
-```
-</CodeGroup>
-
-Pass `action.id` from `pendingActions`. Do not invent approve or deny ids.
-
-## Resume or start another chat
-
-Pass `conversationId` so the hook loads history on mount.
-
-```tsx
-useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-  conversationId, // omit to start a new chat
-});
-
-const { data } = await sendMessage(text);
-// persist data.conversationId and pass it back as conversationId
-```
-
-Store the `conversationId` that `sendMessage` returns, or the `conversationId` field on the hook result. On the next visit, pass that id back in.
-
-The hook has no list-conversations API. You store the ids that you want to reopen.
-
-To start another chat, remount the component without `conversationId`, or clear the prop.
-
-## Switch agent
-
-`agentId` selects the agent. If the identifier changes, remount with the new `agentId`.
-
-Omit `conversationId` unless that conversation belongs to the new agent. A conversation id from a different agent does not resume.
-
-## Going to production
-
-HMAC is off by default. Turn it on before you ship. Agent Chat can require two hashes. Each hash has its own dashboard toggle.
-
-| Hash | Toggle | Input | Where you pass it |
-| --- | --- | --- | --- |
-| `subscriberHash` | **Novu In-App** integration | `subscriberId` | `NovuProvider` |
-| `agentHash` | **Agent Chat** integration | agent identifier | `useAgentChat` |
-
-Both hashes use the same secret: the environment API secret from [API Keys](https://dashboard.novu.co/api-keys). Compute them on your server. Do not compute them in the browser.
-
-### subscriberHash
-
-`subscriberHash` authenticates the signed-in subscriber. Without it, another person can guess a `subscriberId` and open that subscriber's session, including Agent Chat.
-
-If **Security HMAC encryption** is on for **Novu In-App**, pass `subscriberHash` to `NovuProvider`. The hash is `HMAC-SHA256(secretKey, subscriberId)` as a lowercase hex string.
-
-Generation recipes (Node.js, Python, and more): [Secure your Inbox with HMAC](/platform/inbox/prepare-for-production#secure-your-inbox-with-hmac-encryption).
-
-### agentHash
-
-`agentHash` authenticates which agent the subscriber can talk to. Without it, a client can send any public agent identifier that is linked to Agent Chat.
-
-If **Security HMAC encryption** is on for **Agent Chat**:
-
-1. Open [Integrations](https://dashboard.novu.co/integrations).
-2. Select the **Agent Chat** integration.
-3. Enable **Security HMAC encryption**.
-4. On your server, compute `HMAC-SHA256(secretKey, agentIdentifier)` as a lowercase hex string.
-5. Pass that value as `agentHash` to `useAgentChat`.
-
-```tsx
-<NovuProvider
-  applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
-  subscriber="YOUR_SUBSCRIBER_ID"
-  subscriberHash="YOUR_SUBSCRIBER_HASH"
->
-  <Chat />
-</NovuProvider>
-```
-
-```tsx
-useAgentChat({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-  agentHash: 'YOUR_AGENT_HASH',
-});
-```
-
-If only one toggle is on, pass only that hash. If both toggles are on, pass both hashes.
+Parts, retry, resume, and reconnect: [Chat UI](/agents/channels/agent-chat/chat-ui).
 
 ## Next steps
 
 <Columns cols={2}>
+  <Card href="/agents/channels/agent-chat/chat-ui" title="Chat UI" icon="list">
+    Parts, retry, resume, cards, approvals, and reconnect.
+  </Card>
   <Card href="/platform/sdks/react/hooks/use-agent-chat" title="useAgentChat reference" icon="code">
     Props, return value, callbacks, and message parts.
   </Card>
   <Card href="/agents/channels/agent-chat" title="Channel setup" icon="plug">
-    Link Agent Chat on the agent.
+    Link Agent Chat on the agent. Turn on HMAC.
+  </Card>
+  <Card href="/platform/sdks/javascript#agent-chat" title="JavaScript SDK" icon="js">
+    `novu.agentChat.conversation()` in `@novu/js`.
   </Card>
 </Columns>

--- a/docs/agents/channels/agent-chat/quickstart.mdx
+++ b/docs/agents/channels/agent-chat/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Build the Agent Chat UI"
-description: "Install @novu/react, wrap NovuProvider, and use useAgentChat to send, retry, and resume in-app agent conversations."
+description: "Install @novu/react, wrap NovuProvider, and use useAgentChat to send a first in-app agent conversation."
 sidebarTitle: Quickstart
 ---
 
@@ -8,7 +8,7 @@ sidebarTitle: Quickstart
   Agent Chat is in closed beta. Contact us at support@novu.co to get access.
 </Note>
 
-Build a two-way support chat in your React app. You supply the UI. Novu supplies conversation state, delivery, and the live socket.
+Build a two-way agent chat in your React app. You supply the UI. Novu supplies conversation state, delivery, and the live socket.
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@ Complete [channel setup](/agents/channels/agent-chat#setup) first. Then you need
 - A [subscriber](/platform/additional-resources/glossary) id for the signed-in person
 - The public **agent identifier** from the agent page in the dashboard
 
-HMAC: [Security](/agents/channels/agent-chat#security).
+See [Security](/agents/channels/agent-chat#security) for HMAC.
 
 ## Install
 
@@ -71,6 +71,10 @@ export function App() {
 
 `NovuProvider` authenticates the subscriber. `useAgentChat` selects which agent to talk to.
 
+<Note>
+  Replace `YOUR_*` placeholders with values from [API Keys](https://dashboard.novu.co/api-keys) and [Subscribers](/platform/additional-resources/glossary) in the dashboard.
+</Note>
+
 <Prompt description="Add Novu Agent Chat to my React app" icon="plug" actions={["copy", "cursor"]}>
 # Add Novu Agent Chat to a React app
 
@@ -95,8 +99,6 @@ NEVER:
 </Prompt>
 
 ## Send a message
-
-This example starts a new conversation on the first send.
 
 ```tsx
 'use client';
@@ -153,7 +155,7 @@ export default function App() {
 
 Omit `conversationId` to start a new chat. The first successful send creates the conversation.
 
-Parts, retry, resume, and reconnect: [Chat UI](/agents/channels/agent-chat/chat-ui).
+See [Chat UI](/agents/channels/agent-chat/chat-ui) for parts, retry, resume, and reconnect.
 
 ## Next steps
 
@@ -167,7 +169,7 @@ Parts, retry, resume, and reconnect: [Chat UI](/agents/channels/agent-chat/chat-
   <Card href="/agents/channels/agent-chat" title="Channel setup" icon="plug">
     Link Agent Chat on the agent. Turn on HMAC.
   </Card>
-  <Card href="/platform/sdks/javascript#agent-chat" title="JavaScript SDK" icon="js">
+  <Card href="/platform/sdks/javascript#agent-chat" title="JavaScript SDK" icon="code">
     `novu.agentChat.conversation()` in `@novu/js`.
   </Card>
 </Columns>

--- a/docs/agents/custom-code-agent/building-blocks/emit.mdx
+++ b/docs/agents/custom-code-agent/building-blocks/emit.mdx
@@ -1,0 +1,57 @@
+---
+title: "Emit custom events"
+description: "Send a named payload from a custom code agent handler with ctx.emit. Agent Chat renders it as a data part."
+sidebarTitle: Emit
+---
+
+`ctx.emit({ name, data })` sends a named payload on the current turn. It is not a chat message. It is not a [signal](/agents/custom-code-agent/building-blocks/signals).
+
+Use `ctx.reply()` when the subscriber must see text or a card. Use `ctx.emit()` when your client needs structured data during the turn, for example progress or a machine-readable status.
+
+The call posts at once. It does not wait for `ctx.reply()`. If the bridge has no `eventsUrl`, the call is a no-op.
+
+## Channel support
+
+| Channel | What the subscriber sees |
+| --- | --- |
+| [Agent Chat](/agents/channels/agent-chat) | A `data` part on the in-flight assistant message |
+| Slack, Teams, WhatsApp, Telegram, Email | Nothing in the thread. Novu stores the event on the conversation. |
+
+## Send an event
+
+`name` is a non-empty string. `data` is yours. JSON size must stay at or under 64 KB. Novu drops the event when `name` is empty or `data` is over the limit.
+
+```ts
+onMessage: async (message, ctx) => {
+  await ctx.emit({
+    name: 'order-progress',
+    data: { pct: 70 },
+  });
+
+  await ctx.reply('Updating your order…');
+},
+```
+
+You can call `ctx.emit` more than once in one turn. Each call is a separate event.
+
+## Agent Chat
+
+Agent Chat adds each event to the assistant message as `part.type === 'data'`. The fields are `name` and `data`.
+
+Render the parts you support. Skip the rest. The part stays on the message.
+
+Client walk: [Custom data parts](/agents/channels/agent-chat/chat-ui#custom-data-parts).
+
+## Related
+
+<Columns cols={2}>
+  <Card icon="message-circle" href="/agents/custom-code-agent/building-blocks/reply" title="Reply">
+    Send text, markdown, files, or cards to the subscriber.
+  </Card>
+  <Card icon="signal" href="/agents/custom-code-agent/building-blocks/signals" title="Signals">
+    Metadata, workflow triggers, and conversation resolution.
+  </Card>
+  <Card icon="list" href="/agents/channels/agent-chat/chat-ui#custom-data-parts" title="Agent Chat data parts">
+    Render `part.type === 'data'` in your product UI.
+  </Card>
+</Columns>

--- a/docs/agents/custom-code-agent/building-blocks/handle-events.mdx
+++ b/docs/agents/custom-code-agent/building-blocks/handle-events.mdx
@@ -43,7 +43,7 @@ Each event handler receives a context object with the information needed to unde
 - Recent conversation history
 - Provider information
 - Platform-specific details, such as thread or channel identifiers
-- Methods for replying, updating metadata, triggering workflows, or resolving the conversation
+- Methods for replying, emitting custom events, updating metadata, triggering workflows, or resolving the conversation
 
 The context object is how your code talks to Novu. You do not call Slack, Teams, or email APIs directly in the handler.
 

--- a/docs/agents/custom-code-agent/building-blocks/reply.mdx
+++ b/docs/agents/custom-code-agent/building-blocks/reply.mdx
@@ -167,7 +167,7 @@ await ctx.reply(
   </Tab>
 </Tabs>
 
-When a user clicks a button or selects a dropdown value, `onAction` fires with `action.id` and `action.value`. See [Handlers and context](/agents/custom-code-agent/building-blocks/handle-events#onaction). On [Agent Chat](/agents/channels/agent-chat/quickstart#cards), the same tree arrives as a `card` part. The web UI draws it and calls `sendAction`.
+When a user clicks a button or selects a dropdown value, `onAction` fires with `action.id` and `action.value`. See [Handlers and context](/agents/custom-code-agent/building-blocks/handle-events#onaction). On [Agent Chat](/agents/channels/agent-chat/chat-ui#cards), the same tree arrives as a `card` part. The web UI draws it and calls `sendAction`.
 
 ### Available card components
 
@@ -199,7 +199,7 @@ The following table lists the card components you can use in replies:
   <Card icon="code" href="/api-reference/agents/send-an-agent-reply" title="Send an agent reply API">
     Send replies from your backend without a bridge handler.
   </Card>
-  <Card icon="message-circle" href="/agents/channels/agent-chat/quickstart#cards" title="Agent Chat cards">
+  <Card icon="message-circle" href="/agents/channels/agent-chat/chat-ui#cards" title="Agent Chat cards">
     Draw `part.type === 'card'` in your product UI and call `sendAction`.
   </Card>
 </Columns>

--- a/docs/agents/custom-code-agent/building-blocks/reply.mdx
+++ b/docs/agents/custom-code-agent/building-blocks/reply.mdx
@@ -10,7 +10,7 @@ Interactive cards include buttons, dropdowns, links, and text inputs. When a use
 
 Use replies when the agent needs to communicate something to the participant in the conversation.
 
-Replies are user-facing messages your agent sends back into the conversation. Use [signals](/agents/custom-code-agent/building-blocks/signals) when you need to update conversation state, trigger workflows, or resolve the thread without messaging the user.
+Replies are user-facing messages your agent sends back into the conversation. Use [signals](/agents/custom-code-agent/building-blocks/signals) when you need to update conversation state, trigger workflows, or resolve the thread without messaging the user. Use [`ctx.emit`](/agents/custom-code-agent/building-blocks/emit) when your client needs a named payload during the turn.
 
 The public API is `ctx.reply(content, options?)`. You can also return a string or JSX card from a handler instead of calling `ctx.reply()` directly.
 
@@ -193,6 +193,9 @@ The following table lists the card components you can use in replies:
   <Card icon="signal" href="/agents/custom-code-agent/building-blocks/signals" title="Signals">
     Metadata, workflow triggers, and conversation resolution.
   </Card>
+  <Card icon="radio" href="/agents/custom-code-agent/building-blocks/emit" title="Emit custom events">
+    Send a named payload. Agent Chat renders it as a `data` part.
+  </Card>
   <Card icon="sparkles" href="/agents/custom-code-agent/frameworks/ai-sdk" title="AI SDK">
     Build end to end with `@novu/framework/ai-sdk`.
   </Card>
@@ -200,6 +203,6 @@ The following table lists the card components you can use in replies:
     Send replies from your backend without a bridge handler.
   </Card>
   <Card icon="message-circle" href="/agents/channels/agent-chat/chat-ui#cards" title="Agent Chat cards">
-    Draw `part.type === 'card'` in your product UI and call `sendAction`.
+    Render `part.type === 'card'` in your product UI and call `sendAction`.
   </Card>
 </Columns>

--- a/docs/agents/custom-code-agent/building-blocks/signals.mdx
+++ b/docs/agents/custom-code-agent/building-blocks/signals.mdx
@@ -6,7 +6,7 @@ description: "Use signals in custom code agent handlers to update metadata, trig
 
 Signals let you change conversation state without sending another chat message. [Replies](/agents/custom-code-agent/building-blocks/reply) go to the user; signals update metadata, fire workflows, or mark a thread resolved.
 
-Use `ctx.reply()` when the user should see something. Use signals when you only need to persist data, trigger a Novu workflow, or close the conversation.
+Use `ctx.reply()` when the user should see something. Use signals when you only need to persist data, trigger a Novu workflow, or close the conversation. Use [`ctx.emit`](/agents/custom-code-agent/building-blocks/emit) when your client needs a named payload during the turn. That call is not a signal.
 
 ## Channel support
 

--- a/docs/agents/custom-code-agent/concepts.mdx
+++ b/docs/agents/custom-code-agent/concepts.mdx
@@ -95,6 +95,8 @@ That object is the only interface your code needs. You do not integrate Slack, T
 
 Replies talk to the user; signals update the system around the conversation. One handler turn can reply, set metadata, trigger a workflow, and resolve.
 
+[`ctx.emit`](/agents/custom-code-agent/building-blocks/emit) sends a named payload on the turn. It is not a reply and not a signal. Agent Chat renders it as a `data` part.
+
 Signals queue in memory and batch with your next `ctx.reply()` in one request. If the handler exits without calling `ctx.reply()`, pending signals still send.
 
 ## Conversations and workflows

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -493,6 +493,7 @@
                 "pages": [
                   "agents/custom-code-agent/building-blocks/handle-events",
                   "agents/custom-code-agent/building-blocks/reply",
+                  "agents/custom-code-agent/building-blocks/emit",
                   "agents/custom-code-agent/building-blocks/typing-indicator",
                   "agents/custom-code-agent/building-blocks/edit-sent-messages",
                   "agents/custom-code-agent/building-blocks/signals",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -470,7 +470,7 @@
               {
                 "group": "Agent Chat",
                 "root": "agents/channels/agent-chat",
-                "pages": ["agents/channels/agent-chat/quickstart"]
+                "pages": ["agents/channels/agent-chat/quickstart", "agents/channels/agent-chat/chat-ui"]
               }
             ],
             "icon": "messages-square"
@@ -1733,6 +1733,21 @@
     {
       "source": "/agents/agent-chat/quickstart",
       "destination": "/agents/channels/agent-chat/quickstart",
+      "permanent": true
+    },
+    {
+      "source": "/agents/channels/agent-chat/rendering",
+      "destination": "/agents/channels/agent-chat/chat-ui",
+      "permanent": true
+    },
+    {
+      "source": "/agents/channels/agent-chat/production",
+      "destination": "/agents/channels/agent-chat",
+      "permanent": true
+    },
+    {
+      "source": "/agents/channels/agent-chat/messages",
+      "destination": "/agents/channels/agent-chat/chat-ui",
       "permanent": true
     },
     {

--- a/docs/platform/sdks/javascript.mdx
+++ b/docs/platform/sdks/javascript.mdx
@@ -754,11 +754,11 @@ await subscription.delete();
 
 Two-way in-app chat with an agent. The public API is `novu.agentChat.conversation()`. React apps use [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat), which binds this runtime for you.
 
-Product guide: [Build the Agent Chat UI](/agents/channels/agent-chat/quickstart).
+See [Quickstart](/agents/channels/agent-chat/quickstart).
 
 ### conversation()
 
-`conversation()` returns a stable runtime for one agent thread. Omit `conversationId` to start a new chat. Pass `conversationId` to resume. The runtime loads history and opens the socket. When the chat unmounts, call `dispose()`.
+`conversation()` returns a runtime for one conversation. If you pass `conversationId`, later calls with the same `agentId` and `conversationId` reuse that runtime. If you omit `conversationId`, each call creates a new runtime and a new socket. Keep the returned object. When the chat unmounts, call `dispose()`.
 
 Do not call `novu.agentChat.subscribe()` from UI code. The runtime owns the socket.
 
@@ -817,7 +817,7 @@ conversation.dispose();
 
 | Field | Description |
 | --- | --- |
-| `messages` | Folded timeline. |
+| `messages` | Conversation timeline. |
 | `pendingActions` | Tool approvals and MCP connect items that are still pending. |
 | `conversationId` | Server id after create or resume. |
 | `run.isRunning` / `run.typing` | Agent-turn snapshot. |
@@ -827,7 +827,7 @@ conversation.dispose();
 | `isRecovering` / `catchUpError` | Reconnect catch-up. The runtime reconnects on its own. |
 | `error` | Last load, send, retry, or action error. |
 
-Recipes: [Chat UI](/agents/channels/agent-chat/chat-ui).
+See [Chat UI](/agents/channels/agent-chat/chat-ui).
 
 ## Types
 

--- a/docs/platform/sdks/javascript.mdx
+++ b/docs/platform/sdks/javascript.mdx
@@ -752,63 +752,82 @@ await subscription.delete();
 
 ## Agent Chat
 
-Two-way in-app chat with an agent. Use `novu.agentChat` from `@novu/js`, or the [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat) hook in React.
+Two-way in-app chat with an agent. The public API is `novu.agentChat.conversation()`. React apps use [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat), which binds this runtime for you.
 
 Product guide: [Build the Agent Chat UI](/agents/channels/agent-chat/quickstart).
 
-Call `novu.agentChat.subscribe()` while the chat is open so the socket stays connected. Call `unsubscribe()` when the chat unmounts.
+### conversation()
 
-### sendMessage
+`conversation()` returns a stable runtime for one agent thread. Omit `conversationId` to start a new chat. Pass `conversationId` to resume. The runtime loads history and opens the socket. When the chat unmounts, call `dispose()`.
 
-Creates a conversation when `conversationId` is omitted. Later sends must pass the returned id.
+Do not call `novu.agentChat.subscribe()` from UI code. The runtime owns the socket.
 
-| Property | Type | Description |
+| Argument | Type | Description |
 | --- | --- | --- |
-| `agentId` | `string` | Public agent identifier. |
-| `text` | `string` | User message. |
-| `conversationId` | `string` | Existing conversation to append to. |
+| `agentId` | `string` | Public agent identifier from the dashboard. |
+| `conversationId` | `string` | Resume this conversation. Omit this argument to start a new chat. |
 | `agentHash` | `string` | HMAC of `agentId`. Required when Agent Chat HMAC is on. |
 
 ```typescript
-novu.agentChat.subscribe();
+import { Novu } from '@novu/js';
 
-const { data, error } = await novu.agentChat.sendMessage({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-  text: 'Hello',
+const novu = new Novu({
+  applicationIdentifier: 'YOUR_APPLICATION_IDENTIFIER',
+  subscriberId: 'YOUR_SUBSCRIBER_ID',
 });
 
-// data.conversationId, data.messageId
-```
-
-### loadConversation
-
-Loads the newest history page into the local store.
-
-```typescript
-const { data, error } = await novu.agentChat.loadConversation({
+const result = novu.agentChat.conversation({
   agentId: 'YOUR_AGENT_IDENTIFIER',
-  conversationId: 'conv_YOUR_CONVERSATION_ID',
 });
+
+if (!result.ok) {
+  throw result.error;
+}
+
+const conversation = result.data;
+
+const stop = conversation.subscribe((snapshot) => {
+  snapshot.messages;
+  snapshot.run.isRunning;
+  snapshot.conversationId;
+});
+
+const { data, error } = await conversation.sendMessage('Hello');
+// data.conversationId — store this to resume later
+
+stop();
+conversation.dispose();
 ```
 
-### fetchMore
+### Runtime methods
 
-Loads an older history page when `hasMore` is true.
+| Method | Description |
+| --- | --- |
+| `getSnapshot()` | Current immutable snapshot. |
+| `subscribe(listener)` | Call `listener` on every snapshot. Returns a stop function. |
+| `sendMessage(text)` | Send a user message. Creates a conversation when `conversationId` is omitted. |
+| `retryMessage(messageId)` | Resend a message whose `status` is `failed`. Reuses the original idempotency key. |
+| `respondToAction({ actionId, decision })` | Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. |
+| `sendAction({ actionId, sourceMessageId, value })` | Click a Card button. Do not use this for tool approval. |
+| `fetchMore()` | Load the next older history page. |
+| `load()` | Reload the newest history page. Runs on resume when `conversationId` is set. |
+| `dispose()` | Stop listeners and release the socket. |
 
-### respondToAction
+### Snapshot fields
 
-Approves or denies a pending tool. Pass the pending action id, not a client-invented id.
+| Field | Description |
+| --- | --- |
+| `messages` | Folded timeline. |
+| `pendingActions` | Tool approvals and MCP connect items that are still pending. |
+| `conversationId` | Server id after create or resume. |
+| `run.isRunning` / `run.typing` | Agent-turn snapshot. |
+| `conversationStatus` | `'active'` or `'resolved'`. This is not a loading flag. |
+| `status` | History load: `'ready'`, `'loading'`, or `'fetching'`. |
+| `pagination.hasMore` / `pagination.status` | Older history pages. Call `fetchMore()`. |
+| `isRecovering` / `catchUpError` | Reconnect catch-up. The runtime reconnects on its own. |
+| `error` | Last load, send, retry, or action error. |
 
-```typescript
-await novu.agentChat.respondToAction({
-  agentId: 'YOUR_AGENT_IDENTIFIER',
-  conversationId: 'conv_YOUR_CONVERSATION_ID',
-  actionId: 'YOUR_PENDING_ACTION_ID',
-  decision: 'approved',
-});
-```
-
-Live updates emit `agent_chat.messages.updated` on the Novu event emitter.
+Recipes: [Chat UI](/agents/channels/agent-chat/chat-ui).
 
 ## Types
 

--- a/docs/platform/sdks/react/hooks/use-agent-chat.mdx
+++ b/docs/platform/sdks/react/hooks/use-agent-chat.mdx
@@ -9,7 +9,7 @@ description: "API reference for the useAgentChat hook: conversation state, sendM
 
 The `useAgentChat` hook is the headless client for [Agent Chat](/agents/channels/agent-chat). It loads conversation history, sends messages, streams live turns over the socket, and exposes pending tool approvals.
 
-Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Product guide: [Build the UI](/agents/channels/agent-chat/quickstart). Recipes: [Chat UI](/agents/channels/agent-chat/chat-ui). What to show in the UI: [State](/agents/channels/agent-chat/chat-ui#state).
+Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). See [Quickstart](/agents/channels/agent-chat/quickstart), [Chat UI](/agents/channels/agent-chat/chat-ui), and [State](/agents/channels/agent-chat/chat-ui#state).
 
 ## Hook parameters
 
@@ -18,12 +18,12 @@ Pass `agentId` (and optional `conversationId` and `agentHash`), or pass `convers
 | Property | Type | Description |
 | --- | --- | --- |
 | `agentId` | `string` | Public agent identifier from the dashboard. Required unless you pass `conversation`. |
-| `conversationId` | `string` | Resume this conversation and load history on mount. Omit this prop to start a new chat. The first `sendMessage` creates the conversation. Recipe: [Resume a conversation](/agents/channels/agent-chat/chat-ui#resume-a-conversation). |
+| `conversationId` | `string` | Resume this conversation and load history on mount. Omit this prop to start a new chat. The first `sendMessage` creates the conversation. See [Resume a conversation](/agents/channels/agent-chat/chat-ui#resume-a-conversation). |
 | `agentHash` | `string` | HMAC-SHA256 of `agentId` with the environment secret. Required when Security HMAC is on for the Agent Chat integration. |
 | `conversation` | `AgentConversationRuntime` | Share an existing runtime across hook instances. Do not pass `agentId`, `conversationId`, or `agentHash` with this prop. Get the runtime from `novu.agentChat.conversation()`. |
 | `onSuccess` | `(data: LoadConversationResult) => void` | Fires after a history fetch succeeds. |
 | `onError` | `(error: NovuError \| AgentChatPlanLimitError) => void` | Fires when a load, send, retry, or action response fails. Also fires when reconnect catch-up fails. |
-| `onMessage` | `(message: AgentMessage) => void` | Fires once per new message id. History pages are silent. The first envelope of a turn can create an empty assistant message before text arrives. A send that never reaches the server does not fire. The message status becomes `failed` instead. |
+| `onMessage` | `(message: AgentMessage) => void` | Fires once per new message id. History pages are silent. The first event of a turn can create an empty assistant message before text arrives. A send that never reaches the server does not fire. The message status becomes `failed` instead. |
 | `onActionRequested` | `(action: AgentPendingAction) => void` | Fires once per pending action, including actions still pending on mount. Paging backwards is silent. |
 | `onEvent` | `(envelope: AgentEventEnvelope) => void` | Raw live envelopes for this conversation. Duplicate envelopes that the store drops do not fire. |
 
@@ -31,24 +31,24 @@ Pass `agentId` (and optional `conversationId` and `agentHash`), or pass `convers
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `messages` | `AgentMessage[]` | Folded timeline for the current conversation. |
+| `messages` | `AgentMessage[]` | Timeline for the current conversation. |
 | `pendingActions` | `AgentPendingAction[]` | Tool approvals and MCP connect items that are still pending. Derived from `messages`. |
 | `conversationId` | `string \| undefined` | Server conversation id after create or resume. Undefined until the first successful send on a new chat. |
-| `error` | `NovuError \| AgentChatPlanLimitError` | Last error from load, send, retry, `respondToAction`, `sendAction`, or a failed agent run. |
+| `error` | `NovuError \| AgentChatPlanLimitError \| undefined` | Last error from load, send, retry, `respondToAction`, `sendAction`, or a failed agent run. |
 | `isLoading` | `boolean` | True until the first history fetch completes. False when there is no `conversationId` prop. |
 | `isRunning` | `boolean` | True while the agent turn is in progress. Same as `run.isRunning`. |
 | `typing` | `AgentConversationTyping \| undefined` | Ephemeral typing indicator. Same as `run.typing`. Absent when the agent is not typing. |
 | `run` | `{ isRunning: boolean; typing?: AgentConversationTyping }` | Current agent-run snapshot. |
-| `status` | `'active' \| 'resolved'` | Conversation lifecycle. Same value as `conversationStatus`. The agent sets `resolved` with `ctx.resolve()`. Not a loading flag. UI map: [State](/agents/channels/agent-chat/chat-ui#state). |
+| `status` | `'active' \| 'resolved'` | Conversation lifecycle. Same value as `conversationStatus`. The agent sets `resolved` with `ctx.resolve()`. Not a loading flag. See [State](/agents/channels/agent-chat/chat-ui#state). |
 | `conversationStatus` | `'active' \| 'resolved'` | Alias for `status`. |
 | `pagination` | `{ status, hasMore, fetchMore }` | Older history pages. Not a top-level `hasMore` or `fetchMore`. See [Pagination](#pagination). |
 | `isRecovering` | `boolean` | True while reconnect catch-up is in flight for this conversation. |
 | `catchUpError` | `NovuError \| undefined` | Set when reconnect catch-up fails. Separate from send and fetch `error`. |
 | `refetch` | `() => Promise<void>` | Reload the newest history page. No-op when there is no conversation id. |
 | `sendMessage` | `(text: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| AgentChatPlanLimitError }>` | Send a user message. Creates a conversation when `conversationId` is omitted. |
-| `retryMessage` | `(messageId: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| AgentChatPlanLimitError }>` | Resend a message whose `status` is `failed`. Reuses the original idempotency key. Does not create a second message. Recipe: [Retry a failed send](/agents/channels/agent-chat/chat-ui#retry-a-failed-send). |
+| `retryMessage` | `(messageId: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| AgentChatPlanLimitError }>` | Resend a message whose `status` is `failed`. Reuses the original idempotency key. Does not create a second message. See [Retry a failed send](/agents/channels/agent-chat/chat-ui#retry-a-failed-send). |
 | `respondToAction` | `(args: { actionId: string; decision: AgentToolApprovalDecision }) => Promise<{ data?: RespondToActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. Typical decisions: `'approved'` or `'denied'`. |
-| `sendAction` | `(args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{ data?: SendActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Click a Card button. Pass `id` / `value` from the button and `message.id` as `sourceMessageId`. Do not use this for tool approval. Render walk: [Cards](/agents/channels/agent-chat/chat-ui#cards). |
+| `sendAction` | `(args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{ data?: SendActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Click a Card button. Pass `id` / `value` from the button and `message.id` as `sourceMessageId`. Do not use this for tool approval. See [Cards](/agents/channels/agent-chat/chat-ui#cards). |
 
 ## Pagination
 
@@ -60,7 +60,7 @@ Pass `agentId` (and optional `conversationId` and `agentHash`), or pass `convers
 | `hasMore` | `boolean` | True when an older page is available. |
 | `fetchMore` | `() => Promise<{ data?: { messages: AgentMessage[]; hasMore: boolean }; error?: NovuError }>` | Load the next older page. Overlapping calls do not run. |
 
-Recipe: [Older messages](/agents/channels/agent-chat/chat-ui#older-messages).
+See [Older messages](/agents/channels/agent-chat/chat-ui#older-messages).
 
 ## Recovery
 
@@ -71,7 +71,7 @@ The hook reconnects and catches up on its own. Use these fields for a banner.
 | `isRecovering` | `boolean` | True while catch-up is in flight. |
 | `catchUpError` | `NovuError \| undefined` | Set when catch-up fails. `status` does not become an error state. |
 
-Recipe: [Reconnect](/agents/channels/agent-chat/chat-ui#reconnect).
+See [Reconnect](/agents/channels/agent-chat/chat-ui#reconnect).
 
 ## Message type
 
@@ -92,8 +92,8 @@ Recipe: [Reconnect](/agents/channels/agent-chat/chat-ui#reconnect).
 | `tool` | Tool call and result. |
 | `approval` | Gated tool waiting on the subscriber. Use `pendingActions` + `respondToAction`. |
 | `mcp-connection` | MCP server connect card. Open `authorizeUrl` in the browser. |
-| `card` | Structured Card tree (`card` object). Draw it in your UI. Button clicks call `sendAction`. Agents send Cards with [Interactive cards](/agents/custom-code-agent/building-blocks/reply#interactive-cards). Client walk: [Cards](/agents/channels/agent-chat/chat-ui#cards). |
-| `data` | Custom payload (`name` + `data`). The UI decides how to show it. Client walk: [Custom data parts](/agents/channels/agent-chat/chat-ui#custom-data-parts). |
+| `card` | Structured Card tree (`card` object). Render it in your UI. Button clicks call `sendAction`. Agents send Cards with [Interactive cards](/agents/custom-code-agent/building-blocks/reply#interactive-cards). See [Cards](/agents/channels/agent-chat/chat-ui#cards). |
+| `data` | Custom payload (`name` + `data`). The UI decides how to render it. See [Custom data parts](/agents/channels/agent-chat/chat-ui#custom-data-parts). |
 | `file` | File attachment metadata. |
 | `source` | Citation (`url` or `document`). |
 
@@ -108,7 +108,7 @@ Recipe: [Reconnect](/agents/channels/agent-chat/chat-ui#reconnect).
 
 ## Plan limit error
 
-`AgentChatPlanLimitError` is thrown (and returned on the hook `error` field) when the organization is over a plan limit. The HTTP status is `402`.
+`AgentChatPlanLimitError` is set on the hook `error` field when the organization is over a plan limit. The HTTP status is `402`.
 
 | Property | Type | Description |
 | --- | --- | --- |

--- a/docs/platform/sdks/react/hooks/use-agent-chat.mdx
+++ b/docs/platform/sdks/react/hooks/use-agent-chat.mdx
@@ -1,6 +1,6 @@
 ---
 title: "useAgentChat"
-description: "API reference for the useAgentChat hook: conversation state, sendMessage, tool approval, live typing, and history pagination in the Novu React SDK."
+description: "API reference for the useAgentChat hook: conversation state, sendMessage, retry, tool approval, live typing, and history pagination in the Novu React SDK."
 ---
 
 <Note>
@@ -9,17 +9,20 @@ description: "API reference for the useAgentChat hook: conversation state, sendM
 
 The `useAgentChat` hook is the headless client for [Agent Chat](/agents/channels/agent-chat). It loads conversation history, sends messages, streams live turns over the socket, and exposes pending tool approvals.
 
-Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Product guide: [Build the UI](/agents/channels/agent-chat/quickstart).
+Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Product guide: [Build the UI](/agents/channels/agent-chat/quickstart). Recipes: [Chat UI](/agents/channels/agent-chat/chat-ui). What to show in the UI: [State](/agents/channels/agent-chat/chat-ui#state).
 
 ## Hook parameters
 
+Pass `agentId` (and optional `conversationId` and `agentHash`), or pass `conversation`. Do not mix the two.
+
 | Property | Type | Description |
 | --- | --- | --- |
-| `agentId` | `string` | Required. Public agent identifier from the dashboard. |
-| `conversationId` | `string` | Resume this conversation and load history on mount. Omit to start a new chat. The first `sendMessage` creates the conversation. |
+| `agentId` | `string` | Public agent identifier from the dashboard. Required unless you pass `conversation`. |
+| `conversationId` | `string` | Resume this conversation and load history on mount. Omit this prop to start a new chat. The first `sendMessage` creates the conversation. Recipe: [Resume a conversation](/agents/channels/agent-chat/chat-ui#resume-a-conversation). |
 | `agentHash` | `string` | HMAC-SHA256 of `agentId` with the environment secret. Required when Security HMAC is on for the Agent Chat integration. |
+| `conversation` | `AgentConversationRuntime` | Share an existing runtime across hook instances. Do not pass `agentId`, `conversationId`, or `agentHash` with this prop. Get the runtime from `novu.agentChat.conversation()`. |
 | `onSuccess` | `(data: LoadConversationResult) => void` | Fires after a history fetch succeeds. |
-| `onError` | `(error: NovuError \| AgentChatPlanLimitError) => void` | Fires when a load, send, or action response fails. |
+| `onError` | `(error: NovuError \| AgentChatPlanLimitError) => void` | Fires when a load, send, retry, or action response fails. Also fires when reconnect catch-up fails. |
 | `onMessage` | `(message: AgentMessage) => void` | Fires once per new message id. History pages are silent. The first envelope of a turn can create an empty assistant message before text arrives. A send that never reaches the server does not fire. The message status becomes `failed` instead. |
 | `onActionRequested` | `(action: AgentPendingAction) => void` | Fires once per pending action, including actions still pending on mount. Paging backwards is silent. |
 | `onEvent` | `(envelope: AgentEventEnvelope) => void` | Raw live envelopes for this conversation. Duplicate envelopes that the store drops do not fire. |
@@ -31,18 +34,44 @@ Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Produc
 | `messages` | `AgentMessage[]` | Folded timeline for the current conversation. |
 | `pendingActions` | `AgentPendingAction[]` | Tool approvals and MCP connect items that are still pending. Derived from `messages`. |
 | `conversationId` | `string \| undefined` | Server conversation id after create or resume. Undefined until the first successful send on a new chat. |
-| `error` | `NovuError \| AgentChatPlanLimitError` | Last error from load, send, `respondToAction`, or `sendAction`. |
+| `error` | `NovuError \| AgentChatPlanLimitError` | Last error from load, send, retry, `respondToAction`, `sendAction`, or a failed agent run. |
 | `isLoading` | `boolean` | True until the first history fetch completes. False when there is no `conversationId` prop. |
-| `isFetching` | `boolean` | True while a history request is in flight. |
-| `isRunning` | `boolean` | True while the agent turn is in progress. |
-| `typing` | `AgentConversationTyping \| undefined` | Ephemeral typing indicator. Absent when the agent is not typing. |
-| `status` | `AgentConversationStatus` | `active` or `resolved`. |
-| `hasMore` | `boolean` | True when older history pages are available via `fetchMore`. |
+| `isRunning` | `boolean` | True while the agent turn is in progress. Same as `run.isRunning`. |
+| `typing` | `AgentConversationTyping \| undefined` | Ephemeral typing indicator. Same as `run.typing`. Absent when the agent is not typing. |
+| `run` | `{ isRunning: boolean; typing?: AgentConversationTyping }` | Current agent-run snapshot. |
+| `status` | `'active' \| 'resolved'` | Conversation lifecycle. Same value as `conversationStatus`. The agent sets `resolved` with `ctx.resolve()`. Not a loading flag. UI map: [State](/agents/channels/agent-chat/chat-ui#state). |
+| `conversationStatus` | `'active' \| 'resolved'` | Alias for `status`. |
+| `pagination` | `{ status, hasMore, fetchMore }` | Older history pages. Not a top-level `hasMore` or `fetchMore`. See [Pagination](#pagination). |
+| `isRecovering` | `boolean` | True while reconnect catch-up is in flight for this conversation. |
+| `catchUpError` | `NovuError \| undefined` | Set when reconnect catch-up fails. Separate from send and fetch `error`. |
 | `refetch` | `() => Promise<void>` | Reload the newest history page. No-op when there is no conversation id. |
-| `fetchMore` | `() => Promise<{ data?: { messages: AgentMessage[]; hasMore: boolean }; error?: NovuError }>` | Load an older history page. |
 | `sendMessage` | `(text: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| AgentChatPlanLimitError }>` | Send a user message. Creates a conversation when `conversationId` is omitted. |
-| `respondToAction` | `(args: { actionId: string; decision: 'approved' \| 'denied' }) => Promise<{ data?: RespondToActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Approve or deny a pending `tool-approval`. Pass `action.id` from `pendingActions`. |
-| `sendAction` | `(args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{ data?: SendActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Click a Card button. Pass `id` / `value` from the button and `message.id` as `sourceMessageId`. Do not use this for tool approval. Render walk: [Cards](/agents/channels/agent-chat/quickstart#cards). |
+| `retryMessage` | `(messageId: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| AgentChatPlanLimitError }>` | Resend a message whose `status` is `failed`. Reuses the original idempotency key. Does not create a second message. Recipe: [Retry a failed send](/agents/channels/agent-chat/chat-ui#retry-a-failed-send). |
+| `respondToAction` | `(args: { actionId: string; decision: AgentToolApprovalDecision }) => Promise<{ data?: RespondToActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. Typical decisions: `'approved'` or `'denied'`. |
+| `sendAction` | `(args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{ data?: SendActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Click a Card button. Pass `id` / `value` from the button and `message.id` as `sourceMessageId`. Do not use this for tool approval. Render walk: [Cards](/agents/channels/agent-chat/chat-ui#cards). |
+
+## Pagination
+
+`pagination` is the older-history control. It is not a top-level `hasMore` or `fetchMore`.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `status` | `'idle' \| 'loading' \| 'error'` | Status of the older-history request. |
+| `hasMore` | `boolean` | True when an older page is available. |
+| `fetchMore` | `() => Promise<{ data?: { messages: AgentMessage[]; hasMore: boolean }; error?: NovuError }>` | Load the next older page. Overlapping calls do not run. |
+
+Recipe: [Older messages](/agents/channels/agent-chat/chat-ui#older-messages).
+
+## Recovery
+
+The hook reconnects and catches up on its own. Use these fields for a banner.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `isRecovering` | `boolean` | True while catch-up is in flight. |
+| `catchUpError` | `NovuError \| undefined` | Set when catch-up fails. `status` does not become an error state. |
+
+Recipe: [Reconnect](/agents/channels/agent-chat/chat-ui#reconnect).
 
 ## Message type
 
@@ -52,7 +81,7 @@ Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Produc
 | `role` | `AgentMessageRole` | Sender role (`user` or `assistant`). |
 | `parts` | `AgentMessagePart[]` | Ordered content. See part types below. |
 | `createdAt` | `string` | ISO timestamp. |
-| `status` | `'sending' \| 'sent' \| 'failed'` | Delivery status for the local send. |
+| `status` | `'sending' \| 'sent' \| 'failed'` | Delivery status for the local send. If the status is `failed`, call `retryMessage(id)`. |
 
 ### Part types
 
@@ -63,7 +92,8 @@ Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Produc
 | `tool` | Tool call and result. |
 | `approval` | Gated tool waiting on the subscriber. Use `pendingActions` + `respondToAction`. |
 | `mcp-connection` | MCP server connect card. Open `authorizeUrl` in the browser. |
-| `card` | Structured Card tree (`card` object). Draw it in your UI. Button clicks call `sendAction`. Agents send Cards with [Interactive cards](/agents/custom-code-agent/building-blocks/reply#interactive-cards). Client walk: [Cards](/agents/channels/agent-chat/quickstart#cards). |
+| `card` | Structured Card tree (`card` object). Draw it in your UI. Button clicks call `sendAction`. Agents send Cards with [Interactive cards](/agents/custom-code-agent/building-blocks/reply#interactive-cards). Client walk: [Cards](/agents/channels/agent-chat/chat-ui#cards). |
+| `data` | Custom payload (`name` + `data`). The UI decides how to show it. Client walk: [Custom data parts](/agents/channels/agent-chat/chat-ui#custom-data-parts). |
 | `file` | File attachment metadata. |
 | `source` | Citation (`url` or `document`). |
 
@@ -88,4 +118,4 @@ Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Produc
 
 ## JavaScript SDK
 
-The same client lives on `novu.agentChat` in [`@novu/js`](/platform/sdks/javascript#agent-chat): `sendMessage`, `loadConversation`, `fetchMore`, `respondToAction`, `sendAction`, `subscribe`, `unsubscribe`.
+The same runtime lives on `novu.agentChat.conversation()` in [`@novu/js`](/platform/sdks/javascript#agent-chat). The React hook binds that runtime for you. Do not call `novu.agentChat.subscribe()` from React UI code.


### PR DESCRIPTION
## Summary
- Split Agent Chat docs into Overview (setup + HMAC), Quickstart (first send), and Chat UI (state, parts, cards, retry, resume, reconnect).
- Align `useAgentChat` and `@novu/js` with the shipped runtime: `conversation()`, `retryMessage`, `pagination`, recovery fields.
- Add `ctx.emit` under custom-code-agent building blocks and link Agent Chat `data` parts to that page.

## Test plan
- [ ] Sidebar: Agents → Channels → Agent Chat shows Overview, Quickstart, Chat UI
- [ ] Quickstart paste-and-run example compiles mentally (NovuProvider + useAgentChat + text parts)
- [ ] Chat UI State table matches hook fields (`isLoading` / `isRunning` / `status` / `error` / `message.status`)
- [ ] HMAC snippets live only on Overview Security
- [ ] `useAgentChat` has no `isFetching` or top-level `hasMore` / `fetchMore`
- [ ] JS SDK Agent Chat section leads with `conversation()`, not `subscribe()` + `sendMessage()`
- [ ] Custom data: Chat UI links to `/agents/custom-code-agent/building-blocks/emit`
- [ ] Redirects: `/rendering` and `/messages` → Chat UI; `/production` → Overview


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reorganizes Agent Chat documentation into overview, quickstart, and detailed UI guides while updating React and JavaScript SDK references to the shipped conversation runtime.
- Adds documentation for retry, pagination, reconnect recovery, cards, approvals, and custom data parts.
- Documents `ctx.emit` and links it throughout the custom-code agent guides.
- Adds navigation entries and redirects for the reorganized pages.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking correction needed for the JavaScript SDK’s socket-lifecycle wording.

The documented APIs and examples otherwise align with the shipped Agent Chat runtime, but the guide incorrectly presents conversation runtimes as owning independent sockets that are released by `dispose()`.

**Files Needing Attention:** docs/platform/sdks/javascript.mdx

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/agents/channels/agent-chat/chat-ui.mdx | Adds a comprehensive UI guide whose hook fields, message parts, actions, pagination, and recovery examples align with the implementation. |
| docs/platform/sdks/react/hooks/use-agent-chat.mdx | Updates the hook reference to the current runtime-backed API, including retry, pagination, recovery, and shared conversation runtimes. |
| docs/platform/sdks/javascript.mdx | Replaces legacy Agent Chat APIs with `conversation()`, but inaccurately describes shared-socket ownership and disposal. |
| docs/agents/custom-code-agent/building-blocks/emit.mdx | Documents `ctx.emit`, its validation constraints, no-op legacy behavior, and Agent Chat data-part representation. |
| docs/docs.json | Adds the new pages to navigation and redirects former Agent Chat subpaths to their replacement sections. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312450%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12450&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Adocs%2Fplatform%2Fsdks%2Fjavascript.mdx%3A761%0A**Clarify%20shared%20socket%20ownership**%0A%0AThe%20conversation%20runtimes%20share%20the%20Novu%20client's%20socket%20rather%20than%20creating%20one%20socket%20per%20runtime%2C%20and%20%60dispose%28%29%60%20removes%20the%20runtime%20subscription%20without%20disconnecting%20that%20shared%20socket.%20The%20current%20wording%20gives%20developers%20an%20inaccurate%20resource%20and%20lifecycle%20model%20when%20managing%20multiple%20conversations.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12450&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/platform/sdks/javascript.mdx:761
**Clarify shared socket ownership**

The conversation runtimes share the Novu client's socket rather than creating one socket per runtime, and `dispose()` removes the runtime subscription without disconnecting that shared socket. The current wording gives developers an inaccurate resource and lifecycle model when managing multiple conversations.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(docs): tighten Agent Chat copy and ..."](https://github.com/novuhq/novu/commit/2ea273f20a6784804a9d4fb5040e7777066c8398) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56601206)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agent platform and AI integrations](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agent-platform.md)
- Knowledge Base — [JavaScript client SDK](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/javascript-client-sdk.md)
- Knowledge Base — [Developer SDKs and UI packages](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/developer-sdks.md)
</details>


<!-- /greptile_comment -->