### PR TITLE
fix(api-service): allow wildcard CORS for agent-chat routes fixes NV-8689

### DIFF
--- a/apps/api/src/config/cors.config.spec.ts
+++ b/apps/api/src/config/cors.config.spec.ts
@@ -101,5 +101,16 @@ describe('CORS Configuration', () => {
       expect(callbackSpy.firstCall.firstArg).to.be.null;
       expect(callbackSpy.firstCall.lastArg.origin).to.equal('*');
     });
+
+    it('agent-chat routes should be wildcarded', () => {
+      const callbackSpy = spy();
+
+      // @ts-expect-error - corsOptionsDelegate is not typed correctly
+      corsOptionsDelegate({ url: '/v1/agent-chat/conversations' }, callbackSpy);
+
+      expect(callbackSpy.calledOnce).to.be.ok;
+      expect(callbackSpy.firstCall.firstArg).to.be.null;
+      expect(callbackSpy.firstCall.lastArg.origin).to.equal('*');
+    });
   });
 });

--- a/apps/api/src/config/cors.config.ts
+++ b/apps/api/src/config/cors.config.ts
@@ -46,7 +46,11 @@ export const corsOptionsDelegate: Parameters<INestApplication['enableCors']>[0] 
 
 function enableWildcard(req: Request): boolean {
   return (
-    (isDevelopmentEnvironment() || isWidgetRoute(req.url) || isInboxRoute(req.url) || isBlueprintRoute(req.url)) &&
+    (isDevelopmentEnvironment() ||
+      isWidgetRoute(req.url) ||
+      isInboxRoute(req.url) ||
+      isBlueprintRoute(req.url) ||
+      isAgentChatRoute(req.url)) &&
     !isBetterAuthRoute(req.url)
   );
 }
@@ -66,6 +70,10 @@ function isInboxRoute(url: string): boolean {
 
 function isBlueprintRoute(url: string): boolean {
   return url.startsWith('/v1/blueprints');
+}
+
+function isAgentChatRoute(url: string): boolean {
+  return url.startsWith('/v1/agent-chat');
 }
 
 function isDevelopmentEnvironment(): boolean {


### PR DESCRIPTION
## Summary

- Add `/v1/agent-chat/*` to the API wildcard CORS list (same pattern as inbox/widgets/blueprints)
- Add unit test asserting agent-chat routes return `origin: '*'` in production mode

Fixes connect-scaffolded Agent Chat apps failing with browser CORS errors when running on `localhost` or customer domains instead of the Novu dashboard.

## Test plan

- [x] `pnpm exec mocha --require ts-node/register --exit 'src/config/cors.config.spec.ts'` (6 passing)
- [ ] Deploy to staging and verify `npx novu@rc connect --channel agent-chat --region staging` works from `localhost:4012` without a Next.js proxy rewrite
- [ ] Confirm dashboard Agent Chat preview still works
- [ ] Confirm inbox CORS behavior unchanged


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables wildcard CORS for the Agent Chat API so customer-hosted browser clients can call it directly.
- Adds `/v1/agent-chat` to the API routes eligible for wildcard origins.
- Adds production-mode coverage confirming Agent Chat routes receive the wildcard origin configuration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the Agent Chat route following the established wildcard CORS pattern without bypassing endpoint authentication.

The changed prefix maps to the existing Agent Chat route family, and current browser calls use bearer authentication without credentialed fetches; no concrete blocking or non-blocking defect remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/config/cors.config.ts | Extends the existing route-specific wildcard CORS policy to Agent Chat while retaining the Better Auth exclusion and endpoint-level authentication. |
| apps/api/src/config/cors.config.spec.ts | Adds focused coverage that verifies the new Agent Chat route classification returns a wildcard origin. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): allow wildcard CORS fo..."](https://github.com/novuhq/novu/commit/ed20465ec65625925f11060c2e21bd38395a5f39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57023745)</sub>

<!-- /greptile_comment -->