### PR TITLE
fix(dashboard): align preview chat hover timestamps with message text fixes NV-8683

### DIFF
--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
@@ -82,6 +82,9 @@ function formatMessageTime(createdAt: string): string | null {
   return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 }
 
+const MESSAGE_TIME_CLASS =
+  'text-text-soft shrink-0 text-[11px] tabular-nums opacity-0 transition-opacity duration-150 group-hover:opacity-100';
+
 export function AgentAvatar({ className }: { className?: string }) {
   return (
     <span
@@ -159,12 +162,8 @@ export function ChatMessageRow({
   if (isUser) {
     return (
       <div className="animate-in fade-in slide-in-from-bottom-1 group flex flex-col items-end gap-1 duration-200">
-        <div className="flex max-w-full items-end justify-end gap-2">
-          {time ? (
-            <span className="text-text-soft shrink-0 text-[11px] tabular-nums opacity-0 transition-opacity duration-150 group-hover:opacity-100">
-              {time}
-            </span>
-          ) : null}
+        <div className="flex max-w-full items-start justify-end gap-2">
+          {time ? <span className={cn(MESSAGE_TIME_CLASS, 'mt-2')}>{time}</span> : null}
           <div
             className={cn(
               'bg-bg-weak text-text-strong text-paragraph-sm max-w-[min(30rem,85%)] whitespace-pre-wrap break-words rounded-xl px-3 py-2 leading-5',
@@ -206,12 +205,17 @@ export function ChatMessageRow({
       {showAvatar ? <AgentAvatar className="mt-0.5" /> : null}
       <div className="flex min-w-0 max-w-full flex-1 flex-col items-start gap-1.5">
         {text ? (
-          <div className="text-paragraph-sm text-text-strong w-full leading-5">
-            <MarkdownText className="text-paragraph-sm leading-5">{text}</MarkdownText>
-            {isStreaming ? (
-              <span className="bg-text-strong ml-0.5 inline-block h-3.5 w-0.5 animate-pulse align-middle" aria-hidden />
-            ) : null}
+          <div className="flex w-full items-start gap-2">
+            <div className="text-paragraph-sm text-text-strong min-w-0 flex-1 leading-5">
+              <MarkdownText className="text-paragraph-sm leading-5">{text}</MarkdownText>
+              {isStreaming ? (
+                <span className="bg-text-strong ml-0.5 inline-block h-3.5 w-0.5 animate-pulse align-middle" aria-hidden />
+              ) : null}
+            </div>
+            {time ? <span className={cn(MESSAGE_TIME_CLASS, 'mt-2')}>{time}</span> : null}
           </div>
+        ) : time ? (
+          <span className={MESSAGE_TIME_CLASS}>{time}</span>
         ) : null}
         {visibleCards.map((part, index) => (
           <ChatCardPart
@@ -257,11 +261,6 @@ export function ChatMessageRow({
           />
         ))}
       </div>
-      {time ? (
-        <span className="text-text-soft mt-2 shrink-0 self-start text-[11px] tabular-nums opacity-0 transition-opacity duration-150 group-hover:opacity-100">
-          {time}
-        </span>
-      ) : null}
     </div>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx
@@ -1,5 +1,5 @@
 import type { AgentMessage } from '@novu/react';
-import { type ReactNode } from 'react';
+import { type ReactNode, useCallback, useLayoutEffect, useRef, useState } from 'react';
 import {
   RiArrowRightSLine,
   RiChat3Fill,
@@ -85,6 +85,74 @@ function formatMessageTime(createdAt: string): string | null {
 const MESSAGE_TIME_CLASS =
   'text-text-soft shrink-0 text-[11px] tabular-nums opacity-0 transition-opacity duration-150 group-hover:opacity-100';
 
+function useIsMultiline(content: string) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isMultiline, setIsMultiline] = useState(false);
+
+  const measure = useCallback(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const style = getComputedStyle(element);
+    const lineHeight = parseFloat(style.lineHeight);
+    if (!Number.isFinite(lineHeight)) return;
+
+    const paddingTop = parseFloat(style.paddingTop) || 0;
+    const paddingBottom = parseFloat(style.paddingBottom) || 0;
+    const contentHeight = element.scrollHeight - paddingTop - paddingBottom;
+    setIsMultiline(contentHeight > lineHeight + 1);
+  }, []);
+
+  useLayoutEffect(() => {
+    measure();
+
+    const element = ref.current;
+    if (!element) return;
+
+    const resizeObserver = new ResizeObserver(measure);
+    resizeObserver.observe(element);
+
+    return () => resizeObserver.disconnect();
+  }, [content, measure]);
+
+  return { ref, isMultiline };
+}
+
+function UserMessageLine({ text, time, failed }: { text: string; time: string | null; failed?: boolean }) {
+  const { ref, isMultiline } = useIsMultiline(text);
+
+  return (
+    <div className={cn('flex max-w-full justify-end gap-2', isMultiline ? 'items-start' : 'items-center')}>
+      {time ? <span className={cn(MESSAGE_TIME_CLASS, isMultiline && 'mt-2')}>{time}</span> : null}
+      <div
+        ref={ref}
+        className={cn(
+          'bg-bg-weak text-text-strong text-paragraph-sm max-w-[min(30rem,85%)] whitespace-pre-wrap break-words rounded-xl px-3 py-2 leading-5',
+          failed && 'ring-error-light ring-1'
+        )}
+      >
+        {text}
+      </div>
+    </div>
+  );
+}
+
+function AgentTextLine({ text, time, isStreaming }: { text: string; time: string | null; isStreaming: boolean }) {
+  const { ref, isMultiline } = useIsMultiline(text);
+
+  return (
+    <div className={cn('flex w-full gap-2', isMultiline ? 'items-start' : 'items-center')}>
+      <div ref={ref} className="text-paragraph-sm text-text-strong min-w-0 flex-1 leading-5">
+        <MarkdownText className="text-paragraph-sm leading-5">{text}</MarkdownText>
+        {isStreaming ? (
+          <span className="bg-text-strong ml-0.5 inline-block h-3.5 w-0.5 animate-pulse align-middle" aria-hidden />
+        ) : null}
+      </div>
+      {time ? <span className={cn(MESSAGE_TIME_CLASS, isMultiline && 'mt-2')}>{time}</span> : null}
+    </div>
+  );
+}
+
 export function AgentAvatar({ className }: { className?: string }) {
   return (
     <span
@@ -162,17 +230,7 @@ export function ChatMessageRow({
   if (isUser) {
     return (
       <div className="animate-in fade-in slide-in-from-bottom-1 group flex flex-col items-end gap-1 duration-200">
-        <div className="flex max-w-full items-start justify-end gap-2">
-          {time ? <span className={cn(MESSAGE_TIME_CLASS, 'mt-2')}>{time}</span> : null}
-          <div
-            className={cn(
-              'bg-bg-weak text-text-strong text-paragraph-sm max-w-[min(30rem,85%)] whitespace-pre-wrap break-words rounded-xl px-3 py-2 leading-5',
-              failed && 'ring-error-light ring-1'
-            )}
-          >
-            {text}
-          </div>
-        </div>
+        <UserMessageLine text={text} time={time} failed={failed} />
         {failed ? (
           <span className="text-error-base text-label-xs inline-flex items-center gap-1">
             <RiErrorWarningLine className="size-3" aria-hidden />
@@ -205,15 +263,7 @@ export function ChatMessageRow({
       {showAvatar ? <AgentAvatar className="mt-0.5" /> : null}
       <div className="flex min-w-0 max-w-full flex-1 flex-col items-start gap-1.5">
         {text ? (
-          <div className="flex w-full items-start gap-2">
-            <div className="text-paragraph-sm text-text-strong min-w-0 flex-1 leading-5">
-              <MarkdownText className="text-paragraph-sm leading-5">{text}</MarkdownText>
-              {isStreaming ? (
-                <span className="bg-text-strong ml-0.5 inline-block h-3.5 w-0.5 animate-pulse align-middle" aria-hidden />
-              ) : null}
-            </div>
-            {time ? <span className={cn(MESSAGE_TIME_CLASS, 'mt-2')}>{time}</span> : null}
-          </div>
+          <AgentTextLine text={text} time={time} isStreaming={isStreaming} />
         ) : time ? (
           <span className={MESSAGE_TIME_CLASS}>{time}</span>
         ) : null}


### PR DESCRIPTION
## Summary

- Fix hover timestamp placement in the dashboard Web chat preview (`ChatMessageRow` in `agent-chat-parts.tsx`)
- User messages: switch row alignment from `items-end` to `items-start` with `mt-2` on the timestamp so it lines up with the first text line instead of the bubble bottom
- Agent messages: move the timestamp into a flex row beside the text block only (cards/tools/approvals stay below), with a fallback timestamp at the top of the content column when there is no text

## Context

Fixes [NV-8683](https://linear.app/novu/issue/NV-8683/preview-chat-timestamp-is-offset) — timestamps appeared offset on preview chat bubbles (too low on one-liners, below multi-line content on agent replies).

## Test plan

- [ ] Open an agent in the dashboard and open **Preview chat**
- [ ] Send a short user message (e.g. `"Hello"`) and hover — timestamp aligns with the message text, not the bubble bottom
- [ ] Send a long agent reply and hover — timestamp sits at the top-right of the text, not below cards/tools
- [ ] Trigger a tool-only agent response (no text) and hover — timestamp is still visible at the top of the message block


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adjusts hover timestamp placement in dashboard chat previews.
- Measures whether user and agent message text spans multiple lines.
- Vertically centers timestamps beside single-line text and top-aligns them beside multiline text.
- Keeps timestamps visible for agent responses containing cards or tools but no text.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/agent-chat-panel/agent-chat-parts.tsx | Refactors user and agent message text rows to measure rendered height and align hover timestamps with the text content. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): center single-line previ..."](https://github.com/novuhq/novu/commit/48b9dbde77b4c089b54a10495c7b558d3dabe0e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57040167)</sub>

<!-- /greptile_comment -->