### PR TITLE
fix(dashboard): remove redundant docs arrow from web chat preview fixes NV-8682

### DIFF
--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-drawer.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-drawer.tsx
@@ -61,13 +61,6 @@ export function AgentChatDrawer({
               <SheetDescription>Preview this agent in web chat before adding it to your app.</SheetDescription>
             </VisuallyHidden>
           </div>
-          <CompactButton
-            size="lg"
-            variant="ghost"
-            icon={RiArrowRightUpLine}
-            aria-label="Open docs"
-            onClick={() => window.open(AGENT_CHAT_DOCS_URL, '_blank', 'noopener,noreferrer')}
-          />
           <SheetClose asChild>
             <CompactButton size="lg" variant="ghost" icon={RiCloseLine} aria-label="Close" />
           </SheetClose>


### PR DESCRIPTION
## Summary
- Remove the standalone docs arrow button from the Web chat preview drawer header
- Keep the existing inline "Read docs" link, which already opens the same documentation URL

Fixes [NV-8682](https://linear.app/novu/issue/NV-8682/the-arrow-button-is-confusing)

## Test plan
- [ ] Open an agent and launch the Web chat preview drawer
- [ ] Confirm header shows only the inline "Read docs" link and close (X) button
- [ ] Confirm no standalone arrow button appears next to the close button
- [ ] Confirm "Read docs" still opens agent chat documentation in a new tab


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the redundant standalone documentation arrow from the Web chat preview drawer while preserving the existing inline “Read docs” link.
- Leaves the close button as the only icon button in the drawer header.
- Retains documentation navigation through the visible inline link.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the removed control duplicated an unconditional inline link to the same documentation URL.

The remaining “Read docs” link preserves the deleted button’s destination and secure new-tab behavior, while all retained imports and the drawer’s close control remain in use.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-drawer.tsx | Safely removes a duplicate documentation control without affecting the existing docs link, close action, imports, or accessibility. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): remove redundant docs ar..."](https://github.com/novuhq/novu/commit/e885c1a3639cb58c48d93925af316f33d61f7575) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57031804)</sub>

<!-- /greptile_comment -->