### PR TITLE
fix(react): prevent Web Chat Next.js hydration mismatch fixes NV-8709

### DIFF
--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -251,9 +251,6 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const propsRef = useDataRef(props);
   const [loadState, setLoadState] = useState<AgentChatLoadState>(() => ({
     novu,
-    // Always start loading. Node SSR can see `isAgentChatLoaded` as true (eager
-    // import) while the browser first paint is still false — that mismatch
-    // hydrates an empty thread against a "Loading conversation" row.
     status: 'loading',
   }));
 

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -114,7 +114,7 @@ export type UseAgentChatResult = {
 
 const EMPTY_SERVER_SNAPSHOT: AgentConversationSnapshot = {
   key: 'ssr',
-  status: 'ready',
+  status: 'loading',
   run: { isRunning: false },
   conversationStatus: 'active',
   pagination: { hasMore: false, status: 'idle' },
@@ -251,7 +251,10 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const propsRef = useDataRef(props);
   const [loadState, setLoadState] = useState<AgentChatLoadState>(() => ({
     novu,
-    status: novu.isAgentChatLoaded ? 'ready' : 'loading',
+    // Always start loading. Node SSR can see `isAgentChatLoaded` as true (eager
+    // import) while the browser first paint is still false — that mismatch
+    // hydrates an empty thread against a "Loading conversation" row.
+    status: 'loading',
   }));
 
   useEffect(() => {
@@ -478,7 +481,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     pendingActions: [...snapshot.pendingActions],
     conversationId: snapshot.conversationId,
     error: agentChatLoadError ?? (snapshot.error as UseAgentChatResult['error']),
-    isLoading: isAgentChatLoading || (agentChatReady && snapshot.status === 'loading'),
+    isLoading: !agentChatLoadError && (isAgentChatLoading || snapshot.status === 'loading'),
     isRunning: snapshot.run.isRunning,
     typing: snapshot.run.typing,
     status: snapshot.conversationStatus,

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -81,8 +81,6 @@ export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
   return {
     messages: [],
     pendingActions: [],
-    // Next SSR of Client Components resolves this file (Node `import`), then
-    // hydrates with the browser bundle where the first paint is still loading.
     isLoading: true,
     isRunning: false,
     typing: undefined,

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -81,7 +81,9 @@ export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
   return {
     messages: [],
     pendingActions: [],
-    isLoading: false,
+    // Next SSR of Client Components resolves this file (Node `import`), then
+    // hydrates with the browser bundle where the first paint is still loading.
+    isLoading: true,
     isRunning: false,
     typing: undefined,
     status: 'active',


### PR DESCRIPTION
## Summary
- Next.js SSR of Client Components can see `isAgentChatLoaded` as true (eager Node import) while the browser first paint is still loading, so the empty thread hydrates against a "Loading conversation" row.
- `useAgentChat` now always starts in `loading`; the server stub `isLoading` matches that first paint.

## Test plan
- [ ] Load a Next.js app that SSR-renders `useAgentChat` / Web Chat
- [ ] Confirm no React hydration mismatch in the console
- [ ] Confirm the empty-state prompts appear after history loads


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Aligns the Agent Chat server-rendered and initial browser loading states to prevent Next.js hydration mismatches.
- Initializes the client hook in `loading` regardless of eager Node-side module loading.
- Marks the server hook stub as loading to match the browser’s first render.
- Keeps loading active while either Agent Chat initialization or conversation-history loading is in progress.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the server and browser initial states now aligned for hydration.

The loading state transitions reliably to ready or error, and no concrete regression was established in the changed initialization or server-stub behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/hooks/useAgentChat.ts | Makes the initial and server snapshots consistently loading and preserves explicit error handling when deriving the public loading state. |
| packages/react/src/server/index.tsx | Changes the server-safe hook stub to emit the same loading state as the browser’s first render. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    SSR[Server render] -->|isLoading: true| HTML[Loading-state HTML]
    Browser[Browser first render] -->|status: loading| Hydrate[Hydration matches]
    Hydrate --> Load[Load Agent Chat and conversation]
    Load -->|success| Ready[Ready state]
    Load -->|failure| Error[Error state with isLoading false]
```

<sub>Reviews (1): Last reviewed commit: ["chore(react): drop restated hydration co..."](https://github.com/novuhq/novu/commit/30c41c8a0fa6a22c42ef345bdbb2e808b18f2b65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57527696)</sub>

<!-- /greptile_comment -->