### PR TITLE
refactor(api-service,dal,shared): collapse HumanInteraction onto deliveries fixes NV-8703

### DIFF
--- a/apps/api/migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.spec.ts
+++ b/apps/api/migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.spec.ts
@@ -1,0 +1,174 @@
+import { expect } from 'chai';
+import { stub } from 'sinon';
+
+import {
+  buildHumanInteractionCollapseUpdate,
+  collapseHumanInteractionMirroredFields,
+  selectLegacyHumanInteractionIndexNames,
+} from './human-interaction-collapse-deliveries.migration';
+
+describe('human-interaction-collapse-deliveries migration', () => {
+  it('builds a single delivery from top-level fields and fills subscriberIds', () => {
+    const update = buildHumanInteractionCollapseUpdate({
+      _id: 'hi1',
+      subscriberId: 'alice',
+      integrationIdentifier: 'telegram-main',
+      platform: 'telegram',
+      platformMessageId: 'msg-1',
+      platformThreadId: 'thread-1',
+    });
+
+    expect(update).to.deep.equal({
+      $set: {
+        subscriberIds: ['alice'],
+        deliveries: [
+          {
+            subscriberId: 'alice',
+            integrationIdentifier: 'telegram-main',
+            platform: 'telegram',
+            platformMessageId: 'msg-1',
+            platformThreadId: 'thread-1',
+          },
+        ],
+      },
+      $unset: {
+        subscriberId: 1,
+        integrationIdentifier: 1,
+        platform: 1,
+        platformMessageId: 1,
+        platformThreadId: 1,
+      },
+    });
+  });
+
+  it('keeps existing deliveries and still unsets mirrored fields', () => {
+    const update = buildHumanInteractionCollapseUpdate({
+      _id: 'hi2',
+      subscriberId: 'alice',
+      subscriberIds: ['alice', 'bob'],
+      integrationIdentifier: 'telegram-main',
+      platform: 'telegram',
+      platformMessageId: 'msg-1',
+      platformThreadId: 'thread-1',
+      deliveries: [
+        {
+          subscriberId: 'alice',
+          integrationIdentifier: 'telegram-main',
+          platform: 'telegram',
+          platformMessageId: 'msg-1',
+          platformThreadId: 'thread-1',
+        },
+        {
+          subscriberId: 'bob',
+          integrationIdentifier: 'telegram-main',
+          platform: 'telegram',
+          platformMessageId: 'msg-2',
+          platformThreadId: 'thread-2',
+        },
+      ],
+    });
+
+    expect(update?.$set).to.equal(undefined);
+    expect(update?.$unset).to.deep.equal({
+      subscriberId: 1,
+      integrationIdentifier: 1,
+      platform: 1,
+      platformMessageId: 1,
+      platformThreadId: 1,
+    });
+  });
+
+  it('is a no-op for already collapsed rows', () => {
+    expect(
+      buildHumanInteractionCollapseUpdate({
+        _id: 'hi3',
+        subscriberIds: ['alice'],
+        deliveries: [
+          {
+            subscriberId: 'alice',
+            integrationIdentifier: 'telegram-main',
+            platform: 'telegram',
+            platformMessageId: 'msg-1',
+            platformThreadId: 'thread-1',
+          },
+        ],
+      })
+    ).to.equal(null);
+  });
+
+  it('skips deliveries backfill when platform message ids are missing', () => {
+    const update = buildHumanInteractionCollapseUpdate({
+      _id: 'hi4',
+      subscriberId: 'alice',
+      integrationIdentifier: 'telegram-main',
+      platform: 'telegram',
+    });
+
+    expect(update).to.deep.equal({
+      $set: { subscriberIds: ['alice'] },
+      $unset: {
+        subscriberId: 1,
+        integrationIdentifier: 1,
+        platform: 1,
+      },
+    });
+  });
+
+  it('selects only the mirrored-field indexes', () => {
+    expect(
+      selectLegacyHumanInteractionIndexNames([
+        { name: '_id_', key: { _id: 1 } },
+        { name: 'identifier', key: { _environmentId: 1, identifier: 1 } },
+        {
+          name: 'subscriberId_pending',
+          key: { _environmentId: 1, subscriberId: 1, status: 1, createdAt: -1 },
+        },
+        {
+          name: 'subscriberIds_pending',
+          key: { _environmentId: 1, subscriberIds: 1, status: 1, createdAt: -1 },
+        },
+        { name: 'platformMessageId', key: { _environmentId: 1, platformMessageId: 1 } },
+        {
+          name: 'deliveries_platformMessageId',
+          key: { _environmentId: 1, 'deliveries.platformMessageId': 1 },
+        },
+      ])
+    ).to.deep.equal(['subscriberId_pending', 'platformMessageId']);
+  });
+
+  it('bulk-writes backfills and drops mirrored indexes', async () => {
+    const bulkWrite = stub().resolves({ modifiedCount: 1 });
+    const dropIndex = stub().resolves(undefined);
+    const collection = {
+      find: () => ({
+        batchSize: () => [
+          {
+            _id: 'hi1',
+            subscriberId: 'alice',
+            integrationIdentifier: 'telegram-main',
+            platform: 'telegram',
+            platformMessageId: 'msg-1',
+            platformThreadId: 'thread-1',
+          },
+        ],
+      }),
+      bulkWrite,
+      indexes: async () => [
+        { name: 'subscriberId_pending', key: { _environmentId: 1, subscriberId: 1, status: 1, createdAt: -1 } },
+        { name: 'deliveries_platformMessageId', key: { _environmentId: 1, 'deliveries.platformMessageId': 1 } },
+      ],
+      dropIndex,
+    };
+
+    const result = await collapseHumanInteractionMirroredFields(collection as any);
+
+    expect(result).to.deep.equal({
+      scanned: 1,
+      modified: 1,
+      droppedIndexes: ['subscriberId_pending'],
+    });
+    expect(bulkWrite.calledOnce).to.equal(true);
+    expect(bulkWrite.firstCall.args[0]).to.have.length(1);
+    expect(dropIndex.calledOnceWith('subscriberId_pending')).to.equal(true);
+  });
+});

--- a/apps/api/migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.ts
+++ b/apps/api/migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.ts
@@ -36,12 +36,10 @@ export interface HumanInteractionCollapseUpdate {
 
 function resolveSubscriberIds(doc: LegacyHumanInteractionDocument): string[] {
   if (Array.isArray(doc.subscriberIds) && doc.subscriberIds.length > 0) {
-
     return doc.subscriberIds;
   }
 
   if (doc.subscriberId) {
-
     return [doc.subscriberId];
   }
 
@@ -91,7 +89,6 @@ export function buildHumanInteractionCollapseUpdate(
   }
 
   if (Object.keys($set).length === 0 && Object.keys($unset).length === 0) {
-
     return null;
   }
 
@@ -107,7 +104,6 @@ export function selectLegacyHumanInteractionIndexNames(
   return indexes
     .filter((index) => {
       if (index.key.subscriberId !== undefined) {
-
         return true;
       }
 
@@ -152,7 +148,6 @@ export async function collapseHumanInteractionMirroredFields(collection: Collaps
 
   async function flush(): Promise<void> {
     if (batch.length === 0) {
-
       return;
     }
 

--- a/apps/api/migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.ts
+++ b/apps/api/migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.ts
@@ -1,6 +1,6 @@
 import '../../src/config';
 
-import { HumanInteraction } from '@novu/dal';
+import { DalService, HumanInteraction } from '@novu/dal';
 
 const BATCH_SIZE = 500;
 
@@ -191,24 +191,27 @@ export async function collapseHumanInteractionMirroredFields(collection: Collaps
 export async function run() {
   console.log('Start migration - collapse HumanInteraction mirrored fields onto deliveries');
 
-  const { NestFactory } = await import('@nestjs/core');
-  const { AppModule } = await import('../../src/app.module');
-  const app = await NestFactory.create(AppModule, {
-    logger: false,
-  });
+  if (!process.env.MONGO_URL) {
+    throw new Error('MONGO_URL is not set');
+  }
 
-  const result = await collapseHumanInteractionMirroredFields(
-    HumanInteraction.collection as unknown as CollapseCollection
-  );
+  const dalService = new DalService();
+  await dalService.connect(process.env.MONGO_URL);
 
-  console.log(
-    `Backfilled HumanInteraction rows: scanned ${result.scanned} modified ${result.modified}; dropped indexes: ${
-      result.droppedIndexes.join(', ') || 'none'
-    }`
-  );
-  console.log('End migration.');
+  try {
+    const result = await collapseHumanInteractionMirroredFields(
+      HumanInteraction.collection as unknown as CollapseCollection
+    );
 
-  await app.close();
+    console.log(
+      `Backfilled HumanInteraction rows: scanned ${result.scanned} modified ${result.modified}; dropped indexes: ${
+        result.droppedIndexes.join(', ') || 'none'
+      }`
+    );
+    console.log('End migration.');
+  } finally {
+    await dalService.disconnect();
+  }
 }
 
 if (require.main === module) {

--- a/apps/api/migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.ts
+++ b/apps/api/migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.ts
@@ -1,0 +1,229 @@
+import '../../src/config';
+
+import { HumanInteraction } from '@novu/dal';
+
+const BATCH_SIZE = 500;
+
+const MIRRORED_FIELDS = [
+  'subscriberId',
+  'integrationIdentifier',
+  'platform',
+  'platformMessageId',
+  'platformThreadId',
+] as const;
+
+export interface LegacyHumanInteractionDocument {
+  _id: unknown;
+  subscriberId?: string;
+  subscriberIds?: string[];
+  integrationIdentifier?: string;
+  platform?: string;
+  platformMessageId?: string;
+  platformThreadId?: string;
+  deliveries?: Array<{
+    subscriberId: string;
+    integrationIdentifier: string;
+    platform: string;
+    platformMessageId: string;
+    platformThreadId: string;
+  }>;
+}
+
+export interface HumanInteractionCollapseUpdate {
+  $set?: Record<string, unknown>;
+  $unset?: Record<string, 1>;
+}
+
+function resolveSubscriberIds(doc: LegacyHumanInteractionDocument): string[] {
+  if (Array.isArray(doc.subscriberIds) && doc.subscriberIds.length > 0) {
+
+    return doc.subscriberIds;
+  }
+
+  if (doc.subscriberId) {
+
+    return [doc.subscriberId];
+  }
+
+  return [];
+}
+
+/**
+ * Backfill `deliveries` / `subscriberIds` from the mirrored top-level fields
+ * NV-8697 dual-wrote, then drop those fields. Safe to re-run: already-collapsed
+ * rows produce no update.
+ *
+ * Run after the NV-8703 deploy — older API processes still read the mirrored
+ * fields and would miss them if this unsets first.
+ */
+export function buildHumanInteractionCollapseUpdate(
+  doc: LegacyHumanInteractionDocument
+): HumanInteractionCollapseUpdate | null {
+  const $set: Record<string, unknown> = {};
+  const $unset: Record<string, 1> = {};
+
+  const subscriberIds = resolveSubscriberIds(doc);
+
+  if ((!doc.subscriberIds || doc.subscriberIds.length === 0) && subscriberIds.length > 0) {
+    $set.subscriberIds = subscriberIds;
+  }
+
+  const hasDeliveries = Array.isArray(doc.deliveries) && doc.deliveries.length > 0;
+  if (!hasDeliveries && doc.platformMessageId && doc.platformThreadId) {
+    const subscriberId = subscriberIds[0];
+    if (subscriberId && doc.integrationIdentifier && doc.platform) {
+      $set.deliveries = [
+        {
+          subscriberId,
+          integrationIdentifier: doc.integrationIdentifier,
+          platform: doc.platform,
+          platformMessageId: doc.platformMessageId,
+          platformThreadId: doc.platformThreadId,
+        },
+      ];
+    }
+  }
+
+  for (const field of MIRRORED_FIELDS) {
+    if (doc[field] !== undefined) {
+      $unset[field] = 1;
+    }
+  }
+
+  if (Object.keys($set).length === 0 && Object.keys($unset).length === 0) {
+
+    return null;
+  }
+
+  return {
+    ...(Object.keys($set).length > 0 ? { $set } : {}),
+    ...(Object.keys($unset).length > 0 ? { $unset } : {}),
+  };
+}
+
+export function selectLegacyHumanInteractionIndexNames(
+  indexes: Array<{ name: string; key: Record<string, unknown> }>
+): string[] {
+  return indexes
+    .filter((index) => {
+      if (index.key.subscriberId !== undefined) {
+
+        return true;
+      }
+
+      return index.key.platformMessageId !== undefined && index.key['deliveries.platformMessageId'] === undefined;
+    })
+    .map((index) => index.name);
+}
+
+type CollapseCollection = {
+  find: (filter: Record<string, unknown>) => {
+    batchSize: (size: number) => AsyncIterable<LegacyHumanInteractionDocument>;
+  };
+  bulkWrite: (
+    operations: Array<{ updateOne: { filter: { _id: unknown }; update: HumanInteractionCollapseUpdate } }>
+  ) => Promise<{ modifiedCount?: number }>;
+  indexes: () => Promise<Array<{ name: string; key: Record<string, unknown> }>>;
+  dropIndex: (name: string) => Promise<unknown>;
+};
+
+const LEGACY_FIELD_FILTER = {
+  $or: [
+    { subscriberId: { $exists: true } },
+    { integrationIdentifier: { $exists: true } },
+    { platform: { $exists: true } },
+    { platformMessageId: { $exists: true } },
+    { platformThreadId: { $exists: true } },
+    { subscriberIds: { $exists: false } },
+    { subscriberIds: { $size: 0 } },
+    { deliveries: { $exists: false } },
+    { deliveries: { $eq: [] } },
+  ],
+};
+
+export async function collapseHumanInteractionMirroredFields(collection: CollapseCollection): Promise<{
+  scanned: number;
+  modified: number;
+  droppedIndexes: string[];
+}> {
+  let scanned = 0;
+  let modified = 0;
+  let batch: Array<{ updateOne: { filter: { _id: unknown }; update: HumanInteractionCollapseUpdate } }> = [];
+
+  async function flush(): Promise<void> {
+    if (batch.length === 0) {
+
+      return;
+    }
+
+    const result = await collection.bulkWrite(batch);
+    modified += result.modifiedCount ?? batch.length;
+    batch = [];
+  }
+
+  for await (const doc of collection.find(LEGACY_FIELD_FILTER).batchSize(BATCH_SIZE)) {
+    scanned += 1;
+    const update = buildHumanInteractionCollapseUpdate(doc);
+    if (!update) {
+      continue;
+    }
+
+    batch.push({ updateOne: { filter: { _id: doc._id }, update } });
+    if (batch.length >= BATCH_SIZE) {
+      await flush();
+    }
+  }
+
+  await flush();
+
+  const droppedIndexes: string[] = [];
+  const indexes = await collection.indexes();
+  for (const name of selectLegacyHumanInteractionIndexNames(indexes)) {
+    try {
+      await collection.dropIndex(name);
+      droppedIndexes.push(name);
+    } catch (error) {
+      const code = (error as { code?: number }).code;
+      if (code !== 27) {
+        throw error;
+      }
+    }
+  }
+
+  return { scanned, modified, droppedIndexes };
+}
+
+export async function run() {
+  console.log('Start migration - collapse HumanInteraction mirrored fields onto deliveries');
+
+  const { NestFactory } = await import('@nestjs/core');
+  const { AppModule } = await import('../../src/app.module');
+  const app = await NestFactory.create(AppModule, {
+    logger: false,
+  });
+
+  const result = await collapseHumanInteractionMirroredFields(
+    HumanInteraction.collection as unknown as CollapseCollection
+  );
+
+  console.log(
+    `Backfilled HumanInteraction rows: scanned ${result.scanned} modified ${result.modified}; dropped indexes: ${
+      result.droppedIndexes.join(', ') || 'none'
+    }`
+  );
+  console.log('End migration.');
+
+  await app.close();
+}
+
+if (require.main === module) {
+  run()
+    .then(() => {
+      console.log('Migration completed successfully');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('Migration failed', error);
+      process.exit(1);
+    });
+}

--- a/apps/api/src/app/agents/human-relay/human-interaction-inbound.service.spec.ts
+++ b/apps/api/src/app/agents/human-relay/human-interaction-inbound.service.spec.ts
@@ -34,7 +34,7 @@ describe('HumanInteractionInboundService', () => {
       kind: HumanInteractionKindEnum.ASK,
       status: HumanInteractionStatusEnum.PENDING,
       prompt: 'First?',
-      subscriberId: 'sub-1',
+      subscriberIds: ['sub-1'],
       _environmentId: 'env1',
     };
     const humanInteractionRepository = {
@@ -90,7 +90,7 @@ describe('HumanInteractionInboundService', () => {
       requestId: 'hr_1',
       kind: HumanInteractionKindEnum.APPROVE,
       status: HumanInteractionStatusEnum.PENDING,
-      subscriberId: 'sub-1',
+      subscriberIds: ['sub-1'],
       _environmentId: 'env1',
     };
     humanInteractionRepository.findByIdentifier.resolves(pending);
@@ -119,7 +119,7 @@ describe('HumanInteractionInboundService', () => {
       identifier: 'hi_1',
       kind: HumanInteractionKindEnum.APPROVE,
       status: HumanInteractionStatusEnum.PENDING,
-      subscriberId: 'sub-1',
+      subscriberIds: ['sub-1'],
       _environmentId: 'env1',
     });
 
@@ -143,7 +143,7 @@ describe('HumanInteractionInboundService', () => {
       requestId: 'hr_1',
       kind: HumanInteractionKindEnum.APPROVE,
       status: HumanInteractionStatusEnum.EXPIRED,
-      subscriberId: 'sub-1',
+      subscriberIds: ['sub-1'],
       _environmentId: 'env1',
     };
     humanInteractionRepository.findByIdentifier.resolves(expired);
@@ -291,7 +291,6 @@ describe('HumanInteractionInboundService', () => {
       identifier: 'hi_1',
       kind: HumanInteractionKindEnum.APPROVE,
       status: HumanInteractionStatusEnum.PENDING,
-      subscriberId: 'sub-1',
       subscriberIds: ['sub-1', 'sub-2'],
       _environmentId: 'env1',
     });
@@ -319,7 +318,6 @@ describe('HumanInteractionInboundService', () => {
       identifier: 'hi_1',
       kind: HumanInteractionKindEnum.APPROVE,
       status: HumanInteractionStatusEnum.PENDING,
-      subscriberId: 'sub-1',
       subscriberIds: ['sub-1', 'sub-2'],
       _environmentId: 'env1',
     });
@@ -348,7 +346,6 @@ describe('HumanInteractionInboundService', () => {
         kind: HumanInteractionKindEnum.ASK,
         status: HumanInteractionStatusEnum.PENDING,
         prompt: 'Env?',
-        subscriberId: 'sub-1',
         subscriberIds: ['sub-1', 'sub-2'],
         _environmentId: 'env1',
       },
@@ -375,7 +372,6 @@ describe('HumanInteractionInboundService', () => {
       identifier: 'hi_1',
       kind: HumanInteractionKindEnum.APPROVE,
       status: HumanInteractionStatusEnum.PENDING,
-      subscriberId: 'sub-1',
       subscriberIds: ['sub-1', 'sub-2'],
       _environmentId: 'env1',
     };
@@ -399,30 +395,6 @@ describe('HumanInteractionInboundService', () => {
     expect(settlement.settle.calledOnce).to.equal(true);
     expect(result.outcome).to.equal('consumed');
     expect(outboundGateway.replyOnThread.called).to.equal(true);
-  });
-
-  it('still settles legacy rows that only have subscriberId', async () => {
-    const { service, humanInteractionRepository, settlement } = setup();
-    humanInteractionRepository.findByIdentifier.resolves({
-      _id: 'hi1',
-      identifier: 'hi_1',
-      kind: HumanInteractionKindEnum.APPROVE,
-      status: HumanInteractionStatusEnum.PENDING,
-      subscriberId: 'sub-1',
-      _environmentId: 'env1',
-    });
-
-    const result = await service.tryHandleAction(
-      makeTurn({
-        event: AgentEventEnum.ON_ACTION,
-        action: { id: 'human:hi_1:approve' },
-        message: null,
-      }) as any,
-      'conversation'
-    );
-
-    expect(settlement.settle.calledOnce).to.equal(true);
-    expect(result.outcome).to.equal('settled');
   });
 });
 

--- a/apps/api/src/app/agents/human-relay/human-interaction-settlement.service.spec.ts
+++ b/apps/api/src/app/agents/human-relay/human-interaction-settlement.service.spec.ts
@@ -14,12 +14,7 @@ describe('HumanInteractionSettlementService', () => {
         kind: HumanInteractionKindEnum.APPROVE,
         status,
         response,
-        subscriberId: 'sub-1',
         subscriberIds: ['sub-1', 'sub-2'],
-        integrationIdentifier: 'telegram-main',
-        platform: 'telegram',
-        platformMessageId: 'msg-1',
-        platformThreadId: 'thread-1',
         deliveries: [
           {
             subscriberId: 'sub-1',
@@ -55,5 +50,33 @@ describe('HumanInteractionSettlementService', () => {
     expect(outboundGateway.editInConversation.calledTwice).to.equal(true);
     expect(outboundGateway.editInConversation.firstCall.args[4]).to.equal('msg-1');
     expect(outboundGateway.editInConversation.secondCall.args[4]).to.equal('msg-2');
+  });
+
+  it('skips the card edit when the row has no deliveries', async () => {
+    const humanInteractionRepository = {
+      settleIfPending: sinon.stub().resolves({
+        _id: 'hi1',
+        identifier: 'hi_1',
+        _environmentId: 'env1',
+        _agentId: 'agent1',
+        kind: HumanInteractionKindEnum.APPROVE,
+        status: HumanInteractionStatusEnum.APPROVED,
+        subscriberIds: ['sub-1'],
+      }),
+    };
+    const outboundGateway = { editInConversation: sinon.stub().resolves(undefined) };
+    const logger = { setContext: sinon.stub(), warn: sinon.stub() };
+    const service = new HumanInteractionSettlementService(
+      humanInteractionRepository as any,
+      outboundGateway as any,
+      logger as any
+    );
+
+    await service.settle(
+      { _id: 'hi1', _environmentId: 'env1', identifier: 'hi_1' } as any,
+      HumanInteractionStatusEnum.APPROVED
+    );
+
+    expect(outboundGateway.editInConversation.called).to.equal(false);
   });
 });

--- a/apps/api/src/app/agents/human-relay/human-interaction-settlement.service.ts
+++ b/apps/api/src/app/agents/human-relay/human-interaction-settlement.service.ts
@@ -111,7 +111,6 @@ export class HumanInteractionSettlementService {
   }
 
   private deliveryEditTargets(interaction: HumanInteractionEntity): HumanInteractionDelivery[] {
-
     return interaction.deliveries ?? [];
   }
 }

--- a/apps/api/src/app/agents/human-relay/human-interaction-settlement.service.ts
+++ b/apps/api/src/app/agents/human-relay/human-interaction-settlement.service.ts
@@ -110,27 +110,8 @@ export class HumanInteractionSettlementService {
     }
   }
 
-  /**
-   * Prefer persisted `deliveries`. Fall back to the denormalized top-level
-   * message ids for rows created before every path wrote `deliveries[]`.
-   */
   private deliveryEditTargets(interaction: HumanInteractionEntity): HumanInteractionDelivery[] {
-    if (interaction.deliveries && interaction.deliveries.length > 0) {
-      return interaction.deliveries;
-    }
 
-    if (!interaction.platformMessageId || !interaction.platformThreadId) {
-      return [];
-    }
-
-    return [
-      {
-        subscriberId: interaction.subscriberId,
-        integrationIdentifier: interaction.integrationIdentifier,
-        platform: interaction.platform,
-        platformMessageId: interaction.platformMessageId,
-        platformThreadId: interaction.platformThreadId,
-      },
-    ];
+    return interaction.deliveries ?? [];
   }
 }

--- a/apps/api/src/app/human/dtos/interaction-response.dto.ts
+++ b/apps/api/src/app/human/dtos/interaction-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import type { HumanInteractionEntity } from '@novu/dal';
+import { type HumanInteractionEntity, primaryHumanInteractionDelivery } from '@novu/dal';
 import {
   HumanInteractionKindEnum,
   HumanInteractionOption,
@@ -60,6 +60,8 @@ export function toInteractionResponse(
   entity: HumanInteractionEntity,
   failedSubscriberIds?: string[]
 ): InteractionResponseDto {
+  const primary = primaryHumanInteractionDelivery(entity);
+
   return {
     id: entity.identifier,
     kind: entity.kind,
@@ -68,8 +70,8 @@ export function toInteractionResponse(
     options: entity.options,
     from: entity.fromLabel,
     to: humanInteractionRecipientIds(entity),
-    integrationIdentifier: entity.integrationIdentifier,
-    platform: entity.platform,
+    integrationIdentifier: primary?.integrationIdentifier ?? '',
+    platform: primary?.platform ?? '',
     response: entity.response,
     ...(failedSubscriberIds && failedSubscriberIds.length > 0 ? { failedTo: failedSubscriberIds } : {}),
     expiresAt: entity.expiresAt,

--- a/apps/api/src/app/human/e2e/human-interactions.e2e.ts
+++ b/apps/api/src/app/human/e2e/human-interactions.e2e.ts
@@ -200,7 +200,7 @@ describe('Human interactions (create → deliver → resolve) #novu-v2', () => {
       expect(sentPayload).to.not.include('Powered by');
 
       const row = await humanInteractionRepository.findByIdentifier(session.environment._id, interaction.id);
-      expect(row!.platformMessageId).to.be.a('string');
+      expect(row!.deliveries?.[0]?.platformMessageId).to.be.a('string');
 
       await clickAction(`human:${interaction.id}:approve`);
 
@@ -382,7 +382,9 @@ describe('Human interactions (create → deliver → resolve) #novu-v2', () => {
       const firstRow = await humanInteractionRepository.findByIdentifier(session.environment._id, first.id);
       // The stored id is the adapter's `chatId:messageId` composite; the webhook's
       // reply_to_message carries only the bare Telegram message id.
-      const bareMessageId = Number(firstRow!.platformMessageId!.split(':').pop());
+      const platformMessageId = firstRow!.deliveries?.[0]?.platformMessageId;
+      expect(platformMessageId).to.be.a('string');
+      const bareMessageId = Number(platformMessageId!.split(':').pop());
 
       await sendMessageToRelay('answer to the first', {
         reply_to_message: { message_id: bareMessageId },

--- a/apps/api/src/app/human/e2e/human-interactions.e2e.ts
+++ b/apps/api/src/app/human/e2e/human-interactions.e2e.ts
@@ -200,7 +200,7 @@ describe('Human interactions (create → deliver → resolve) #novu-v2', () => {
       expect(sentPayload).to.not.include('Powered by');
 
       const row = await humanInteractionRepository.findByIdentifier(session.environment._id, interaction.id);
-      expect(row!.deliveries?.[0]?.platformMessageId).to.be.a('string');
+      expect(row?.deliveries?.[0]?.platformMessageId).to.be.a('string');
 
       await clickAction(`human:${interaction.id}:approve`);
 
@@ -382,9 +382,9 @@ describe('Human interactions (create → deliver → resolve) #novu-v2', () => {
       const firstRow = await humanInteractionRepository.findByIdentifier(session.environment._id, first.id);
       // The stored id is the adapter's `chatId:messageId` composite; the webhook's
       // reply_to_message carries only the bare Telegram message id.
-      const platformMessageId = firstRow!.deliveries?.[0]?.platformMessageId;
+      const platformMessageId = firstRow?.deliveries?.[0]?.platformMessageId;
       expect(platformMessageId).to.be.a('string');
-      const bareMessageId = Number(platformMessageId!.split(':').pop());
+      const bareMessageId = Number(platformMessageId?.split(':').pop());
 
       await sendMessageToRelay('answer to the first', {
         reply_to_message: { message_id: bareMessageId },

--- a/apps/api/src/app/human/services/human-interaction-lifecycle.ts
+++ b/apps/api/src/app/human/services/human-interaction-lifecycle.ts
@@ -15,17 +15,13 @@ export interface PendingHumanInteractionInput {
   prompt: string;
   options?: string[];
   from?: string;
-  subscriberId: string;
   subscriberIds: string[];
   agentId: string;
-  integrationIdentifier: string;
-  platform: string;
   environmentId: string;
   organizationId: string;
   ttlSeconds?: number;
   requestId?: string;
   conversationId?: string;
-  platformThreadId?: string;
 }
 
 export interface HumanDeliveryRefs {
@@ -70,12 +66,8 @@ export function buildPendingHumanInteraction(input: PendingHumanInteractionInput
       ? { options: input.options.map((label, index) => ({ id: `opt_${index + 1}`, label })) }
       : {}),
     ...(input.from ? { fromLabel: input.from } : {}),
-    subscriberId: input.subscriberId,
     subscriberIds: input.subscriberIds,
     _agentId: input.agentId,
-    integrationIdentifier: input.integrationIdentifier,
-    platform: input.platform,
-    ...(input.platformThreadId ? { platformThreadId: input.platformThreadId } : {}),
     ...(input.conversationId ? { _conversationId: input.conversationId } : {}),
     expiresAt: new Date(Date.now() + ttlSeconds * 1000).toISOString(),
     _environmentId: input.environmentId,
@@ -167,8 +159,7 @@ export async function deliverToTargets(
     }
   }
 
-  const [first] = deliveries;
-  if (!first) {
+  if (deliveries.length === 0) {
     await repository
       .delete({ _id: interaction._id, _environmentId: interaction._environmentId })
       .catch(() => undefined);
@@ -183,23 +174,18 @@ export async function deliverToTargets(
   const recipientPatch =
     failedSubscriberIds.length > 0
       ? {
-          subscriberId: first.subscriberId,
           subscriberIds: deliveries.map((delivery) => delivery.subscriberId),
         }
       : {};
 
   await repository.stampDelivery(interaction._environmentId, interaction._id, {
-    platformMessageId: first.platformMessageId,
-    platformThreadId: first.platformThreadId,
-    ...(conversationId ? { _conversationId: conversationId } : {}),
     deliveries,
+    ...(conversationId ? { _conversationId: conversationId } : {}),
     ...recipientPatch,
   });
 
   const delivered: HumanInteractionEntity = {
     ...interaction,
-    platformMessageId: first.platformMessageId,
-    platformThreadId: first.platformThreadId,
     deliveries,
     ...(conversationId ? { _conversationId: conversationId } : {}),
     ...recipientPatch,
@@ -209,7 +195,9 @@ export async function deliverToTargets(
     const settled = await repository.markDeliveredIfPending(interaction._environmentId, interaction._id);
 
     return {
-      interaction: settled ?? { ...delivered, status: HumanInteractionStatusEnum.DELIVERED },
+      interaction: settled
+        ? { ...settled, deliveries }
+        : { ...delivered, status: HumanInteractionStatusEnum.DELIVERED },
       failedSubscriberIds,
     };
   }

--- a/apps/api/src/app/human/usecases/create-conversation-interaction/create-conversation-interaction.usecase.spec.ts
+++ b/apps/api/src/app/human/usecases/create-conversation-interaction/create-conversation-interaction.usecase.spec.ts
@@ -61,19 +61,20 @@ describe('CreateConversationInteraction', () => {
     expect(humanInteractionRepository.create.firstCall.args[0]).to.include({
       kind: HumanInteractionKindEnum.APPROVE,
       requestId: 'hr_1',
-      subscriberId: 'sub-1',
       _agentId: 'agent1',
       _conversationId: 'conv1',
     });
     expect(humanInteractionRepository.create.firstCall.args[0].subscriberIds).to.deep.equal(['sub-1']);
+    expect(humanInteractionRepository.create.firstCall.args[0]).to.not.have.property('subscriberId');
+    expect(humanInteractionRepository.create.firstCall.args[0]).to.not.have.property('platform');
     expect(outboundGateway.deliver.calledOnce).to.equal(true);
     expect(humanInteractionRepository.stampDelivery.calledOnce).to.equal(true);
     expect(humanInteractionRepository.stampDelivery.firstCall.args[2]).to.deep.include({
-      platformMessageId: 'msg-1',
       _conversationId: 'conv1',
     });
+    expect(humanInteractionRepository.stampDelivery.firstCall.args[2]).to.not.have.property('platformMessageId');
     expect(humanInteractionRepository.stampDelivery.firstCall.args[2].deliveries).to.have.length(1);
-    expect(result.platformMessageId).to.equal('msg-1');
+    expect(result.deliveries?.[0]?.platformMessageId).to.equal('msg-1');
     expect(result._conversationId).to.equal('conv1');
   });
 
@@ -141,7 +142,6 @@ describe('CreateConversationInteraction', () => {
 
     await usecase.execute({ ...command, to: ['alice', 'bob'] } as any);
 
-    expect(humanInteractionRepository.create.firstCall.args[0].subscriberId).to.equal('alice');
     expect(humanInteractionRepository.create.firstCall.args[0].subscriberIds).to.deep.equal(['alice', 'bob']);
     expect(outboundGateway.deliver.calledOnce).to.equal(true);
     expect(humanInteractionRepository.stampDelivery.firstCall.args[2].subscriberIds).to.equal(undefined);

--- a/apps/api/src/app/human/usecases/create-conversation-interaction/create-conversation-interaction.usecase.ts
+++ b/apps/api/src/app/human/usecases/create-conversation-interaction/create-conversation-interaction.usecase.ts
@@ -48,17 +48,13 @@ export class CreateConversationInteraction {
         prompt: command.prompt,
         options: command.options,
         from: command.from,
-        subscriberId: primarySubscriberId,
         subscriberIds,
         agentId: command.conversation._agentId,
-        integrationIdentifier: command.integrationIdentifier,
-        platform: command.channel.platform,
         environmentId: command.environmentId,
         organizationId: command.organizationId,
         ttlSeconds: command.ttlSeconds,
         requestId: command.requestId,
         conversationId: command.conversation._id,
-        platformThreadId: command.channel.platformThreadId,
       })
     );
 

--- a/apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.spec.ts
+++ b/apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.spec.ts
@@ -11,9 +11,7 @@ describe('CreateInteraction', () => {
       kind: HumanInteractionKindEnum.APPROVE,
       status: HumanInteractionStatusEnum.PENDING,
       prompt: 'Deploy?',
-      subscriberId: 'sub-1',
-      integrationIdentifier: 'telegram-main',
-      platform: 'telegram',
+      subscriberIds: ['sub-1'],
       expiresAt: '2026-01-01T00:00:00.000Z',
       createdAt: '2026-01-01T00:00:00.000Z',
       _environmentId: 'env1',
@@ -77,15 +75,19 @@ describe('CreateInteraction', () => {
     });
     expect(humanInteractionRepository.create.firstCall.args[0]).to.include({
       _agentId: 'agent-hitl',
-      subscriberId: 'sub-1',
       kind: HumanInteractionKindEnum.APPROVE,
       prompt: 'Deploy?',
     });
     expect(humanInteractionRepository.create.firstCall.args[0].subscriberIds).to.deep.equal(['sub-1']);
+    expect(humanInteractionRepository.create.firstCall.args[0]).to.not.have.property('subscriberId');
+    expect(humanInteractionRepository.create.firstCall.args[0]).to.not.have.property('platform');
     expect(deliveryService.deliver.calledOnce).to.equal(true);
     expect(humanInteractionRepository.stampDelivery.firstCall.args[2].deliveries).to.have.length(1);
+    expect(humanInteractionRepository.stampDelivery.firstCall.args[2]).to.not.have.property('platformMessageId');
     expect(result.id).to.equal('hi_1');
     expect(result.to).to.deep.equal(['sub-1']);
+    expect(result.platform).to.equal('telegram');
+    expect(result.integrationIdentifier).to.equal('telegram-main');
   });
 
   it('defaults to the human-relay agent when agentIdentifier is omitted', async () => {

--- a/apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.ts
+++ b/apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.ts
@@ -31,8 +31,7 @@ export class CreateInteraction {
 
     const agent = await this.resolveAgent(command);
     const subscriberIds = normalizeHumanTo(command.to);
-    const primarySubscriberId = subscriberIds[0];
-    if (!primarySubscriberId) {
+    if (subscriberIds.length === 0) {
       throw new BadRequestException('`to` must include at least one subscriberId');
     }
 
@@ -57,22 +56,14 @@ export class CreateInteraction {
       }))
     );
 
-    const [primaryTarget] = resolved;
-    if (!primaryTarget) {
-      throw new BadRequestException('`to` must include at least one subscriberId');
-    }
-
     const interaction = await this.humanInteractionRepository.create(
       buildPendingHumanInteraction({
         kind: command.kind,
         prompt: command.prompt,
         options: command.options,
         from: command.from,
-        subscriberId: primarySubscriberId,
         subscriberIds,
         agentId: agent._id,
-        integrationIdentifier: primaryTarget.target.integrationIdentifier,
-        platform: primaryTarget.target.platform,
         environmentId: command.environmentId,
         organizationId: command.organizationId,
         ttlSeconds: command.ttlSeconds,

--- a/libs/dal/src/repositories/human-interaction/human-interaction.entity.ts
+++ b/libs/dal/src/repositories/human-interaction/human-interaction.entity.ts
@@ -79,7 +79,6 @@ export interface HumanInteractionDelivery {
 export function primaryHumanInteractionDelivery(
   interaction: Pick<HumanInteractionEntity, 'deliveries'>
 ): HumanInteractionDelivery | undefined {
-
   return interaction.deliveries?.[0];
 }
 

--- a/libs/dal/src/repositories/human-interaction/human-interaction.entity.ts
+++ b/libs/dal/src/repositories/human-interaction/human-interaction.entity.ts
@@ -39,30 +39,16 @@ export class HumanInteractionEntity {
    */
   requestId?: string;
 
-  /** External subscriberId of the primary human (first listed recipient). */
-  subscriberId: string;
-
   /** All Novu subscriberIds allowed to settle. First valid answer wins. */
-  subscriberIds?: string[];
+  subscriberIds: string[];
 
   /** Agent that owns delivery and the inbound webhook. */
   _agentId: string;
 
-  integrationIdentifier: string;
-
-  /** Platform slug (telegram | slack | ...). */
-  platform: string;
-
-  /** Platform thread the card was delivered on — reply-to correlation + edits. */
-  platformThreadId?: string;
-
-  /** Platform message id of the delivered card — exact reply-to matching. */
-  platformMessageId?: string;
-
   /**
-   * Per-recipient delivery refs. In-thread cards write a single element;
-   * public/CLI fan-out writes one per DM. Top-level `platformMessageId` is
-   * denormalized from `deliveries[0]` for legacy indexes.
+   * Per-recipient delivery refs. In-thread cards write a single element
+   * (the current conversation) even when `subscriberIds` lists several
+   * people who may settle. Public/CLI fan-out writes one per successful DM.
    */
   deliveries?: HumanInteractionDelivery[];
 
@@ -88,6 +74,13 @@ export interface HumanInteractionDelivery {
   platform: string;
   platformMessageId: string;
   platformThreadId: string;
+}
+
+export function primaryHumanInteractionDelivery(
+  interaction: Pick<HumanInteractionEntity, 'deliveries'>
+): HumanInteractionDelivery | undefined {
+
+  return interaction.deliveries?.[0];
 }
 
 export type HumanInteractionDBModel = ChangePropsValueType<

--- a/libs/dal/src/repositories/human-interaction/human-interaction.repository.ts
+++ b/libs/dal/src/repositories/human-interaction/human-interaction.repository.ts
@@ -5,10 +5,6 @@ import { BaseRepositoryV2 } from '../base-repository-v2';
 import { HumanInteractionDBModel, HumanInteractionDelivery, HumanInteractionEntity } from './human-interaction.entity';
 import { HumanInteraction } from './human-interaction.schema';
 
-function subscriberScope(subscriberId: string) {
-  return { $or: [{ subscriberId }, { subscriberIds: subscriberId }] };
-}
-
 @Injectable()
 export class HumanInteractionRepository extends BaseRepositoryV2<
   HumanInteractionDBModel,
@@ -26,7 +22,7 @@ export class HumanInteractionRepository extends BaseRepositoryV2<
   async countPendingForSubscriber(environmentId: string, subscriberId: string): Promise<number> {
     return this.count({
       _environmentId: environmentId,
-      ...subscriberScope(subscriberId),
+      subscriberIds: subscriberId,
       status: HumanInteractionStatusEnum.PENDING,
     });
   }
@@ -39,7 +35,7 @@ export class HumanInteractionRepository extends BaseRepositoryV2<
     return this.find(
       {
         _environmentId: environmentId,
-        ...subscriberScope(subscriberId),
+        subscriberIds: subscriberId,
         kind: HumanInteractionKindEnum.ASK,
         status: HumanInteractionStatusEnum.PENDING,
       },
@@ -88,10 +84,7 @@ export class HumanInteractionRepository extends BaseRepositoryV2<
       {
         _environmentId: environmentId,
         status: HumanInteractionStatusEnum.PENDING,
-        $or: [
-          { platformMessageId: { $in: platformMessageIds } },
-          { 'deliveries.platformMessageId': { $in: platformMessageIds } },
-        ],
+        'deliveries.platformMessageId': { $in: platformMessageIds },
       },
       '*'
     );
@@ -101,25 +94,14 @@ export class HumanInteractionRepository extends BaseRepositoryV2<
     environmentId: string,
     id: string,
     delivery: {
-      platformMessageId?: string;
-      platformThreadId?: string;
+      deliveries: HumanInteractionDelivery[];
       _conversationId?: string;
-      deliveries?: HumanInteractionDelivery[];
-      subscriberId?: string;
       subscriberIds?: string[];
     }
   ): Promise<void> {
-    const $set: Record<string, unknown> = {};
-    if (delivery.platformMessageId) $set.platformMessageId = delivery.platformMessageId;
-    if (delivery.platformThreadId) $set.platformThreadId = delivery.platformThreadId;
+    const $set: Record<string, unknown> = { deliveries: delivery.deliveries };
     if (delivery._conversationId) $set._conversationId = delivery._conversationId;
-    if (delivery.deliveries) $set.deliveries = delivery.deliveries;
-    if (delivery.subscriberId) $set.subscriberId = delivery.subscriberId;
     if (delivery.subscriberIds) $set.subscriberIds = delivery.subscriberIds;
-
-    if (Object.keys($set).length === 0) {
-      return;
-    }
 
     await this.update({ _id: id, _environmentId: environmentId }, { $set });
   }
@@ -189,7 +171,7 @@ export class HumanInteractionRepository extends BaseRepositoryV2<
       {
         _environmentId: params.environmentId,
         _organizationId: params.organizationId,
-        ...(params.subscriberId ? subscriberScope(params.subscriberId) : {}),
+        ...(params.subscriberId ? { subscriberIds: params.subscriberId } : {}),
         ...(params.status ? { status: params.status } : {}),
         ...(params.before ? { _id: { $lt: params.before } } : {}),
       },

--- a/libs/dal/src/repositories/human-interaction/human-interaction.schema.ts
+++ b/libs/dal/src/repositories/human-interaction/human-interaction.schema.ts
@@ -53,31 +53,13 @@ const humanInteractionSchema = new Schema<HumanInteractionDBModel>(
     requestId: {
       type: Schema.Types.String,
     },
-    subscriberId: {
-      type: Schema.Types.String,
-      required: true,
-    },
     subscriberIds: {
       type: [Schema.Types.String],
-      default: undefined,
+      required: true,
     },
     _agentId: {
       type: Schema.Types.ObjectId,
       required: true,
-    },
-    integrationIdentifier: {
-      type: Schema.Types.String,
-      required: true,
-    },
-    platform: {
-      type: Schema.Types.String,
-      required: true,
-    },
-    platformThreadId: {
-      type: Schema.Types.String,
-    },
-    platformMessageId: {
-      type: Schema.Types.String,
     },
     deliveries: {
       type: [humanInteractionDeliverySchema],
@@ -120,10 +102,8 @@ const humanInteractionSchema = new Schema<HumanInteractionDBModel>(
 
 humanInteractionSchema.index({ _environmentId: 1, identifier: 1 }, { unique: true });
 // Pending-cap counts + "most recent pending ask" bare-reply correlation.
-humanInteractionSchema.index({ _environmentId: 1, subscriberId: 1, status: 1, createdAt: -1 });
 humanInteractionSchema.index({ _environmentId: 1, subscriberIds: 1, status: 1, createdAt: -1 });
 // Exact reply-to correlation by delivered card message id.
-humanInteractionSchema.index({ _environmentId: 1, platformMessageId: 1 });
 humanInteractionSchema.index({ _environmentId: 1, 'deliveries.platformMessageId': 1 });
 // Conversation-scoped pending-ask correlation for framework HITL.
 humanInteractionSchema.index({ _environmentId: 1, _conversationId: 1, status: 1, kind: 1, createdAt: -1 });

--- a/packages/shared/src/utils/normalize-human-to.spec.ts
+++ b/packages/shared/src/utils/normalize-human-to.spec.ts
@@ -28,11 +28,8 @@ describe('normalizeHumanTo', () => {
 });
 
 describe('humanInteractionRecipientIds', () => {
-  it('prefers subscriberIds and falls back to subscriberId for legacy rows', () => {
-    expect(humanInteractionRecipientIds({ subscriberId: 'alice', subscriberIds: ['alice', 'bob'] })).toEqual([
-      'alice',
-      'bob',
-    ]);
-    expect(humanInteractionRecipientIds({ subscriberId: 'alice' })).toEqual(['alice']);
+  it('returns subscriberIds and an empty list when they are missing', () => {
+    expect(humanInteractionRecipientIds({ subscriberIds: ['alice', 'bob'] })).toEqual(['alice', 'bob']);
+    expect(humanInteractionRecipientIds({})).toEqual([]);
   });
 });

--- a/packages/shared/src/utils/normalize-human-to.ts
+++ b/packages/shared/src/utils/normalize-human-to.ts
@@ -46,7 +46,6 @@ export function normalizeHumanTo(to: string | string[]): string[] {
 }
 
 export function humanInteractionRecipientIds(interaction: { subscriberIds?: string[] }): string[] {
-
   return interaction.subscriberIds ?? [];
 }
 

--- a/packages/shared/src/utils/normalize-human-to.ts
+++ b/packages/shared/src/utils/normalize-human-to.ts
@@ -45,15 +45,9 @@ export function normalizeHumanTo(to: string | string[]): string[] {
   throw new Error('`to` must include at least one subscriberId');
 }
 
-export function humanInteractionRecipientIds(interaction: {
-  subscriberId: string;
-  subscriberIds?: string[];
-}): string[] {
-  if (interaction.subscriberIds && interaction.subscriberIds.length > 0) {
-    return interaction.subscriberIds;
-  }
+export function humanInteractionRecipientIds(interaction: { subscriberIds?: string[] }): string[] {
 
-  return [interaction.subscriberId];
+  return interaction.subscriberIds ?? [];
 }
 
 function countUniqueHumanTo(to: string | string[]): number {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

NV-8697 dual-wrote HumanInteraction delivery metadata: top-level `subscriberId` / `integrationIdentifier` / `platform` / `platformMessageId` / `platformThreadId` plus `deliveries[]` and `subscriberIds`. That duplication was intentional until this follow-up.

This change makes `deliveries[]` and `subscriberIds` the only persisted shape:

- In-thread `ctx.*` still stamps one delivery (the current conversation card), even when several subscribers may settle
- Public / CLI always stamps `deliveries` (length 1 for a single `to`, one per successful DM for fan-out)
- Writers no longer set the mirrored top-level fields
- Readers query `deliveries.platformMessageId` and `subscriberIds` only
- List/create responses still expose `platform` / `integrationIdentifier` from `deliveries[0]`

A Mongo migration backfills existing rows, then unsets the old fields and drops the mirrored indexes.

Run after this deploy (older API processes still read the mirrored fields):

```bash
npm run migration -- ./migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.ts
```

https://linear.app/novu/issue/NV-8703/hitl-collapse-humaninteraction-onto-deliveries-drop-mirrored-top-level

```mermaid
flowchart LR
  create["create / stamp"] --> deliveries["deliveries[]"]
  create --> subscriberIds["subscriberIds"]
  deliveries --> inbound["reply-to + card edit"]
  subscriberIds --> settle["who may settle"]
  deliveries --> api["API platform / integrationIdentifier"]
```

### Screenshots

Not visual.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

Stacked on NV-8697. `subscriberIds` cannot be derived from `deliveries[].subscriberId` — in-thread `to` is a settlement allow-list, not a fan-out.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb37bcbe-1505-4641-90f0-403aa8ec004b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb37bcbe-1505-4641-90f0-403aa8ec004b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR completes the HumanInteraction persistence refactor by making `deliveries` and `subscriberIds` authoritative.
- Updates creation, settlement, response mapping, and repository queries to use the collapsed shape.
- Adds a migration that backfills existing records, removes mirrored fields, and drops obsolete indexes.
- Updates unit and end-to-end coverage for delivery fan-out and settlement behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/migrations/human-interaction-collapse-deliveries/human-interaction-collapse-deliveries.migration.ts | Backfills the authoritative arrays, removes legacy mirrored fields, and drops obsolete indexes. |
| apps/api/src/app/human/services/human-interaction-lifecycle.ts | Persists per-recipient delivery records and maintains the settlement recipient list after partial delivery. |
| libs/dal/src/repositories/human-interaction/human-interaction.repository.ts | Moves pending-recipient and reply-correlation queries exclusively to the collapsed persistence shape. |
| libs/dal/src/repositories/human-interaction/human-interaction.schema.ts | Makes subscriberIds authoritative and replaces mirrored-field indexes with array-field indexes. |
| apps/api/src/app/agents/human-relay/human-interaction-settlement.service.ts | Uses persisted deliveries as the sole source of message-edit targets. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Create[Create interaction] --> Recipients[Persist subscriberIds]
  Create --> Deliver[Deliver cards]
  Deliver --> Refs[Persist deliveries]
  Refs --> Correlate[Correlate inbound replies]
  Refs --> Edit[Edit settled cards]
  Recipients --> Settle[Authorize settlement]
  Migration[Collapse migration] --> Recipients
  Migration --> Refs
  Migration --> Cleanup[Remove mirrored fields and indexes]
```

<sub>Reviews (5): Last reviewed commit: ["chore(api-service): improve migration"](https://github.com/novuhq/novu/commit/85a7e61f49fefa5ef889c772093c03f49ee6b01a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57505636)</sub>

<!-- /greptile_comment -->