### PR TITLE
fix(api-service): enhance error handling and logging in Idempotencyinterceptor; add status code checks in tests fixes NV-8679

### DIFF
--- a/apps/api/src/app/shared/framework/idempotency-http-error.spec.ts
+++ b/apps/api/src/app/shared/framework/idempotency-http-error.spec.ts
@@ -1,4 +1,10 @@
-import { HttpException, HttpStatus, InternalServerErrorException, UnprocessableEntityException } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  InternalServerErrorException,
+  ServiceUnavailableException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import { expect } from 'chai';
 import { restoreCachedHttpException, serializeCachedHttpError } from './idempotency-http-error';
 
@@ -19,6 +25,16 @@ describe('idempotency-http-error', () => {
     expect(restored).to.be.instanceOf(HttpException);
     expect(restored.getStatus()).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
     expect(restored.message).to.equal('workflow_not_found');
+  });
+
+  it('round-trips a kill-switch 503 without collapsing it to 500', () => {
+    const original = new ServiceUnavailableException('Service temporarily unavailable for this organization');
+    const restored = restoreCachedHttpException(JSON.parse(JSON.stringify(serializeCachedHttpError(original))));
+
+    expect(restored).to.be.instanceOf(HttpException);
+    expect(restored).to.not.be.instanceOf(InternalServerErrorException);
+    expect(restored.getStatus()).to.equal(HttpStatus.SERVICE_UNAVAILABLE);
+    expect(restored.message).to.equal('Service temporarily unavailable for this organization');
   });
 
   it('restores non-HTTP errors as a sanitized InternalServerErrorException', () => {

--- a/apps/api/src/app/shared/framework/idempotency-http-error.spec.ts
+++ b/apps/api/src/app/shared/framework/idempotency-http-error.spec.ts
@@ -1,0 +1,31 @@
+import { HttpException, HttpStatus, InternalServerErrorException, UnprocessableEntityException } from '@nestjs/common';
+import { expect } from 'chai';
+import { restoreCachedHttpException, serializeCachedHttpError } from './idempotency-http-error';
+
+describe('idempotency-http-error', () => {
+  it('round-trips an HttpException through JSON without becoming a 503', () => {
+    const original = new UnprocessableEntityException('workflow_not_found');
+    const restored = restoreCachedHttpException(JSON.parse(JSON.stringify(serializeCachedHttpError(original))));
+
+    expect(restored).to.be.instanceOf(HttpException);
+    expect(restored.getStatus()).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+    expect(restored.message).to.equal('workflow_not_found');
+  });
+
+  it('restores a legacy JSON.stringified HttpException from cache', () => {
+    const original = new UnprocessableEntityException('workflow_not_found');
+    const restored = restoreCachedHttpException(JSON.parse(JSON.stringify(original)));
+
+    expect(restored).to.be.instanceOf(HttpException);
+    expect(restored.getStatus()).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+    expect(restored.message).to.equal('workflow_not_found');
+  });
+
+  it('restores non-HTTP errors as a sanitized InternalServerErrorException', () => {
+    const restored = restoreCachedHttpException(JSON.parse(JSON.stringify(serializeCachedHttpError(new Error('boom')))));
+
+    expect(restored).to.be.instanceOf(InternalServerErrorException);
+    expect(restored.getStatus()).to.equal(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(restored.message).to.not.equal('boom');
+  });
+});

--- a/apps/api/src/app/shared/framework/idempotency-http-error.ts
+++ b/apps/api/src/app/shared/framework/idempotency-http-error.ts
@@ -6,7 +6,7 @@ export type CachedHttpError = {
 };
 
 export function serializeCachedHttpError(err: unknown): CachedHttpError {
-  if (err instanceof HttpException && err.getStatus() < HttpStatus.INTERNAL_SERVER_ERROR) {
+  if (err instanceof HttpException && !(err instanceof InternalServerErrorException)) {
     return {
       statusCode: err.getStatus(),
       response: err.getResponse(),
@@ -32,10 +32,14 @@ export function restoreCachedHttpException(data: unknown): HttpException {
     statusCode = data.status;
   }
 
+  if (statusCode === HttpStatus.INTERNAL_SERVER_ERROR) {
+    return new InternalServerErrorException();
+  }
+
   if (
     statusCode != null &&
     statusCode >= 400 &&
-    statusCode < HttpStatus.INTERNAL_SERVER_ERROR &&
+    statusCode <= 599 &&
     (typeof response === 'string' || isRecord(response) || Array.isArray(response))
   ) {
     return new HttpException(response, statusCode);

--- a/apps/api/src/app/shared/framework/idempotency-http-error.ts
+++ b/apps/api/src/app/shared/framework/idempotency-http-error.ts
@@ -1,0 +1,49 @@
+import { HttpException, HttpStatus, InternalServerErrorException } from '@nestjs/common';
+
+export type CachedHttpError = {
+  statusCode: number;
+  response: string | object;
+};
+
+export function serializeCachedHttpError(err: unknown): CachedHttpError {
+  if (err instanceof HttpException && err.getStatus() < HttpStatus.INTERNAL_SERVER_ERROR) {
+    return {
+      statusCode: err.getStatus(),
+      response: err.getResponse(),
+    };
+  }
+
+  return {
+    statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+    response: new InternalServerErrorException().getResponse(),
+  };
+}
+
+export function restoreCachedHttpException(data: unknown): HttpException {
+  if (!isRecord(data)) {
+    return new InternalServerErrorException();
+  }
+
+  const response = data.response;
+  let statusCode: number | undefined;
+  if (typeof data.statusCode === 'number') {
+    statusCode = data.statusCode;
+  } else if (typeof data.status === 'number') {
+    statusCode = data.status;
+  }
+
+  if (
+    statusCode != null &&
+    statusCode >= 400 &&
+    statusCode < HttpStatus.INTERNAL_SERVER_ERROR &&
+    (typeof response === 'string' || isRecord(response) || Array.isArray(response))
+  ) {
+    return new HttpException(response, statusCode);
+  }
+
+  return new InternalServerErrorException();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/api/src/app/shared/framework/idempotency.e2e.ts
+++ b/apps/api/src/app/shared/framework/idempotency.e2e.ts
@@ -154,6 +154,8 @@ describe('Idempotency Test', async () => {
       testIdempotencyPost(IDEMPOTENCE_IMMEDIATE_EXCEPTION, key)
     );
     expect(error?.message).to.eq(error2?.message);
+    expect(error?.statusCode).to.eq(error2?.statusCode);
+    expect(error2?.statusCode).to.not.eq(503);
   });
   it('should return 400 when key bigger than allowed limit', async () => {
     const key = Array.from({ length: 256 })

--- a/apps/api/src/app/shared/framework/idempotency.interceptor.spec.ts
+++ b/apps/api/src/app/shared/framework/idempotency.interceptor.spec.ts
@@ -1,0 +1,122 @@
+import { ExecutionContext, HttpException, HttpStatus, UnprocessableEntityException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { CacheService, FeatureFlagsService, PinoLogger } from '@novu/application-generic';
+import { ApiAuthSchemeEnum } from '@novu/shared';
+import { expect } from 'chai';
+import { createHash } from 'crypto';
+import { lastValueFrom, of } from 'rxjs';
+import sinon from 'sinon';
+import { serializeCachedHttpError } from './idempotency-http-error';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+
+describe('IdempotencyInterceptor', () => {
+  const body = { name: 'missing-workflow' };
+  const bodyHash = createHash('blake2s256')
+    .update(Buffer.from(JSON.stringify(body)))
+    .digest('hex');
+  let cacheService: sinon.SinonStubbedInstance<CacheService>;
+  let featureFlagsService: sinon.SinonStubbedInstance<FeatureFlagsService>;
+  let interceptor: IdempotencyInterceptor;
+  let nextHandle: sinon.SinonStub;
+  let logger: { setContext: sinon.SinonStub; warn: sinon.SinonStub; error: sinon.SinonStub; trace: sinon.SinonStub };
+
+  beforeEach(() => {
+    cacheService = sinon.createStubInstance(CacheService);
+    featureFlagsService = sinon.createStubInstance(FeatureFlagsService);
+    featureFlagsService.getFlag.resolves(true);
+    logger = {
+      setContext: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      trace: sinon.stub(),
+    };
+
+    interceptor = new IdempotencyInterceptor(
+      { getAllAndOverride: sinon.stub().returns(false) } as unknown as Reflector,
+      cacheService as unknown as CacheService,
+      featureFlagsService as unknown as FeatureFlagsService,
+      logger as unknown as PinoLogger
+    );
+
+    nextHandle = sinon.stub().returns(of({ ok: true }));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('replays a cached workflow_not_found error as 422 instead of 503', async () => {
+    cacheService.setIfNotExist.resolves(null);
+    cacheService.get.resolves(
+      JSON.stringify({
+        status: 'error',
+        bodyHash,
+        data: serializeCachedHttpError(new UnprocessableEntityException('workflow_not_found')),
+      })
+    );
+
+    try {
+      await lastValueFrom(await interceptor.intercept(createContext(body), { handle: nextHandle }));
+      expect.fail('Expected HttpException');
+    } catch (err) {
+      expect(err).to.be.instanceOf(HttpException);
+      expect((err as HttpException).getStatus()).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+      expect((err as HttpException).message).to.equal('workflow_not_found');
+      expect(nextHandle.called).to.equal(false);
+    }
+  });
+
+  it('replays a legacy JSON.stringified HttpException as 422 instead of 503', async () => {
+    cacheService.setIfNotExist.resolves(null);
+    cacheService.get.resolves(
+      JSON.stringify({
+        status: 'error',
+        bodyHash,
+        data: JSON.parse(JSON.stringify(new UnprocessableEntityException('workflow_not_found'))),
+      })
+    );
+
+    try {
+      await lastValueFrom(await interceptor.intercept(createContext(body), { handle: nextHandle }));
+      expect.fail('Expected HttpException');
+    } catch (err) {
+      expect(err).to.be.instanceOf(HttpException);
+      expect((err as HttpException).getStatus()).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+      expect((err as HttpException).message).to.equal('workflow_not_found');
+    }
+  });
+
+  it('returns 409 when the idempotency cache entry is missing', async () => {
+    cacheService.setIfNotExist.resolves(null);
+    cacheService.get.resolves(undefined as unknown as string);
+
+    try {
+      await lastValueFrom(await interceptor.intercept(createContext(body), { handle: nextHandle }));
+      expect.fail('Expected HttpException');
+    } catch (err) {
+      expect(err).to.be.instanceOf(HttpException);
+      expect((err as HttpException).getStatus()).to.equal(HttpStatus.CONFLICT);
+      expect(nextHandle.called).to.equal(false);
+    }
+  });
+});
+
+function createContext(body: object): ExecutionContext {
+  const request = {
+    method: 'POST',
+    headers: { 'idempotency-key': 'ea398302-4865-4851-a9a9-25da599c923d' },
+    body,
+    user: { _id: 'user-id', organizationId: 'org-id', environmentId: 'env-id' },
+    authScheme: ApiAuthSchemeEnum.API_KEY,
+  };
+  const response = { set: sinon.stub() };
+
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+  } as unknown as ExecutionContext;
+}

--- a/apps/api/src/app/shared/framework/idempotency.interceptor.ts
+++ b/apps/api/src/app/shared/framework/idempotency.interceptor.ts
@@ -23,6 +23,7 @@ import { createHash } from 'crypto';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { EXCLUDE_FROM_IDEMPOTENCY } from './exclude-from-idempotency';
+import { restoreCachedHttpException, serializeCachedHttpError } from './idempotency-http-error';
 
 const IDEMPOTENCY_CACHE_TTL = 60 * 60 * 24; // 24h
 const IDEMPOTENCY_PROGRESS_TTL = 60 * 5; // 5min
@@ -110,16 +111,17 @@ export class IdempotencyInterceptor implements NestInterceptor {
         return await this.handlerDuplicateRequest(context, bodyHash);
       }
     } catch (err) {
-      this.logger.warn(
-        `An error occurred while making idempotency check, key:${idempotencyKey}. error: ${err.message}`
-      );
       if (err instanceof HttpException) {
         return throwError(() => err);
       }
-    }
 
-    // something unexpected happened, both cached response and handler did not execute as expected
-    return throwError(() => new ServiceUnavailableException());
+      this.logger.warn(
+        { err, idempotencyKey },
+        `An error occurred while making idempotency check, key:${idempotencyKey}`
+      );
+
+      return throwError(() => new ServiceUnavailableException());
+    }
   }
 
   private getIdempotencyKey(context: ExecutionContext): string | undefined {
@@ -165,7 +167,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
       }
       await this.cacheService.set(key, JSON.stringify(val), { ttl });
     } catch (err) {
-      this.logger.warn(`An error occurred while setting idempotency cache, key:${key} error: ${err.message}`);
+      this.logger.warn({ err, key }, `An error occurred while setting idempotency cache, key:${key}`);
     }
 
     return null;
@@ -200,6 +202,18 @@ export class IdempotencyInterceptor implements NestInterceptor {
     this.setHeaders(context.switchToHttp().getResponse(), {
       [HttpResponseHeaderKeysEnum.IDEMPOTENCY_KEY]: idempotencyKey,
     });
+    if (!data) {
+      this.logger.warn({ idempotencyKey }, `Idempotency cache entry is missing, key:${idempotencyKey}`);
+      this.setHeaders(context.switchToHttp().getResponse(), {
+        [HttpResponseHeaderKeysEnum.RETRY_AFTER]: `1`,
+        [HttpResponseHeaderKeysEnum.LINK]: DOCS_LINK,
+      });
+
+      throw new ConflictException(
+        `Request with key "${idempotencyKey}" is currently being processed. Please retry after 1 second`
+      );
+    }
+
     const parsed = JSON.parse(data);
     if (parsed.status === ReqStatusEnum.PROGRESS) {
       // api call is in progress, so client need to handle this case
@@ -228,9 +242,10 @@ export class IdempotencyInterceptor implements NestInterceptor {
 
     // already seen the request return cached response
     if (parsed.status === ReqStatusEnum.ERROR) {
+      const restored = restoreCachedHttpException(parsed.data);
       this.logger.trace(`returning cached error response. key: "${idempotencyKey}"`);
 
-      throw parsed.data;
+      throw restored;
     }
 
     return of(parsed.data);
@@ -266,7 +281,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
           {
             status: ReqStatusEnum.ERROR,
             bodyHash,
-            data: err,
+            data: serializeCachedHttpError(err),
           },
           IDEMPOTENCY_CACHE_TTL
         ).catch(() => {});


### PR DESCRIPTION
…

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves meaningful HTTP status codes and response bodies when idempotency errors are cached and replayed, while continuing to sanitize internal and non-HTTP errors.
- Adds explicit cached-error serialization and restoration helpers.
- Replays cached HTTP exceptions instead of throwing plain deserialized objects.
- Handles missing cache entries as in-progress conflicts with retry guidance.
- Adds unit and end-to-end coverage for status preservation, legacy entries, and sanitized internal errors.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/shared/framework/idempotency-http-error.ts | Introduces bounded serialization and restoration that preserves non-500 HTTP errors, including the previously mishandled 503 response, while sanitizing internal errors. |
| apps/api/src/app/shared/framework/idempotency.interceptor.ts | Integrates cached-error restoration, structured logging, and explicit handling for missing idempotency cache entries. |
| apps/api/src/app/shared/framework/idempotency-http-error.spec.ts | Covers current and legacy error round trips, meaningful 503 preservation, and internal-error sanitization. |
| apps/api/src/app/shared/framework/idempotency.interceptor.spec.ts | Verifies cached and legacy 422 replay behavior and the missing-cache conflict response. |
| apps/api/src/app/shared/framework/idempotency.e2e.ts | Strengthens duplicate-request coverage by asserting that replay preserves the status and does not substitute 503. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Idempotent request fails] --> B[Serialize HTTP status and response]
  B --> C[Store error in cache]
  D[Duplicate request] --> E[Read cached entry]
  E --> F[Restore HttpException]
  F --> G[Replay original status and response]
```

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): improve error serializ..."](https://github.com/novuhq/novu/commit/fcc1a76c0580dc21a0628c6b51718154c29c52f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56603228)</sub>

**Context used:**

- Knowledge Base — [API service and application boundary](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/api-service.md)

<!-- /greptile_comment -->