### PR TITLE
fix(novu,shared): pin scaffold SDK packages to npm next on staging/local fixes NV-8680

### DIFF
--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.21.0-rc.5",
+  "version": "2.21.0-rc.7",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.20.1",
+  "version": "2.21.0-rc.5",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {
@@ -52,6 +52,7 @@
     "novu": "./dist/src/index.js"
   },
   "devDependencies": {
+    "@novu/shared": "workspace:*",
     "@types/configstore": "^5.0.1",
     "@types/cross-spawn": "6.0.0",
     "@types/diff": "7.0.2",
@@ -76,7 +77,6 @@
     "@inkjs/ui": "2.0.0",
     "@novu/framework": "workspace:*",
     "@novu/ntfr-client": "^0.0.5",
-    "@novu/shared": "workspace:*",
     "@segment/analytics-node": "^1.1.4",
     "async-sema": "3.0.1",
     "axios": "^1.18.1",

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.21.0-rc.7",
+  "version": "2.21.0-rc.5",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/novu/scripts/build-ui.mjs
+++ b/packages/novu/scripts/build-ui.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { build } from 'esbuild';
@@ -55,4 +56,48 @@ await build({
   ...sharedConfig,
   entryPoints: [resolve(root, 'src/commands/connect/ui/index.tsx')],
   outfile: resolve(root, 'dist/src/commands/connect/ui/index.mjs'),
+});
+
+/**
+ * Bundle the CLI entry, replacing the tsc-emitted dist/src/index.js.
+ *
+ * Packages declared in `dependencies` stay external and install from npm.
+ * Everything else — workspace packages like @novu/shared and their own deps —
+ * is compiled into the bundle, so the published CLI can never skew against a
+ * stale npm build of a workspace package (the UI bundles above already inline
+ * @novu/shared for the same reason).
+ */
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+const npmDependencies = new Set(Object.keys(pkg.dependencies ?? {}));
+
+const externalizeNpmDependencies = {
+  name: 'externalize-npm-dependencies',
+  setup(pluginBuild) {
+    pluginBuild.onResolve({ filter: /^[^./]/ }, (args) => {
+      const packageName = args.path.startsWith('@')
+        ? args.path.split('/').slice(0, 2).join('/')
+        : args.path.split('/')[0];
+      if (npmDependencies.has(packageName)) {
+        return { path: args.path, external: true };
+      }
+
+      // Fall through: workspace packages get bundled, node builtins stay
+      // external via platform: 'node'.
+      return null;
+    });
+  },
+};
+
+await build({
+  entryPoints: [resolve(root, 'src/index.ts')],
+  outfile: resolve(root, 'dist/src/index.js'),
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: ['node18'],
+  jsx: 'automatic',
+  jsxImportSource: 'react',
+  sourcemap: false,
+  logLevel: 'info',
+  plugins: [externalizeNpmDependencies],
 });

--- a/packages/novu/src/commands/connect/index.ts
+++ b/packages/novu/src/commands/connect/index.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import chalk from 'chalk';
@@ -24,7 +25,14 @@ interface UiBundle {
 const dynamicImport = new Function('specifier', 'return import(specifier)') as (specifier: string) => Promise<unknown>;
 
 async function loadInkUi(): Promise<UiBundle> {
-  const bundlePath = path.join(__dirname, 'ui', 'index.mjs');
+  // The Ink bundle is emitted to dist/src/commands/connect/ui/index.mjs.
+  // `__dirname` is this file's directory under the tsc module layout, but
+  // `dist/src` when running from the bundled CLI entry — try both.
+  const candidates = [
+    path.join(__dirname, 'ui', 'index.mjs'),
+    path.join(__dirname, 'commands', 'connect', 'ui', 'index.mjs'),
+  ];
+  const bundlePath = candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[0];
   try {
     const url = pathToFileURL(bundlePath).href;
 

--- a/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.spec.ts
@@ -45,45 +45,31 @@ describe('scaffoldAgentChatProject', () => {
 });
 
 describe('resolveAgentChatNovuDependencies', () => {
-  const localNovuDeps = { reactDir: '/repo/packages/react', jsDir: '/repo/packages/js' };
-
-  it('pins @novu/react and @novu/js to rc on staging, even from a monorepo checkout', () => {
-    expect(resolveAgentChatNovuDependencies(NOVU_STAGING_API_URL, localNovuDeps)).toEqual({
-      react: 'rc',
-      js: 'rc',
-      useLocalAliases: false,
+  it('pins @novu/react and @novu/js to next on staging API', () => {
+    expect(resolveAgentChatNovuDependencies(NOVU_STAGING_API_URL)).toEqual({
+      react: 'next',
+      js: 'next',
     });
   });
 
-  it('uses file: links for a monorepo checkout against a local API only', () => {
-    expect(resolveAgentChatNovuDependencies('http://localhost:3000', localNovuDeps)).toEqual({
-      react: 'file:/repo/packages/react',
-      js: 'file:/repo/packages/js',
-      useLocalAliases: true,
+  it('pins @novu/react and @novu/js to next on local API', () => {
+    expect(resolveAgentChatNovuDependencies('http://localhost:3000')).toEqual({
+      react: 'next',
+      js: 'next',
     });
   });
 
-  it('uses rc from npm when scaffolding from a monorepo against production API', () => {
-    expect(resolveAgentChatNovuDependencies('https://api.novu.co', localNovuDeps)).toEqual({
-      react: 'rc',
-      js: 'rc',
-      useLocalAliases: false,
+  it('uses latest from npm when scaffolding against production API', () => {
+    expect(resolveAgentChatNovuDependencies('https://api.novu.co')).toEqual({
+      react: 'latest',
+      js: 'latest',
     });
   });
 
-  it('uses rc @novu/react when there is no local checkout', () => {
-    expect(resolveAgentChatNovuDependencies('https://api.novu.co', undefined)).toEqual({
-      react: 'rc',
-      js: 'rc',
-      useLocalAliases: false,
-    });
-  });
-
-  it('pins rc packages when --staging region is set even with a custom api url', () => {
-    expect(resolveAgentChatNovuDependencies('http://localhost:3000', localNovuDeps, CloudRegionEnum.STAGING)).toEqual({
-      react: 'rc',
-      js: 'rc',
-      useLocalAliases: false,
+  it('pins next packages when --staging region is set even with a custom api url', () => {
+    expect(resolveAgentChatNovuDependencies('http://localhost:3000', CloudRegionEnum.STAGING)).toEqual({
+      react: 'next',
+      js: 'next',
     });
   });
 });

--- a/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts
+++ b/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { isNovuLocalApiUrl, isNovuStagingApiUrl } from '@novu/shared';
+import { getNovuScaffoldSdkTag } from '@novu/shared';
 import { CloudRegionEnum } from '../../../dev/enums';
 import { tryGitInit } from '../../../init/helpers/git';
 import { isFolderEmpty } from '../../../init/helpers/is-folder-empty';
@@ -89,7 +89,7 @@ async function mergeAgentChatIntoProject(projectDir: string, input: ScaffoldAgen
     throw new Error(`Cannot merge Agent Chat into "${resolved}" — no package.json found.`);
   }
 
-  const dependenciesChanged = ensureAgentChatDependencies(resolved, findLocalNovuDeps(), input.apiUrl, input.region);
+  const dependenciesChanged = ensureAgentChatDependencies(resolved, input.apiUrl, input.region);
   const componentsDir = path.join(resolved, 'components', 'agent-chat');
   fs.mkdirSync(componentsDir, { recursive: true });
   copyTemplateComponents(componentsDir);
@@ -109,19 +109,14 @@ async function mergeAgentChatIntoProject(projectDir: string, input: ScaffoldAgen
   }
 }
 
-function ensureAgentChatDependencies(
-  projectDir: string,
-  localNovuDeps: LocalNovuDeps | undefined,
-  apiUrl: string,
-  region?: CloudRegionEnum
-): boolean {
+function ensureAgentChatDependencies(projectDir: string, apiUrl: string, region?: CloudRegionEnum): boolean {
   const packageJsonPath = path.join(projectDir, 'package.json');
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
     dependencies?: Record<string, string>;
     scripts?: Record<string, string>;
   };
   const dependencies = packageJson.dependencies ?? {};
-  const sdk = resolveAgentChatNovuDependencies(apiUrl, localNovuDeps, region);
+  const sdk = resolveAgentChatNovuDependencies(apiUrl, region);
   const required = {
     '@novu/react': sdk.react,
     ...(sdk.js ? { '@novu/js': sdk.js } : {}),
@@ -133,19 +128,6 @@ function ensureAgentChatDependencies(
   for (const [name, version] of Object.entries(required)) {
     if (dependencies[name] !== version) {
       dependencies[name] = version;
-      changed = true;
-    }
-  }
-
-  if (sdk.useLocalAliases && packageJson.scripts) {
-    for (const [name, script] of Object.entries(packageJson.scripts)) {
-      const usesNextDev = script.includes('next dev') && !script.includes('next dev --webpack');
-      const usesNextBuild = script.includes('next build') && !script.includes('next build --webpack');
-      if (!usesNextDev && !usesNextBuild) continue;
-
-      packageJson.scripts[name] = script
-        .replace(/next dev(?=\s|$)/g, 'next dev --webpack')
-        .replace(/next build(?=\s|$)/g, 'next build --webpack');
       changed = true;
     }
   }
@@ -172,8 +154,6 @@ async function writeStandaloneAgentChatApp(root: string, input: ScaffoldAgentCha
   fs.mkdirSync(path.join(root, 'app'), { recursive: true });
   fs.mkdirSync(path.join(root, 'components', 'agent-chat'), { recursive: true });
 
-  const localNovuDeps = findLocalNovuDeps();
-
   copyTemplateComponents(path.join(root, 'components', 'agent-chat'));
 
   fs.writeFileSync(path.join(root, 'app', 'layout.tsx'), STANDALONE_LAYOUT, 'utf8');
@@ -192,10 +172,10 @@ async function writeStandaloneAgentChatApp(root: string, input: ScaffoldAgentCha
     }),
     'utf8'
   );
-  const sdk = resolveAgentChatNovuDependencies(input.apiUrl, localNovuDeps, input.region);
+  const sdk = resolveAgentChatNovuDependencies(input.apiUrl, input.region);
   fs.writeFileSync(path.join(root, 'package.json'), renderPackageJson(path.basename(root), sdk), 'utf8');
   fs.writeFileSync(path.join(root, 'tsconfig.json'), STANDALONE_TSCONFIG, 'utf8');
-  fs.writeFileSync(path.join(root, 'next.config.mjs'), renderNextConfig(root, localNovuDeps, sdk), 'utf8');
+  fs.writeFileSync(path.join(root, 'next.config.mjs'), STANDALONE_NEXT_CONFIG, 'utf8');
   fs.writeFileSync(path.join(root, '.env.local'), renderEnvLocal(input), 'utf8');
   fs.writeFileSync(path.join(root, '.env.example'), renderEnvExample(input), 'utf8');
   fs.writeFileSync(path.join(root, '.gitignore'), STANDALONE_GITIGNORE, 'utf8');
@@ -312,71 +292,15 @@ function appendEnvExample(projectDir: string, input: ScaffoldAgentChatProjectInp
   });
 }
 
-function findMonorepoReactPackageDir(): string | undefined {
-  let dir = __dirname;
-  for (let depth = 0; depth < 12; depth++) {
-    const candidate = path.join(dir, 'packages', 'react', 'package.json');
-    if (fs.existsSync(candidate)) {
-      return path.dirname(candidate);
-    }
-
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-
-  return undefined;
-}
-
-type LocalNovuDeps = {
-  reactDir: string;
-  jsDir: string;
-};
-
-function findLocalNovuDeps(): LocalNovuDeps | undefined {
-  const reactDir = findMonorepoReactPackageDir();
-  if (!reactDir) {
-    return undefined;
-  }
-
-  const jsDir = path.join(path.dirname(reactDir), 'js');
-  if (!fs.existsSync(path.join(jsDir, 'package.json'))) {
-    return undefined;
-  }
-
-  return { reactDir, jsDir };
-}
-
-function toPosixRelative(from: string, to: string): string {
-  const rel = path.relative(from, to).split(path.sep).join('/');
-  return rel.startsWith('.') ? rel : `./${rel}`;
-}
-
 export type AgentChatNovuDependencies = {
   react: string;
   js?: string;
-  useLocalAliases: boolean;
 };
 
-export function resolveAgentChatNovuDependencies(
-  apiUrl: string,
-  localNovuDeps: LocalNovuDeps | undefined,
-  region?: CloudRegionEnum
-): AgentChatNovuDependencies {
-  if (isNovuStagingApiUrl(apiUrl) || region === CloudRegionEnum.STAGING) {
-    return { react: 'rc', js: 'rc', useLocalAliases: false };
-  }
+export function resolveAgentChatNovuDependencies(apiUrl: string, region?: CloudRegionEnum): AgentChatNovuDependencies {
+  const tag = getNovuScaffoldSdkTag(apiUrl, region);
 
-  if (localNovuDeps && isNovuLocalApiUrl(apiUrl)) {
-    return {
-      react: `file:${localNovuDeps.reactDir}`,
-      js: `file:${localNovuDeps.jsDir}`,
-      useLocalAliases: true,
-    };
-  }
-
-  // The scaffold template tracks dashboard APIs that may not be on npm `latest` yet.
-  return { react: 'rc', js: 'rc', useLocalAliases: false };
+  return { react: tag, js: tag };
 }
 
 function renderPackageJson(name: string, sdk: AgentChatNovuDependencies): string {
@@ -385,8 +309,8 @@ function renderPackageJson(name: string, sdk: AgentChatNovuDependencies): string
       name,
       private: true,
       scripts: {
-        dev: sdk.useLocalAliases ? 'next dev -p 4012 --webpack' : 'next dev -p 4012',
-        build: sdk.useLocalAliases ? 'next build --webpack' : 'next build',
+        dev: 'next dev -p 4012',
+        build: 'next build',
         start: 'next start -p 4012',
       },
       dependencies: {
@@ -408,45 +332,6 @@ function renderPackageJson(name: string, sdk: AgentChatNovuDependencies): string
     null,
     2
   );
-}
-
-function renderNextConfig(
-  scaffoldRoot: string,
-  localNovuDeps: LocalNovuDeps | undefined,
-  sdk: AgentChatNovuDependencies
-): string {
-  if (!sdk.useLocalAliases || !localNovuDeps) {
-    return STANDALONE_NEXT_CONFIG;
-  }
-
-  const reactRel = toPosixRelative(scaffoldRoot, localNovuDeps.reactDir);
-  const jsRel = toPosixRelative(scaffoldRoot, localNovuDeps.jsDir);
-
-  return `import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const novuReact = path.resolve(__dirname, '${reactRel}');
-const novuJs = path.resolve(__dirname, '${jsRel}');
-
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  transpilePackages: ['@novu/react', '@novu/js'],
-  // Turbopack cannot resolve file: symlinks outside the app root — webpack aliases
-  // point at the local monorepo packages when connect scaffolds from a dev checkout.
-  webpack: (config) => {
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      '@novu/react': novuReact,
-      '@novu/js': novuJs,
-    };
-
-    return config;
-  },
-};
-
-export default nextConfig;
-`;
 }
 
 function escapeJs(value: string): string {

--- a/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts
+++ b/packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts
@@ -32,7 +32,21 @@ export type ScaffoldAgentChatProjectResult = {
   chatPath: string;
 };
 
-const TEMPLATE_ROOT = path.join(__dirname, '../../templates/agent-chat/ts');
+/**
+ * Templates live at <build root>/commands/connect/templates/agent-chat/ts.
+ * Under the module layout (tsc output or ts-node dev) `__dirname` is this
+ * file's directory; from the bundled CLI entry it is `dist/src` — try both.
+ */
+function resolveTemplateRoot(): string {
+  const candidates = [
+    path.join(__dirname, '../../templates/agent-chat/ts'),
+    path.join(__dirname, 'commands/connect/templates/agent-chat/ts'),
+  ];
+
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[0];
+}
+
+const TEMPLATE_ROOT = resolveTemplateRoot();
 
 export function defaultAgentChatScaffoldDirName(agentIdentifier: string): string {
   return `${agentIdentifier}-agent-chat`;

--- a/packages/novu/src/commands/connect/pipeline/ai-sdk/scaffold.ts
+++ b/packages/novu/src/commands/connect/pipeline/ai-sdk/scaffold.ts
@@ -11,6 +11,7 @@ export async function scaffoldAiSdkProject(input: {
   agentIdentifier: string;
   silent?: boolean;
   llmAuth: LlmAuthChoice;
+  region?: string;
 }): Promise<ScaffoldBridgeProjectResult> {
   return scaffoldBridgeProject({
     parentDir: input.parentDir,
@@ -22,5 +23,6 @@ export async function scaffoldAiSdkProject(input: {
     agentIdentifier: input.agentIdentifier,
     silent: input.silent,
     llmAuth: input.llmAuth,
+    region: input.region,
   });
 }

--- a/packages/novu/src/commands/connect/pipeline/bridge-adapter/engine.ts
+++ b/packages/novu/src/commands/connect/pipeline/bridge-adapter/engine.ts
@@ -103,6 +103,7 @@ async function scaffoldThenReconcile(
         agentIdentifier: input.agent.identifier,
         silent: false,
         llmAuth,
+        region: input.options.region,
       }),
   });
 

--- a/packages/novu/src/commands/connect/pipeline/bridge-adapter/types.ts
+++ b/packages/novu/src/commands/connect/pipeline/bridge-adapter/types.ts
@@ -38,6 +38,7 @@ export type BridgeAdapterScaffoldInput = {
   agentIdentifier: string;
   silent?: boolean;
   llmAuth: LlmAuthChoice;
+  region?: string;
 };
 
 export type BridgeAdapterRequirementsInput = {

--- a/packages/novu/src/commands/connect/pipeline/bridge/scaffold-project.ts
+++ b/packages/novu/src/commands/connect/pipeline/bridge/scaffold-project.ts
@@ -20,6 +20,7 @@ export type ScaffoldBridgeProjectInput = {
   agentIdentifier: string;
   silent?: boolean;
   llmAuth?: LlmAuthChoice;
+  region?: string;
 };
 
 export type ScaffoldBridgeProjectResult = {
@@ -87,6 +88,7 @@ export async function scaffoldBridgeProject(input: ScaffoldBridgeProjectInput): 
     skipInstall: skippedInstall,
     silent: input.silent,
     llmAuth: input.llmAuth,
+    region: input.region,
   });
 
   tryGitInit(root);

--- a/packages/novu/src/commands/connect/pipeline/custom-code/index.ts
+++ b/packages/novu/src/commands/connect/pipeline/custom-code/index.ts
@@ -54,6 +54,7 @@ export async function runCustomCodeProjectSetup(input: CustomCodeSetupInput): Pr
         apiUrl: input.options.apiUrl,
         agentIdentifier: input.agent.identifier,
         silent: false,
+        region: input.options.region,
       }),
   });
 

--- a/packages/novu/src/commands/connect/pipeline/langchain/scaffold.ts
+++ b/packages/novu/src/commands/connect/pipeline/langchain/scaffold.ts
@@ -11,6 +11,7 @@ export async function scaffoldLangChainProject(input: {
   agentIdentifier: string;
   silent?: boolean;
   llmAuth: LlmAuthChoice;
+  region?: string;
 }): Promise<ScaffoldBridgeProjectResult> {
   return scaffoldBridgeProject({
     parentDir: input.parentDir,
@@ -22,5 +23,6 @@ export async function scaffoldLangChainProject(input: {
     agentIdentifier: input.agentIdentifier,
     silent: input.silent,
     llmAuth: input.llmAuth,
+    region: input.region,
   });
 }

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -1,7 +1,7 @@
 import { getNovuScaffoldSdkTag } from '@novu/shared';
 import { Sema } from 'async-sema';
 import { async as glob } from 'fast-glob';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -16,6 +16,20 @@ import { copy } from '../helpers/copy';
 import { install } from '../helpers/install';
 import { resolveAgentZodDependencies } from './agent-scaffold-deps';
 import { GetTemplateFileArgs, InstallTemplateArgs, TemplateTypeEnum } from './types';
+
+/**
+ * Templates ship next to this module (<build root>/commands/init/templates).
+ * `__dirname` is that directory under the tsc module layout and ts-node dev,
+ * but `dist/src` when running from the bundled CLI entry — try both, using the
+ * always-present `github` template dir as the marker.
+ */
+function resolveTemplatesDir(): string {
+  const candidates = [__dirname, path.join(__dirname, 'commands', 'init', 'templates')];
+
+  return candidates.find((candidate) => existsSync(path.join(candidate, 'github'))) ?? __dirname;
+}
+
+const TEMPLATES_DIR = resolveTemplatesDir();
 
 function resolveCliPackageJson(): Record<string, any> | null {
   const distIndex = __dirname.lastIndexOf(`${path.sep}dist${path.sep}`);
@@ -47,7 +61,7 @@ function resolveCliTag(): string {
  * Get the file path for a given file in a template, e.g. "next.config.js".
  */
 export const getTemplateFile = ({ template, mode, file }: GetTemplateFileArgs): string => {
-  return path.join(__dirname, template, mode, file);
+  return path.join(TEMPLATES_DIR, template, mode, file);
 };
 
 export const SRC_DIR_NAMES = ['app', 'pages', 'styles'];
@@ -86,7 +100,7 @@ export const installTemplate = async ({
    * Copy the template files to the target directory.
    */
   if (!silent) console.log('\nInitializing project with template:', template, '\n');
-  const templatePath = path.join(__dirname, template, mode);
+  const templatePath = path.join(TEMPLATES_DIR, template, mode);
   const copySource = ['**'];
   if (!eslint) copySource.push('!eslintrc.json');
   if (!template.includes('react')) {
@@ -281,7 +295,7 @@ export const installTemplate = async ({
   if (!isAgentTemplate && template !== TemplateTypeEnum.APP_CHAT_SDK) {
     await copy(copySource, `${root}/.github`, {
       parents: true,
-      cwd: path.join(__dirname, `./github`),
+      cwd: path.join(TEMPLATES_DIR, `./github`),
     });
   }
 

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -1,3 +1,4 @@
+import { getNovuScaffoldSdkTag } from '@novu/shared';
 import { Sema } from 'async-sema';
 import { async as glob } from 'fast-glob';
 import { readFileSync } from 'fs';
@@ -28,14 +29,8 @@ function resolveCliPackageJson(): Record<string, any> | null {
   }
 }
 
-function resolveFrameworkVersion(): string {
-  const pkg = resolveCliPackageJson();
-  if (!pkg) return 'latest';
-
-  const ver = pkg.dependencies?.['@novu/framework'];
-  if (!ver || ver.startsWith('workspace:')) return 'latest';
-
-  return ver;
+function resolveFrameworkVersion(apiUrl: string, region?: string): string {
+  return getNovuScaffoldSdkTag(apiUrl, region);
 }
 
 function resolveCliTag(): string {
@@ -78,6 +73,7 @@ export const installTemplate = async ({
   silent,
   skipInstall,
   llmAuth,
+  region,
 }: InstallTemplateArgs) => {
   if (!silent) console.log(bold(`Using ${packageManager}.`));
 
@@ -302,7 +298,7 @@ export const installTemplate = async ({
   };
 
   if (isAgentTemplate) {
-    baseDependencies['@novu/framework'] = resolveFrameworkVersion();
+    baseDependencies['@novu/framework'] = resolveFrameworkVersion(apiUrl, region);
   }
 
   if (isAiSdkTemplate || isLangChainTemplate) {
@@ -317,7 +313,7 @@ export const installTemplate = async ({
   }
 
   if (!isAgentTemplate && !isChatSdkTemplate) {
-    baseDependencies['@novu/framework'] = resolveFrameworkVersion();
+    baseDependencies['@novu/framework'] = resolveFrameworkVersion(apiUrl, region);
     baseDependencies['@novu/nextjs'] = '^2.5.0';
   }
 

--- a/packages/novu/src/commands/init/templates/types.ts
+++ b/packages/novu/src/commands/init/templates/types.ts
@@ -46,4 +46,6 @@ export interface InstallTemplateArgs {
   skipInstall?: boolean;
   /** LLM provider wiring for ai-sdk / langchain agent scaffolds. */
   llmAuth?: LlmAuthChoice;
+  /** Cloud region from connect — staging forces pre-release SDK tags. */
+  region?: string;
 }

--- a/packages/shared/src/utils/novu-connect-cli.spec.ts
+++ b/packages/shared/src/utils/novu-connect-cli.spec.ts
@@ -52,7 +52,9 @@ describe('novu-connect-cli', () => {
   it('pins scaffold SDK packages to next on staging, local, or staging region', () => {
     expect(getNovuScaffoldSdkTag(NOVU_STAGING_API_URL)).toBe('next');
     expect(getNovuScaffoldSdkTag('http://localhost:3000')).toBe('next');
+    expect(getNovuScaffoldSdkTag('https://api.novu.localhost')).toBe('next');
     expect(getNovuScaffoldSdkTag('https://api.novu.co', 'staging')).toBe('next');
+    expect(getNovuScaffoldSdkTag('https://api.novu.co', 'local')).toBe('next');
     expect(getNovuScaffoldSdkTag('https://api.novu.co')).toBe('latest');
   });
 

--- a/packages/shared/src/utils/novu-connect-cli.spec.ts
+++ b/packages/shared/src/utils/novu-connect-cli.spec.ts
@@ -4,6 +4,7 @@ import {
   getNovuConnectInvocation,
   getNovuConnectPackageTag,
   getNovuConnectTargetFlags,
+  getNovuScaffoldSdkTag,
   NOVU_STAGING_API_URL,
 } from './novu-connect-cli';
 
@@ -46,6 +47,13 @@ describe('novu-connect-cli', () => {
       '--connect-dashboard-url http://localhost:4201',
       '--dashboard-url http://localhost:4201',
     ]);
+  });
+
+  it('pins scaffold SDK packages to next on staging, local, or staging region', () => {
+    expect(getNovuScaffoldSdkTag(NOVU_STAGING_API_URL)).toBe('next');
+    expect(getNovuScaffoldSdkTag('http://localhost:3000')).toBe('next');
+    expect(getNovuScaffoldSdkTag('https://api.novu.co', 'staging')).toBe('next');
+    expect(getNovuScaffoldSdkTag('https://api.novu.co')).toBe('latest');
   });
 
   it('does not add dashboard URLs for cloud dashboards', () => {

--- a/packages/shared/src/utils/novu-connect-cli.ts
+++ b/packages/shared/src/utils/novu-connect-cli.ts
@@ -3,6 +3,9 @@ export const NOVU_STAGING_API_URL = 'https://api.novu-staging.co';
 
 export type NovuConnectPackageTag = 'latest' | 'rc';
 
+/** npm dist-tag for @novu/react, @novu/js, and @novu/framework in connect scaffolds. */
+export type NovuScaffoldSdkTag = 'next' | 'latest';
+
 export type NovuConnectTargetOptions = {
   apiUrl?: string | null;
   connectDashboardUrl?: string | null;
@@ -55,6 +58,14 @@ export function isNovuLocalApiUrl(apiUrl: string | null | undefined): boolean {
 
 export function getNovuConnectPackageTag(apiUrl?: string | null): NovuConnectPackageTag {
   return isNovuStagingApiUrl(apiUrl) || isNovuLocalApiUrl(apiUrl) ? 'rc' : 'latest';
+}
+
+export function isNovuPreReleaseConnectMode(apiUrl?: string | null, region?: string | null): boolean {
+  return isNovuStagingApiUrl(apiUrl) || isNovuLocalApiUrl(apiUrl) || region === 'staging';
+}
+
+export function getNovuScaffoldSdkTag(apiUrl?: string | null, region?: string | null): NovuScaffoldSdkTag {
+  return isNovuPreReleaseConnectMode(apiUrl, region) ? 'next' : 'latest';
 }
 
 export function getNovuConnectRegionFlag(apiUrl?: string | null): '--region staging' | undefined {

--- a/packages/shared/src/utils/novu-connect-cli.ts
+++ b/packages/shared/src/utils/novu-connect-cli.ts
@@ -50,7 +50,9 @@ export function isNovuLocalApiUrl(apiUrl: string | null | undefined): boolean {
   try {
     const hostname = new URL(normalized).hostname;
 
-    return hostname === 'localhost' || hostname === '127.0.0.1';
+    // `.localhost` is reserved for loopback (RFC 6761) — covers the
+    // `api.novu.localhost` local-dev host alongside plain localhost.
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname.endsWith('.localhost');
   } catch {
     return false;
   }
@@ -61,7 +63,7 @@ export function getNovuConnectPackageTag(apiUrl?: string | null): NovuConnectPac
 }
 
 export function isNovuPreReleaseConnectMode(apiUrl?: string | null, region?: string | null): boolean {
-  return isNovuStagingApiUrl(apiUrl) || isNovuLocalApiUrl(apiUrl) || region === 'staging';
+  return isNovuStagingApiUrl(apiUrl) || isNovuLocalApiUrl(apiUrl) || region === 'staging' || region === 'local';
 }
 
 export function getNovuScaffoldSdkTag(apiUrl?: string | null, region?: string | null): NovuScaffoldSdkTag {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3936,9 +3936,6 @@ importers:
       '@novu/ntfr-client':
         specifier: ^0.0.5
         version: 0.0.5
-      '@novu/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@segment/analytics-node':
         specifier: ^1.1.4
         version: 1.1.4
@@ -4048,6 +4045,9 @@ importers:
         specifier: ^3.25.1
         version: 3.25.1(zod@3.25.20)
     devDependencies:
+      '@novu/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@types/configstore':
         specifier: ^5.0.1
         version: 5.0.1


### PR DESCRIPTION
## Summary
- Add `getNovuScaffoldSdkTag()` in `@novu/shared` to resolve scaffold dependency tags from connect mode
- Pin `@novu/react`, `@novu/js`, and `@novu/framework` to npm `next` when connect runs against staging API, `--region staging`, or localhost
- Keep `npx novu@rc` for the CLI itself; production scaffolds still use npm `latest`
- Remove monorepo `file:` symlinks from agent-chat scaffolds to avoid SDK version skew (e.g. local react + npm framework)

## Test plan
- [x] `vitest run scaffold-agent-chat.spec.ts`
- [x] `vitest run novu-connect-cli.spec.ts`
- [ ] Run `npx novu@rc connect --channel agent-chat --api-url http://localhost:3000` and verify `package.json` has `@novu/react: "next"`
- [ ] Run bridge scaffold against staging and verify `@novu/framework: "next"`
- [ ] Run connect against `https://api.novu.co` and verify SDK deps stay on `latest`


Made with [Cursor](https://cursor.com)









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes scaffold SDK tag selection and propagates connect-region metadata through Agent Chat and bridge templates.
- Staging and local scaffolds select prerelease SDK tags while production uses `latest`.
- The CLI entry is bundled with workspace code and resolves packaged UI/template assets across bundled and module layouts.
- Agent Chat scaffolds stop using local workspace package aliases.

<h3>Confidence Score: 4/5</h3>

The PR does not appear safe to merge until staging and local bridge scaffolds use an `@novu/framework` version or dist-tag that the repository’s publication process actually provides.

Staging and local scaffold generation still writes `@novu/framework: "next"`, while the checked `next` publication workflow excludes that package and its project lacks the workflow’s publish target, leaving generated projects unable to install through the repository-defined release path.

**Files Needing Attention:** packages/novu/src/commands/init/templates/index.ts, packages/framework/project.json, .github/workflows/release-packages.yml

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/novu-connect-cli.ts | Centralizes prerelease-mode detection and correctly includes local API hosts and the local region. |
| packages/novu/src/commands/init/templates/index.ts | Resolves packaged template locations and applies environment-specific SDK tags when generating scaffold dependencies. |
| packages/novu/src/commands/connect/pipeline/agent-chat/scaffold-agent-chat.ts | Replaces monorepo file aliases with npm tags and supports template lookup from the bundled CLI layout. |
| packages/novu/scripts/build-ui.mjs | Adds a bundled CommonJS CLI entry while leaving declared runtime dependencies external. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Connect API URL and region] --> B[getNovuScaffoldSdkTag]
  B -->|staging or local| C[next]
  B -->|production| D[latest]
  C --> E[Agent Chat SDK dependencies]
  C --> F[Framework scaffold dependency]
  D --> E
  D --> F
```

<sub>Reviews (5): Last reviewed commit: ["Revert &quot;chore(novu): bump CLI version to..."](https://github.com/novuhq/novu/commit/3f6ad571465a364525c0bb5dbd049124a19a23f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56632182)</sub>

<!-- /greptile_comment -->