### PR TITLE
fix(shared): stop Agent Chat embed prompt from looping on live verify fixes NV-8699

### DIFF
--- a/packages/shared/src/utils/connect-embed-prompt.ts
+++ b/packages/shared/src/utils/connect-embed-prompt.ts
@@ -238,7 +238,7 @@ Follow these docs (fetch as \`.md\`). **Skip** dashboard "create agent / connect
 Hard rules (also in docs):
 
 - Use **\`${agentId}\`** as the agent identifier everywhere.
-- Use \`toModelMessages(ctx.history)\`; do not call \`ctx.reply()\` when returning \`generateText()\`.
+- Use \`hydrateUnreachableAttachmentUrls(toModelMessages(ctx))\`; do not call \`ctx.reply()\` when returning \`generateText()\`.
 - Reuse the project's existing AI SDK provider; never hardcode API keys.`;
 }
 
@@ -306,28 +306,40 @@ Must render (capabilities only — match this app's routing, components, and sty
 If you need a working example of those capabilities:
 
 - GitHub: ${CONNECT_EMBED_TEMPLATE_URL}
-- Local checkout: \`${CONNECT_EMBED_TEMPLATE_LOCAL_PATH}/\`
+- Novu monorepo only: \`${CONNECT_EMBED_TEMPLATE_LOCAL_PATH}/\`
 
 Hard rules (partly in docs, rest connect-specific):
 
 - Install \`@novu/react\`; no \`<AgentChat />\` component exists.
 - Wire env vars from the Context section; do not hardcode identifiers in source.
+- Pass \`socketUrl\` from env as-is — do not rewrite \`127.0.0.1\` to \`localhost\` or swap in \`socket.novu.co\`.
+- Do not gate the first send behind a second click or a "connected" wait the SDK does not expose.
 - **Match this app's design system** — do not paste scaffold CSS, dashboard components, or dashboard tokens.
 - If HMAC is enabled: follow the quickstart "Going to production" section for \`subscriberHash\` / \`agentHash\`.
-- Smoke-test subscriber id when the app has no auth yet: \`${input.subscriberId}\``;
+- When the app has no auth yet, use subscriber id \`${input.subscriberId}\` — do not send a test message to prove it.`;
 }
 
 function renderVerifySection(includeHandler: boolean): string {
-  const bridgeLine = includeHandler
-    ? '- Confirm `/api/novu` (or your Chat SDK webhook route) responds without errors.'
-    : '';
+  const lines = [
+    '## Verify',
+    '',
+    'Do **not** open a browser, send a chat message, or inspect WebSocket traffic.',
+    '',
+    '- Skim the files you added for missing imports or hardcoded ids. Do not start `dev` or run a full-project typecheck.',
+    '- `NovuProvider` and `useAgentChat` read the Context env vars — do not hardcode identifiers.',
+    '- If `NEXT_PUBLIC_NOVU_SOCKET_URL` is set, pass it through as-is.',
+  ];
 
-  return `## Verify
+  if (includeHandler) {
+    lines.push('- The Part 1 route/handler files exist. Do not curl them.');
+  }
 
-- Run \`npm run dev:novu\` (or this project's equivalent).
-${bridgeLine}
-- Open Agent Chat in the app; send **one** message — reply must appear on the **first** message.
-- In DevTools → Network → WS: socket must hit your environment (e.g. \`127.0.0.1:8787\` locally), not \`socket.novu.co\` when testing against local API.`;
+  lines.push(
+    '',
+    "Then tell the user: run `npm run dev:novu` (or this project's equivalent) and send a message in Agent Chat."
+  );
+
+  return lines.join('\n');
 }
 
 function renderDocsSection(): string {

--- a/packages/shared/src/utils/connect-embed-prompt.ts
+++ b/packages/shared/src/utils/connect-embed-prompt.ts
@@ -238,7 +238,7 @@ Follow these docs (fetch as \`.md\`). **Skip** dashboard "create agent / connect
 Hard rules (also in docs):
 
 - Use **\`${agentId}\`** as the agent identifier everywhere.
-- Use \`hydrateUnreachableAttachmentUrls(toModelMessages(ctx))\`; do not call \`ctx.reply()\` when returning \`generateText()\`.
+- Use \`toModelMessages(ctx)\`; do not call \`ctx.reply()\` when returning \`generateText()\`.
 - Reuse the project's existing AI SDK provider; never hardcode API keys.`;
 }
 


### PR DESCRIPTION
## Summary

- Coding agents following the Agent Chat embed prompt were stuck looping on live verification (open chat, send a message, inspect WebSockets).
- Verify is now a static skim: no browser, no send, no DevTools. Socket URL and first-send stay as wiring rules; the user runs `npm run dev:novu` and sends the test message.
- Also aligns the AI SDK handler hint with generated code (`hydrateUnreachableAttachmentUrls(toModelMessages(ctx))`).

Linear: https://linear.app/novu/issue/NV-8699/stop-agent-chat-embed-prompt-from-looping-on-live-verify

## Test plan

- [ ] Open an existing-project Agent Chat connect embed prompt and confirm Verify does not ask to open the app, send a message, or inspect WS
- [ ] Confirm Hard rules still tell the agent to pass `socketUrl` as-is and not gate the first send
- [ ] Self-hosted path still includes Part 1 file-exists check; managed/demo path does not
- [ ] Paste the prompt into a coding agent on a sample app and confirm it stops after wiring instead of looping on chat/WS


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces live Agent Chat verification with a static wiring review so coding agents stop looping on browser and WebSocket checks.
- Updates the AI SDK handler hint to use `toModelMessages(ctx)`.
- Preserves socket URL and first-send wiring requirements.
- Limits runtime verification to instructions for the user.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/connect-embed-prompt.ts | Updates Agent Chat onboarding instructions and removes the helper reference responsible for the previous unresolved-import finding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(shared): drop hydrate wrap from Agen..."](https://github.com/novuhq/novu/commit/d6e3d068d38d108b327de448a6ff4b8ebf951156) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57083746)</sub>

<!-- /greptile_comment -->