### PR TITLE
fix(dashboard): add vertical scroll in translation json editor fixes NV-8696

### DIFF
--- a/apps/dashboard/src/components/translations/translation-drawer/editor-actions.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/editor-actions.tsx
@@ -119,7 +119,7 @@ export function EditorActions({ selectedTranslation, modifiedContent, isReadOnly
 
   return (
     <>
-      <div className="flex flex-col items-start gap-6 self-stretch px-3 pb-3 pt-3">
+      <div className="flex shrink-0 flex-col items-start gap-6 self-stretch px-3 pb-3 pt-3">
         <div className="flex w-full items-center justify-between">
           <div className="flex items-center gap-3">
             <FlagCircle locale={selectedLocale} size="md" />

--- a/apps/dashboard/src/components/translations/translation-drawer/editor-panel.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/editor-panel.tsx
@@ -12,9 +12,9 @@ import { EditorActions } from './editor-actions';
 
 export function EditorPanelSkeleton() {
   return (
-    <div className="flex flex-1 flex-col bg-neutral-50">
+    <div className="flex min-h-0 flex-1 flex-col bg-neutral-50">
       {/* EditorActions skeleton - matches exact HTML structure */}
-      <div className="flex flex-col items-start gap-6 self-stretch px-3 pb-3 pt-3">
+      <div className="flex shrink-0 flex-col items-start gap-6 self-stretch px-3 pb-3 pt-3">
         {/* First row: Flag + locale info + Import button */}
         <div className="flex w-full items-center justify-between">
           <div className="flex items-center gap-3">
@@ -38,8 +38,8 @@ export function EditorPanelSkeleton() {
       </div>
 
       {/* JSON Editor skeleton - matches the actual editor */}
-      <div className="flex-1 px-3 pb-3">
-        <div className="relative h-[calc(100%-24px)] rounded-lg border border-neutral-200 bg-white p-4">
+      <div className="flex min-h-0 flex-1 flex-col px-3 pb-3">
+        <div className="relative min-h-0 flex-1 rounded-lg border border-neutral-200 bg-white p-4">
           {/* Line numbers and content like real editor */}
           <div className="flex gap-4">
             <div className="text-neutral-400">
@@ -51,7 +51,7 @@ export function EditorPanelSkeleton() {
           </div>
         </div>
         {/* Footer timestamp */}
-        <div className="mt-2 px-1 h-6 flex items-center">
+        <div className="mt-2 flex h-6 shrink-0 items-center px-1">
           <Skeleton className="h-3 w-60" /> {/* "Last updated at Jul 22, 2025 15:11:30 UTC" */}
         </div>
       </div>
@@ -73,11 +73,10 @@ const BASIC_SETUP = { lineNumbers: true, defaultKeymap: true };
 
 function JSONEditor({ content, onChange, error, updatedAt, isOutdated, isReadOnly = false }: JSONEditorProps) {
   return (
-    // 112px is the height of the actions section
-    <div className="min-h-0 flex-1 px-3 pb-3 flex flex-col max-h-[calc(100%-112px)]">
+    <div className="flex min-h-0 flex-1 flex-col px-3 pb-3">
       <div
         className={cn(
-          'relative overflow-hidden w-full rounded-lg border bg-white min-h-0 flex-1',
+          'relative flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-lg border bg-white',
           error ? 'border-red-300' : 'border-neutral-200',
           isReadOnly && 'bg-neutral-50'
         )}
@@ -90,16 +89,13 @@ function JSONEditor({ content, onChange, error, updatedAt, isOutdated, isReadOnl
           basicSetup={BASIC_SETUP}
           placeholder="Enter JSON content..."
           height="100%"
-          className={cn(
-            'flex-1 [&_.cm-scroller]:p-4 [&_div.cm-gutters]:bg-background [&_div.cm-gutters]:-translate-x-[16px] [&_div.cm-gutters]:pl-4 [&_div.cm-gutters]:-ml-4 [&_.cm-editor]:h-full rounded-lg [&_.cm-scroller]:h-full! [&_.cm-scroller]:overflow-auto [&_.cm-content]:max-w-[calc(100%-2rem)]',
-            error ? 'h-[calc(100%-32px)]' : 'h-full'
-          )}
+          className="min-h-0 flex-1 rounded-lg [&_.cm-content]:max-w-[calc(100%-2rem)] [&_.cm-editor]:h-full [&_.cm-scroller]:h-full! [&_.cm-scroller]:overflow-auto [&_.cm-scroller]:p-4 [&_div.cm-gutters]:-ml-4 [&_div.cm-gutters]:-translate-x-[16px] [&_div.cm-gutters]:bg-background [&_div.cm-gutters]:pl-4"
           foldGutter
           multiline
           readOnly={isReadOnly}
         />
         {error && (
-          <div className="px-4 py-2 text-xs text-red-500 h-min">
+          <div className="shrink-0 px-4 py-2 text-xs text-red-500">
             <span className="font-medium">Invalid JSON:</span> {error}
           </div>
         )}
@@ -111,7 +107,7 @@ function JSONEditor({ content, onChange, error, updatedAt, isOutdated, isReadOnl
       </div>
 
       {isOutdated && (
-        <div className="mt-3 px-1">
+        <div className="mt-3 shrink-0 px-1">
           <InlineToast
             variant="warning"
             title="Warning:"
@@ -120,7 +116,7 @@ function JSONEditor({ content, onChange, error, updatedAt, isOutdated, isReadOnl
         </div>
       )}
 
-      <div className="mt-2 px-1">
+      <div className="mt-2 shrink-0 px-1">
         <TimeDisplayHoverCard date={updatedAt} className="text-2xs text-neutral-400">
           Last updated at {formatTranslationDate(updatedAt, DATE_FORMAT_OPTIONS)}{' '}
           {formatTranslationTime(updatedAt, TIME_FORMAT_OPTIONS)} UTC

--- a/apps/dashboard/src/components/translations/translation-drawer/locale-list.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/locale-list.tsx
@@ -15,7 +15,7 @@ import { formatTranslationDate, formatTranslationTime, getLocaleDisplayName } fr
 
 export function LocaleListSkeleton() {
   return (
-    <div className="w-[400px] border-r border-neutral-200">
+    <div className="w-[400px] shrink-0 overflow-y-auto border-r border-neutral-200">
       {/* Status section skeleton */}
       <div className="flex flex-col items-start gap-3 self-stretch border-b border-neutral-100 p-4">
         <div className="flex w-full items-center justify-between">
@@ -176,7 +176,7 @@ export function LocaleList({
   }, [locales, actualDefaultLocale]);
 
   return (
-    <div className="min-w-[400px] border-r border-neutral-200">
+    <div className="min-w-[400px] shrink-0 overflow-y-auto border-r border-neutral-200">
       <TranslationStatusSection updatedAt={updatedAt} outdatedLocales={outdatedLocales} />
 
       <div className="p-4">

--- a/apps/dashboard/src/components/translations/translation-drawer/translation-drawer-content.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/translation-drawer-content.tsx
@@ -85,7 +85,7 @@ export const TranslationDrawerContent = forwardRef<TranslationDrawerContentRef, 
         <TranslationHeader resourceName={translationGroup.resourceName} />
 
         {!isDevEnvironment && (
-          <div className="border-b border-neutral-200 px-6 py-3">
+          <div className="shrink-0 border-b border-neutral-200 px-6 py-3">
             <InlineToast
               variant="warning"
               title="View-only mode"
@@ -94,8 +94,7 @@ export const TranslationDrawerContent = forwardRef<TranslationDrawerContentRef, 
           </div>
         )}
 
-        {/* 109px is the height of the header and footer */}
-        <div className="flex flex-1 h-[calc(100%-109px)]">
+        <div className="flex min-h-0 flex-1 overflow-hidden">
           <LocaleList
             locales={translationGroup.locales}
             selectedLocale={selectedLocale}
@@ -119,7 +118,7 @@ export const TranslationDrawerContent = forwardRef<TranslationDrawerContentRef, 
           />
         </div>
 
-        <div className="flex items-center justify-end border-t border-neutral-200 bg-white px-6 py-3">
+        <div className="flex shrink-0 items-center justify-end border-t border-neutral-200 bg-white px-6 py-3">
           <PermissionButton
             permission={PermissionsEnum.WORKFLOW_WRITE}
             variant="secondary"

--- a/apps/dashboard/src/components/translations/translation-drawer/translation-drawer.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/translation-drawer.tsx
@@ -13,7 +13,7 @@ function TranslationDrawerSkeleton() {
   return (
     <div className="flex h-full w-full flex-col">
       {/* Header skeleton */}
-      <header className="border-bg-soft flex h-12 w-full flex-row items-center gap-3 border-b px-3 py-4">
+      <header className="border-bg-soft flex h-12 w-full shrink-0 flex-row items-center gap-3 border-b px-3 py-4">
         <div className="flex flex-1 items-center gap-2 overflow-hidden text-sm font-medium">
           <Skeleton className="h-4 w-4" /> {/* Translate icon */}
           <Skeleton className="h-4 w-48" /> {/* Resource name */}
@@ -21,13 +21,13 @@ function TranslationDrawerSkeleton() {
       </header>
 
       {/* Main content skeleton */}
-      <div className="flex h-full">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         <LocaleListSkeleton />
         <EditorPanelSkeleton />
       </div>
 
       {/* Footer skeleton */}
-      <div className="flex items-center justify-end border-t border-neutral-200 bg-white px-6 py-3">
+      <div className="flex shrink-0 items-center justify-end border-t border-neutral-200 bg-white px-6 py-3">
         <Skeleton className="h-8 w-24" /> {/* Save changes button */}
       </div>
     </div>

--- a/apps/dashboard/src/components/translations/translation-drawer/translation-header.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/translation-header.tsx
@@ -6,7 +6,7 @@ type TranslationHeaderProps = {
 
 export function TranslationHeader({ resourceName }: TranslationHeaderProps) {
   return (
-    <header className="border-bg-soft flex h-12 w-full flex-row items-center gap-3 border-b px-3 py-4">
+    <header className="border-bg-soft flex h-12 w-full shrink-0 flex-row items-center gap-3 border-b px-3 py-4">
       <div className="flex flex-1 items-center gap-2 overflow-hidden text-sm font-medium">
         <RiTranslate2 className="h-4 w-4 text-neutral-600" />
         <span className="flex-1 truncate pr-10">{resourceName}</span>


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restructures the translation drawer’s flex sizing and overflow behavior so long JSON translations and locale lists can scroll vertically without displacing fixed controls.
- Replaces manually calculated content heights with bounded `min-h-0` and `flex-1` layouts.
- Keeps headers, action bars, warnings, timestamps, and footers from shrinking.
- Adds independent vertical scrolling to the locale list and CodeMirror editor.
- Updates loading skeletons to match the resulting layout.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code regression identified.

The revised layout has a bounded height chain from the drawer through the split pane and editor, while fixed controls are excluded from shrinking and overflowing content receives dedicated scroll containers.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/translations/translation-drawer/editor-panel.tsx | Reworks the editor and skeleton into bounded flex columns, allowing CodeMirror to scroll while errors, warnings, and timestamps remain visible. |
| apps/dashboard/src/components/translations/translation-drawer/translation-drawer-content.tsx | Makes the central split pane consume only available drawer height while preserving the header, warning, and footer. |
| apps/dashboard/src/components/translations/translation-drawer/locale-list.tsx | Adds independent vertical scrolling and prevents the fixed-width locale pane from shrinking. |
| apps/dashboard/src/components/translations/translation-drawer/translation-drawer.tsx | Aligns the loading skeleton’s height and overflow behavior with the loaded drawer. |
| apps/dashboard/src/components/translations/translation-drawer/editor-actions.tsx | Prevents the editor action section from shrinking when editor content grows. |
| apps/dashboard/src/components/translations/translation-drawer/translation-header.tsx | Prevents the drawer header from shrinking within the vertical flex layout. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;next&#39; into NV-8696"](https://github.com/novuhq/novu/commit/ce6f1a0c9deeef66e7d299853956dc0e33c53a10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57027239)</sub>

<!-- /greptile_comment -->