### PR TITLE
fix(api-service): add translations support to sender name and preheader fields fixes NV-8691

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -284,8 +284,11 @@ describe('EmailOutputRendererUsecase', () => {
     });
   });
 
-  describe('preheader injection', () => {
-    const buildPreheaderCommand = (preheader: string): EmailOutputRendererCommand => ({
+  describe('sender and preheader metadata', () => {
+    const buildPreheaderCommand = (
+      preheader: string,
+      controlValues: Record<string, unknown> = {}
+    ): EmailOutputRendererCommand => ({
       dbWorkflow: mockDbWorkflow,
       controlValues: {
         subject: 'Welcome Email',
@@ -299,6 +302,7 @@ describe('EmailOutputRendererUsecase', () => {
             },
           ],
         } satisfies MailyJSONContent),
+        ...controlValues,
       },
       fullPayloadForRender: mockFullPayload,
       stepId: 'fake_step_id',
@@ -322,6 +326,38 @@ describe('EmailOutputRendererUsecase', () => {
 
       expect(result.body).to.include("$'");
       expect(result.body.split('Unique body marker')).to.have.lengthOf(2);
+    });
+
+    it('should translate subject, sender name, and preheader only', async () => {
+      translateStub.callsFake(async (command: { content: string }) =>
+        command.content
+          .replace('{{t.subject}}', 'Willkommen')
+          .replace('{{t.senderName}}', 'Acme Sicherheit')
+          .replace('{{t.preheader}}', 'Ein Blick hinein')
+      );
+
+      const result = await emailOutputRendererUsecase.execute(
+        buildPreheaderCommand('{{t.preheader}}', {
+          subject: '{{t.subject}}',
+          from: { email: '{{t.senderEmail}}', name: '{{t.senderName}}' },
+          replyTo: '{{t.replyTo}}',
+        })
+      );
+
+      expect(result.subject).to.equal('Willkommen');
+      expect(result.from).to.deep.equal({ email: '{{t.senderEmail}}', name: 'Acme Sicherheit' });
+      expect(result.replyTo).to.equal('{{t.replyTo}}');
+      expect(result.preheader).to.equal('Ein Blick hinein');
+      expect(result.body).to.include('Ein Blick hinein');
+    });
+
+    it('should preserve an empty translated preheader', async () => {
+      translateStub.callsFake(async (command: { content: string }) => command.content.replace('{{t.preheader}}', ''));
+
+      const result = await emailOutputRendererUsecase.execute(buildPreheaderCommand('{{t.preheader}}'));
+
+      expect(result).to.have.property('preheader', '');
+      expect(result.body).to.not.include('{{t.preheader}}');
     });
   });
 

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -50,6 +50,13 @@ type TranslationContext = {
   resourceId: string;
 };
 
+interface TranslatableEmailControls {
+  [key: string]: unknown;
+  subject: string;
+  from?: Pick<NonNullable<EmailControlType['from']>, 'name'>;
+  preheader?: string;
+}
+
 export class EmailOutputRendererCommand extends RenderCommand {
   dbWorkflow: NotificationTemplateEntity;
   locale?: string;
@@ -130,17 +137,11 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     const controlMeta = {
       ...(from && { from }),
       ...(replyTo && { replyTo }),
-      ...(preheader && { preheader }),
+      ...(preheader !== undefined && { preheader }),
       ...(useProviderDefaults !== undefined && { useProviderDefaults }),
     };
 
     if (!body || typeof body !== 'string') {
-      /**
-       * Force type mapping in case undefined control.
-       * This passes responsibility to framework to throw type validation exceptions
-       * rather than handling invalid types here.
-       */
-
       return {
         subject: controlSubject as string,
         body: body as string,
@@ -161,29 +162,52 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
 
     const { _environmentId: environmentId, _organizationId: organizationId, _id: workflowId } = dbWorkflow;
 
-    const workflowTranslationContext = await this.createTranslationContext({
-      environmentId,
-      organizationId,
-      resourceId: workflowId,
-      resourceType: LocalizationResourceEnum.WORKFLOW,
-      locale,
-      organization,
-      resourceEntity: dbWorkflow,
-    });
+    const [translatedControls, workflowTranslationContext] = await Promise.all([
+      this.processTranslations({
+        controls: {
+          subject: controlSubject as string,
+          ...(from?.name !== undefined && { from: { name: from.name } }),
+          ...(preheader !== undefined && { preheader }),
+        },
+        variables: fullPayloadForRender,
+        environmentId,
+        organizationId,
+        resourceId: workflowId,
+        resourceType: LocalizationResourceEnum.WORKFLOW,
+        locale,
+        organization,
+        resourceEntity: dbWorkflow,
+      }) as Promise<TranslatableEmailControls>,
+      this.createTranslationContext({
+        environmentId,
+        organizationId,
+        resourceId: workflowId,
+        resourceType: LocalizationResourceEnum.WORKFLOW,
+        locale,
+        organization,
+        resourceEntity: dbWorkflow,
+      }),
+    ]);
 
-    // Step 1: Apply translations to subject (already liquid-interpolated)
-    const translatedSubject = await this.processSubjectTranslations(
-      controlSubject as string,
-      fullPayloadForRender,
-      environmentId,
-      organizationId,
-      workflowId,
-      locale,
-      organization,
-      workflowTranslationContext
-    );
+    const translatedSubject = decodeHTML(this.unescapeJsonString(translatedControls.subject));
+    const translatedFromName =
+      translatedControls.from?.name === undefined
+        ? undefined
+        : decodeHTML(this.unescapeJsonString(translatedControls.from.name));
+    const translatedPreheader =
+      translatedControls.preheader === undefined
+        ? undefined
+        : decodeHTML(this.unescapeJsonString(translatedControls.preheader));
+    const translatedFrom = from ? { ...from, ...(from.name !== undefined && { name: translatedFromName }) } : undefined;
 
-    // Step 2: Process body content (with translations applied before rendering)
+    const translatedControlMeta = {
+      ...(translatedFrom && { from: translatedFrom }),
+      ...(replyTo && { replyTo }),
+      ...(preheader !== undefined && { preheader: translatedPreheader }),
+      ...(useProviderDefaults !== undefined && { useProviderDefaults }),
+    };
+
+    // Process body content with translations applied before rendering
     const renderedHtml = await this.renderWithLayout({
       body,
       stepLayoutId,
@@ -200,17 +224,17 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
       workflowTranslationContext,
     });
 
-    // Step 3: Add Novu branding
+    // Add Novu branding
     const htmlWithBranding = await this.appendNovuBranding(renderedHtml, organizationId, organization);
     const cleanedHtml = this.cleanupRenderedHtml(htmlWithBranding);
-    const htmlWithPreheader = injectRenderedPreheader(cleanedHtml, preheader);
+    const htmlWithPreheader = injectRenderedPreheader(cleanedHtml, translatedPreheader);
 
-    // Step 4: Sanitize output if needed
+    // Sanitize output if needed
     if (disableOutputSanitization) {
       return {
         subject: translatedSubject,
         body: htmlWithPreheader,
-        ...controlMeta,
+        ...translatedControlMeta,
       };
     }
 
@@ -219,7 +243,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     return {
       subject: translatedSubject,
       body: sanitizedBody,
-      ...controlMeta,
+      ...translatedControlMeta,
     };
   }
 
@@ -490,38 +514,6 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
 
       return processedHtml;
     }
-  }
-
-  private async processSubjectTranslations(
-    subject: string,
-    variables: FullPayloadForRender,
-    environmentId: string,
-    organizationId: string,
-    workflowId?: string,
-    locale?: string,
-    organization?: OrganizationEntity,
-    translationContext?: TranslationContext | null
-  ): Promise<string> {
-    const unescapedVariables = this.deepUnescapeTranslationStrings(variables) as FullPayloadForRender;
-
-    const translatedSubject = translationContext
-      ? await this.processStringWithContext({
-          context: translationContext,
-          content: subject,
-          variables: unescapedVariables,
-        })
-      : await this.processStringTranslations({
-          content: subject,
-          variables: unescapedVariables,
-          environmentId,
-          organizationId,
-          resourceId: workflowId,
-          resourceType: LocalizationResourceEnum.WORKFLOW,
-          locale,
-          organization,
-        });
-
-    return decodeHTML(this.unescapeJsonString(translatedSubject));
   }
 
   private async processTextTranslations({

--- a/apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx
@@ -15,7 +15,6 @@ import {
   SheetTitle,
 } from '@/components/primitives/sheet';
 import { Switch } from '@/components/primitives/switch';
-import { Textarea } from '@/components/primitives/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { ControlInput } from '@/components/workflow-editor/control-input';
 import {
@@ -33,7 +32,6 @@ import { useParseVariables } from '@/hooks/use-parse-variables';
 import { usePrimaryEmailIntegration } from '@/hooks/use-primary-email-integration';
 
 const AGENT_TRIGGER_DOCS_URL = 'https://docs.novu.co/agents/get-started/mental-model';
-const PREHEADER_MAX_LENGTH = 84;
 
 type SenderConfigDrawerProps = {
   open: boolean;
@@ -299,6 +297,7 @@ export function SenderConfigDrawer({ open, onOpenChange, disabled = false }: Sen
                       isAllowedVariable={isAllowedVariable}
                       size="sm"
                       indentWithTab={false}
+                      enableTranslations
                     />
                   </InputWrapper>
                 </InputRoot>
@@ -425,15 +424,20 @@ export function SenderConfigDrawer({ open, onOpenChange, disabled = false }: Sen
               </Tooltip>
             </FormLabel>
             <FormControl>
-              <Textarea
-                value={localPreheader}
-                onChange={(event) => setLocalPreheader(event.target.value.slice(0, PREHEADER_MAX_LENGTH))}
-                placeholder="One-line summary shown next to the subject"
-                maxLength={PREHEADER_MAX_LENGTH}
-                showCounter
-                disabled={disabled}
-                className="min-h-[96px]"
-              />
+              <InputRoot className="min-h-[96px] items-start">
+                <ControlInput
+                  placeholder="One-line summary shown next to the subject"
+                  disabled={disabled}
+                  value={localPreheader}
+                  onChange={setLocalPreheader}
+                  variables={variables}
+                  isAllowedVariable={isAllowedVariable}
+                  size="2xs"
+                  multiline
+                  indentWithTab={false}
+                  enableTranslations
+                />
+              </InputRoot>
             </FormControl>
           </FormItem>
         </SheetMain>

--- a/libs/application-generic/src/dtos/workflow/controls/email-control.dto.ts
+++ b/libs/application-generic/src/dtos/workflow/controls/email-control.dto.ts
@@ -1,15 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import {
-  IsBoolean,
-  IsIn,
-  IsOptional,
-  IsString,
-  MaxLength,
-  MinLength,
-  ValidateIf,
-  ValidateNested,
-} from 'class-validator';
+import { IsBoolean, IsIn, IsOptional, IsString, MinLength, ValidateIf, ValidateNested } from 'class-validator';
 import { SkipControlDto } from '../skip.dto';
 
 export class EmailFromControlDto {
@@ -87,12 +78,8 @@ export class EmailControlDto extends SkipControlDto {
   @IsString()
   replyTo?: string;
 
-  @ApiPropertyOptional({
-    description: 'One-line inbox preview text shown next to the subject.',
-    maxLength: 84,
-  })
+  @ApiPropertyOptional({ description: 'One-line inbox preview text shown next to the subject.' })
   @IsOptional()
   @IsString()
-  @MaxLength(84)
   preheader?: string;
 }

--- a/libs/application-generic/src/schemas/control/email-control.schema.ts
+++ b/libs/application-generic/src/schemas/control/email-control.schema.ts
@@ -20,7 +20,7 @@ export const emailControlZodSchema = z
       .optional(),
     useProviderDefaults: z.boolean().optional(),
     replyTo: z.string().optional(),
-    preheader: z.string().max(84).optional(),
+    preheader: z.string().optional(),
   })
   .strict();
 

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -395,6 +395,8 @@ describe('Novu Client', () => {
               return {
                 subject: `body static prefix ${controls.name}`,
                 body: controls.name,
+                from: controls.from,
+                preheader: controls.preheader,
               };
             },
             {
@@ -402,6 +404,13 @@ describe('Novu Client', () => {
                 type: 'object',
                 properties: {
                   name: { type: 'string', default: '{{payload.name}}' },
+                  from: {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                    required: ['name'],
+                    additionalProperties: false,
+                  },
+                  preheader: { type: 'string' },
                 },
                 required: [],
                 additionalProperties: false,
@@ -432,8 +441,11 @@ describe('Novu Client', () => {
           lastName: "Smith's",
         },
         state: [],
-        controls: {},
-        context: {},
+        controls: {
+          from: { name: '{{payload.name}} {{subscriber.lastName}}' },
+          preheader: '{{env.name}} {{context.traceId}} {{t.preheader}}',
+        },
+        context: { traceId: 'trace-123' },
         env: testEventEnv,
       };
 
@@ -442,8 +454,10 @@ describe('Novu Client', () => {
       expect(emailExecutionResult).toBeDefined();
       expect(emailExecutionResult.outputs).toBeDefined();
       if (!emailExecutionResult.outputs) throw new Error('executionResult.outputs is undefined');
-      const { subject } = emailExecutionResult.outputs;
+      const { subject, from, preheader } = emailExecutionResult.outputs;
       expect(subject).toBe('body static prefix John');
+      expect(from?.name).toBe("John Smith's");
+      expect(preheader).toBe('Test trace-123 {{t.preheader}}');
     });
 
     it('should render step results in preview', async () => {


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds translation support for email sender names and preheaders while preserving translated preheaders in rendered metadata and HTML.
- Translates subject, sender name, and preheader together without translating sender email or reply-to.
- Replaces the preheader textarea with a translation-aware multiline control and removes the former 84-character limit across UI and validation schemas.
- Extends API and framework tests for translated metadata, empty preheaders, and variable interpolation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness, security, or contract failures identified.

The metadata translation flow preserves non-translatable sender fields, handles absent and empty preheaders explicitly, and is covered across API rendering and framework interpolation paths.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts | Extends translation processing from the subject to sender name and preheader, preserving empty preheaders and injecting translated preview text into the rendered email. |
| apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts | Adds coverage for selective email metadata translation and empty translated preheaders. |
| apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx | Enables translation-aware sender-name and multiline preheader editing while removing the previous client-side length cap. |
| libs/application-generic/src/dtos/workflow/controls/email-control.dto.ts | Removes the API DTO’s 84-character preheader restriction. |
| libs/application-generic/src/schemas/control/email-control.schema.ts | Aligns the shared email control schema by allowing preheaders of arbitrary string length. |
| packages/framework/src/client.test.ts | Verifies sender-name and preheader interpolation through framework workflow execution. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Email controls] --> B[Interpolate workflow variables]
  B --> C[Translate subject, sender name, and preheader]
  C --> D[Decode translated metadata]
  D --> E[Inject translated preheader into HTML]
  E --> F[Sanitize and return email output]
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): add translations suppo..."](https://github.com/novuhq/novu/commit/211e2ccc41ec30cf4d5ff7f4fb55ada4a117d491) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56770742)</sub>

<!-- /greptile_comment -->