### PR TITLE
feat(novu,shared): upgrade connect Agent Chat template to dashboard structure fixes NV-8680

### DIFF
--- a/packages/novu/src/commands/connect/help-text.ts
+++ b/packages/novu/src/commands/connect/help-text.ts
@@ -151,7 +151,7 @@ Non-interactive (agent / CI) contract:
   Defaults (do not pass unless needed):
     - Dashboard OAuth: omit --secret-key and --keyless (creates the agent in the user's Development environment)
     - Demo runtime: omit --runtime (shared Claude runtime in keyless mode; authenticated environments need a demo integration)
-    - US region: omit --region (use --region eu for EU Novu Cloud)
+    - US region: omit --region (use --region eu for EU Novu Cloud, or --staging / --region staging)
 
   Not supported headlessly with --keyless:
     - teams → do not pass --channel teams with --keyless; omit --keyless to authenticate via the dashboard (teams finishes in the dashboard)

--- a/packages/novu/src/commands/connect/pipeline/agent-chat/run-agent-chat-setup.ts
+++ b/packages/novu/src/commands/connect/pipeline/agent-chat/run-agent-chat-setup.ts
@@ -85,6 +85,7 @@ export async function runAgentChatProjectSetup(input: {
     applicationIdentifier,
     subscriberId,
     apiUrl: input.auth.apiUrl,
+    region: input.options.region,
     mergeIntoProjectDir: input.bridgeProjectDir,
     mergeAtRoot: input.autoMergeIntoBridge,
   });

--- a/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.spec.ts
@@ -1,8 +1,13 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { NOVU_STAGING_API_URL } from '@novu/shared';
 import { describe, expect, it } from 'vitest';
-import { assertSafeScaffoldDirectoryName, scaffoldAgentChatProject } from './scaffold-agent-chat';
+import {
+  assertSafeScaffoldDirectoryName,
+  resolveAgentChatNovuDependencies,
+  scaffoldAgentChatProject,
+} from './scaffold-agent-chat';
 
 describe('assertSafeScaffoldDirectoryName', () => {
   it('accepts a simple directory name', () => {
@@ -35,5 +40,32 @@ describe('scaffoldAgentChatProject', () => {
         apiUrl: 'http://localhost:3000',
       })
     ).rejects.toThrow(/Invalid scaffold directory name/);
+  });
+});
+
+describe('resolveAgentChatNovuDependencies', () => {
+  const localNovuDeps = { reactDir: '/repo/packages/react', jsDir: '/repo/packages/js' };
+
+  it('pins @novu/react and @novu/js to rc on staging, even from a monorepo checkout', () => {
+    expect(resolveAgentChatNovuDependencies(NOVU_STAGING_API_URL, localNovuDeps)).toEqual({
+      react: 'rc',
+      js: 'rc',
+      useLocalAliases: false,
+    });
+  });
+
+  it('uses file: links for a local monorepo checkout against non-staging APIs', () => {
+    expect(resolveAgentChatNovuDependencies('https://api.novu.co', localNovuDeps)).toEqual({
+      react: 'file:/repo/packages/react',
+      js: 'file:/repo/packages/js',
+      useLocalAliases: true,
+    });
+  });
+
+  it('uses latest @novu/react when there is no local checkout', () => {
+    expect(resolveAgentChatNovuDependencies('https://api.novu.co', undefined)).toEqual({
+      react: 'latest',
+      useLocalAliases: false,
+    });
   });
 });

--- a/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.spec.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { NOVU_STAGING_API_URL } from '@novu/shared';
 import { describe, expect, it } from 'vitest';
+import { CloudRegionEnum } from '../../../dev/enums';
 import {
   assertSafeScaffoldDirectoryName,
   resolveAgentChatNovuDependencies,
@@ -54,17 +55,34 @@ describe('resolveAgentChatNovuDependencies', () => {
     });
   });
 
-  it('uses file: links for a local monorepo checkout against non-staging APIs', () => {
-    expect(resolveAgentChatNovuDependencies('https://api.novu.co', localNovuDeps)).toEqual({
+  it('uses file: links for a monorepo checkout against a local API only', () => {
+    expect(resolveAgentChatNovuDependencies('http://localhost:3000', localNovuDeps)).toEqual({
       react: 'file:/repo/packages/react',
       js: 'file:/repo/packages/js',
       useLocalAliases: true,
     });
   });
 
-  it('uses latest @novu/react when there is no local checkout', () => {
+  it('uses rc from npm when scaffolding from a monorepo against production API', () => {
+    expect(resolveAgentChatNovuDependencies('https://api.novu.co', localNovuDeps)).toEqual({
+      react: 'rc',
+      js: 'rc',
+      useLocalAliases: false,
+    });
+  });
+
+  it('uses rc @novu/react when there is no local checkout', () => {
     expect(resolveAgentChatNovuDependencies('https://api.novu.co', undefined)).toEqual({
-      react: 'latest',
+      react: 'rc',
+      js: 'rc',
+      useLocalAliases: false,
+    });
+  });
+
+  it('pins rc packages when --staging region is set even with a custom api url', () => {
+    expect(resolveAgentChatNovuDependencies('http://localhost:3000', localNovuDeps, CloudRegionEnum.STAGING)).toEqual({
+      react: 'rc',
+      js: 'rc',
       useLocalAliases: false,
     });
   });

--- a/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts
+++ b/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { isNovuStagingApiUrl } from '@novu/shared';
 import { tryGitInit } from '../../../init/helpers/git';
 import { isFolderEmpty } from '../../../init/helpers/is-folder-empty';
 import { getOnline } from '../../../init/helpers/is-online';
@@ -86,7 +87,7 @@ async function mergeAgentChatIntoProject(projectDir: string, input: ScaffoldAgen
     throw new Error(`Cannot merge Agent Chat into "${resolved}" — no package.json found.`);
   }
 
-  const dependenciesChanged = ensureAgentChatDependencies(resolved, findLocalNovuDeps());
+  const dependenciesChanged = ensureAgentChatDependencies(resolved, findLocalNovuDeps(), input.apiUrl);
   const componentsDir = path.join(resolved, 'components', 'agent-chat');
   fs.mkdirSync(componentsDir, { recursive: true });
   copyTemplateComponents(componentsDir);
@@ -106,16 +107,21 @@ async function mergeAgentChatIntoProject(projectDir: string, input: ScaffoldAgen
   }
 }
 
-function ensureAgentChatDependencies(projectDir: string, localNovuDeps: LocalNovuDeps | undefined): boolean {
+function ensureAgentChatDependencies(
+  projectDir: string,
+  localNovuDeps: LocalNovuDeps | undefined,
+  apiUrl: string
+): boolean {
   const packageJsonPath = path.join(projectDir, 'package.json');
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
     dependencies?: Record<string, string>;
     scripts?: Record<string, string>;
   };
   const dependencies = packageJson.dependencies ?? {};
+  const sdk = resolveAgentChatNovuDependencies(apiUrl, localNovuDeps);
   const required = {
-    '@novu/react': resolveNovuReactDependency(localNovuDeps),
-    ...(localNovuDeps ? { '@novu/js': `file:${localNovuDeps.jsDir}` } : {}),
+    '@novu/react': sdk.react,
+    ...(sdk.js ? { '@novu/js': sdk.js } : {}),
     'react-markdown': '^10.1.0',
     'remark-gfm': '^4.0.1',
   };
@@ -128,7 +134,7 @@ function ensureAgentChatDependencies(projectDir: string, localNovuDeps: LocalNov
     }
   }
 
-  if (localNovuDeps && packageJson.scripts) {
+  if (sdk.useLocalAliases && packageJson.scripts) {
     for (const [name, script] of Object.entries(packageJson.scripts)) {
       const usesNextDev = script.includes('next dev') && !script.includes('next dev --webpack');
       const usesNextBuild = script.includes('next build') && !script.includes('next build --webpack');
@@ -185,11 +191,11 @@ async function writeStandaloneAgentChatApp(root: string, input: ScaffoldAgentCha
   );
   fs.writeFileSync(
     path.join(root, 'package.json'),
-    renderPackageJson(path.basename(root), root, localNovuDeps),
+    renderPackageJson(path.basename(root), localNovuDeps, input.apiUrl),
     'utf8'
   );
   fs.writeFileSync(path.join(root, 'tsconfig.json'), STANDALONE_TSCONFIG, 'utf8');
-  fs.writeFileSync(path.join(root, 'next.config.mjs'), renderNextConfig(root, localNovuDeps), 'utf8');
+  fs.writeFileSync(path.join(root, 'next.config.mjs'), renderNextConfig(root, localNovuDeps, input.apiUrl), 'utf8');
   fs.writeFileSync(path.join(root, '.env.local'), renderEnvLocal(input), 'utf8');
   fs.writeFileSync(path.join(root, '.env.example'), renderEnvExample(input), 'utf8');
   fs.writeFileSync(path.join(root, '.gitignore'), STANDALONE_GITIGNORE, 'utf8');
@@ -346,28 +352,46 @@ function toPosixRelative(from: string, to: string): string {
   return rel.startsWith('.') ? rel : `./${rel}`;
 }
 
-function resolveNovuReactDependency(localNovuDeps: LocalNovuDeps | undefined): string {
-  if (localNovuDeps) {
-    return `file:${localNovuDeps.reactDir}`;
+export type AgentChatNovuDependencies = {
+  react: string;
+  js?: string;
+  useLocalAliases: boolean;
+};
+
+export function resolveAgentChatNovuDependencies(
+  apiUrl: string,
+  localNovuDeps: LocalNovuDeps | undefined
+): AgentChatNovuDependencies {
+  if (isNovuStagingApiUrl(apiUrl)) {
+    return { react: 'rc', js: 'rc', useLocalAliases: false };
   }
 
-  return 'latest';
+  if (localNovuDeps) {
+    return {
+      react: `file:${localNovuDeps.reactDir}`,
+      js: `file:${localNovuDeps.jsDir}`,
+      useLocalAliases: true,
+    };
+  }
+
+  return { react: 'latest', useLocalAliases: false };
 }
 
-function renderPackageJson(name: string, scaffoldRoot: string, localNovuDeps: LocalNovuDeps | undefined): string {
-  const usesLocalNovu = Boolean(localNovuDeps);
+function renderPackageJson(name: string, localNovuDeps: LocalNovuDeps | undefined, apiUrl: string): string {
+  const sdk = resolveAgentChatNovuDependencies(apiUrl, localNovuDeps);
 
   return JSON.stringify(
     {
       name,
       private: true,
       scripts: {
-        dev: usesLocalNovu ? 'next dev -p 4012 --webpack' : 'next dev -p 4012',
-        build: usesLocalNovu ? 'next build --webpack' : 'next build',
+        dev: sdk.useLocalAliases ? 'next dev -p 4012 --webpack' : 'next dev -p 4012',
+        build: sdk.useLocalAliases ? 'next build --webpack' : 'next build',
         start: 'next start -p 4012',
       },
       dependencies: {
-        '@novu/react': resolveNovuReactDependency(localNovuDeps),
+        '@novu/react': sdk.react,
+        ...(sdk.js ? { '@novu/js': sdk.js } : {}),
         next: '^16.2.11',
         react: '^18.3.1',
         'react-dom': '^18.3.1',
@@ -386,8 +410,8 @@ function renderPackageJson(name: string, scaffoldRoot: string, localNovuDeps: Lo
   );
 }
 
-function renderNextConfig(scaffoldRoot: string, localNovuDeps: LocalNovuDeps | undefined): string {
-  if (!localNovuDeps) {
+function renderNextConfig(scaffoldRoot: string, localNovuDeps: LocalNovuDeps | undefined, apiUrl: string): string {
+  if (!resolveAgentChatNovuDependencies(apiUrl, localNovuDeps).useLocalAliases || !localNovuDeps) {
     return STANDALONE_NEXT_CONFIG;
   }
 

--- a/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts
+++ b/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts
@@ -1,7 +1,8 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { isNovuStagingApiUrl } from '@novu/shared';
+import { isNovuLocalApiUrl, isNovuStagingApiUrl } from '@novu/shared';
+import { CloudRegionEnum } from '../../../dev/enums';
 import { tryGitInit } from '../../../init/helpers/git';
 import { isFolderEmpty } from '../../../init/helpers/is-folder-empty';
 import { getOnline } from '../../../init/helpers/is-online';
@@ -15,6 +16,7 @@ export type ScaffoldAgentChatProjectInput = {
   applicationIdentifier: string;
   subscriberId: string;
   apiUrl: string;
+  region?: CloudRegionEnum;
   /** When set, merge chat UI into an existing bridge scaffold instead of creating a sibling app. */
   mergeIntoProjectDir?: string;
   /** Replace the root page when merging into a project scaffolded during this connect run. */
@@ -87,7 +89,7 @@ async function mergeAgentChatIntoProject(projectDir: string, input: ScaffoldAgen
     throw new Error(`Cannot merge Agent Chat into "${resolved}" — no package.json found.`);
   }
 
-  const dependenciesChanged = ensureAgentChatDependencies(resolved, findLocalNovuDeps(), input.apiUrl);
+  const dependenciesChanged = ensureAgentChatDependencies(resolved, findLocalNovuDeps(), input.apiUrl, input.region);
   const componentsDir = path.join(resolved, 'components', 'agent-chat');
   fs.mkdirSync(componentsDir, { recursive: true });
   copyTemplateComponents(componentsDir);
@@ -110,7 +112,8 @@ async function mergeAgentChatIntoProject(projectDir: string, input: ScaffoldAgen
 function ensureAgentChatDependencies(
   projectDir: string,
   localNovuDeps: LocalNovuDeps | undefined,
-  apiUrl: string
+  apiUrl: string,
+  region?: CloudRegionEnum
 ): boolean {
   const packageJsonPath = path.join(projectDir, 'package.json');
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
@@ -118,7 +121,7 @@ function ensureAgentChatDependencies(
     scripts?: Record<string, string>;
   };
   const dependencies = packageJson.dependencies ?? {};
-  const sdk = resolveAgentChatNovuDependencies(apiUrl, localNovuDeps);
+  const sdk = resolveAgentChatNovuDependencies(apiUrl, localNovuDeps, region);
   const required = {
     '@novu/react': sdk.react,
     ...(sdk.js ? { '@novu/js': sdk.js } : {}),
@@ -189,13 +192,10 @@ async function writeStandaloneAgentChatApp(root: string, input: ScaffoldAgentCha
     }),
     'utf8'
   );
-  fs.writeFileSync(
-    path.join(root, 'package.json'),
-    renderPackageJson(path.basename(root), localNovuDeps, input.apiUrl),
-    'utf8'
-  );
+  const sdk = resolveAgentChatNovuDependencies(input.apiUrl, localNovuDeps, input.region);
+  fs.writeFileSync(path.join(root, 'package.json'), renderPackageJson(path.basename(root), sdk), 'utf8');
   fs.writeFileSync(path.join(root, 'tsconfig.json'), STANDALONE_TSCONFIG, 'utf8');
-  fs.writeFileSync(path.join(root, 'next.config.mjs'), renderNextConfig(root, localNovuDeps, input.apiUrl), 'utf8');
+  fs.writeFileSync(path.join(root, 'next.config.mjs'), renderNextConfig(root, localNovuDeps, sdk), 'utf8');
   fs.writeFileSync(path.join(root, '.env.local'), renderEnvLocal(input), 'utf8');
   fs.writeFileSync(path.join(root, '.env.example'), renderEnvExample(input), 'utf8');
   fs.writeFileSync(path.join(root, '.gitignore'), STANDALONE_GITIGNORE, 'utf8');
@@ -360,13 +360,14 @@ export type AgentChatNovuDependencies = {
 
 export function resolveAgentChatNovuDependencies(
   apiUrl: string,
-  localNovuDeps: LocalNovuDeps | undefined
+  localNovuDeps: LocalNovuDeps | undefined,
+  region?: CloudRegionEnum
 ): AgentChatNovuDependencies {
-  if (isNovuStagingApiUrl(apiUrl)) {
+  if (isNovuStagingApiUrl(apiUrl) || region === CloudRegionEnum.STAGING) {
     return { react: 'rc', js: 'rc', useLocalAliases: false };
   }
 
-  if (localNovuDeps) {
+  if (localNovuDeps && isNovuLocalApiUrl(apiUrl)) {
     return {
       react: `file:${localNovuDeps.reactDir}`,
       js: `file:${localNovuDeps.jsDir}`,
@@ -374,12 +375,11 @@ export function resolveAgentChatNovuDependencies(
     };
   }
 
-  return { react: 'latest', useLocalAliases: false };
+  // The scaffold template tracks dashboard APIs that may not be on npm `latest` yet.
+  return { react: 'rc', js: 'rc', useLocalAliases: false };
 }
 
-function renderPackageJson(name: string, localNovuDeps: LocalNovuDeps | undefined, apiUrl: string): string {
-  const sdk = resolveAgentChatNovuDependencies(apiUrl, localNovuDeps);
-
+function renderPackageJson(name: string, sdk: AgentChatNovuDependencies): string {
   return JSON.stringify(
     {
       name,
@@ -410,8 +410,12 @@ function renderPackageJson(name: string, localNovuDeps: LocalNovuDeps | undefine
   );
 }
 
-function renderNextConfig(scaffoldRoot: string, localNovuDeps: LocalNovuDeps | undefined, apiUrl: string): string {
-  if (!resolveAgentChatNovuDependencies(apiUrl, localNovuDeps).useLocalAliases || !localNovuDeps) {
+function renderNextConfig(
+  scaffoldRoot: string,
+  localNovuDeps: LocalNovuDeps | undefined,
+  sdk: AgentChatNovuDependencies
+): string {
+  if (!sdk.useLocalAliases || !localNovuDeps) {
     return STANDALONE_NEXT_CONFIG;
   }
 

--- a/packages/novu/src/commands/connect/resolve-options.spec.ts
+++ b/packages/novu/src/commands/connect/resolve-options.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { CloudRegionEnum } from '../dev/enums';
+import { resolveConnectCommandOptions } from './resolve-options';
+
+describe('resolveConnectCommandOptions', () => {
+  it('maps --staging to the staging region and URLs', () => {
+    const resolved = resolveConnectCommandOptions({
+      region: CloudRegionEnum.US,
+      staging: true,
+    });
+
+    expect(resolved.region).toBe(CloudRegionEnum.STAGING);
+    expect(resolved.apiUrl).toBe('https://api.novu-staging.co');
+    expect(resolved.dashboardUrl).toBe('https://dashboard.novu-staging.co');
+  });
+
+  it('keeps an explicit --api-url when --staging is set', () => {
+    const resolved = resolveConnectCommandOptions({
+      region: CloudRegionEnum.US,
+      staging: true,
+      apiUrl: 'https://api.novu-staging.co/',
+    });
+
+    expect(resolved.apiUrl).toBe('https://api.novu-staging.co');
+  });
+});

--- a/packages/novu/src/commands/connect/resolve-options.ts
+++ b/packages/novu/src/commands/connect/resolve-options.ts
@@ -8,6 +8,8 @@ export type ConnectCommandInput = Omit<ConnectCommandOptions, 'apiUrl' | 'dashbo
   apiUrl?: string;
   dashboardUrl?: string;
   connectDashboardUrl?: string;
+  /** Shorthand for `--region staging`. Wins over `--region`. */
+  staging?: boolean;
 };
 
 function resolveRuntimeFromFlags(input: ConnectCommandInput): AgentConnectMode | undefined {
@@ -19,7 +21,7 @@ function resolveRuntimeFromFlags(input: ConnectCommandInput): AgentConnectMode |
 }
 
 export function resolveConnectCommandOptions(input: ConnectCommandInput): ConnectCommandOptions {
-  const region = input.region;
+  const region = input.staging ? CloudRegionEnum.STAGING : input.region;
   if (!CONNECT_REGION_VALUES.includes(region)) {
     throw new Error(`Invalid --region "${region}". Expected one of: ${CONNECT_REGION_VALUES.join(', ')}.`);
   }

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/agent-chat.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/agent-chat.tsx
@@ -5,7 +5,6 @@ import { ChatPanel } from './chat-panel';
 
 export function AgentChat() {
   const agentId = process.env.NEXT_PUBLIC_NOVU_AGENT_ID ?? '';
-  const subscriberId = process.env.NEXT_PUBLIC_NOVU_SUBSCRIBER_ID ?? '';
 
   const {
     messages,
@@ -17,23 +16,20 @@ export function AgentChat() {
     isRunning,
     isLoading,
     typing,
-    hasMore,
-    isFetching,
-    fetchMore,
+    pagination,
   } = useAgentChat({ agentId });
 
   return (
     <ChatPanel
-      subscriberId={subscriberId}
       error={error}
       messages={messages}
       pendingActions={pendingActions}
       isRunning={isRunning}
       isLoading={isLoading}
       typing={typing}
-      hasMore={hasMore}
-      isFetching={isFetching}
-      onFetchMore={fetchMore}
+      hasMore={pagination.hasMore}
+      isFetching={pagination.status === 'loading'}
+      onFetchMore={pagination.fetchMore}
       onRespond={respondToAction}
       onCardAction={sendAction}
       onSend={sendMessage}

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/agent-chat.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/agent-chat.tsx
@@ -8,7 +8,7 @@ export function AgentChat() {
 
   const {
     messages,
-    pendingActions = [],
+    pendingActions,
     sendMessage,
     sendAction,
     respondToAction,
@@ -23,7 +23,7 @@ export function AgentChat() {
     <ChatPanel
       error={error}
       messages={messages}
-      pendingActions={pendingActions}
+      hasPendingActions={Boolean(pendingActions?.length)}
       isRunning={isRunning}
       isLoading={isLoading}
       typing={typing}

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/chat-panel.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/chat-panel.tsx
@@ -3,14 +3,12 @@
 import type { AgentConversationTyping, AgentMessage, AgentPendingAction, UseAgentChatResult } from '@novu/react';
 import { ChatThread } from './chat-thread';
 import { Composer } from './composer';
-import { PendingActionCard } from './pending-action-card';
 
 /**
  * Presentational shell. Swap this (and the components it uses) for your own UI —
  * it only consumes values from `useAgentChat`.
  */
 export type ChatPanelProps = {
-  subscriberId: string;
   error?: { message: string };
   messages: AgentMessage[];
   pendingActions: AgentPendingAction[];
@@ -26,7 +24,6 @@ export type ChatPanelProps = {
 };
 
 export function ChatPanel({
-  subscriberId,
   error,
   messages,
   pendingActions,
@@ -44,31 +41,23 @@ export function ChatPanel({
 
   return (
     <div className="chat-main">
-      <header className="chat-topbar">
-        <p>
-          Chatting as <strong>{subscriberId}</strong>
-        </p>
-      </header>
-
       <ChatThread
         messages={messages}
         isRunning={isRunning}
         isLoading={isLoading}
         typing={typing}
+        hasPendingActions={pendingActions.length > 0}
         hasMore={hasMore}
         isFetching={isFetching}
         onFetchMore={onFetchMore}
         onCardAction={onCardAction}
+        onRespond={onRespond}
         cardActionsDisabled={interactionDisabled}
         onSend={onSend}
       />
 
       <div className="chat-foot">
         <div className="chat-foot-inner">
-          {pendingActions.map((action) => (
-            <PendingActionCard key={action.id} action={action} disabled={interactionDisabled} onRespond={onRespond} />
-          ))}
-
           {error ? (
             <div className="banner-error" role="alert">
               {error.message}

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/chat-panel.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/chat-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AgentConversationTyping, AgentMessage, AgentPendingAction, UseAgentChatResult } from '@novu/react';
+import type { AgentConversationTyping, AgentMessage, UseAgentChatResult } from '@novu/react';
 import { ChatThread } from './chat-thread';
 import { Composer } from './composer';
 
@@ -11,7 +11,7 @@ import { Composer } from './composer';
 export type ChatPanelProps = {
   error?: { message: string };
   messages: AgentMessage[];
-  pendingActions: AgentPendingAction[];
+  hasPendingActions: boolean;
   isRunning: boolean;
   isLoading: boolean;
   typing?: AgentConversationTyping;
@@ -26,7 +26,7 @@ export type ChatPanelProps = {
 export function ChatPanel({
   error,
   messages,
-  pendingActions,
+  hasPendingActions,
   isRunning,
   isLoading,
   typing,
@@ -46,7 +46,7 @@ export function ChatPanel({
         isRunning={isRunning}
         isLoading={isLoading}
         typing={typing}
-        hasPendingActions={pendingActions.length > 0}
+        hasPendingActions={hasPendingActions}
         hasMore={hasMore}
         isFetching={isFetching}
         onFetchMore={onFetchMore}

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/chat-thread.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/chat-thread.tsx
@@ -2,13 +2,13 @@
 
 import type { AgentMessage, UseAgentChatResult } from '@novu/react';
 import { useCallback, useEffect, useRef } from 'react';
-import { ChatIcon } from './icons';
+import { ChevronIcon } from './icons';
 import { MessageRow } from './message-bubble';
 
 /** Matches `AgentConversationTyping` from `@novu/react` / the event protocol. */
 type TypingState = { status?: string };
 
-const STARTER_PROMPTS = ['Hello', 'What can you do?', 'List my MCP tools'] as const;
+const STARTER_PROMPTS = ['Hello', 'What can you do?', 'What tools do you have available?'] as const;
 
 type ChatThreadProps = {
   messages: AgentMessage[];
@@ -17,34 +17,23 @@ type ChatThreadProps = {
   isLoading: boolean;
   /** Live `channel.typing` from `useAgentChat`. Absent when the agent is idle. */
   typing?: TypingState;
+  hasPendingActions: boolean;
   hasMore: boolean;
   isFetching: boolean;
   onFetchMore: () => Promise<unknown>;
   onCardAction: UseAgentChatResult['sendAction'];
+  onRespond: UseAgentChatResult['respondToAction'];
   cardActionsDisabled: boolean;
   onSend: UseAgentChatResult['sendMessage'];
 };
 
 function AgentStatusRow({ status }: { status?: string }) {
-  // Server statuses often arrive with their own trailing ellipsis or dots.
-  const label = status?.trim().replace(/[.\u2026]+$/, '');
+  const label = status?.trim().replace(/[.\u2026]+$/, '') || 'Thinking';
 
   return (
-    <output className="typing-row" aria-label={label || 'Agent is typing'}>
-      <span className="agent-avatar" aria-hidden>
-        <ChatIcon size={14} />
-      </span>
-      <span className="typing-bubble">
-        {label ? (
-          <span className="typing-label">{label}…</span>
-        ) : (
-          <span className="typing-dots" aria-hidden>
-            <span />
-            <span />
-            <span />
-          </span>
-        )}
-      </span>
+    <output className="typing-row" aria-label={label}>
+      <ChevronIcon size={14} />
+      <span className="typing-label">{label}…</span>
     </output>
   );
 }
@@ -54,15 +43,18 @@ export function ChatThread({
   isRunning,
   isLoading,
   typing,
+  hasPendingActions,
   hasMore,
   isFetching,
   onFetchMore,
   onCardAction,
+  onRespond,
   cardActionsDisabled,
   onSend,
 }: ChatThreadProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const lastMessage = messages[messages.length - 1];
+  const showTypingRow = (Boolean(typing) || isRunning || isLoading) && !hasPendingActions;
 
   // Keyed on the tail, not the count: an older page prepends and must not scroll.
   useEffect(() => {
@@ -99,11 +91,7 @@ export function ChatThread({
 
         {messages.length === 0 && !isRunning && !isLoading ? (
           <div className="thread-empty">
-            <div className="thread-empty-glyph">
-              <ChatIcon />
-            </div>
-            <h1>Your agent is ready</h1>
-            <p>Send a message to see how it replies.</p>
+            <p>Hello, I&apos;m your agent. How can I help you today?</p>
             <div className="starter-prompts">
               {STARTER_PROMPTS.map((prompt) => (
                 <button type="button" key={prompt} onClick={() => void onSend(prompt)}>
@@ -113,17 +101,17 @@ export function ChatThread({
             </div>
           </div>
         ) : (
-          messages.map((message, index) => (
+          messages.map((message) => (
             <MessageRow
               key={message.id}
               message={message}
-              showAvatar={message.role !== 'user' && messages[index - 1]?.role !== message.role}
               onCardAction={onCardAction}
+              onRespond={onRespond}
               cardActionsDisabled={cardActionsDisabled}
             />
           ))
         )}
-        {typing || isRunning || isLoading ? (
+        {showTypingRow ? (
           <AgentStatusRow status={typing?.status || (isLoading ? 'Loading conversation' : undefined)} />
         ) : null}
       </div>

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/composer.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/composer.tsx
@@ -59,21 +59,16 @@ export function Composer({ isLoading, isRunning, onSend }: ComposerProps) {
           autoComplete="off"
           aria-label="Message your agent"
         />
-        <button
-          type="submit"
-          className="composer-send"
-          disabled={disabled || !draft.trim()}
-          aria-label={isRunning ? 'Agent is responding' : 'Send message'}
-        >
-          {isRunning ? <span className="spinner" aria-hidden /> : <SendIcon />}
-        </button>
-      </div>
-      <div className="composer-hints">
-        <kbd>Enter</kbd>
-        <span>to send</span>
-        <span aria-hidden>·</span>
-        <kbd>Shift + Enter</kbd>
-        <span>for a new line</span>
+        <div className="composer-toolbar">
+          <button
+            type="submit"
+            className="composer-send"
+            disabled={disabled || !draft.trim()}
+            aria-label={isRunning ? 'Agent is responding' : 'Send message'}
+          >
+            {isRunning ? <span className="spinner" aria-hidden /> : <SendIcon />}
+          </button>
+        </div>
       </div>
     </form>
   );

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/globals.css
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/globals.css
@@ -429,6 +429,86 @@
     gap: 6px;
   }
 
+  .tool-list-stack {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    gap: 4px;
+    width: 100%;
+  }
+
+  .expandable-row {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .expandable-row > summary {
+    display: flex;
+    width: fit-content;
+    max-width: 100%;
+    align-items: center;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .expandable-row > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .expandable-row[open] > summary .expandable-chevron {
+    transform: rotate(90deg);
+  }
+
+  .decision-card-args[open] > summary .expandable-chevron {
+    transform: rotate(90deg);
+  }
+
+  .expandable-chevron {
+    flex-shrink: 0;
+    color: var(--ink-soft);
+    transition: transform 150ms var(--ease-out);
+  }
+
+  .expandable-body {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 4px;
+    border: 1px solid var(--stroke);
+    border-radius: 6px;
+    padding: 8px 10px;
+  }
+
+  .payload-peek {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .payload-peek-label {
+    color: var(--ink-soft);
+    font-size: 11px;
+    font-weight: 500;
+  }
+
+  .payload-peek-value {
+    max-height: 112px;
+    overflow: auto;
+    margin: 0;
+    color: var(--ink-subtle);
+    font-size: 12px;
+    line-height: 16px;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  .part-status-chevron {
+    color: var(--ink-soft);
+  }
+
   .message-card-actions button,
   .button {
     display: inline-flex;
@@ -487,6 +567,7 @@
     font-size: 12px;
   }
 
+  .tool-chip-failed,
   .tool-chip[data-state="failed"],
   .part-status [data-tone="danger"] {
     color: var(--danger);
@@ -535,8 +616,9 @@
   .decision-card {
     display: flex;
     width: 100%;
-    align-items: center;
-    gap: 12px;
+    flex-direction: column;
+    gap: 16px;
+    overflow: hidden;
     border: 1px solid var(--stroke);
     border-radius: 8px;
     background: var(--surface-weak);
@@ -544,10 +626,103 @@
     animation: message-in 200ms var(--ease-out);
   }
 
-  .decision-card-icon {
+  .decision-card-approval {
+    align-items: stretch;
+  }
+
+  .decision-card-header {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .decision-card-title-row {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 4px;
+    color: var(--ink);
+  }
+
+  .decision-card-title-row h2 {
+    min-width: 0;
+    flex: 1;
+    margin: 0;
+    overflow: hidden;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.084px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .decision-card-header p {
+    margin: 0;
+    color: var(--ink);
+    font-size: 12px;
+    line-height: 1.7;
+  }
+
+  .decision-card-args {
+    min-width: 0;
+  }
+
+  .decision-card-args > summary {
+    display: flex;
+    width: fit-content;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    list-style: none;
+    color: var(--ink-subtle);
+    font-size: 12px;
+    font-weight: 500;
+  }
+
+  .decision-card-args > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .decision-card-args > summary:hover {
+    color: var(--ink);
+  }
+
+  .decision-card-args .payload-peek {
+    margin-top: 6px;
+  }
+
+  .decision-card-actions {
+    display: flex;
+    width: 100%;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+
+  .decision-card-actions-split {
+    justify-content: space-between;
+  }
+
+  .decision-card-trust,
+  .decision-card-primary-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .decision-card-mcp {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .decision-card-mcp-icon {
     display: grid;
-    width: 32px;
-    height: 32px;
+    width: 40px;
+    height: 40px;
     flex-shrink: 0;
     place-items: center;
     border-radius: 50%;
@@ -556,23 +731,13 @@
     color: var(--ink-soft);
   }
 
-  .decision-card-icon-warning {
-    background: var(--warning-soft);
-    box-shadow: none;
-    color: var(--warning);
-  }
-
-  .decision-card-copy {
+  .decision-card-mcp .decision-card-copy {
     min-width: 0;
     flex: 1;
   }
 
-  .decision-card-copy h2,
-  .decision-card-copy p {
+  .decision-card-mcp .decision-card-copy h2 {
     margin: 0;
-  }
-
-  .decision-card-copy h2 {
     overflow: hidden;
     font-size: 13px;
     font-weight: 600;
@@ -580,50 +745,20 @@
     white-space: nowrap;
   }
 
-  .decision-card-copy p {
-    margin-top: 2px;
+  .decision-card-mcp .decision-card-copy p {
+    margin: 2px 0 0;
     color: var(--ink-soft);
     font-size: 12px;
   }
 
-  .decision-card-copy code {
+  .decision-card-copy h2 code {
     font-size: 12px;
+    font-weight: 600;
   }
 
-  .decision-card-copy details {
-    margin-top: 6px;
+  .decision-card-error {
+    color: var(--danger);
   }
-
-  .decision-card-copy summary {
-    width: fit-content;
-    cursor: pointer;
-    color: var(--ink-soft);
-    font-size: 12px;
-  }
-
-  .decision-card-copy pre {
-    max-height: 140px;
-    overflow: auto;
-    margin: 6px 0 0;
-    border-radius: 8px;
-    background: var(--surface);
-    padding: 8px;
-    font-size: 10px;
-    line-height: 1.5;
-    white-space: pre-wrap;
-  }
-
-  .decision-card-buttons {
-    display: flex;
-    flex-shrink: 0;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 6px;
-  }
-
-.decision-card-copy .decision-card-error {
-  color: var(--danger);
-}
 
   .banner-error {
     border: 1px solid var(--danger-line);
@@ -732,19 +867,19 @@
       padding-left: 12px;
     }
 
-    .decision-card {
-      align-items: flex-start;
+    .decision-card-mcp {
       flex-wrap: wrap;
     }
 
-    .decision-card-copy {
-      width: calc(100% - 44px);
+    .decision-card-actions-split {
+      flex-direction: column;
+      align-items: stretch;
     }
 
-    .decision-card-buttons {
+    .decision-card-trust,
+    .decision-card-primary-actions {
       width: 100%;
       justify-content: flex-start;
-      padding-left: 44px;
     }
 
     .message-row time {

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/globals.css
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/globals.css
@@ -1,15 +1,15 @@
 .novu-agent-chat {
   box-sizing: border-box;
   color-scheme: light;
-  --canvas: #f6f7f9;
+  --canvas: #ffffff;
   --surface: #ffffff;
-  --surface-weak: #f5f7fa;
-  --stroke: #e1e4ea;
-  --stroke-strong: #c9cfd9;
-  --ink: #0e121b;
-  --ink-subtle: #525866;
-  --ink-soft: #525866;
-  --ink-muted: #626977;
+  --surface-weak: #f5f5f4;
+  --stroke: #ebebea;
+  --stroke-strong: #d6d6d4;
+  --ink: #171717;
+  --ink-subtle: #404040;
+  --ink-soft: #737373;
+  --ink-muted: #a3a3a3;
   --primary: #dd2450;
   --primary-hover: #c41e46;
   --primary-soft: rgba(221, 36, 80, 0.08);
@@ -21,9 +21,8 @@
   --warning-soft: #fdf6e7;
   --warning-line: #f2dfb5;
   --success: #1a7544;
-  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   --shadow-xs: 0 1px 2px rgba(14, 18, 27, 0.04);
-  --shadow-sm: 0 8px 24px rgba(14, 18, 27, 0.07);
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   background: var(--canvas);
   color: var(--ink);
@@ -35,868 +34,736 @@
 
 .novu-agent-chat.agent-chat-page {
   display: flex;
-  width: min(100%, 920px);
+  width: min(100%, 720px);
   min-height: 100dvh;
   margin: 0 auto;
-  padding: 24px;
 }
 
 @scope (.novu-agent-chat) {
-* {
-  box-sizing: border-box;
-  scrollbar-width: thin;
-  scrollbar-color: #d5d9e0 transparent;
-}
-
-button,
-textarea {
-  color: inherit;
-  font: inherit;
-}
-
-button {
-  cursor: pointer;
-}
-
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.45;
-}
-
-code,
-kbd,
-pre {
-  font-family: var(--font-mono);
-}
-
-::selection {
-  background: var(--primary-soft);
-}
-
-button:focus-visible,
-textarea:focus-visible,
-a:focus-visible,
-summary:focus-visible {
-  border-radius: 6px;
-  outline: 2px solid var(--primary-line);
-  outline-offset: 2px;
-}
-
-.chat-main {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  min-width: 0;
-  min-height: 560px;
-  overflow: hidden;
-  border: 1px solid var(--stroke);
-  border-radius: 14px;
-  background: var(--surface);
-  box-shadow: var(--shadow-xs);
-}
-
-.chat-topbar {
-  display: flex;
-  min-height: 44px;
-  flex-shrink: 0;
-  align-items: center;
-  border-bottom: 1px solid var(--stroke);
-  padding: 8px 16px;
-}
-
-.chat-topbar p {
-  min-width: 0;
-  margin: 0;
-  overflow: hidden;
-  color: var(--ink-soft);
-  font-size: 12px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.chat-topbar strong {
-  color: var(--ink-subtle);
-  font-weight: 500;
-}
-
-.thread {
-  display: flex;
-  min-height: 0;
-  flex: 1;
-  flex-direction: column;
-  overflow-y: auto;
-  scroll-behavior: smooth;
-}
-
-.thread-inner {
-  display: flex;
-  width: min(100%, 672px);
-  min-height: 100%;
-  flex: 1;
-  flex-direction: column;
-  gap: 12px;
-  margin: 0 auto;
-  padding: 20px 16px 32px;
-}
-
-.thread-older {
-  display: flex;
-  justify-content: center;
-}
-
-.thread-older-btn,
-.starter-prompts button {
-  display: inline-flex;
-  min-height: 28px;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  border: 1px solid var(--stroke);
-  border-radius: 999px;
-  background: var(--surface);
-  color: var(--ink-subtle);
-  font-size: 11px;
-  font-weight: 500;
-  transition: border-color 150ms var(--ease-out), background 150ms var(--ease-out);
-}
-
-.thread-older-btn {
-  padding: 4px 12px;
-}
-
-.thread-older-btn:hover:not(:disabled),
-.starter-prompts button:hover:not(:disabled) {
-  border-color: var(--stroke-strong);
-  background: var(--surface-weak);
-}
-
-.thread-empty {
-  display: flex;
-  max-width: 360px;
-  flex: 1;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  margin: auto;
-  padding: 40px 16px;
-  text-align: center;
-}
-
-.thread-empty-glyph {
-  display: grid;
-  width: 48px;
-  height: 48px;
-  place-items: center;
-  margin-bottom: 20px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, #ff884d, #dd2450);
-  box-shadow: 0 12px 24px -8px rgba(221, 36, 80, 0.38), inset 0 1px rgba(255, 255, 255, 0.25);
-  color: #ffffff;
-}
-
-.thread-empty h1 {
-  margin: 0;
-  font-size: 15px;
-  font-weight: 600;
-  letter-spacing: -0.015em;
-}
-
-.thread-empty p {
-  margin: 6px 0 0;
-  color: var(--ink-soft);
-  font-size: 12px;
-}
-
-.starter-prompts {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 8px;
-  margin-top: 20px;
-}
-
-.starter-prompts button {
-  padding: 4px 12px;
-}
-
-.message-row {
-  animation: message-in 200ms var(--ease-out);
-}
-
-@keyframes message-in {
-  from {
-    opacity: 0;
-    transform: translateY(4px);
+  * {
+    box-sizing: border-box;
+    scrollbar-width: thin;
+    scrollbar-color: #d5d9e0 transparent;
   }
-}
 
-.message-row time {
-  flex-shrink: 0;
-  align-self: flex-start;
-  margin-top: 8px;
-  color: var(--ink-muted);
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-  opacity: 0;
-  transition: opacity 150ms ease-out;
-}
-
-.message-row:hover time {
-  opacity: 1;
-}
-
-.message-row-user {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 4px;
-}
-
-.message-user-line {
-  display: flex;
-  max-width: 100%;
-  align-items: flex-end;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.message-row-user time {
-  align-self: flex-end;
-  margin-bottom: 7px;
-}
-
-.message-row-agent,
-.typing-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-}
-
-.agent-avatar,
-.agent-avatar-spacer {
-  width: 28px;
-  height: 28px;
-  flex-shrink: 0;
-}
-
-.agent-avatar {
-  display: grid;
-  place-items: center;
-  margin-top: 2px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #ff884d, #dd2450);
-  color: #ffffff;
-}
-
-.message-agent-content {
-  display: flex;
-  min-width: 0;
-  max-width: min(544px, calc(100% - 48px));
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 6px;
-}
-
-.message-bubble {
-  color: var(--ink);
-  font-size: 14px;
-  line-height: 20px;
-  word-break: break-word;
-}
-
-.message-bubble-user {
-  max-width: min(480px, 85%);
-  border-radius: 16px 16px 5px 16px;
-  background: var(--surface-weak);
-  padding: 8px 14px;
-  white-space: pre-wrap;
-}
-
-.message-bubble-agent {
-  border: 1px solid var(--stroke);
-  border-radius: 5px 16px 16px;
-  background: var(--surface);
-  box-shadow: var(--shadow-xs);
-  padding: 10px 14px;
-}
-
-.message-row[data-status='failed'] .message-bubble-user {
-  box-shadow: 0 0 0 1px var(--danger-line);
-}
-
-.message-failed {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  color: var(--danger);
-  font-size: 11px;
-  font-weight: 500;
-}
-
-.md > :first-child {
-  margin-top: 0;
-}
-
-.md > :last-child {
-  margin-bottom: 0;
-}
-
-.md p {
-  margin: 0 0 8px;
-}
-
-.md a,
-.message-card > a {
-  color: var(--primary);
-  font-weight: 500;
-  text-decoration: underline;
-  text-decoration-color: var(--primary-line);
-  text-underline-offset: 2px;
-}
-
-.md code {
-  border-radius: 5px;
-  background: var(--surface-weak);
-  box-shadow: inset 0 0 0 1px var(--stroke);
-  padding: 1px 5px;
-  font-size: 0.82em;
-}
-
-.md pre {
-  max-width: 100%;
-  overflow-x: auto;
-  border-radius: 8px;
-  background: var(--surface-weak);
-  box-shadow: inset 0 0 0 1px var(--stroke);
-  padding: 10px 12px;
-  font-size: 11px;
-  line-height: 1.55;
-}
-
-.md pre code {
-  background: none;
-  box-shadow: none;
-  padding: 0;
-}
-
-.md ul,
-.md ol {
-  display: grid;
-  gap: 4px;
-  margin: 8px 0;
-  padding-left: 20px;
-}
-
-.md blockquote {
-  margin: 8px 0;
-  border-left: 1px solid var(--stroke-strong);
-  padding-left: 12px;
-  color: var(--ink-subtle);
-}
-
-.md h1,
-.md h2,
-.md h3 {
-  margin: 16px 0 6px;
-  font-size: 1em;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-
-.md table {
-  width: 100%;
-  margin: 8px 0;
-  border: 1px solid var(--stroke);
-  border-radius: 8px;
-  border-collapse: separate;
-  border-spacing: 0;
-  overflow: hidden;
-  font-size: 12px;
-}
-
-.md th,
-.md td {
-  padding: 6px 9px;
-  text-align: left;
-  vertical-align: top;
-}
-
-.md th {
-  background: var(--surface-weak);
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.md tr + tr td {
-  border-top: 1px solid var(--stroke);
-}
-
-.stream-cursor {
-  display: inline-block;
-  width: 2px;
-  height: 14px;
-  margin-left: 2px;
-  animation: cursor-pulse 1s ease-in-out infinite;
-  background: var(--ink);
-  vertical-align: -2px;
-}
-
-@keyframes cursor-pulse {
-  50% {
-    opacity: 0.2;
+  button,
+  textarea {
+    color: inherit;
+    font: inherit;
   }
-}
 
-.message-card {
-  display: flex;
-  width: 100%;
-  flex-direction: column;
-  gap: 10px;
-  border: 1px solid var(--stroke);
-  border-radius: 5px 16px 16px;
-  background: var(--surface);
-  box-shadow: var(--shadow-xs);
-  padding: 10px 14px;
-}
-
-.message-card img {
-  width: 100%;
-  max-height: 180px;
-  border-radius: 8px;
-  object-fit: cover;
-}
-
-.message-card h2 {
-  margin: 0;
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.message-card-subtitle {
-  margin: -6px 0 0;
-  color: var(--ink-soft);
-  font-size: 12px;
-}
-
-.message-card hr {
-  width: 100%;
-  margin: 0;
-  border: 0;
-  border-top: 1px solid var(--stroke);
-}
-
-.message-card > a {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  align-self: flex-start;
-  font-size: 12px;
-  text-decoration: none;
-}
-
-.message-card-actions,
-.tool-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.message-card-actions button,
-.button {
-  display: inline-flex;
-  min-height: 30px;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  border: 1px solid var(--stroke);
-  border-radius: 8px;
-  background: var(--surface);
-  padding: 5px 10px;
-  color: var(--ink-subtle);
-  font-size: 11px;
-  font-weight: 500;
-  text-decoration: none;
-  transition: border-color 150ms var(--ease-out), background 150ms var(--ease-out);
-}
-
-.message-card-actions button:hover:not(:disabled),
-.button-secondary:hover:not(:disabled) {
-  border-color: var(--stroke-strong);
-  background: var(--surface-weak);
-}
-
-.message-card-actions button[data-style='primary'],
-.button-primary {
-  border-color: var(--primary);
-  background: var(--primary);
-  color: #ffffff;
-}
-
-.message-card-actions button[data-style='primary']:hover:not(:disabled),
-.button-primary:hover:not(:disabled) {
-  border-color: var(--primary-hover);
-  background: var(--primary-hover);
-}
-
-.message-card-actions button[data-style='danger'] {
-  border-color: var(--danger-line);
-  color: var(--danger);
-}
-
-.tool-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  border: 1px solid var(--stroke);
-  border-radius: 999px;
-  background: var(--surface-weak);
-  padding: 4px 10px;
-  color: var(--ink-subtle);
-  font-size: 11px;
-  font-weight: 500;
-}
-
-.tool-chip code {
-  font-size: 10px;
-}
-
-.tool-chip[data-state='failed'] {
-  border-color: var(--danger-line);
-  background: var(--danger-soft);
-  color: var(--danger);
-}
-
-.typing-row {
-  animation: message-in 200ms var(--ease-out);
-}
-
-.typing-bubble {
-  display: flex;
-  height: 36px;
-  align-items: center;
-  border: 1px solid var(--stroke);
-  border-radius: 5px 16px 16px;
-  background: var(--surface);
-  box-shadow: var(--shadow-xs);
-  padding: 0 14px;
-}
-
-.typing-label {
-  animation: cursor-pulse 1.4s ease-in-out infinite;
-  color: var(--ink-soft);
-  font-size: 11px;
-}
-
-.typing-dots {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.typing-dots span {
-  width: 6px;
-  height: 6px;
-  animation: typing-dot 900ms ease-in-out infinite;
-  border-radius: 50%;
-  background: var(--ink-soft);
-}
-
-.typing-dots span:nth-child(2) {
-  animation-delay: 150ms;
-}
-
-.typing-dots span:nth-child(3) {
-  animation-delay: 300ms;
-}
-
-@keyframes typing-dot {
-  50% {
-    transform: translateY(-3px);
+  button {
+    cursor: pointer;
   }
-}
 
-.chat-foot {
-  position: relative;
-  flex-shrink: 0;
-}
-
-.chat-foot::before {
-  position: absolute;
-  right: 0;
-  bottom: 100%;
-  left: 0;
-  height: 24px;
-  background: linear-gradient(to top, var(--surface), transparent);
-  content: '';
-  pointer-events: none;
-}
-
-.chat-foot-inner {
-  display: flex;
-  width: min(100%, 672px);
-  flex-direction: column;
-  gap: 8px;
-  margin: 0 auto;
-  padding: 12px 16px;
-}
-
-.pending-action {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  border: 1px solid var(--stroke);
-  border-radius: 12px;
-  background: var(--surface);
-  box-shadow: var(--shadow-xs);
-  padding: 12px;
-  animation: message-in 200ms var(--ease-out);
-}
-
-.pending-action-icon {
-  display: grid;
-  width: 32px;
-  height: 32px;
-  flex-shrink: 0;
-  place-items: center;
-  border-radius: 50%;
-  background: var(--surface-weak);
-  color: var(--ink-soft);
-}
-
-.pending-action-icon-warning {
-  background: var(--warning-soft);
-  color: var(--warning);
-}
-
-.pending-action-copy {
-  min-width: 0;
-  flex: 1;
-}
-
-.pending-action-copy h2,
-.pending-action-copy p {
-  margin: 0;
-}
-
-.pending-action-copy h2 {
-  overflow: hidden;
-  font-size: 12px;
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.pending-action-copy p {
-  margin-top: 2px;
-  color: var(--ink-soft);
-  font-size: 11px;
-}
-
-.pending-action-copy code {
-  font-size: 11px;
-}
-
-.pending-action-copy details {
-  margin-top: 6px;
-}
-
-.pending-action-copy summary {
-  width: fit-content;
-  cursor: pointer;
-  color: var(--ink-soft);
-  font-size: 11px;
-}
-
-.pending-action-copy pre {
-  max-height: 140px;
-  overflow: auto;
-  margin: 6px 0 0;
-  border-radius: 8px;
-  background: var(--surface-weak);
-  padding: 8px;
-  font-size: 10px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-}
-
-.pending-action-buttons {
-  display: flex;
-  flex-shrink: 0;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 6px;
-}
-
-.pending-action-error {
-  color: var(--danger) !important;
-}
-
-.banner-error {
-  border: 1px solid var(--danger-line);
-  border-radius: 8px;
-  background: var(--danger-soft);
-  padding: 8px 12px;
-  color: var(--danger);
-  font-size: 11px;
-}
-
-.composer-box {
-  display: flex;
-  align-items: flex-end;
-  gap: 8px;
-  border: 1px solid var(--stroke);
-  border-radius: 16px;
-  background: var(--surface);
-  box-shadow: var(--shadow-xs);
-  padding: 6px 6px 6px 16px;
-  transition: border-color 150ms ease-out, box-shadow 150ms ease-out;
-}
-
-.composer-box:focus-within {
-  border-color: var(--stroke-strong);
-  box-shadow: var(--shadow-sm);
-}
-
-.composer textarea {
-  min-width: 0;
-  min-height: 32px;
-  max-height: 128px;
-  flex: 1;
-  resize: none;
-  overflow-y: auto;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  padding: 6px 0;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.composer textarea::placeholder {
-  color: var(--ink-muted);
-}
-
-.composer-send {
-  display: grid;
-  width: 32px;
-  height: 32px;
-  flex-shrink: 0;
-  place-items: center;
-  border: 0;
-  border-radius: 50%;
-  background: var(--primary);
-  color: #ffffff;
-  transition: background 150ms ease-out, transform 100ms ease-out;
-}
-
-.composer-send:hover:not(:disabled) {
-  background: var(--primary-hover);
-}
-
-.composer-send:active:not(:disabled) {
-  transform: scale(0.94);
-}
-
-.composer-hints {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  margin-top: 6px;
-  padding: 0 4px;
-  color: var(--ink-muted);
-  font-size: 11px;
-}
-
-.composer-hints kbd {
-  height: 17px;
-  border: 1px solid var(--stroke);
-  border-radius: 4px;
-  background: var(--surface-weak);
-  padding: 0 4px;
-  color: var(--ink-soft);
-  font-size: 9px;
-  line-height: 15px;
-}
-
-.spinner {
-  width: 12px;
-  height: 12px;
-  flex-shrink: 0;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: spin 700ms linear infinite;
-}
-
-.button-primary .spinner,
-.composer-send .spinner {
-  border-color: rgba(255, 255, 255, 0.45);
-  border-top-color: #ffffff;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
+  button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
   }
-}
 
-@media (max-width: 680px) {
+  code,
+  kbd,
+  pre {
+    font-family: var(--font-mono);
+  }
+
+  ::selection {
+    background: var(--primary-soft);
+  }
+
+  button:focus-visible,
+  textarea:focus-visible,
+  a:focus-visible,
+  summary:focus-visible {
+    border-radius: 6px;
+    outline: 2px solid var(--primary-line);
+    outline-offset: 2px;
+  }
+
   .chat-main {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-width: 0;
     min-height: 100dvh;
-    border-width: 0;
-    border-radius: 0;
+    overflow: hidden;
   }
 
-  .thread-inner,
-  .chat-foot-inner {
-    padding-right: 14px;
-    padding-left: 14px;
+  .thread {
+    display: flex;
+    min-height: 0;
+    flex: 1;
+    flex-direction: column;
+    overflow-y: auto;
   }
 
-  .pending-action {
-    align-items: flex-start;
-    flex-wrap: wrap;
-  }
-
-  .pending-action-copy {
-    width: calc(100% - 44px);
-  }
-
-  .pending-action-buttons {
+  .thread-inner {
+    display: flex;
     width: 100%;
-    justify-content: flex-start;
-    padding-left: 44px;
+    min-height: 100%;
+    flex: 1;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 16px 24px;
+  }
+
+  .thread-older {
+    display: flex;
+    justify-content: center;
+  }
+
+  .thread-older-btn,
+  .starter-prompts button {
+    display: inline-flex;
+    min-height: 28px;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border: 1px solid var(--stroke);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--ink-subtle);
+    font-size: 12px;
+    font-weight: 500;
+    transition:
+      border-color 150ms var(--ease-out),
+      background 150ms var(--ease-out);
+  }
+
+  .thread-older-btn {
+    padding: 4px 12px;
+  }
+
+  .thread-older-btn:hover:not(:disabled),
+  .starter-prompts button:hover:not(:disabled) {
+    border-color: var(--stroke-strong);
+    background: var(--surface-weak);
+  }
+
+  .thread-empty {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    margin: auto;
+    padding: 40px 16px;
+    text-align: center;
+  }
+
+  .thread-empty p {
+    max-width: 280px;
+    margin: 0;
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  .starter-prompts {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  .starter-prompts button {
+    padding: 4px 12px;
+  }
+
+  .message-row {
+    animation: message-in 200ms var(--ease-out);
+  }
+
+  @keyframes message-in {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
   }
 
   .message-row time {
-    display: none;
+    flex-shrink: 0;
+    align-self: flex-start;
+    margin-top: 8px;
+    color: var(--ink-muted);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    opacity: 0;
+    transition: opacity 150ms ease-out;
+  }
+
+  .message-row:hover time {
+    opacity: 1;
+  }
+
+  .message-row-user {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+  }
+
+  .message-user-line {
+    display: flex;
+    max-width: 100%;
+    align-items: flex-end;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .message-row-user time {
+    align-self: flex-end;
+    margin-bottom: 7px;
+  }
+
+  .message-row-agent {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
   }
 
   .message-agent-content {
-    max-width: calc(100% - 38px);
+    display: flex;
+    min-width: 0;
+    max-width: min(36rem, 100%);
+    flex: 1;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
   }
 
-  .composer-hints {
+  .message-text,
+  .message-bubble {
+    color: var(--ink);
+    font-size: 14px;
+    line-height: 20px;
+    word-break: break-word;
+  }
+
+  .message-bubble-user {
+    max-width: min(30rem, 85%);
+    border-radius: 12px;
+    background: var(--surface-weak);
+    padding: 8px 12px;
+    white-space: pre-wrap;
+  }
+
+  .message-row[data-status="failed"] .message-bubble-user {
+    box-shadow: 0 0 0 1px var(--danger-line);
+  }
+
+  .message-failed {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--danger);
+    font-size: 11px;
+    font-weight: 500;
+  }
+
+  .md > :first-child {
+    margin-top: 0;
+  }
+
+  .md > :last-child {
+    margin-bottom: 0;
+  }
+
+  .md p {
+    margin: 0 0 8px;
+  }
+
+  .md a,
+  .message-card > a {
+    color: var(--primary);
+    font-weight: 500;
+    text-decoration: underline;
+    text-decoration-color: var(--primary-line);
+    text-underline-offset: 2px;
+  }
+
+  .md code {
+    border-radius: 5px;
+    background: var(--surface-weak);
+    box-shadow: inset 0 0 0 1px var(--stroke);
+    padding: 1px 5px;
+    font-size: 0.82em;
+  }
+
+  .md pre {
+    max-width: 100%;
+    overflow-x: auto;
+    border-radius: 8px;
+    background: var(--surface-weak);
+    box-shadow: inset 0 0 0 1px var(--stroke);
+    padding: 10px 12px;
+    font-size: 11px;
+    line-height: 1.55;
+  }
+
+  .md pre code {
+    background: none;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .md ul,
+  .md ol {
+    display: grid;
+    gap: 4px;
+    margin: 8px 0;
+    padding-left: 20px;
+  }
+
+  .md blockquote {
+    margin: 8px 0;
+    border-left: 1px solid var(--stroke-strong);
+    padding-left: 12px;
+    color: var(--ink-subtle);
+  }
+
+  .md h1,
+  .md h2,
+  .md h3 {
+    margin: 16px 0 6px;
+    font-size: 1em;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .md table {
+    width: 100%;
+    margin: 8px 0;
+    border: 1px solid var(--stroke);
+    border-radius: 8px;
+    border-collapse: separate;
+    border-spacing: 0;
     overflow: hidden;
+    font-size: 12px;
+  }
+
+  .md th,
+  .md td {
+    padding: 6px 9px;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  .md th {
+    background: var(--surface-weak);
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  .md tr + tr td {
+    border-top: 1px solid var(--stroke);
+  }
+
+  .stream-cursor {
+    display: inline-block;
+    width: 2px;
+    height: 14px;
+    margin-left: 2px;
+    animation: cursor-pulse 1s ease-in-out infinite;
+    background: var(--ink);
+    vertical-align: -2px;
+  }
+
+  @keyframes cursor-pulse {
+    50% {
+      opacity: 0.2;
+    }
+  }
+
+  .message-card {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    gap: 10px;
+    border: 1px solid var(--stroke);
+    border-radius: 16px 16px 16px 6px;
+    background: var(--surface);
+    box-shadow: var(--shadow-xs);
+    padding: 10px 14px;
+  }
+
+  .message-card img {
+    width: 100%;
+    max-height: 160px;
+    border-radius: 8px;
+    object-fit: cover;
+  }
+
+  .message-card h2 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .message-card-subtitle {
+    margin: -6px 0 0;
+    color: var(--ink-soft);
+    font-size: 12px;
+  }
+
+  .message-card hr {
+    width: 100%;
+    margin: 0;
+    border: 0;
+    border-top: 1px solid var(--stroke);
+  }
+
+  .message-card > a {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    align-self: flex-start;
+    font-size: 12px;
+    text-decoration: none;
+  }
+
+  .message-card-actions,
+  .tool-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .message-card-actions button,
+  .button {
+    display: inline-flex;
+    min-height: 28px;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border: 1px solid var(--stroke);
+    border-radius: 6px;
+    background: var(--surface);
+    padding: 4px 10px;
+    color: var(--ink-subtle);
+    font-size: 12px;
+    font-weight: 500;
+    text-decoration: none;
+    transition:
+      border-color 150ms var(--ease-out),
+      background 150ms var(--ease-out);
+  }
+
+  .message-card-actions button:hover:not(:disabled),
+  .button-secondary:hover:not(:disabled) {
+    border-color: var(--stroke-strong);
+    background: var(--surface-weak);
+  }
+
+  .message-card-actions button[data-style="primary"],
+  .button-primary {
+    border-color: var(--primary);
+    background: var(--primary);
+    color: #ffffff;
+  }
+
+  .message-card-actions button[data-style="primary"]:hover:not(:disabled),
+  .button-primary:hover:not(:disabled) {
+    border-color: var(--primary-hover);
+    background: var(--primary-hover);
+  }
+
+  .message-card-actions button[data-style="danger"] {
+    border-color: var(--danger-line);
+    color: var(--danger);
+  }
+
+  .tool-chip,
+  .part-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--ink-soft);
+    font-size: 12px;
+  }
+
+  .tool-chip code,
+  .part-status code {
+    font-size: 12px;
+  }
+
+  .tool-chip[data-state="failed"],
+  .part-status [data-tone="danger"] {
+    color: var(--danger);
+  }
+
+  .part-status [data-tone="ok"] {
+    color: var(--ink-subtle);
+  }
+
+  .typing-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--ink-soft);
+    animation: message-in 200ms var(--ease-out);
+  }
+
+  .typing-label {
+    font-size: 12px;
+  }
+
+  .chat-foot {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .chat-foot::before {
+    position: absolute;
+    right: 0;
+    bottom: 100%;
+    left: 0;
+    height: 32px;
+    background: linear-gradient(to top, var(--surface), transparent);
+    content: "";
+    pointer-events: none;
+  }
+
+  .chat-foot-inner {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px 16px 16px;
+  }
+
+  .decision-card {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    gap: 12px;
+    border: 1px solid var(--stroke);
+    border-radius: 8px;
+    background: var(--surface-weak);
+    padding: 11px;
+    animation: message-in 200ms var(--ease-out);
+  }
+
+  .decision-card-icon {
+    display: grid;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--surface);
+    box-shadow: inset 0 0 0 1px var(--stroke);
+    color: var(--ink-soft);
+  }
+
+  .decision-card-icon-warning {
+    background: var(--warning-soft);
+    box-shadow: none;
+    color: var(--warning);
+  }
+
+  .decision-card-copy {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .decision-card-copy h2,
+  .decision-card-copy p {
+    margin: 0;
+  }
+
+  .decision-card-copy h2 {
+    overflow: hidden;
+    font-size: 13px;
+    font-weight: 600;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
-}
 
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    scroll-behavior: auto !important;
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+  .decision-card-copy p {
+    margin-top: 2px;
+    color: var(--ink-soft);
+    font-size: 12px;
   }
-}
+
+  .decision-card-copy code {
+    font-size: 12px;
+  }
+
+  .decision-card-copy details {
+    margin-top: 6px;
+  }
+
+  .decision-card-copy summary {
+    width: fit-content;
+    cursor: pointer;
+    color: var(--ink-soft);
+    font-size: 12px;
+  }
+
+  .decision-card-copy pre {
+    max-height: 140px;
+    overflow: auto;
+    margin: 6px 0 0;
+    border-radius: 8px;
+    background: var(--surface);
+    padding: 8px;
+    font-size: 10px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+
+  .decision-card-buttons {
+    display: flex;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 6px;
+  }
+
+.decision-card-copy .decision-card-error {
+  color: var(--danger);
 }
 
-@media (max-width: 680px) {
-  .novu-agent-chat.agent-chat-page {
-    padding: 0;
+  .banner-error {
+    border: 1px solid var(--danger-line);
+    border-radius: 8px;
+    background: var(--danger-soft);
+    padding: 8px 12px;
+    color: var(--danger);
+    font-size: 12px;
+  }
+
+  .composer-box {
+    display: flex;
+    min-height: 108px;
+    flex-direction: column;
+    border: 1px solid rgba(42, 28, 0, 0.07);
+    border-radius: 12px;
+    background: var(--surface);
+    box-shadow:
+      0 8px 12px rgba(25, 25, 25, 0.03),
+      0 2px 6px rgba(25, 25, 25, 0.03);
+    padding: 12px 8px 8px 16px;
+    transition: box-shadow 150ms ease-out;
+  }
+
+  .composer-box:focus-within {
+    box-shadow:
+      0 8px 12px rgba(25, 25, 25, 0.03),
+      0 2px 6px rgba(25, 25, 25, 0.03),
+      0 0 0 1px rgba(42, 28, 0, 0.14);
+  }
+
+  .composer textarea {
+    min-width: 0;
+    min-height: 60px;
+    max-height: 128px;
+    flex: 1;
+    resize: none;
+    overflow-y: auto;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    padding: 0 8px 0 0;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.4;
+  }
+
+  .composer textarea::placeholder {
+    color: var(--ink-muted);
+  }
+
+  .composer-toolbar {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .composer-send {
+    display: grid;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    place-items: center;
+    border: 0;
+    border-radius: 50%;
+    background: var(--primary);
+    color: #ffffff;
+    transition:
+      background 150ms ease-out,
+      transform 100ms ease-out;
+  }
+
+  .composer-send:hover:not(:disabled) {
+    background: var(--primary-hover);
+  }
+
+  .composer-send:active:not(:disabled) {
+    transform: scale(0.94);
+  }
+
+  .spinner {
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: spin 700ms linear infinite;
+  }
+
+  .button-primary .spinner,
+  .composer-send .spinner {
+    border-color: rgba(255, 255, 255, 0.45);
+    border-top-color: #ffffff;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (max-width: 680px) {
+    .thread-inner,
+    .chat-foot-inner {
+      padding-right: 12px;
+      padding-left: 12px;
+    }
+
+    .decision-card {
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+
+    .decision-card-copy {
+      width: calc(100% - 44px);
+    }
+
+    .decision-card-buttons {
+      width: 100%;
+      justify-content: flex-start;
+      padding-left: 44px;
+    }
+
+    .message-row time {
+      display: none;
+    }
+
+    .message-agent-content {
+      max-width: 100%;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      scroll-behavior: auto !important;
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
   }
 }

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/icons.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/icons.tsx
@@ -89,6 +89,26 @@ export function CheckIcon({ size = 12, className }: IconProps) {
   );
 }
 
+export function TerminalIcon({ size = 20, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M4 17V7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Z" />
+      <path d="m8 12 2.5 2.5L16 9" />
+    </svg>
+  );
+}
+
 export function ShieldIcon({ size = 15, className }: IconProps) {
   return (
     <svg

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/message-bubble.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/message-bubble.tsx
@@ -1,30 +1,37 @@
 'use client';
 
 import type { AgentMessage, UseAgentChatResult } from '@novu/react';
-import { ArrowUpRightIcon, ChatIcon, ToolIcon, WarningIcon } from './icons';
+import { ArrowUpRightIcon, WarningIcon } from './icons';
 import { Markdown } from './markdown';
 import { formatTime, safeExternalUrl } from './message-utils';
+import { McpConnectionCard, ToolApprovalCard } from './pending-action-card';
 
 type AgentMessagePart = AgentMessage['parts'][number];
 type TextPart = Extract<AgentMessagePart, { type: 'text' }>;
 type ToolPart = Extract<AgentMessagePart, { type: 'tool' }>;
 type CardPart = Extract<AgentMessagePart, { type: 'card' }>;
+type ApprovalPart = Extract<AgentMessagePart, { type: 'approval' }>;
+type McpConnectionPart = Extract<AgentMessagePart, { type: 'mcp-connection' }>;
 type CardAction = Parameters<UseAgentChatResult['sendAction']>[0];
 
 type MessageRowProps = {
   message: AgentMessage;
-  showAvatar: boolean;
   onCardAction: UseAgentChatResult['sendAction'];
+  onRespond: UseAgentChatResult['respondToAction'];
   cardActionsDisabled: boolean;
 };
 
-export function MessageRow({ message, showAvatar, onCardAction, cardActionsDisabled }: MessageRowProps) {
+export function MessageRow({ message, onCardAction, onRespond, cardActionsDisabled }: MessageRowProps) {
   const isUser = message.role === 'user';
   const textParts = message.parts.filter((part): part is TextPart => part.type === 'text');
   const text = textParts.map((part) => part.text).join('');
   const isStreaming = textParts.some((part) => part.state === 'streaming');
   const tools = message.parts.filter((part): part is ToolPart => part.type === 'tool');
   const cards = message.parts.filter((part): part is CardPart => part.type === 'card');
+  const approvals = message.parts.filter((part): part is ApprovalPart => part.type === 'approval');
+  const mcpConnections = message.parts.filter((part): part is McpConnectionPart => part.type === 'mcp-connection');
+  const gatedToolUseIds = new Set(approvals.map((part) => part.toolUseId));
+  const visibleTools = tools.filter((tool) => !gatedToolUseIds.has(tool.toolUseId));
   const time = formatTime(message.createdAt);
   const failed = message.status === 'failed';
 
@@ -45,23 +52,15 @@ export function MessageRow({ message, showAvatar, onCardAction, cardActionsDisab
     );
   }
 
-  if (!text && tools.length === 0 && cards.length === 0) {
-    return null;
-  }
+  const hasContent =
+    Boolean(text) || visibleTools.length > 0 || cards.length > 0 || approvals.length > 0 || mcpConnections.length > 0;
+  if (!hasContent) return null;
 
   return (
     <article className="message-row message-row-agent">
-      {showAvatar ? (
-        <span className="agent-avatar" aria-hidden>
-          <ChatIcon size={14} />
-        </span>
-      ) : (
-        <span className="agent-avatar-spacer" aria-hidden />
-      )}
-
       <div className="message-agent-content">
         {text ? (
-          <div className="message-bubble message-bubble-agent">
+          <div className="message-text">
             <Markdown text={text} />
             {isStreaming ? <span className="stream-cursor" aria-hidden /> : null}
           </div>
@@ -76,13 +75,21 @@ export function MessageRow({ message, showAvatar, onCardAction, cardActionsDisab
           />
         ))}
 
-        {tools.length > 0 ? (
+        {visibleTools.length > 0 ? (
           <div className="tool-list">
-            {tools.map((tool) => (
+            {visibleTools.map((tool) => (
               <ToolChip key={tool.toolUseId} tool={tool} />
             ))}
           </div>
         ) : null}
+
+        {approvals.map((part) => (
+          <ToolApprovalCard key={part.approvalId} part={part} disabled={cardActionsDisabled} onRespond={onRespond} />
+        ))}
+
+        {mcpConnections.map((part) => (
+          <McpConnectionCard key={part.actionId} part={part} />
+        ))}
       </div>
 
       {time ? <time>{time}</time> : null}
@@ -216,6 +223,8 @@ function MessageCard({
                 ))}
               </div>
             );
+          default:
+            return null;
         }
       })}
     </section>
@@ -228,8 +237,8 @@ function ToolChip({ tool }: { tool: ToolPart }) {
 
   return (
     <span className="tool-chip" data-state={failed ? 'failed' : running ? 'running' : 'complete'}>
-      {running ? <span className="spinner" aria-hidden /> : failed ? <WarningIcon size={12} /> : <ToolIcon size={12} />}
-      <span>{running ? 'Running' : failed ? 'Failed' : 'Used'}:</span>
+      {running ? <span className="spinner" aria-hidden /> : null}
+      <span>{running ? 'Running' : failed ? 'Failed' : 'Used'}</span>
       <code>{tool.toolName}</code>
     </span>
   );

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/message-bubble.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/message-bubble.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { AgentMessage, UseAgentChatResult } from '@novu/react';
-import { ArrowUpRightIcon, WarningIcon } from './icons';
+import type { ReactNode } from 'react';
+import { ArrowUpRightIcon, ChevronIcon, WarningIcon } from './icons';
 import { Markdown } from './markdown';
 import { formatTime, safeExternalUrl } from './message-utils';
 import { McpConnectionCard, ToolApprovalCard } from './pending-action-card';
@@ -14,6 +15,88 @@ type ApprovalPart = Extract<AgentMessagePart, { type: 'approval' }>;
 type McpConnectionPart = Extract<AgentMessagePart, { type: 'mcp-connection' }>;
 type CardAction = Parameters<UseAgentChatResult['sendAction']>[0];
 
+function prettyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatToolOutput(output: ToolPart['output']): string | undefined {
+  if (!output?.length) {
+    return undefined;
+  }
+
+  const chunks = output.map((part) => {
+    switch (part.type) {
+      case 'text':
+        return part.text;
+      case 'json':
+        return prettyJson(part.value);
+      case 'citation':
+        return part.title ? `${part.title}\n${part.url}` : part.url;
+      case 'media':
+        return part.name ?? part.mediaType;
+      default:
+        return prettyJson(part.data);
+    }
+  });
+
+  return chunks.filter(Boolean).join('\n\n') || undefined;
+}
+
+function PayloadPeek({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="payload-peek">
+      <span className="payload-peek-label">{label}</span>
+      <pre className="payload-peek-value">{value}</pre>
+    </div>
+  );
+}
+
+function ExpandableRow({
+  id,
+  className,
+  summary,
+  children,
+}: {
+  id?: string;
+  className?: string;
+  summary: ReactNode;
+  children?: ReactNode;
+}) {
+  if (!children) {
+    return (
+      <span id={id} className={className}>
+        {summary}
+      </span>
+    );
+  }
+
+  return (
+    <details id={id} className={`expandable-row${className ? ` ${className}` : ''}`}>
+      <summary>{summary}</summary>
+      <div className="expandable-body">{children}</div>
+    </details>
+  );
+}
+
+function isPoweredByWatermark(content: string): boolean {
+  const trimmed = content.trim();
+
+  return /^powered by/i.test(trimmed) && /novu/i.test(trimmed);
+}
+
+function stripPoweredByWatermark(text: string): string {
+  return text
+    .replace(
+      /(?:\n+)?(?:Powered by\s*\[[^\]]+\]\([^)]+\)|Powered by\s*<https?:\/\/[^|>]+\|[^>]+>|\[Powered by Novu\]\([^)]+\)|Powered by\s*<a\b[^>]*>[\s\S]*?<\/a>|Powered by Novu\u200B?)\s*$/i,
+      ''
+    )
+    .trimEnd();
+}
+
 type MessageRowProps = {
   message: AgentMessage;
   onCardAction: UseAgentChatResult['sendAction'];
@@ -24,10 +107,17 @@ type MessageRowProps = {
 export function MessageRow({ message, onCardAction, onRespond, cardActionsDisabled }: MessageRowProps) {
   const isUser = message.role === 'user';
   const textParts = message.parts.filter((part): part is TextPart => part.type === 'text');
-  const text = textParts.map((part) => part.text).join('');
+  const cards = message.parts.filter((part): part is CardPart => part.type === 'card');
+  const unwrappedCardText = cards
+    .map((part) => brandedReplyMarkdown(part.card))
+    .filter((value): value is string => Boolean(value))
+    .join('\n\n');
+  const visibleCards = cards.filter((part) => brandedReplyMarkdown(part.card) === null);
+  const text = stripPoweredByWatermark(
+    [textParts.map((part) => part.text).join(''), unwrappedCardText].filter(Boolean).join('\n\n')
+  );
   const isStreaming = textParts.some((part) => part.state === 'streaming');
   const tools = message.parts.filter((part): part is ToolPart => part.type === 'tool');
-  const cards = message.parts.filter((part): part is CardPart => part.type === 'card');
   const approvals = message.parts.filter((part): part is ApprovalPart => part.type === 'approval');
   const mcpConnections = message.parts.filter((part): part is McpConnectionPart => part.type === 'mcp-connection');
   const gatedToolUseIds = new Set(approvals.map((part) => part.toolUseId));
@@ -53,7 +143,11 @@ export function MessageRow({ message, onCardAction, onRespond, cardActionsDisabl
   }
 
   const hasContent =
-    Boolean(text) || visibleTools.length > 0 || cards.length > 0 || approvals.length > 0 || mcpConnections.length > 0;
+    Boolean(text) ||
+    visibleTools.length > 0 ||
+    visibleCards.length > 0 ||
+    approvals.length > 0 ||
+    mcpConnections.length > 0;
   if (!hasContent) return null;
 
   return (
@@ -66,7 +160,7 @@ export function MessageRow({ message, onCardAction, onRespond, cardActionsDisabl
           </div>
         ) : null}
 
-        {cards.map((part, index) => (
+        {visibleCards.map((part, index) => (
           <MessageCard
             key={`${message.id}-card-${index}`}
             card={part.card}
@@ -76,7 +170,7 @@ export function MessageRow({ message, onCardAction, onRespond, cardActionsDisabl
         ))}
 
         {visibleTools.length > 0 ? (
-          <div className="tool-list">
+          <div className="tool-list tool-list-stack">
             {visibleTools.map((tool) => (
               <ToolChip key={tool.toolUseId} tool={tool} />
             ))}
@@ -118,6 +212,38 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function readString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function brandedReplyMarkdown(card: Record<string, unknown>): string | null {
+  if (readString(card.title) || readString(card.subtitle) || safeExternalUrl(readString(card.imageUrl))) {
+    return null;
+  }
+
+  const children = Array.isArray(card.children) ? card.children : [];
+  const texts: string[] = [];
+  let sawWatermark = false;
+
+  for (const child of children) {
+    if (!isRecord(child) || child.type !== 'text') {
+      return null;
+    }
+
+    const content = readString(child.content);
+    if (!content) continue;
+
+    if (isPoweredByWatermark(content)) {
+      sawWatermark = true;
+      continue;
+    }
+
+    texts.push(content);
+  }
+
+  if (!sawWatermark || texts.length === 0) {
+    return null;
+  }
+
+  return texts.join('\n\n');
 }
 
 function cardButtonsFromNode(node: unknown): CardButtonView[] {
@@ -234,12 +360,40 @@ function MessageCard({
 function ToolChip({ tool }: { tool: ToolPart }) {
   const running = tool.state === 'input-streaming' || tool.state === 'input-available';
   const failed = tool.state === 'output-error';
+  let statusLabel = 'Used';
+
+  if (running) {
+    statusLabel = 'Running';
+  } else if (failed) {
+    statusLabel = 'Failed';
+  }
+
+  const inputPreview = tool.input && Object.keys(tool.input).length > 0 ? prettyJson(tool.input) : undefined;
+  const outputPreview = formatToolOutput(tool.output);
 
   return (
-    <span className="tool-chip" data-state={failed ? 'failed' : running ? 'running' : 'complete'}>
-      {running ? <span className="spinner" aria-hidden /> : null}
-      <span>{running ? 'Running' : failed ? 'Failed' : 'Used'}</span>
-      <code>{tool.toolName}</code>
-    </span>
+    <ExpandableRow
+      summary={
+        <span
+          className={`tool-chip${failed ? ' tool-chip-failed' : ''}`}
+          data-state={failed ? 'failed' : running ? 'running' : 'complete'}
+        >
+          {running ? (
+            <span className="spinner" aria-hidden />
+          ) : (
+            <ChevronIcon size={14} className="expandable-chevron" />
+          )}
+          <span>{statusLabel}</span>
+          <code>{tool.toolName}</code>
+        </span>
+      }
+    >
+      {inputPreview || outputPreview ? (
+        <>
+          {inputPreview ? <PayloadPeek label="Input" value={inputPreview} /> : null}
+          {outputPreview ? <PayloadPeek label="Result" value={outputPreview} /> : null}
+        </>
+      ) : null}
+    </ExpandableRow>
   );
 }

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/pending-action-card.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/pending-action-card.tsx
@@ -1,37 +1,37 @@
 'use client';
 
-import type { AgentPendingAction, UseAgentChatResult } from '@novu/react';
+import type { AgentMessage, UseAgentChatResult } from '@novu/react';
 import { useState } from 'react';
 import { ArrowUpRightIcon, PlugIcon, ShieldIcon } from './icons';
 import { safeExternalUrl } from './message-utils';
 
 type RespondToAction = UseAgentChatResult['respondToAction'];
 type Decision = Parameters<RespondToAction>[0]['decision'];
+type ApprovalPart = Extract<AgentMessage['parts'][number], { type: 'approval' }>;
+type McpConnectionPart = Extract<AgentMessage['parts'][number], { type: 'mcp-connection' }>;
 
-type PendingActionCardProps = {
-  action: AgentPendingAction;
-  disabled: boolean;
-  onRespond: RespondToAction;
-};
+export function McpConnectionCard({ part }: { part: McpConnectionPart }) {
+  const authorizeUrl = safeExternalUrl(part.authorizeUrlWithAutoApprove || part.authorizeUrl);
 
-export function PendingActionCard({ action, disabled, onRespond }: PendingActionCardProps) {
-  if (action.type === 'mcp-connection') {
-    return <McpConnectionCard action={action} />;
+  if (part.state !== 'pending') {
+    const connected = part.state === 'connected';
+
+    return (
+      <span className="part-status">
+        <span>{part.displayName}</span>
+        <span aria-hidden>·</span>
+        <span data-tone={connected ? 'ok' : 'danger'}>{connected ? 'Connected' : part.message || 'Failed'}</span>
+      </span>
+    );
   }
 
-  return <ToolApprovalCard action={action} disabled={disabled} onRespond={onRespond} />;
-}
-
-function McpConnectionCard({ action }: { action: Extract<AgentPendingAction, { type: 'mcp-connection' }> }) {
-  const authorizeUrl = safeExternalUrl(action.authorizeUrlWithAutoApprove || action.authorizeUrl);
-
   return (
-    <section className="pending-action">
-      <span className="pending-action-icon" aria-hidden>
+    <section className="decision-card">
+      <span className="decision-card-icon" aria-hidden>
         <PlugIcon />
       </span>
-      <div className="pending-action-copy">
-        <h2>Connect {action.displayName}</h2>
+      <div className="decision-card-copy">
+        <h2>Connect {part.displayName}?</h2>
         <p>The agent needs authorization to continue.</p>
       </div>
       <a
@@ -51,17 +51,29 @@ function McpConnectionCard({ action }: { action: Extract<AgentPendingAction, { t
   );
 }
 
-function ToolApprovalCard({
-  action,
+export function ToolApprovalCard({
+  part,
   disabled,
   onRespond,
 }: {
-  action: Extract<AgentPendingAction, { type: 'tool-approval' }>;
+  part: ApprovalPart;
   disabled: boolean;
   onRespond: RespondToAction;
 }) {
   const [busy, setBusy] = useState<Decision>();
   const [failure, setFailure] = useState<string>();
+
+  if (part.state !== 'pending') {
+    const approved = part.state === 'approved';
+
+    return (
+      <span className="part-status">
+        <code>{part.toolName}</code>
+        <span aria-hidden>·</span>
+        <span data-tone={approved ? 'ok' : 'danger'}>{approved ? 'Approved' : 'Denied'}</span>
+      </span>
+    );
+  }
 
   async function respond(decision: Decision) {
     if (disabled || busy) return;
@@ -70,7 +82,7 @@ function ToolApprovalCard({
     setFailure(undefined);
 
     try {
-      const result = await onRespond({ actionId: action.id, decision });
+      const result = await onRespond({ actionId: part.approvalId, decision });
       if (result.error) setFailure(result.error.message);
     } finally {
       setBusy(undefined);
@@ -78,30 +90,30 @@ function ToolApprovalCard({
   }
 
   return (
-    <section className="pending-action pending-action-approval">
-      <span className="pending-action-icon pending-action-icon-warning" aria-hidden>
+    <section className="decision-card">
+      <span className="decision-card-icon decision-card-icon-warning" aria-hidden>
         <ShieldIcon />
       </span>
 
-      <div className="pending-action-copy">
+      <div className="decision-card-copy">
         <h2>
-          Run <code>{action.toolName}</code>?
+          Run <code>{part.toolName}</code>?
         </h2>
         <p>The agent is waiting for your approval.</p>
-        {Object.keys(action.input ?? {}).length > 0 ? (
+        {Object.keys(part.input ?? {}).length > 0 ? (
           <details>
             <summary>Review arguments</summary>
-            <pre>{JSON.stringify(action.input, null, 2)}</pre>
+            <pre>{JSON.stringify(part.input, null, 2)}</pre>
           </details>
         ) : null}
         {failure ? (
-          <p className="pending-action-error" role="alert">
+          <p className="decision-card-error" role="alert">
             {failure}
           </p>
         ) : null}
       </div>
 
-      <div className="pending-action-buttons">
+      <div className="decision-card-buttons">
         <button
           type="button"
           className="button button-secondary"
@@ -120,7 +132,7 @@ function ToolApprovalCard({
           {busy === 'approved' ? <span className="spinner" aria-hidden /> : null}
           Approve once
         </button>
-        {action.trustToolActionId ? (
+        {part.trustToolActionId ? (
           <button
             type="button"
             className="button button-secondary"
@@ -130,14 +142,14 @@ function ToolApprovalCard({
             Always allow this tool
           </button>
         ) : null}
-        {action.trustServerActionId && action.source?.type === 'mcp' ? (
+        {part.trustServerActionId && part.source?.type === 'mcp' ? (
           <button
             type="button"
             className="button button-secondary"
             disabled={disabled || Boolean(busy)}
             onClick={() => void respond('trust-server')}
           >
-            Always allow {action.source.serverName}
+            Always allow {part.source.serverName}
           </button>
         ) : null}
       </div>

--- a/packages/novu/src/commands/connect/templates/agent-chat/ts/pending-action-card.tsx
+++ b/packages/novu/src/commands/connect/templates/agent-chat/ts/pending-action-card.tsx
@@ -1,14 +1,129 @@
 'use client';
 
 import type { AgentMessage, UseAgentChatResult } from '@novu/react';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
-import { ArrowUpRightIcon, PlugIcon, ShieldIcon } from './icons';
+import { ArrowUpRightIcon, ChevronIcon, PlugIcon, TerminalIcon } from './icons';
 import { safeExternalUrl } from './message-utils';
 
 type RespondToAction = UseAgentChatResult['respondToAction'];
 type Decision = Parameters<RespondToAction>[0]['decision'];
 type ApprovalPart = Extract<AgentMessage['parts'][number], { type: 'approval' }>;
 type McpConnectionPart = Extract<AgentMessage['parts'][number], { type: 'mcp-connection' }>;
+
+function prettyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function PayloadPeek({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="payload-peek">
+      <span className="payload-peek-label">{label}</span>
+      <pre className="payload-peek-value">{value}</pre>
+    </div>
+  );
+}
+
+function ExpandableRow({
+  id,
+  className,
+  summary,
+  children,
+}: {
+  id?: string;
+  className?: string;
+  summary: ReactNode;
+  children?: ReactNode;
+}) {
+  if (!children) {
+    return (
+      <span id={id} className={className}>
+        {summary}
+      </span>
+    );
+  }
+
+  return (
+    <details id={id} className={`expandable-row${className ? ` ${className}` : ''}`}>
+      <summary>{summary}</summary>
+      <div className="expandable-body">{children}</div>
+    </details>
+  );
+}
+
+function ToolApprovalActions({
+  disabled,
+  busy,
+  onRespond,
+  trustToolActionId,
+  trustServerActionId,
+  source,
+}: {
+  disabled: boolean;
+  busy?: Decision;
+  onRespond: (decision: Decision) => void;
+  trustToolActionId?: string;
+  trustServerActionId?: string;
+  source?: ApprovalPart['source'];
+}) {
+  const trustServerLabel = trustServerActionId && source?.type === 'mcp' ? source.serverName : undefined;
+  const hasTrustActions = Boolean(trustToolActionId) || Boolean(trustServerLabel);
+
+  return (
+    <div className={`decision-card-actions${hasTrustActions ? ' decision-card-actions-split' : ''}`}>
+      {hasTrustActions ? (
+        <div className="decision-card-trust">
+          {trustToolActionId ? (
+            <button
+              type="button"
+              className="button button-secondary"
+              disabled={disabled || Boolean(busy)}
+              onClick={() => onRespond('trust-tool')}
+            >
+              {busy === 'trust-tool' ? <span className="spinner" aria-hidden /> : null}
+              Always allow for this tool
+            </button>
+          ) : null}
+          {trustServerLabel ? (
+            <button
+              type="button"
+              className="button button-secondary"
+              disabled={disabled || Boolean(busy)}
+              onClick={() => onRespond('trust-server')}
+            >
+              {busy === 'trust-server' ? <span className="spinner" aria-hidden /> : null}
+              Always allow {trustServerLabel}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+      <div className="decision-card-primary-actions">
+        <button
+          type="button"
+          className="button button-secondary"
+          disabled={disabled || Boolean(busy)}
+          onClick={() => onRespond('denied')}
+        >
+          {busy === 'denied' ? <span className="spinner" aria-hidden /> : null}
+          Deny
+        </button>
+        <button
+          type="button"
+          className="button button-primary"
+          disabled={disabled || Boolean(busy)}
+          onClick={() => onRespond('approved')}
+        >
+          {busy === 'approved' ? <span className="spinner" aria-hidden /> : null}
+          Approve once
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export function McpConnectionCard({ part }: { part: McpConnectionPart }) {
   const authorizeUrl = safeExternalUrl(part.authorizeUrlWithAutoApprove || part.authorizeUrl);
@@ -18,6 +133,7 @@ export function McpConnectionCard({ part }: { part: McpConnectionPart }) {
 
     return (
       <span className="part-status">
+        <ChevronIcon size={14} className="part-status-chevron" />
         <span>{part.displayName}</span>
         <span aria-hidden>·</span>
         <span data-tone={connected ? 'ok' : 'danger'}>{connected ? 'Connected' : part.message || 'Failed'}</span>
@@ -26,8 +142,8 @@ export function McpConnectionCard({ part }: { part: McpConnectionPart }) {
   }
 
   return (
-    <section className="decision-card">
-      <span className="decision-card-icon" aria-hidden>
+    <section className="decision-card decision-card-mcp">
+      <span className="decision-card-mcp-icon" aria-hidden>
         <PlugIcon />
       </span>
       <div className="decision-card-copy">
@@ -62,16 +178,24 @@ export function ToolApprovalCard({
 }) {
   const [busy, setBusy] = useState<Decision>();
   const [failure, setFailure] = useState<string>();
+  const inputPreview = part.input && Object.keys(part.input).length > 0 ? prettyJson(part.input) : undefined;
 
   if (part.state !== 'pending') {
     const approved = part.state === 'approved';
 
     return (
-      <span className="part-status">
-        <code>{part.toolName}</code>
-        <span aria-hidden>·</span>
-        <span data-tone={approved ? 'ok' : 'danger'}>{approved ? 'Approved' : 'Denied'}</span>
-      </span>
+      <ExpandableRow
+        summary={
+          <span className="part-status">
+            <ChevronIcon size={14} className="expandable-chevron" />
+            <code>{part.toolName}</code>
+            <span aria-hidden>·</span>
+            <span data-tone={approved ? 'ok' : 'danger'}>{approved ? 'Approved' : 'Denied'}</span>
+          </span>
+        }
+      >
+        {inputPreview ? <PayloadPeek label="Input" value={inputPreview} /> : null}
+      </ExpandableRow>
     );
   }
 
@@ -90,22 +214,13 @@ export function ToolApprovalCard({
   }
 
   return (
-    <section className="decision-card">
-      <span className="decision-card-icon decision-card-icon-warning" aria-hidden>
-        <ShieldIcon />
-      </span>
-
-      <div className="decision-card-copy">
-        <h2>
-          Run <code>{part.toolName}</code>?
-        </h2>
+    <section className="decision-card decision-card-approval">
+      <div className="decision-card-header">
+        <div className="decision-card-title-row">
+          <TerminalIcon size={20} />
+          <h2>Run {part.toolName}?</h2>
+        </div>
         <p>The agent is waiting for your approval.</p>
-        {Object.keys(part.input ?? {}).length > 0 ? (
-          <details>
-            <summary>Review arguments</summary>
-            <pre>{JSON.stringify(part.input, null, 2)}</pre>
-          </details>
-        ) : null}
         {failure ? (
           <p className="decision-card-error" role="alert">
             {failure}
@@ -113,46 +228,24 @@ export function ToolApprovalCard({
         ) : null}
       </div>
 
-      <div className="decision-card-buttons">
-        <button
-          type="button"
-          className="button button-secondary"
-          disabled={disabled || Boolean(busy)}
-          onClick={() => void respond('denied')}
-        >
-          {busy === 'denied' ? <span className="spinner" aria-hidden /> : null}
-          Deny
-        </button>
-        <button
-          type="button"
-          className="button button-primary"
-          disabled={disabled || Boolean(busy)}
-          onClick={() => void respond('approved')}
-        >
-          {busy === 'approved' ? <span className="spinner" aria-hidden /> : null}
-          Approve once
-        </button>
-        {part.trustToolActionId ? (
-          <button
-            type="button"
-            className="button button-secondary"
-            disabled={disabled || Boolean(busy)}
-            onClick={() => void respond('trust-tool')}
-          >
-            Always allow this tool
-          </button>
-        ) : null}
-        {part.trustServerActionId && part.source?.type === 'mcp' ? (
-          <button
-            type="button"
-            className="button button-secondary"
-            disabled={disabled || Boolean(busy)}
-            onClick={() => void respond('trust-server')}
-          >
-            Always allow {part.source.serverName}
-          </button>
-        ) : null}
-      </div>
+      {inputPreview ? (
+        <details className="decision-card-args">
+          <summary>
+            <ChevronIcon size={14} className="expandable-chevron" />
+            Arguments
+          </summary>
+          <PayloadPeek label="Input" value={inputPreview} />
+        </details>
+      ) : null}
+
+      <ToolApprovalActions
+        disabled={disabled}
+        busy={busy}
+        onRespond={(decision) => void respond(decision)}
+        trustToolActionId={part.trustToolActionId}
+        trustServerActionId={part.trustServerActionId}
+        source={part.source}
+      />
     </section>
   );
 }

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -199,6 +199,7 @@ program
     'Override the Connect browser-auth URL (default follows --region, e.g. dashboard.novu.co)'
   )
   .option('--region <region>', `Novu region (${Object.values(CloudRegionEnum).join(' | ')})`, CloudRegionEnum.US)
+  .option('--staging', 'Shorthand for --region staging', false)
   .option(
     '--prompt <text>',
     'Pre-fill the agent description (alternative to positional <prompt>; positional wins when both are set)'

--- a/packages/shared/src/utils/connect-embed-prompt.spec.ts
+++ b/packages/shared/src/utils/connect-embed-prompt.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildConnectEmbedPrompt,
+  CONNECT_EMBED_TEMPLATE_LOCAL_PATH,
+  CONNECT_EMBED_TEMPLATE_URL,
+} from './connect-embed-prompt';
+
+describe('buildConnectEmbedPrompt', () => {
+  const prompt = buildConnectEmbedPrompt({
+    agentName: 'Support',
+    agentIdentifier: 'support-agent',
+    applicationIdentifier: 'app-id',
+    subscriberId: 'sub-1',
+    connectMode: 'demo',
+  });
+
+  it('points embed agents at the connect template, not dashboard chat', () => {
+    expect(prompt).toContain(CONNECT_EMBED_TEMPLATE_URL);
+    expect(prompt).toContain(CONNECT_EMBED_TEMPLATE_LOCAL_PATH);
+    expect(prompt).not.toContain('apps/dashboard/src/components/agents/agent-chat-panel');
+  });
+
+  it('lists the must-render capabilities and host-app styling rule', () => {
+    expect(prompt).toContain('Must render');
+    expect(prompt).toContain('Approvals + MCP authorize **in the thread**');
+    expect(prompt).toContain('Thinking indicator');
+    expect(prompt).toContain("Match this app's design system");
+    expect(prompt).toContain('do not paste scaffold CSS');
+  });
+});

--- a/packages/shared/src/utils/connect-embed-prompt.ts
+++ b/packages/shared/src/utils/connect-embed-prompt.ts
@@ -4,6 +4,11 @@ export { APPLICATION_IDENTIFIER_PLACEHOLDER, SUBSCRIBER_ID_PLACEHOLDER } from '.
 
 export const CONNECT_EMBED_DOCS_INDEX = 'https://docs.novu.co/llms.txt';
 
+export const CONNECT_EMBED_TEMPLATE_URL =
+  'https://github.com/novuhq/novu/tree/next/packages/novu/src/commands/connect/templates/agent-chat/ts';
+
+export const CONNECT_EMBED_TEMPLATE_LOCAL_PATH = 'packages/novu/src/commands/connect/templates/agent-chat/ts';
+
 export type ConnectEmbedRuntime =
   | 'ai-sdk'
   | 'langchain'
@@ -285,22 +290,29 @@ function renderAgentChatSection(input: { subscriberId: string }): string {
 
 Follow these docs (fetch as \`.md\`). **Skip** dashboard channel-setup steps.
 
-- https://docs.novu.co/agents/channels/agent-chat/quickstart.md — main UI guide
+- https://docs.novu.co/agents/channels/agent-chat/quickstart.md — hook + parts API
 - https://docs.novu.co/platform/sdks/react/hooks/use-agent-chat.md — hook reference
 
-Reference implementation (behavior only — do not copy UI or dashboard imports):
+Must render (capabilities only — match this app's routing, components, and styling):
 
-- GitHub: https://github.com/novuhq/novu/tree/next/apps/dashboard/src/components/agents/agent-chat-panel
-- If the Novu monorepo is checked out locally, read \`apps/dashboard/src/components/agents/agent-chat-panel/\`
-- Study: \`NovuProvider\` (\`apiUrl\` + \`socketUrl\`), \`useAgentChat\`, \`message.parts\`, \`sendAction\`, \`respondToAction\`, composer disable while \`isRunning\` / \`isLoading\`
-- Adapt patterns to this project's framework and styling; do not import dashboard components or design tokens
+- Empty state + 2–3 starter prompts
+- \`message.parts\`: text (markdown + streaming cursor), tool rows, cards (\`sendAction\`)
+- Approvals + MCP authorize **in the thread** via \`respondToAction\` / authorize URL — not a footer stack
+- Thinking indicator from \`typing\` / \`isRunning\` ("Thinking…"); hide it while a pending approval or MCP connect is on screen
+- Composer disabled while \`isRunning\` / \`isLoading\`
+- Error banner
+- Optional: load older messages with \`pagination.hasMore\` / \`pagination.fetchMore\`
+
+If you need a working example of those capabilities:
+
+- GitHub: ${CONNECT_EMBED_TEMPLATE_URL}
+- Local checkout: \`${CONNECT_EMBED_TEMPLATE_LOCAL_PATH}/\`
 
 Hard rules (partly in docs, rest connect-specific):
 
 - Install \`@novu/react\`; no \`<AgentChat />\` component exists.
 - Wire env vars from the Context section; do not hardcode identifiers in source.
-- Render \`message.parts\`, a composer (disable while \`isRunning\` / \`isLoading\`), and tool approvals via \`respondToAction\`.
-- **Match this app's routing and styling** — do not paste the connect scaffold template wholesale.
+- **Match this app's design system** — do not paste scaffold CSS, dashboard components, or dashboard tokens.
 - If HMAC is enabled: follow the quickstart "Going to production" section for \`subscriberHash\` / \`agentHash\`.
 - Smoke-test subscriber id when the app has no auth yet: \`${input.subscriberId}\``;
 }


### PR DESCRIPTION
## Summary

- Restyle the `npx novu connect` Agent Chat scaffold to match dashboard **structure** (full-page thread, flat assistant text, user bubble, in-thread cards / approvals / MCP, Thinking…, starters) with its own CSS tokens and no new UI deps.
- Point embed-into-existing-app agents at that recipe: must-render checklist + GitHub template URL + docs. Stop pointing at dashboard `agent-chat-panel`.
- `--staging` / `--region staging` pin `@novu/react` and `@novu/js` to `rc` in scaffolded apps (not `latest`, not local `file:` links).

Linear: [NV-8680](https://linear.app/novu/issue/NV-8680/upgrade-npx-novu-connect-agent-chat-template-to-dashboard-structure)

```mermaid
flowchart LR
  A[npx novu connect] --> B{empty dir?}
  B -->|yes| C[Copy scaffold template]
  B -->|no| D[Embed prompt]
  D --> E[Checklist + template URL + docs]
  E --> F[Host app styling]
  C --> G[Dashboard structure, own CSS]
```

## Test plan

- [ ] `npx novu connect --channel agent-chat` in an empty dir: empty state is “Hello, I’m your agent…” + the three starters; no subscriber topbar; no footer pending stack
- [ ] Send a message: streaming cursor, Thinking… row, composer locked while running
- [ ] When the agent emits a card / approval / MCP authorize: they render **in the thread**
- [ ] Embed path: prompt mentions the checklist + `packages/novu/src/commands/connect/templates/agent-chat/ts` and does **not** mention `apps/dashboard/.../agent-chat-panel`
- [ ] `--staging` (or `--region staging`) scaffold `package.json` has `"@novu/react": "rc"` and `"@novu/js": "rc"`
- [ ] Without `--staging`, a monorepo checkout still `file:`-links local packages


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refreshes the generated Agent Chat interface and embed guidance while correcting SDK dependency selection for production and staging scaffolds.
- Reworks the scaffold into a full-page threaded chat with inline actions, approvals, tool details, typing state, and starter prompts.
- Directs existing-project integrations to the standalone Agent Chat recipe and required implementation checklist.
- Pins compatible release-candidate Novu SDKs for staging and non-local scaffolds while preserving local package aliases for local API development.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts | Resolves staging and production scaffolds to compatible release-candidate SDKs while retaining local aliases only for local API development. |
| packages/novu/src/commands/connect/resolve-options.ts | Materializes the staging shorthand as the staging region before resolving URLs. |
| packages/novu/src/commands/connect/pipeline/agent-chat/run-agent-chat-setup.ts | Propagates the resolved region into both standalone and merged Agent Chat scaffolding. |
| packages/novu/src/commands/connect/templates/agent-chat/ts/agent-chat.tsx | Adapts the scaffold to the release-candidate pagination and inline-action Agent Chat APIs. |
| packages/novu/src/commands/connect/templates/agent-chat/ts/chat-thread.tsx | Implements the revised full-thread presentation, starter prompts, pagination, and run-status display. |
| packages/shared/src/utils/connect-embed-prompt.ts | Updates embed guidance to reference the standalone template structure instead of dashboard-internal components. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[npx novu connect] --> B[Resolve region and URLs]
  B --> C{Project setup mode}
  C -->|Scaffold| D[Resolve Novu SDK dependencies]
  D --> E{Staging or non-local API?}
  E -->|Yes| F[Install @novu/react and @novu/js rc]
  E -->|Local monorepo API| G[Use local file aliases]
  C -->|Embed| H[Write environment configuration and implementation guidance]
  F --> I[Generate threaded Agent Chat UI]
  G --> I
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;next&#39; into nv-8680-upgrade..."](https://github.com/novuhq/novu/commit/7f3fdbf26859faed42b58c2ee2859649aff0ba2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56604623)</sub>

<!-- /greptile_comment -->