### PR TITLE
fix(dashboard,novu,shared): pin Agent Chat connect flags and skip picker fixes NV-8704

### DIFF
--- a/apps/dashboard/src/components/agents/agent-chat-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-setup-guide.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useState } from 'react';
 import type { AgentResponse } from '@/api/agents';
 import { AgentChatSetupSteps } from '@/components/agents/agent-chat-setup-steps';
+import type { ConnectorId } from '@/components/agents/connectors/connector-options';
 import { useAgentChatPreview } from '@/hooks/use-agent-chat-preview';
-import { useAgentChatPrompt } from '@/hooks/use-agent-chat-prompt';
+import { resolveAgentChatConnectRuntime, useAgentChatPrompt } from '@/hooks/use-agent-chat-prompt';
 import { ListeningStatus, ProviderSetupStepperRail, SetupStepperRail } from './setup-guide-primitives';
 
 export type AgentChatSetupGuideProps = {
@@ -14,6 +15,8 @@ export type AgentChatSetupGuideProps = {
   onStepsCompleted?: () => void;
   /** Integrations tab: same content without Overview chrome */
   embedded?: boolean;
+  /** Self-hosted connector picked at agent creation. */
+  connectorId?: ConnectorId;
 };
 
 /**
@@ -28,8 +31,10 @@ export function AgentChatSetupGuide({
   stepOffset = 1,
   onStepsCompleted,
   embedded = false,
+  connectorId,
 }: AgentChatSetupGuideProps) {
-  const prompt = useAgentChatPrompt(agent);
+  const prompt = useAgentChatPrompt(agent, connectorId);
+  const runtime = resolveAgentChatConnectRuntime(agent, connectorId);
   const { openPreview } = useAgentChatPreview();
   const [isConnected, setIsConnected] = useState(false);
 
@@ -47,6 +52,7 @@ export function AgentChatSetupGuide({
       stepOffset={stepOffset}
       firstIncompleteStep={firstIncompleteStep}
       onOpenChat={() => openPreview(agent.identifier)}
+      runtime={runtime}
     />
   );
 

--- a/apps/dashboard/src/components/agents/agent-chat-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-chat-setup-steps.tsx
@@ -1,3 +1,4 @@
+import type { NovuConnectBridgeRuntime } from '@novu/shared';
 import { RiArrowRightSLine } from 'react-icons/ri';
 import {
   AGENT_CHAT_DOCS_URL,
@@ -18,6 +19,8 @@ type AgentChatSetupStepsProps = {
   /** Omit to show all steps as completed (connected recap). */
   firstIncompleteStep?: number;
   onOpenChat?: () => void;
+  /** Self-hosted connector already chosen in the dashboard. Pins `--runtime` on the TUI command. */
+  runtime?: NovuConnectBridgeRuntime;
 };
 
 export function AgentChatSetupSteps({
@@ -26,12 +29,14 @@ export function AgentChatSetupSteps({
   stepOffset = 1,
   firstIncompleteStep,
   onOpenChat,
+  runtime,
 }: AgentChatSetupStepsProps) {
   const base = stepOffset;
   const tuiCommandOptions = {
     apiUrl: apiHostnameManager.getHostname(),
     agentIdentifier,
     connectDashboardUrl: window.location.origin,
+    runtime,
   };
   const tuiDisplayCommand = buildAgentChatTuiCommandForDisplay(tuiCommandOptions);
   const tuiCopyCommand = buildAgentChatTuiCommand(tuiCommandOptions);
@@ -68,8 +73,19 @@ export function AgentChatSetupSteps({
         title="Add Web Chat to your app"
         description={
           <>
-            Paste the prompt into your coding agent. It runs <span className="font-code">npx novu connect --ci</span>{' '}
-            and asks you questions. Or copy the command and run the TUI yourself.{' '}
+            {runtime ? (
+              <>
+                Paste the prompt into your coding agent. It runs one{' '}
+                <span className="font-code">npx novu connect --ci</span> with the runtime and channel you already chose.
+                Or copy the command and run it yourself.{' '}
+              </>
+            ) : (
+              <>
+                Paste the prompt into your coding agent. It runs{' '}
+                <span className="font-code">npx novu connect --ci</span> and asks you questions. Or copy the command and
+                run the TUI yourself.{' '}
+              </>
+            )}
             <ExternalLink href={AGENT_CHAT_DOCS_URL} className="inline-flex">
               Read docs
             </ExternalLink>

--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -46,11 +46,13 @@ function buildConnectScaffoldParts({
   apiUrl,
   connectDashboardUrl,
   runtime,
+  agentIdentifier,
 }: {
   secretKey: string;
   apiUrl: string;
   connectDashboardUrl: string;
   runtime: ConnectRuntimeFlag;
+  agentIdentifier: string;
 }): string[] {
   return [
     `${getNovuConnectInvocation(apiUrl)} --runtime ${runtime}`,
@@ -60,6 +62,7 @@ function buildConnectScaffoldParts({
       connectDashboardUrl,
     }),
     '--channel skip',
+    `--agent-identifier ${agentIdentifier}`,
   ];
 }
 
@@ -68,17 +71,25 @@ function buildConnectScaffoldCommand({
   apiUrl,
   connectDashboardUrl,
   runtime,
+  agentIdentifier,
   masked,
 }: {
   secretKey: string;
   apiUrl: string;
   connectDashboardUrl: string;
   runtime: ConnectRuntimeFlag;
+  agentIdentifier: string;
   masked: boolean;
 }): string {
   const key = masked ? maskSecretKey(secretKey) : secretKey;
 
-  return buildConnectScaffoldParts({ secretKey: key, apiUrl, connectDashboardUrl, runtime }).join(' \\\n  ');
+  return buildConnectScaffoldParts({
+    secretKey: key,
+    apiUrl,
+    connectDashboardUrl,
+    runtime,
+    agentIdentifier,
+  }).join(' \\\n  ');
 }
 
 function buildConnectScaffoldCopyCommand({
@@ -86,13 +97,15 @@ function buildConnectScaffoldCopyCommand({
   apiUrl,
   connectDashboardUrl,
   runtime,
+  agentIdentifier,
 }: {
   secretKey: string;
   apiUrl: string;
   connectDashboardUrl: string;
   runtime: ConnectRuntimeFlag;
+  agentIdentifier: string;
 }): string {
-  return buildConnectScaffoldParts({ secretKey, apiUrl, connectDashboardUrl, runtime }).join(' ');
+  return buildConnectScaffoldParts({ secretKey, apiUrl, connectDashboardUrl, runtime, agentIdentifier }).join(' ');
 }
 
 function getProviderSlackMessage(agentName: string): string {
@@ -403,7 +416,7 @@ export function AgentCodeSetupSection({
             </Tooltip>
           </span>
         }
-        description="Run this in an empty directory to scaffold a Next.js bridge app. When prompted, select the agent you created above. `--channel skip` skips channel setup because you already connected a provider in the dashboard."
+        description="Run this in an empty directory to scaffold a Next.js bridge app. `--runtime` and `--agent-identifier` are already set from the dashboard. `--channel skip` skips channel setup because you already connected a provider here."
         rightContent={
           apiKeysQuery.isLoading || !secretKey ? (
             <Skeleton className="h-[80px] w-full rounded-lg" />
@@ -414,6 +427,7 @@ export function AgentCodeSetupSection({
                 apiUrl: currentApiUrl,
                 connectDashboardUrl,
                 runtime: connectRuntime,
+                agentIdentifier: agent.identifier,
                 masked: true,
               })}
               copyCommand={buildConnectScaffoldCopyCommand({
@@ -421,6 +435,7 @@ export function AgentCodeSetupSection({
                 apiUrl: currentApiUrl,
                 connectDashboardUrl,
                 runtime: connectRuntime,
+                agentIdentifier: agent.identifier,
               })}
             />
           )

--- a/apps/dashboard/src/components/agents/agent-integration-guides/agent-chat-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/agent-chat-agent-integration-guide.tsx
@@ -14,7 +14,7 @@ import { SetupGuideCard } from '@/components/agents/setup-guide-card';
 import { SetupStepperRail } from '@/components/agents/setup-guide-primitives';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useAgentChatPreview } from '@/hooks/use-agent-chat-preview';
-import { useAgentChatPrompt } from '@/hooks/use-agent-chat-prompt';
+import { resolveAgentChatConnectRuntime, useAgentChatPrompt } from '@/hooks/use-agent-chat-prompt';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 import { SectionLinkButton } from './agent-connected-details-shell';
@@ -106,6 +106,7 @@ function AgentChatConnectedRecap({
   const navigate = useNavigate();
   const { currentEnvironment } = useEnvironment();
   const prompt = useAgentChatPrompt(agent);
+  const runtime = resolveAgentChatConnectRuntime(agent);
   const { openPreview } = useAgentChatPreview();
 
   const isConnected = isAgentIntegrationConnected(integrationLink);
@@ -168,7 +169,12 @@ function AgentChatConnectedRecap({
 
       <SetupGuideCard label="Setup steps" persistKey={persistKey} defaultExpanded={false}>
         <SetupStepperRail className="gap-8 py-6 pb-3 pr-3 md:pr-6">
-          <AgentChatSetupSteps prompt={prompt} agentIdentifier={agent.identifier} onOpenChat={handleOpenChat} />
+          <AgentChatSetupSteps
+            prompt={prompt}
+            agentIdentifier={agent.identifier}
+            onOpenChat={handleOpenChat}
+            runtime={runtime}
+          />
         </SetupStepperRail>
       </SetupGuideCard>
     </div>

--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -370,10 +370,12 @@ export function AgentSetupSteps({
   // start at 1 here instead of continuing from 3.
   const isOnboarding = Boolean(connectSummary);
   const brainStepsBefore = isOnboarding ? BRAIN_STEPS : 0;
-  const handlerStepsAfter = isManagedRuntime ? 0 : HANDLER_STEPS;
 
   const legacyDefaultFromAgent = useCloudMergedListenStep ? undefined : agent.integrations?.[0];
   const selectedProviderId = selectedIntegration?.providerId ?? legacyDefaultFromAgent?.providerId;
+  // Agent Chat's first prompt already scaffolds the handler with `--runtime` + `--channel agent-chat`.
+  const skipHandlerSection = isManagedRuntime || selectedProviderId === ChatProviderIdEnum.NovuAgentChat;
+  const handlerStepsAfter = skipHandlerSection ? 0 : HANDLER_STEPS;
   const isEmailChannelSelected = selectedProviderId === EmailProviderIdEnum.NovuAgent;
   const effectiveIntegrationId = validatedSelectedId ?? selectedIntegrationId ?? legacyDefaultFromAgent?.integrationId;
 
@@ -845,6 +847,7 @@ export function AgentSetupSteps({
                       stepOffset={providerGuideStepOffset}
                       embedded={false}
                       isOnboarding={isOnboarding}
+                      connectorId={connectSummary?.connectorId}
                       onStepsCompleted={handleProviderStepsCompleted}
                       onWelcomeSent={
                         guideProviderId !== EmailProviderIdEnum.NovuAgent
@@ -865,6 +868,7 @@ export function AgentSetupSteps({
                 stepOffset={providerGuideStepOffset}
                 embedded={false}
                 isOnboarding={isOnboarding}
+                connectorId={connectSummary?.connectorId}
                 onStepsCompleted={handleProviderStepsCompleted}
                 onWelcomeSent={
                   isOnboarding && guideProviderId && guideProviderId !== EmailProviderIdEnum.NovuAgent
@@ -878,7 +882,7 @@ export function AgentSetupSteps({
         ) : null}
       </AnimatePresence>
 
-      {channelReadyForBridge && !isManagedRuntime && (
+      {channelReadyForBridge && !skipHandlerSection && (
         <div className="pl-8">
           <AgentCodeSetupSection
             agent={agent}

--- a/apps/dashboard/src/hooks/use-agent-chat-prompt.ts
+++ b/apps/dashboard/src/hooks/use-agent-chat-prompt.ts
@@ -16,10 +16,6 @@ export function resolveAgentChatConnectRuntime(
     return connectorId;
   }
 
-  if (agent.runtime === 'self-hosted') {
-    return 'ai-sdk';
-  }
-
   return undefined;
 }
 

--- a/apps/dashboard/src/hooks/use-agent-chat-prompt.ts
+++ b/apps/dashboard/src/hooks/use-agent-chat-prompt.ts
@@ -1,13 +1,34 @@
+import { buildAgentChatPrompt, isNovuConnectBridgeRuntime, type NovuConnectBridgeRuntime } from '@novu/shared';
 import { useMemo } from 'react';
 import type { AgentResponse } from '@/api/agents';
-import { buildAgentChatPrompt } from '@/components/agents/agent-chat-setup-content';
+import type { ConnectorId } from '@/components/agents/connectors/connector-options';
 import { apiHostnameManager } from '@/utils/api-hostname-manager';
 
-export function useAgentChatPrompt(agent: AgentResponse): string {
+export function resolveAgentChatConnectRuntime(
+  agent: AgentResponse,
+  connectorId?: ConnectorId
+): NovuConnectBridgeRuntime | undefined {
+  if (agent.runtime === 'managed') {
+    return undefined;
+  }
+
+  if (isNovuConnectBridgeRuntime(connectorId)) {
+    return connectorId;
+  }
+
+  if (agent.runtime === 'self-hosted') {
+    return 'ai-sdk';
+  }
+
+  return undefined;
+}
+
+export function useAgentChatPrompt(agent: AgentResponse, connectorId?: ConnectorId): string {
   const apiUrl = apiHostnameManager.getHostname();
+  const runtime = resolveAgentChatConnectRuntime(agent, connectorId);
 
   return useMemo(
-    () => buildAgentChatPrompt(agent.name, agent.identifier, apiUrl),
-    [agent.name, agent.identifier, apiUrl]
+    () => buildAgentChatPrompt(agent.name, agent.identifier, apiUrl, { runtime }),
+    [agent.name, agent.identifier, apiUrl, runtime]
   );
 }

--- a/packages/novu/src/commands/connect/pipeline/bridge/create-bridge-agent.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/bridge/create-bridge-agent.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ConnectApiClient } from '../../api/client';
+import type { ConnectCommandOptions } from '../../types';
+import type { ConnectUI } from '../../ui/ui';
+
+const listAgents = vi.fn();
+const createBridgeAgent = vi.fn();
+
+vi.mock('../../api/agents', () => ({
+  listAgents: (...args: unknown[]) => listAgents(...args),
+  createBridgeAgent: (...args: unknown[]) => createBridgeAgent(...args),
+}));
+
+import { createBridgeAgentFlow } from './create-bridge-agent';
+
+const client = {} as ConnectApiClient;
+
+function createUi() {
+  return {
+    pickExistingOrCreate: vi.fn(),
+    promptForAgentName: vi.fn(),
+    creatingAgent: vi.fn(),
+  } as unknown as ConnectUI & {
+    pickExistingOrCreate: ReturnType<typeof vi.fn>;
+    promptForAgentName: ReturnType<typeof vi.fn>;
+    creatingAgent: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('createBridgeAgentFlow', () => {
+  it('reuses --agent-identifier and skips the picker', async () => {
+    const ui = createUi();
+    listAgents.mockResolvedValue([
+      { _id: '1', identifier: 'fred', name: 'Fred', runtime: 'self-hosted' },
+      { _id: '2', identifier: 'other', name: 'Other', runtime: 'self-hosted' },
+    ]);
+
+    const result = await createBridgeAgentFlow(client, ui, {
+      agentIdentifier: 'fred',
+    } as ConnectCommandOptions);
+
+    expect(result).toEqual({
+      agent: { id: '1', identifier: 'fred', name: 'Fred' },
+      flow: 'reused',
+    });
+    expect(ui.pickExistingOrCreate).not.toHaveBeenCalled();
+    expect(createBridgeAgent).not.toHaveBeenCalled();
+  });
+
+  it('throws when --agent-identifier does not match this environment', async () => {
+    const ui = createUi();
+    listAgents.mockResolvedValue([{ _id: '1', identifier: 'fred', name: 'Fred', runtime: 'self-hosted' }]);
+
+    await expect(
+      createBridgeAgentFlow(client, ui, { agentIdentifier: 'missing' } as ConnectCommandOptions)
+    ).rejects.toThrow('No agent found with identifier "missing" in this environment.');
+    expect(ui.pickExistingOrCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/novu/src/commands/connect/pipeline/bridge/create-bridge-agent.ts
+++ b/packages/novu/src/commands/connect/pipeline/bridge/create-bridge-agent.ts
@@ -3,6 +3,7 @@ import type { ConnectApiClient } from '../../api/client';
 import type { AgentSummary, ConnectCommandOptions } from '../../types';
 import type { ConnectUI } from '../../ui/ui';
 import { defaultAgentNameFromDir, deriveAgentIdentifier } from '../chat-sdk/derive-identifier';
+import { resolveExistingAgentByIdentifier } from '../resolve-existing-agent';
 
 export async function createBridgeAgentFlow(
   client: ConnectApiClient,
@@ -10,6 +11,12 @@ export async function createBridgeAgentFlow(
   options: ConnectCommandOptions
 ): Promise<{ agent: AgentSummary; flow: 'created' | 'reused' }> {
   const existingAgents = await listAgents(client);
+  const requestedIdentifier = options.agentIdentifier?.trim();
+
+  if (requestedIdentifier) {
+    return { agent: resolveExistingAgentByIdentifier(existingAgents, requestedIdentifier), flow: 'reused' };
+  }
+
   const bridgeAgents = existingAgents.filter((agent) => agent.runtime !== 'managed');
 
   if (bridgeAgents.length > 0) {

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -24,7 +24,8 @@ Do **not** ask Step 0 when the user only wants to connect a **channel** in the c
 
 **Mandatory routing rules:**
 
-- **Agent Chat / web chat named explicitly** → use `--channel agent-chat` and skip the channel picker. Use the custom code bridge only when the user also asks for AI SDK, LangChain, or handler wiring; otherwise use the managed path. On an Agent Chat-only request, do not pass `--runtime` or `--agent-chat-setup`. This rule takes precedence over generic "add an agent to my app" wording.
+- **Flags already in the user prompt** (`--runtime`, `--channel`, `--agent-identifier`) → copy those flags onto the connect command. Do **not** ask Step 0, B1, or B2 for values the prompt already locked. A dashboard-created bridge agent that names `--runtime ai-sdk|langchain|custom-code` is the custom-code path even when Agent Chat is also named.
+- **Agent Chat / web chat named explicitly** → use `--channel agent-chat` and skip the channel picker. Use the custom code bridge only when the user also asks for AI SDK, LangChain, or handler wiring, or already passes `--runtime`; otherwise use the managed path. On an Agent Chat-only request (no runtime / handler signal), do not pass `--runtime` or `--agent-chat-setup`. This rule takes precedence over generic "add an agent to my app" wording.
 - **MS Teams + no dashboard-login signal** → dashboard redirect. Do **not** run `npx novu connect`. Never pass `--channel teams` with `--keyless`.
 - **"Add an agent to my app"** (or equivalent) → **custom code bridge**. Never use the managed path.
 - **"Connect a Novu agent to \<channel\> for this project"** (or similar channel-only wording) → **managed**. **Never** bridge. *"For this project"* means the current workspace directory, not "wire my handler."
@@ -371,10 +372,13 @@ Same channel picker and rules as [Step M1](#step-m1--choose-channel-and-collect-
 - **Never pass `--keyless`** on the bridge path.
 - **Do not** infer or confirm a managed-agent description (skip [Step M2](#step-m2--infer-the-agents-purpose-then-confirm) entirely).
 - **Runtime** is chosen in Step B2, not here.
+- If the user prompt already includes `--channel <value>`, use that value and skip this picker.
 
 ## Step B2 — Pick bridge runtime
 
 **Goal:** lock `--runtime ai-sdk` or `--runtime langchain` before running connect.
+
+If the user prompt already includes `--runtime ai-sdk`, `--runtime langchain`, or `--runtime custom-code`, use that value and skip this step.
 
 Use the **Read** tool on `package.json` and inspect `dependencies` / `devDependencies` in the file content. **Never** use Bash (`grep`, `cat`, `jq`, or shell pipelines) to read package.json.
 
@@ -404,7 +408,8 @@ If you must ask, call `AskQuestion` / `AskUserQuestion`:
 npx novu@latest connect \
   --ci \
   --runtime <ai-sdk|langchain> \
-  --channel <slack|email|telegram|whatsapp|teams|agent-chat|skip>
+  --channel <slack|email|telegram|whatsapp|teams|agent-chat|skip> \
+  --agent-identifier <id>   # when the dashboard already created the agent
 ```
 
 **Canonical example (dashboard OAuth, AI SDK, slack, existing project):**

--- a/packages/shared/src/utils/agent-chat-connect-prompt.spec.ts
+++ b/packages/shared/src/utils/agent-chat-connect-prompt.spec.ts
@@ -59,6 +59,28 @@ describe('agent-chat-connect-prompt', () => {
     expect(prompt).toContain('--region staging');
   });
 
+  it('pins runtime and agent on the TUI command for a dashboard-created bridge agent', () => {
+    expect(
+      buildAgentChatTuiCommand({
+        apiUrl: NOVU_STAGING_API_URL,
+        agentIdentifier: 'staging-investigator',
+        runtime: 'ai-sdk',
+      })
+    ).toBe(
+      'npx novu@rc connect --runtime ai-sdk --channel agent-chat --region staging --agent-identifier staging-investigator'
+    );
+  });
+
+  it('tells the coding agent not to re-pick runtime or channel when runtime is known', () => {
+    const prompt = buildAgentChatPrompt('Fred', 'fred', NOVU_STAGING_API_URL, { runtime: 'ai-sdk' });
+
+    expect(prompt).toContain('--runtime ai-sdk');
+    expect(prompt).toContain('--channel agent-chat');
+    expect(prompt).toContain('--agent-identifier fred');
+    expect(prompt).toContain('Do not ask me to pick runtime, channel, or agent');
+    expect(prompt).not.toContain('Connect a Novu agent to Agent Chat for this project');
+  });
+
   it('keeps the production copy prompt on US Cloud', () => {
     const prompt = buildOnboardingAgentPrompt('https://api.novu.co');
 

--- a/packages/shared/src/utils/agent-chat-connect-prompt.ts
+++ b/packages/shared/src/utils/agent-chat-connect-prompt.ts
@@ -11,16 +11,38 @@ import {
 export const AGENT_CHAT_DOCS_URL = 'https://docs.novu.co/agents/channels/agent-chat';
 export const AGENT_ONBOARDING_PLAYBOOK_URL = 'https://novu.co/agents.md';
 
+export const NOVU_CONNECT_BRIDGE_RUNTIMES = ['ai-sdk', 'langchain', 'custom-code'] as const;
+export type NovuConnectBridgeRuntime = (typeof NOVU_CONNECT_BRIDGE_RUNTIMES)[number];
+
+export function isNovuConnectBridgeRuntime(value: string | null | undefined): value is NovuConnectBridgeRuntime {
+  return value === 'ai-sdk' || value === 'langchain' || value === 'custom-code';
+}
+
+function bridgeRuntimeLabel(runtime: NovuConnectBridgeRuntime): string {
+  switch (runtime) {
+    case 'ai-sdk':
+      return 'AI SDK';
+    case 'langchain':
+      return 'LangChain';
+    case 'custom-code':
+      return 'custom code';
+  }
+}
+
 export type BuildAgentChatTuiCommandOptions = NovuConnectTargetOptions & {
   agentIdentifier?: string | null;
+  runtime?: NovuConnectBridgeRuntime | null;
 };
 
 export function buildAgentChatTuiCommandParts(
   apiUrlOrOptions?: string | null | BuildAgentChatTuiCommandOptions
 ): string[] {
   const options = normalizeConnectTargetOptions<BuildAgentChatTuiCommandOptions>(apiUrlOrOptions);
+  const runtime = options.runtime && isNovuConnectBridgeRuntime(options.runtime) ? options.runtime : undefined;
   const parts = [
-    `${getNovuConnectInvocation(options.apiUrl)} --channel agent-chat`,
+    runtime
+      ? `${getNovuConnectInvocation(options.apiUrl)} --runtime ${runtime} --channel agent-chat`
+      : `${getNovuConnectInvocation(options.apiUrl)} --channel agent-chat`,
     ...getNovuConnectTargetFlags(options),
   ];
   const agentIdentifier = options.agentIdentifier?.trim();
@@ -58,12 +80,37 @@ function signedInDashboardLine(apiUrl?: string | null): string {
   return `I'm signed in to the Novu dashboard, so use dashboard login (not keyless mode).`;
 }
 
+export type BuildAgentChatPromptOptions = {
+  runtime?: NovuConnectBridgeRuntime | null;
+};
+
 /**
  * Dashboard Copy prompt / Open in Cursor text. Same shape as the onboarding
  * prompt: signed-in line + intent + agents.md. The playbook owns `--ci`,
  * questions, and flags. Staging and local dev use `novu@rc` (staging also passes `--region staging`).
+ *
+ * When `runtime` is set, this is a dashboard-created bridge agent: one connect
+ * run must scaffold the handler and attach Agent Chat. Do not ask for runtime or channel again.
  */
-export function buildAgentChatPrompt(agentName: string, agentIdentifier: string, apiUrl?: string | null): string {
+export function buildAgentChatPrompt(
+  agentName: string,
+  agentIdentifier: string,
+  apiUrl?: string | null,
+  promptOptions?: BuildAgentChatPromptOptions
+): string {
+  const runtime =
+    promptOptions?.runtime && isNovuConnectBridgeRuntime(promptOptions.runtime) ? promptOptions.runtime : undefined;
+
+  if (runtime) {
+    const lines = [
+      `${signedInDashboardLine(apiUrl)} Add Agent Chat to this project for an existing ${bridgeRuntimeLabel(runtime)} bridge agent following instructions from this markdown file: ${AGENT_ONBOARDING_PLAYBOOK_URL}`,
+      buildNovuConnectStagingHint(apiUrl),
+      `The dashboard already created "${agentName}" (id: ${agentIdentifier}) with ${bridgeRuntimeLabel(runtime)} and Agent Chat selected. Run one \`npx novu connect\` with \`--runtime ${runtime} --channel agent-chat --agent-identifier ${agentIdentifier}\`. Do not ask me to pick runtime, channel, or agent. Scaffold or embed in that same run, then start the app with \`npm run dev:novu\`.`,
+    ].filter((line): line is string => Boolean(line));
+
+    return lines.join('\n\n');
+  }
+
   const lines = [
     `${signedInDashboardLine(apiUrl)} Connect a Novu agent to Agent Chat for this project following instructions from this markdown file: ${AGENT_ONBOARDING_PLAYBOOK_URL}`,
     buildNovuConnectStagingHint(apiUrl),


### PR DESCRIPTION
## Summary
- Dashboard Agent Chat onboarding now uses **one** `npx novu connect` run that already includes `--runtime`, `--channel agent-chat`, and `--agent-identifier` from the agent you created.
- The copy prompt tells the coding agent not to ask for runtime, channel, or agent again. The second “Scaffold your agent project” block is hidden for Agent Chat.
- CLI bridge path now honors `--agent-identifier` and skips the TUI agent picker (this was ignored when `--runtime` was set).

Linear: https://linear.app/novu/issue/NV-8704/single-agent-chat-connect-run-should-pin-dashboard-runtime-and-skip

## Test plan
- [ ] Create a self-hosted Agent Chat agent (AI SDK). Confirm the first command includes `--runtime ai-sdk --channel agent-chat --agent-identifier <id>`.
- [ ] Confirm no second scaffold/`npx novu connect` step appears after the first step.
- [ ] Run local CLI: `node packages/novu/dist/src/index.js connect --runtime ai-sdk --channel agent-chat --api-url http://localhost:3000 --connect-dashboard-url http://localhost:4201 --dashboard-url http://localhost:4201 --agent-identifier <id>` — no agent picker.
- [ ] Managed Claude Agent Chat: still channel-only, no handler scaffold block.
- [ ] Slack/email self-hosted: scaffold section still shows, with `--runtime`, `--agent-identifier`, and `--channel skip`.


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consolidates dashboard-created Agent Chat bridge onboarding into one pinned `novu connect` run and makes the CLI reuse the requested agent without showing the picker.
- Passes the creation-time connector runtime and agent identifier into Agent Chat setup commands and prompts.
- Hides the redundant handler-scaffolding section for Agent Chat.
- Resolves `--agent-identifier` before the bridge-agent picker and adds focused tests.
- Removes the incorrect AI SDK fallback for self-hosted agents.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/hooks/use-agent-chat-prompt.ts | Resolves concrete bridge runtimes only from connector context, eliminating the incorrect AI SDK fallback for generic self-hosted agents. |
| apps/dashboard/src/components/agents/agent-setup-steps.tsx | Passes the creation connector into Agent Chat onboarding and suppresses the redundant handler section for Agent Chat. |
| packages/shared/src/utils/agent-chat-connect-prompt.ts | Adds runtime-aware Agent Chat prompts and commands that pin runtime, channel, and agent identity when known. |
| packages/novu/src/commands/connect/pipeline/bridge/create-bridge-agent.ts | Reuses an explicitly identified existing agent before invoking the interactive bridge-agent picker. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Dashboard creates bridge agent] --> B[Creation summary retains connector runtime]
  B --> C[Agent Chat setup guide]
  C --> D[Build pinned connect command]
  D --> E[novu connect receives runtime, channel, and agent identifier]
  E --> F[Resolve existing agent]
  F --> G[Skip agent picker]
  G --> H[Scaffold handler and attach Agent Chat in one run]
```

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): do not guess Agent Chat ..."](https://github.com/novuhq/novu/commit/6c02cd004e41889d85fa531031eca1307ae19ab6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57448910)</sub>

<!-- /greptile_comment -->