### PR TITLE
fix(js): overlay edit/delete across agent-chat history pages fixes NV-8675

### DIFF
--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -346,9 +346,14 @@ export class AgentChatStore {
     olderCursor: string | null
   ): ConversationEntry {
     const previous = entry.messages;
+    const pageMaxSequence = envelopes.reduce((max, envelope) => Math.max(max, envelope.sequence), 0);
+    const liveAhead = [...entry.messageMutations.values()].filter(
+      (envelope) => envelope.sequence > pageMaxSequence
+    );
     entry.messageMutations.clear();
     this.#recordMcpConnectionResults(entry, envelopes);
     this.#recordMessageMutations(entry, envelopes);
+    this.#recordMessageMutations(entry, liveAhead);
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
     const serverIds = new Set(folded.messages.map((message) => message.id));
     const localOnly = previous.filter((message) => !serverIds.has(message.id));

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -346,6 +346,7 @@ export class AgentChatStore {
     olderCursor: string | null
   ): ConversationEntry {
     const previous = entry.messages;
+    entry.messageMutations.clear();
     this.#recordMcpConnectionResults(entry, envelopes);
     this.#recordMessageMutations(entry, envelopes);
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
@@ -465,7 +466,7 @@ export class AgentChatStore {
     const next = applyEnvelope(entry, envelope);
     applyState(entry, {
       ...next,
-      messages: this.#overlayMessages(entry, next.messages),
+      messages: this.#applyMcpConnectionResults(entry, next.messages),
     });
     this.#publish(entry, { kind: 'live', envelope }, messagesAddedSince(previous, entry.messages));
 

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -176,9 +176,10 @@ export class AgentChatStore {
       return messages;
     }
 
-    const mutations = [...entry.messageMutations.values()].sort((left, right) => left.sequence - right.sequence);
-
-    return applyEnvelopes({ ...createInitialAgentConversationState(), messages }, mutations).messages;
+    return applyEnvelopes(
+      { ...createInitialAgentConversationState(), messages },
+      [...entry.messageMutations.values()]
+    ).messages;
   }
 
   #overlayMessages(entry: ConversationEntry, messages: AgentMessage[]): AgentMessage[] {
@@ -346,14 +347,8 @@ export class AgentChatStore {
     olderCursor: string | null
   ): ConversationEntry {
     const previous = entry.messages;
-    const pageMaxSequence = envelopes.reduce((max, envelope) => Math.max(max, envelope.sequence), 0);
-    const liveAhead = [...entry.messageMutations.values()].filter(
-      (envelope) => envelope.sequence > pageMaxSequence
-    );
-    entry.messageMutations.clear();
     this.#recordMcpConnectionResults(entry, envelopes);
     this.#recordMessageMutations(entry, envelopes);
-    this.#recordMessageMutations(entry, liveAhead);
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
     const serverIds = new Set(folded.messages.map((message) => message.id));
     const localOnly = previous.filter((message) => !serverIds.has(message.id));

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -41,6 +41,12 @@ export type ConversationEntry = AgentConversationState & {
   reportedActionIds: Set<string>;
   /** Terminal MCP results retained while history pages load independently. */
   mcpConnectionResults: Map<string, McpConnectionResult>;
+  /**
+   * Latest `channel.edit` / `channel.delete` per message id.
+   * History pages fold in isolation, so a mutation on a newer page must still
+   * apply when `fetchMore` prepends the original `MESSAGE`.
+   */
+  messageMutations: Map<string, AgentEventEnvelope>;
   /** True while reconnect catch-up is in flight for this holder. */
   isRecovering: boolean;
   /** Set when catch-up hits the safety page limit or HTTP fails. Cleared on success. */
@@ -149,6 +155,36 @@ export class AgentChatStore {
     }));
   }
 
+  #recordMessageMutations(entry: ConversationEntry, envelopes: AgentEventEnvelope[]): void {
+    for (const envelope of envelopes) {
+      const { event } = envelope;
+      if (event.type !== 'channel.edit' && event.type !== 'channel.delete') {
+        continue;
+      }
+
+      const existing = entry.messageMutations.get(event.messageId);
+      if (existing && existing.sequence > envelope.sequence) {
+        continue;
+      }
+
+      entry.messageMutations.set(event.messageId, envelope);
+    }
+  }
+
+  #applyMessageMutations(entry: ConversationEntry, messages: AgentMessage[]): AgentMessage[] {
+    if (entry.messageMutations.size === 0) {
+      return messages;
+    }
+
+    const mutations = [...entry.messageMutations.values()].sort((left, right) => left.sequence - right.sequence);
+
+    return applyEnvelopes({ ...createInitialAgentConversationState(), messages }, mutations).messages;
+  }
+
+  #overlayMessages(entry: ConversationEntry, messages: AgentMessage[]): AgentMessage[] {
+    return this.#applyMcpConnectionResults(entry, this.#applyMessageMutations(entry, messages));
+  }
+
   clear(): void {
     this.#byKey.clear();
   }
@@ -211,6 +247,7 @@ export class AgentChatStore {
       olderCursor: null,
       reportedActionIds: new Set(),
       mcpConnectionResults: new Map(),
+      messageMutations: new Map(),
       isRecovering: false,
       paginationStatus: 'idle',
       paginationEpoch: 0,
@@ -310,13 +347,14 @@ export class AgentChatStore {
   ): ConversationEntry {
     const previous = entry.messages;
     this.#recordMcpConnectionResults(entry, envelopes);
+    this.#recordMessageMutations(entry, envelopes);
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
     const serverIds = new Set(folded.messages.map((message) => message.id));
     const localOnly = previous.filter((message) => !serverIds.has(message.id));
 
     applyState(entry, {
       ...folded,
-      messages: this.#applyMcpConnectionResults(entry, [...folded.messages, ...localOnly]),
+      messages: this.#overlayMessages(entry, [...folded.messages, ...localOnly]),
     });
     entry.olderCursor = olderCursor;
     entry.paginationEpoch += 1;
@@ -382,9 +420,10 @@ export class AgentChatStore {
     olderCursor: string | null
   ): ConversationEntry {
     this.#recordMcpConnectionResults(entry, envelopes);
+    this.#recordMessageMutations(entry, envelopes);
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
     const existingIds = new Set(entry.messages.map((message) => message.id));
-    const olderMessages = this.#applyMcpConnectionResults(
+    const olderMessages = this.#overlayMessages(
       entry,
       folded.messages.filter((message) => !existingIds.has(message.id))
     );
@@ -422,10 +461,11 @@ export class AgentChatStore {
 
     const previous = entry.messages;
     this.#recordMcpConnectionResults(entry, [envelope]);
+    this.#recordMessageMutations(entry, [envelope]);
     const next = applyEnvelope(entry, envelope);
     applyState(entry, {
       ...next,
-      messages: this.#applyMcpConnectionResults(entry, next.messages),
+      messages: this.#overlayMessages(entry, next.messages),
     });
     this.#publish(entry, { kind: 'live', envelope }, messagesAddedSince(previous, entry.messages));
 

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -1881,59 +1881,6 @@ describe('AgentChat', () => {
     ]);
   });
 
-  it('reload drops a stale edit overlay that is not on the new history page', async () => {
-    getEvents.mockResolvedValueOnce(
-      historyEventPage(
-        [
-          {
-            sequence: 2,
-            event: {
-              type: 'message',
-              role: 'user',
-              messageId: 'msg_keep0000001',
-              content: { markdown: 'keep' },
-            },
-          },
-          {
-            sequence: 3,
-            event: {
-              type: 'channel.edit',
-              messageId: 'msg_edit0000001',
-              content: { markdown: 'edited' },
-            },
-          },
-        ],
-        'act_page0001'
-      )
-    );
-    await agentChat.loadConversation({
-      agentId: 'agent_1',
-      conversationId: 'conv_abcdefghijkl',
-    });
-
-    getEvents.mockResolvedValueOnce(
-      historyPage([{ sequence: 4, messageId: 'msg_keep0000001', role: 'user', markdown: 'keep' }], 'act_page0001')
-    );
-    await agentChat.loadConversation({
-      agentId: 'agent_1',
-      conversationId: 'conv_abcdefghijkl',
-    });
-
-    getEvents.mockResolvedValueOnce(
-      historyPage([{ sequence: 1, messageId: 'msg_edit0000001', role: 'user', markdown: 'original' }], null)
-    );
-
-    const result = await agentChat.fetchMore({
-      agentId: 'agent_1',
-      conversationId: 'conv_abcdefghijkl',
-    });
-
-    expect(result.data?.messages[0]).toMatchObject({
-      id: 'msg_edit0000001',
-      parts: [{ type: 'text', text: 'original', state: 'done' }],
-    });
-  });
-
   it('reload keeps a live delete that arrived while history GET was in flight', async () => {
     getEvents.mockResolvedValueOnce(
       historyPage(

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -844,22 +844,37 @@ describe('AgentChat', () => {
     olderCursor: string | null = null,
     conversationId = 'conv_abcdefghijkl'
   ) {
-    return {
-      events: events.map((event) => ({
-        version: AGENT_EVENT_PROTOCOL_VERSION,
-        conversationId: 'internal',
-        conversationIdentifier: conversationId,
-        agentId: 'agent_1',
-        runId: 'history',
-        turnId: 't1',
+    return historyEventPage(
+      events.map((event) => ({
         sequence: event.sequence,
-        timestamp: '2026-08-07T12:00:00.000Z',
         event: {
           type: 'message' as const,
           role: event.role,
           messageId: event.messageId,
           content: { markdown: event.markdown },
         },
+      })),
+      olderCursor,
+      conversationId
+    );
+  }
+
+  function historyEventPage(
+    events: Array<{ sequence: number; event: Record<string, unknown> }>,
+    olderCursor: string | null = null,
+    conversationId = 'conv_abcdefghijkl'
+  ) {
+    return {
+      events: events.map((item) => ({
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: conversationId,
+        agentId: 'agent_1',
+        runId: 'history',
+        turnId: 't1',
+        sequence: item.sequence,
+        timestamp: '2026-08-07T12:00:00.000Z',
+        event: item.event,
       })),
       olderCursor,
     };
@@ -1714,6 +1729,118 @@ describe('AgentChat', () => {
     expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_old0000001', 'msg_new0000001']);
     expect(result.data?.hasMore).toBe(true);
     expect(agentChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' })?.hasMore).toBe(true);
+  });
+
+  it('fetchMore does not resurrect a message deleted on a newer page', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyEventPage(
+        [
+          {
+            sequence: 2,
+            event: {
+              type: 'message',
+              role: 'user',
+              messageId: 'msg_keep0000001',
+              content: { markdown: 'keep' },
+            },
+          },
+          { sequence: 3, event: { type: 'channel.delete', messageId: 'msg_gone0000001' } },
+        ],
+        'act_page0001'
+      )
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 1, messageId: 'msg_gone0000001', role: 'user', markdown: 'deleted later' }], null)
+    );
+
+    const result = await agentChat.fetchMore({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_keep0000001']);
+    expect(
+      agentChat
+        .getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' })
+        ?.messages.map((message) => message.id)
+    ).toEqual(['msg_keep0000001']);
+  });
+
+  it('fetchMore applies an edit from a newer page onto the older message', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyEventPage(
+        [
+          {
+            sequence: 2,
+            event: {
+              type: 'message',
+              role: 'user',
+              messageId: 'msg_keep0000001',
+              content: { markdown: 'keep' },
+            },
+          },
+          {
+            sequence: 3,
+            event: {
+              type: 'channel.edit',
+              messageId: 'msg_edit0000001',
+              content: { markdown: 'edited' },
+            },
+          },
+        ],
+        'act_page0001'
+      )
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 1, messageId: 'msg_edit0000001', role: 'user', markdown: 'original' }], null)
+    );
+
+    const result = await agentChat.fetchMore({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_edit0000001', 'msg_keep0000001']);
+    expect(result.data?.messages[0]).toMatchObject({
+      id: 'msg_edit0000001',
+      parts: [{ type: 'text', text: 'edited', state: 'done' }],
+    });
+  });
+
+  it('fetchMore does not resurrect a message deleted live while it was off-screen', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 2, messageId: 'msg_keep0000001', role: 'user', markdown: 'keep' }], 'act_page0001')
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveEnvelope({ sequence: 3, event: { type: 'channel.delete', messageId: 'msg_gone0000001' } })
+    );
+
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 1, messageId: 'msg_gone0000001', role: 'user', markdown: 'deleted later' }], null)
+    );
+
+    const result = await agentChat.fetchMore({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_keep0000001']);
   });
 
   it('fetchMore no-ops when olderCursor is null and does not call getEvents', async () => {

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -1912,7 +1912,7 @@ describe('AgentChat', () => {
     });
 
     getEvents.mockResolvedValueOnce(
-      historyPage([{ sequence: 2, messageId: 'msg_keep0000001', role: 'user', markdown: 'keep' }], 'act_page0001')
+      historyPage([{ sequence: 4, messageId: 'msg_keep0000001', role: 'user', markdown: 'keep' }], 'act_page0001')
     );
     await agentChat.loadConversation({
       agentId: 'agent_1',
@@ -1932,6 +1932,55 @@ describe('AgentChat', () => {
       id: 'msg_edit0000001',
       parts: [{ type: 'text', text: 'original', state: 'done' }],
     });
+  });
+
+  it('reload keeps a live delete that arrived while history GET was in flight', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyPage(
+        [
+          { sequence: 1, messageId: 'msg_gone0000001', role: 'user', markdown: 'deleted later' },
+          { sequence: 2, messageId: 'msg_keep0000001', role: 'user', markdown: 'keep' },
+        ],
+        null
+      )
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    let resolveEvents!: (value: ReturnType<typeof historyPage>) => void;
+    getEvents.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveEvents = resolve;
+        })
+    );
+
+    const reload = agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+    await waitForGetEventsCalls(2);
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveEnvelope({ sequence: 3, event: { type: 'channel.delete', messageId: 'msg_gone0000001' } })
+    );
+
+    resolveEvents(
+      historyPage(
+        [
+          { sequence: 1, messageId: 'msg_gone0000001', role: 'user', markdown: 'deleted later' },
+          { sequence: 2, messageId: 'msg_keep0000001', role: 'user', markdown: 'keep' },
+        ],
+        null
+      )
+    );
+
+    const result = await reload;
+
+    expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_keep0000001']);
   });
 
   it('fetchMore no-ops when olderCursor is null and does not call getEvents', async () => {

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -1843,6 +1843,97 @@ describe('AgentChat', () => {
     expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_keep0000001']);
   });
 
+  it('live source after an edit keeps the source part', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 1, messageId: 'msg_asst0000001', role: 'assistant', markdown: 'original' }], null)
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveEnvelope({
+        sequence: 2,
+        event: { type: 'channel.edit', messageId: 'msg_asst0000001', content: { markdown: 'edited' } },
+      })
+    );
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveEnvelope({
+        sequence: 3,
+        event: {
+          type: 'source',
+          messageId: 'msg_asst0000001',
+          sourceType: 'url',
+          url: 'https://example.com',
+          title: 'Example',
+        },
+      })
+    );
+
+    expect(
+      agentChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' })?.messages[0]?.parts
+    ).toMatchObject([
+      { type: 'text', text: 'edited', state: 'done' },
+      { type: 'source', sourceType: 'url', url: 'https://example.com', title: 'Example' },
+    ]);
+  });
+
+  it('reload drops a stale edit overlay that is not on the new history page', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyEventPage(
+        [
+          {
+            sequence: 2,
+            event: {
+              type: 'message',
+              role: 'user',
+              messageId: 'msg_keep0000001',
+              content: { markdown: 'keep' },
+            },
+          },
+          {
+            sequence: 3,
+            event: {
+              type: 'channel.edit',
+              messageId: 'msg_edit0000001',
+              content: { markdown: 'edited' },
+            },
+          },
+        ],
+        'act_page0001'
+      )
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 2, messageId: 'msg_keep0000001', role: 'user', markdown: 'keep' }], 'act_page0001')
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 1, messageId: 'msg_edit0000001', role: 'user', markdown: 'original' }], null)
+    );
+
+    const result = await agentChat.fetchMore({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(result.data?.messages[0]).toMatchObject({
+      id: 'msg_edit0000001',
+      parts: [{ type: 'text', text: 'original', state: 'done' }],
+    });
+  });
+
   it('fetchMore no-ops when olderCursor is null and does not call getEvents', async () => {
     getEvents.mockResolvedValue(
       historyPage([{ sequence: 1, messageId: 'msg_only0000001', role: 'user', markdown: 'only page' }], null)


### PR DESCRIPTION
## Summary

- Agent-chat GET pages still return the raw `client_events` ledger. History pages fold in isolation, so a later `channel.edit` / `channel.delete` on a newer page never reached the original `MESSAGE` on `fetchMore`.
- The store now records the highest-sequence edit/delete per `messageId` on `ConversationEntry` and replays that overlay after `absorbHistoryPage` and `prependOlderPage` (same seam as MCP connection results).
- Live still records mutations so an off-screen delete survives `fetchMore`, but it does not replay them. `applyEnvelope` already folds live edit/delete, and a second replay wiped later `source` parts. `absorbHistoryPage` clears the map first so a reload does not keep stale tombstones.

```mermaid
flowchart TD
  live["applyLiveEnvelope"] --> rec["record mutation"]
  rec --> fold["applyEnvelope once"]
  fold --> mcp["MCP overlay only"]
  hist["absorbHistoryPage / prependOlderPage"] --> rec2["record mutation"]
  rec2 --> page["fold page from empty"]
  page --> both["mutation overlay then MCP overlay"]
```

## Test plan

- [ ] Cold load a conversation whose newest page has `DELETE`/`EDIT` and no original `MESSAGE`
- [ ] `fetchMore` into the original `MESSAGE` page: deleted bubble stays gone; edited bubble shows latest text
- [ ] Delete a message live while it is off-screen, then `fetchMore`: it does not come back
- [ ] Edit a live assistant message, then receive a `source` part: both the new text and the source part remain
- [ ] Reload history, then `fetchMore`: overlays come from the new GET page only


Made with [Cursor](https://cursor.com)





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves the latest edit or delete for each Agent Chat message and reapplies those mutations when older history pages are loaded.
- Adds per-conversation mutation tracking and history-page overlays.
- Records live mutations without replaying them twice over live message parts.
- Adds pagination and reload-race coverage for edits and deletes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported reload race now preserves a live mutation that arrives while history is in flight.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/js/src/agent-chat/agent-chat-store.ts | Adds per-message mutation retention and overlays those mutations across history pagination while preserving single-fold live behavior. |
| packages/js/src/agent-chat/agent-chat.test.ts | Adds coverage for cross-page edits and deletes, off-screen live deletion, source preservation, and the reload/live-event race. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Live[Live event] --> Record[Record latest mutation]
  Live --> Fold[Fold live event once]
  History[History page] --> Record
  History --> PageFold[Fold page independently]
  PageFold --> MutationOverlay[Apply retained edit/delete overlay]
  MutationOverlay --> McpOverlay[Apply MCP result overlay]
  McpOverlay --> Timeline[Publish conversation timeline]
```

<sub>Reviews (3): Last reviewed commit: ["fix(js): keep edit/delete overlay across..."](https://github.com/novuhq/novu/commit/f1c8284cb2ddedd13d091205aed8dc941b031237) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57078812)</sub>

**Context used:**

- Knowledge Base — [Agent platform and AI integrations](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agent-platform.md)

<!-- /greptile_comment -->