### PR TITLE
refactor(js,react): tighten Web Chat public API and JSDoc fixes NV-8710

### DIFF
--- a/docs/agents/channels/web-chat/chat-ui.mdx
+++ b/docs/agents/channels/web-chat/chat-ui.mdx
@@ -20,7 +20,7 @@ Use these fields to drive the UI. See [`useWebChat`](/platform/sdks/react/hooks/
 | --- | --- |
 | `isLoading` | First history fetch. False when there is no `conversationId`. Show a spinner. |
 | `isRunning` | Agent turn in progress. Disable the composer. `typing` is optional status text. |
-| `status` | Conversation is `active` or `resolved`. Do not use it to disable the composer. |
+| `conversationStatus` | Conversation is `active` or `resolved`. Do not use it to disable the composer. |
 | `error` | Last load, send, retry, action, or run error. Show the message. |
 | `message.status` | `sending`, `sent`, or `failed`. If `failed`, call `retryMessage`. See [Retry](#retry-a-failed-send). |
 
@@ -332,4 +332,4 @@ const { isRecovering, catchUpError } = useWebChat({
 {catchUpError ? <p>{catchUpError.message}</p> : null}
 ```
 
-`catchUpError` is separate from send and fetch `error`. `status` does not become an error state when catch-up fails.
+`catchUpError` is separate from send and fetch `error`. `conversationStatus` does not become an error state when recovery fails.

--- a/docs/platform/sdks/javascript.mdx
+++ b/docs/platform/sdks/javascript.mdx
@@ -778,15 +778,9 @@ const novu = new Novu({
 
 await loadWebChat(novu);
 
-const result = novu.webChat.conversation({
+const conversation = novu.webChat.conversation({
   agentId: 'YOUR_AGENT_IDENTIFIER',
 });
-
-if (!result.ok) {
-  throw result.error;
-}
-
-const conversation = result.data;
 
 const stop = conversation.subscribe((snapshot) => {
   snapshot.messages;
@@ -807,7 +801,7 @@ conversation.dispose();
 | --- | --- |
 | `getSnapshot()` | Current immutable snapshot. |
 | `subscribe(listener)` | Call `listener` on every snapshot. Returns a stop function. |
-| `sendMessage(text)` | Send a user message. Creates a conversation when `conversationId` is omitted. |
+| `sendMessage(input)` | Send a user message. `input` is a string, or `{ text, metadata }`. Creates a conversation when `conversationId` is omitted. |
 | `retryMessage(messageId)` | Resend a message whose `status` is `failed`. Reuses the original idempotency key. |
 | `respondToAction({ actionId, decision })` | Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. |
 | `sendAction({ actionId, sourceMessageId, value })` | Click a Card button. Do not use this for tool approval. |
@@ -826,7 +820,7 @@ conversation.dispose();
 | `conversationStatus` | `'active'` or `'resolved'`. This is not a loading flag. |
 | `status` | History load: `'ready'`, `'loading'`, or `'fetching'`. |
 | `pagination.hasMore` / `pagination.status` | Older history pages. Call `fetchMore()`. |
-| `isRecovering` / `catchUpError` | Reconnect catch-up. The runtime reconnects on its own. |
+| `isRecovering` / `catchUpError` | Reconnect recovery. The runtime reconnects on its own. |
 | `error` | Last load, send, retry, or action error. |
 
 See [Chat UI](/agents/channels/web-chat/chat-ui).

--- a/docs/platform/sdks/react/hooks/use-web-chat.mdx
+++ b/docs/platform/sdks/react/hooks/use-web-chat.mdx
@@ -22,7 +22,7 @@ Pass `agentId` (and optional `conversationId` and `agentHash`), or pass `convers
 | `agentHash` | `string` | HMAC-SHA256 of `agentId` with the environment secret. Required when Security HMAC is on for the Web Chat integration. |
 | `conversation` | `AgentConversationRuntime` | Share an existing runtime across hook instances. Do not pass `agentId`, `conversationId`, or `agentHash` with this prop. Get the runtime from `loadWebChat(novu)` then `novu.webChat.conversation()`. |
 | `onSuccess` | `(data: LoadConversationResult) => void` | Fires after a history fetch succeeds. |
-| `onError` | `(error: NovuError \| WebChatPlanLimitError) => void` | Fires when a load, send, retry, or action response fails. Also fires when reconnect catch-up fails. |
+| `onError` | `(error: NovuError \| WebChatPlanLimitError) => void` | Fires when a load, send, retry, or action response fails. Also fires when reconnect recovery fails. |
 | `onMessage` | `(message: AgentMessage) => void` | Fires once per new message id. History pages are silent. The first event of a turn can create an empty assistant message before text arrives. A send that never reaches the server does not fire. The message status becomes `failed` instead. |
 | `onActionRequested` | `(action: AgentPendingAction) => void` | Fires once per pending action, including actions still pending on mount. Paging backwards is silent. |
 | `onEvent` | `(envelope: AgentEventEnvelope) => void` | Raw live envelopes for this conversation. Duplicate envelopes that the store drops do not fire. |
@@ -39,13 +39,12 @@ Pass `agentId` (and optional `conversationId` and `agentHash`), or pass `convers
 | `isRunning` | `boolean` | True while the agent turn is in progress. Same as `run.isRunning`. |
 | `typing` | `AgentConversationTyping \| undefined` | Ephemeral typing indicator. Same as `run.typing`. Absent when the agent is not typing. |
 | `run` | `{ isRunning: boolean; typing?: AgentConversationTyping }` | Current agent-run snapshot. |
-| `status` | `'active' \| 'resolved'` | Conversation lifecycle. Same value as `conversationStatus`. The agent sets `resolved` with `ctx.resolve()`. Not a loading flag. See [State](/agents/channels/web-chat/chat-ui#state). |
-| `conversationStatus` | `'active' \| 'resolved'` | Alias for `status`. |
+| `conversationStatus` | `'active' \| 'resolved'` | Conversation lifecycle. The agent sets `resolved` with `ctx.resolve()`. Not a loading flag. See [State](/agents/channels/web-chat/chat-ui#state). |
 | `pagination` | `{ status, hasMore, fetchMore }` | Older history pages. Not a top-level `hasMore` or `fetchMore`. See [Pagination](#pagination). |
-| `isRecovering` | `boolean` | True while reconnect catch-up is in flight for this conversation. |
-| `catchUpError` | `NovuError \| undefined` | Set when reconnect catch-up fails. Separate from send and fetch `error`. |
+| `isRecovering` | `boolean` | True while reconnect recovery is in progress. |
+| `catchUpError` | `NovuError \| undefined` | Set when reconnect recovery fails. Separate from send and fetch `error`. |
 | `refetch` | `() => Promise<void>` | Reload the newest history page. No-op when there is no conversation id. |
-| `sendMessage` | `(text: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| WebChatPlanLimitError }>` | Send a user message. Creates a conversation when `conversationId` is omitted. |
+| `sendMessage` | `(input: SendMessageInput) => Promise<{ data?: SendMessageResult; error?: NovuError \| WebChatPlanLimitError }>` | Send a user message. `input` is a string, or `{ text, metadata }`. Creates a conversation when `conversationId` is omitted. |
 | `retryMessage` | `(messageId: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| WebChatPlanLimitError }>` | Resend a message whose `status` is `failed`. Reuses the original idempotency key. Does not create a second message. See [Retry a failed send](/agents/channels/web-chat/chat-ui#retry-a-failed-send). |
 | `respondToAction` | `(args: { actionId: string; decision: AgentToolApprovalDecision }) => Promise<{ data?: RespondToActionResult; error?: NovuError \| WebChatPlanLimitError }>` | Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. Typical decisions: `'approved'` or `'denied'`. |
 | `sendAction` | `(args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{ data?: SendActionResult; error?: NovuError \| WebChatPlanLimitError }>` | Click a Card button. Pass `id` / `value` from the button and `message.id` as `sourceMessageId`. Do not use this for tool approval. See [Cards](/agents/channels/web-chat/chat-ui#cards). |
@@ -68,8 +67,8 @@ The hook reconnects and catches up on its own. Use these fields for a banner.
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `isRecovering` | `boolean` | True while catch-up is in flight. |
-| `catchUpError` | `NovuError \| undefined` | Set when catch-up fails. `status` does not become an error state. |
+| `isRecovering` | `boolean` | True while recovery is in progress. |
+| `catchUpError` | `NovuError \| undefined` | Set when recovery fails. `conversationStatus` does not become an error state. |
 
 See [Reconnect](/agents/channels/web-chat/chat-ui#reconnect).
 

--- a/packages/js/src/event-emitter/novu-event-emitter.ts
+++ b/packages/js/src/event-emitter/novu-event-emitter.ts
@@ -1,14 +1,20 @@
 import mitt, { Emitter } from 'mitt';
-import { EventHandler, EventNames, Events } from './types';
+import { EventHandler, Events } from './types';
+import type { WebChatMessagesUpdated } from './web-chat-events';
+
+type InternalEvents = Events & {
+  'web_chat.messages.updated': { data: WebChatMessagesUpdated };
+};
+type InternalEventNames = keyof InternalEvents;
 
 export class NovuEventEmitter {
-  #mittEmitter: Emitter<Events>;
+  #mittEmitter: Emitter<InternalEvents>;
 
   constructor() {
     this.#mittEmitter = mitt();
   }
 
-  on<Key extends EventNames>(eventName: Key, listener: EventHandler<Events[Key]>): () => void {
+  on<Key extends InternalEventNames>(eventName: Key, listener: EventHandler<InternalEvents[Key]>): () => void {
     this.#mittEmitter.on(eventName, listener);
 
     return () => {
@@ -16,11 +22,11 @@ export class NovuEventEmitter {
     };
   }
 
-  off<Key extends EventNames>(eventName: Key, listener: EventHandler<Events[Key]>): void {
+  off<Key extends InternalEventNames>(eventName: Key, listener: EventHandler<InternalEvents[Key]>): void {
     this.#mittEmitter.off(eventName, listener);
   }
 
-  emit<Key extends EventNames>(type: Key, event?: Events[Key]): void {
-    this.#mittEmitter.emit(type, event as Events[Key]);
+  emit<Key extends InternalEventNames>(type: Key, event?: InternalEvents[Key]): void {
+    this.#mittEmitter.emit(type, event as InternalEvents[Key]);
   }
 }

--- a/packages/js/src/event-emitter/types.ts
+++ b/packages/js/src/event-emitter/types.ts
@@ -47,7 +47,6 @@ import type {
 } from '../subscriptions/types';
 import type { TagsFilter } from '../types';
 import { Session, WebSocketEvent } from '../types';
-import type { WebChatMessagesUpdated } from './web-chat-events';
 
 type NovuPendingEvent<A, D = undefined> = {
   args: A;
@@ -187,10 +186,6 @@ type SocketEvents = {
   [key in WebChatAgentEvent]: { result: AgentEventEnvelope };
 };
 
-type WebChatEvents = {
-  'web_chat.messages.updated': { data: WebChatMessagesUpdated };
-};
-
 /**
  * Events that are emitted by Novu Event Emitter.
  *
@@ -234,7 +229,6 @@ export type Events = SessionInitializeEvents &
   ChannelEndpointLinkEvents &
   SocketConnectEvents &
   SocketEvents &
-  WebChatEvents &
   NotificationReadEvents &
   NotificationUnreadEvents &
   NotificationSeenEvents &

--- a/packages/js/src/event-emitter/web-chat-events.ts
+++ b/packages/js/src/event-emitter/web-chat-events.ts
@@ -1,40 +1,41 @@
 import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
+import type { NovuError } from '../utils/errors';
 import type {
   AgentConversationStatus,
   AgentConversationTyping,
   AgentMessage,
   AgentPendingAction,
 } from '../web-chat/agent-message.types';
-import type { NovuError } from '../utils/errors';
 
 export type WebChatPaginationStatus = 'idle' | 'loading' | 'error';
 
+/** Older-history page state. */
 export type WebChatPagination = {
   status: WebChatPaginationStatus;
   hasMore: boolean;
 };
 
-/** What caused a fold. A live fold carries the envelope that caused it. Internal to the store seam. */
+/** Why the snapshot changed. A live update includes the envelope that caused it. */
 export type WebChatChangeSource =
   | { kind: 'live'; envelope: AgentEventEnvelope }
   | { kind: 'history' }
   | { kind: 'local' };
 
 /**
- * What one fold added to a holder, next to the folded snapshot.
- * A `history` fold replays stored events, so it is catch-up and not new activity.
+ * What one update added, next to the snapshot.
+ * A `history` update replays stored events, so it is not new activity.
  */
 export type WebChatChange = WebChatChangeSource & {
-  /** Messages this fold added. A fold that only changes existing messages adds none. */
+  /** Messages this update added. An update that only changes existing messages adds none. */
   addedMessages: AgentMessage[];
-  /** Actions that became pending in this fold. One action is reported one time. */
+  /** Actions that became pending in this update. Each action is reported one time. */
   newActions: AgentPendingAction[];
 };
 
 export type WebChatMessagesUpdated = {
   agentId: string;
   conversationId?: string;
-  /** Immutable holder key. Stable for the life of the local conversation entry. */
+  /** Stable session key for this local conversation. */
   key: string;
   messages: AgentMessage[];
   isRunning: boolean;
@@ -43,9 +44,9 @@ export type WebChatMessagesUpdated = {
   hasMore: boolean;
   pagination: WebChatPagination;
   error?: NovuError;
-  /** True while reconnect catch-up is in flight for this conversation. */
+  /** True while reconnect recovery is in progress. */
   isRecovering: boolean;
-  /** Set when catch-up hits the safety page limit or HTTP ultimately fails. */
+  /** Set when reconnect recovery fails. */
   catchUpError?: NovuError;
   change: WebChatChange;
 };

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,22 +1,31 @@
 export type * from 'json-logic-js';
 export type {
+  ChannelConnectionResponse,
+  ChannelEndpointResponse,
+  CreateChannelConnectionArgs,
+  CreateChannelEndpointArgs,
+  DeleteChannelConnectionArgs,
+  DeleteChannelEndpointArgs,
+  GenerateChatOAuthUrlArgs,
+  GetChannelConnectionArgs,
+  GetChannelEndpointArgs,
+  LinkChannelEndpointArgs,
+  LinkChannelEndpointResponse,
+  ListChannelConnectionsArgs,
+  ListChannelEndpointsArgs,
+} from './channel-connections';
+export type { EventHandler, Events, SocketEventNames } from './event-emitter';
+export { NOTIFICATION_COUNT_SYNC_EVENTS } from './notifications/count-sync-events';
+export { Novu } from './novu';
+export type {
   AgentApprovalPart,
   AgentApprovalPartState,
   AgentCardPart,
-  WebChatChange,
-  WebChatDefinition,
-  WebChatPagination,
-  WebChatPaginationStatus,
-  WebChatToolsDefinition,
-  AgentConversationError,
-  AgentConversationPaginationSnapshot,
   AgentConversationPublicationMeta,
   AgentConversationRunSnapshot,
   AgentConversationRuntime,
-  AgentConversationRuntimeActions,
   AgentConversationSessionStatus,
   AgentConversationSnapshot,
-  AgentConversationState,
   AgentConversationStatus,
   AgentConversationTyping,
   AgentDataPart,
@@ -42,43 +51,34 @@ export type {
   AgentToolPartFor,
   AgentToolPartState,
   ConversationArgs,
-  ConversationErr,
-  ConversationOk,
-  ConversationResult,
-  FetchMoreArgs,
   FetchMoreResult,
-  LoadConversationArgs,
   LoadConversationResult,
-  RespondToActionArgs,
   RespondToActionResult,
-  SendActionArgs,
+  RetryMessageResult,
   SendActionResult,
-  SendMessageArgs,
   SendMessageInput,
   SendMessageResult,
+  WebChat,
+  WebChatDefinition,
+  WebChatPagination,
+  WebChatPaginationStatus,
+  WebChatToolsDefinition,
 } from './web-chat';
 export { WebChatPlanLimitError, type WebChatPlanLimitReason } from './web-chat/web-chat-plan-limit-error';
-export { derivePendingActions } from './web-chat/derive-pending-actions';
-export type {
-  ChannelConnectionResponse,
-  ChannelEndpointResponse,
-  CreateChannelConnectionArgs,
-  CreateChannelEndpointArgs,
-  DeleteChannelConnectionArgs,
-  DeleteChannelEndpointArgs,
-  GenerateChatOAuthUrlArgs,
-  GetChannelConnectionArgs,
-  GetChannelEndpointArgs,
-  LinkChannelEndpointArgs,
-  LinkChannelEndpointResponse,
-  ListChannelConnectionsArgs,
-  ListChannelEndpointsArgs,
-} from './channel-connections';
-export type { EventHandler, Events, SocketEventNames } from './event-emitter';
-export { NOTIFICATION_COUNT_SYNC_EVENTS } from './notifications/count-sync-events';
-export { Novu } from './novu';
 
-/** Loads Web Chat on a {@link Novu} instance. Prefer this named export for explicit agent bootstrap. */
+/**
+ * Load Web Chat on a {@link Novu} instance. Safe to call more than one time.
+ * Apps that never call this method do not download the Web Chat bundle.
+ *
+ * @example
+ * ```ts
+ * import { Novu, loadWebChat } from '@novu/js';
+ *
+ * const novu = new Novu({ applicationIdentifier, subscriberId });
+ * await loadWebChat(novu);
+ * const conversation = novu.webChat.conversation({ agentId: 'YOUR_AGENT_IDENTIFIER' });
+ * ```
+ */
 export function loadWebChat(novu: import('./novu').Novu): Promise<import('./web-chat').WebChat> {
   return novu.loadWebChat();
 }

--- a/packages/js/src/notifications/notification.ts
+++ b/packages/js/src/notifications/notification.ts
@@ -14,7 +14,7 @@ import {
   unsnooze,
 } from './helpers';
 
-export class Notification implements Pick<NovuEventEmitter, 'on'>, InboxNotification {
+export class Notification implements InboxNotification {
   #emitter: NovuEventEmitter;
   #inboxService: InboxService;
 

--- a/packages/js/src/novu.load-web-chat.test.ts
+++ b/packages/js/src/novu.load-web-chat.test.ts
@@ -118,7 +118,7 @@ describe('Novu.loadWebChat', () => {
     const webChat = await novu.loadWebChat();
 
     expect(notifications.data?.notifications).toEqual([]);
-    expect(webChat.conversation({ agentId: 'agent_1' }).ok).toBe(true);
+    expect(webChat.conversation({ agentId: 'agent_1' })).toBeDefined();
     expect(novu.notifications).toBeDefined();
     expect(novu.socket).toBeDefined();
   });

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -1,4 +1,3 @@
-import type { WebChat } from './web-chat';
 import { HttpClient, InboxService } from './api';
 import { ChannelConnections } from './channel-connections';
 import { ChannelEndpoints } from './channel-endpoints';
@@ -11,10 +10,11 @@ import { Subscriptions } from './subscriptions';
 import type { Context, NovuOptions, Subscriber } from './types';
 import { buildContextKey } from './utils/build-context-key';
 import { buildSubscriber } from './utils/build-subscriber';
+import type { WebChat } from './web-chat';
 import { createSocket } from './ws';
 import type { BaseSocketInterface } from './ws/base-socket';
 
-export class Novu implements Pick<NovuEventEmitter, 'on'> {
+export class Novu {
   #emitter: NovuEventEmitter;
   #session: Session;
   #httpClient: HttpClient;
@@ -62,14 +62,14 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
   }
 
   /**
-   * True after {@link Novu.loadWebChat} has resolved on this instance.
+   * True after `loadWebChat` has resolved on this instance.
    */
   public get isWebChatLoaded(): boolean {
     return this.#webChat !== undefined;
   }
 
   /**
-   * Web Chat runtime. Call {@link Novu.loadWebChat} before first use.
+   * Web Chat client. Call `loadWebChat` before first use.
    * @throws When Web Chat has not been loaded yet.
    */
   public get webChat(): WebChat {
@@ -81,8 +81,8 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
   }
 
   /**
-   * Loads the Web Chat module. Idempotent — safe to call multiple times.
-   * Inbox-only apps that never call this method do not download the agent graph.
+   * Load the Web Chat module. Safe to call more than one time.
+   * Apps that never call this method do not download the Web Chat bundle.
    */
   public loadWebChat(): Promise<WebChat> {
     if (this.#webChat) {

--- a/packages/js/src/web-chat/agent-conversation-runtime.test.ts
+++ b/packages/js/src/web-chat/agent-conversation-runtime.test.ts
@@ -1,7 +1,7 @@
 import { WebChatService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
-import { WebChat } from './web-chat';
 import type { AgentConversationSnapshot } from './conversation-runtime.types';
+import { WebChat } from './web-chat';
 
 describe('AgentConversationRuntime', () => {
   const inboxServiceInstance = { isSessionInitialized: true } as any;
@@ -31,40 +31,22 @@ describe('AgentConversationRuntime', () => {
   });
 
   afterEach(() => {
-    for (const result of [
-      webChat.conversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' }),
-      webChat.conversation({ agentId: 'agent_1' }),
-    ]) {
-      if (result.ok) {
-        result.data.dispose();
-      }
-    }
+    webChat.conversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' }).dispose();
+    webChat.conversation({ agentId: 'agent_1' }).dispose();
   });
 
   it('reuses a runtime keyed by agent and conversation id', () => {
     const first = webChat.conversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
     const second = webChat.conversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
 
-    expect(first.ok).toBe(true);
-    expect(second.ok).toBe(true);
-    if (!first.ok || !second.ok) {
-      return;
-    }
-
-    expect(first.data).toBe(second.data);
-    first.data.dispose();
+    expect(first).toBe(second);
+    first.dispose();
   });
 
   it('returns the same frozen snapshot reference until the next publication', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 
-    const created = webChat.conversation({ agentId: 'agent_1' });
-    expect(created.ok).toBe(true);
-    if (!created.ok) {
-      return;
-    }
-
-    const runtime = created.data;
+    const runtime = webChat.conversation({ agentId: 'agent_1' });
     const before = runtime.getSnapshot();
 
     await runtime.sendMessage('hello');
@@ -104,12 +86,7 @@ describe('AgentConversationRuntime', () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
     getEvents.mockResolvedValue({ events: [], olderCursor: null });
 
-    const created = webChat.conversation({ agentId: 'agent_1' });
-    if (!created.ok) {
-      return;
-    }
-
-    const runtime = created.data;
+    const runtime = webChat.conversation({ agentId: 'agent_1' });
     const seen: AgentConversationSnapshot[] = [];
 
     const unsubscribe = runtime.subscribe((snapshot) => {
@@ -141,12 +118,8 @@ describe('AgentConversationRuntime', () => {
   it('separates run, conversationStatus, pagination, and session status in the snapshot', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000001' });
 
-    const created = webChat.conversation({ agentId: 'agent_1' });
-    if (!created.ok) {
-      return;
-    }
-
-    await created.data.sendMessage('hello');
+    const runtime = webChat.conversation({ agentId: 'agent_1' });
+    await runtime.sendMessage('hello');
 
     emitter.emit('web_chat.agent_event', {
       result: {
@@ -176,7 +149,7 @@ describe('AgentConversationRuntime', () => {
       },
     });
 
-    const snapshot = created.data.getSnapshot();
+    const snapshot = runtime.getSnapshot();
     expect(snapshot.status).toBe('ready');
     expect(snapshot.run.isRunning).toBe(true);
     expect(snapshot.run.typing?.status).toBe('Thinking…');
@@ -184,59 +157,43 @@ describe('AgentConversationRuntime', () => {
     expect(snapshot.pagination.hasMore).toBe(false);
     expect(snapshot.pagination.status).toBe('idle');
 
-    created.data.dispose();
+    runtime.dispose();
   });
 
   it('replaces a stale resume runtime when the create-flow runtime registers', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 
     const createFlow = webChat.conversation({ agentId: 'agent_1' });
-    if (!createFlow.ok) {
-      return;
-    }
-
     const staleResume = webChat.conversation({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(staleResume.ok).toBe(true);
-    if (!staleResume.ok) {
-      return;
-    }
 
-    expect(staleResume.data).not.toBe(createFlow.data);
+    expect(staleResume).not.toBe(createFlow);
 
-    await createFlow.data.sendMessage('hello');
+    await createFlow.sendMessage('hello');
 
     const resumed = webChat.conversation({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(resumed.ok).toBe(true);
-    if (!resumed.ok) {
-      return;
-    }
 
-    expect(resumed.data).toBe(createFlow.data);
-    expect(resumed.data).not.toBe(staleResume.data);
-    expect(resumed.data.getSnapshot().messages[0]).toMatchObject({
+    expect(resumed).toBe(createFlow);
+    expect(resumed).not.toBe(staleResume);
+    expect(resumed.getSnapshot().messages[0]).toMatchObject({
       role: 'user',
       parts: [{ type: 'text', text: 'hello' }],
     });
 
-    createFlow.data.dispose();
+    createFlow.dispose();
   });
 
   it('clearCache disposes runtimes so a later resume gets a fresh instance', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 
     const created = webChat.conversation({ agentId: 'agent_1' });
-    if (!created.ok) {
-      return;
-    }
-
-    await created.data.sendMessage('hello');
-    const disposedRuntime = created.data;
+    await created.sendMessage('hello');
+    const disposedRuntime = created;
 
     webChat.clearCache();
 
@@ -244,14 +201,10 @@ describe('AgentConversationRuntime', () => {
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(resumed.ok).toBe(true);
-    if (!resumed.ok) {
-      return;
-    }
 
-    expect(resumed.data).not.toBe(disposedRuntime);
+    expect(resumed).not.toBe(disposedRuntime);
 
-    resumed.data.dispose();
+    resumed.dispose();
   });
 
   it('does not register a disposed runtime after an in-flight send completes', async () => {
@@ -264,15 +217,11 @@ describe('AgentConversationRuntime', () => {
     );
 
     const created = webChat.conversation({ agentId: 'agent_1' });
-    if (!created.ok) {
-      return;
-    }
-
-    const sendPromise = created.data.sendMessage('hello');
+    const sendPromise = created.sendMessage('hello');
     await Promise.resolve();
     expect(sendMessage).toHaveBeenCalledTimes(1);
 
-    created.data.dispose();
+    created.dispose();
 
     resolveSend({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
     await sendPromise;
@@ -281,28 +230,20 @@ describe('AgentConversationRuntime', () => {
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(resumed.ok).toBe(true);
-    if (!resumed.ok) {
-      return;
-    }
 
-    expect(resumed.data).not.toBe(created.data);
+    expect(resumed).not.toBe(created);
 
-    resumed.data.dispose();
+    resumed.dispose();
   });
 
   it('isolates snapshot messages from store mutations', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 
     const created = webChat.conversation({ agentId: 'agent_1' });
-    if (!created.ok) {
-      return;
-    }
+    await created.sendMessage('hello');
 
-    await created.data.sendMessage('hello');
-
-    const snapshot = created.data.getSnapshot();
-    const storeBefore = webChat.getConversation({ agentId: 'agent_1', key: created.data.key });
+    const snapshot = created.getSnapshot();
+    const storeBefore = webChat.getConversation({ agentId: 'agent_1', key: created.key });
 
     expect(snapshot.messages[0]?.parts[0]).toMatchObject({ type: 'text', text: 'hello' });
     expect(Object.isFrozen(snapshot.messages[0])).toBe(true);
@@ -317,6 +258,6 @@ describe('AgentConversationRuntime', () => {
 
     expect(storeBefore?.messages[0]?.parts[0]).toMatchObject({ type: 'text', text: 'hello' });
 
-    created.data.dispose();
+    created.dispose();
   });
 });

--- a/packages/js/src/web-chat/agent-conversation-runtime.ts
+++ b/packages/js/src/web-chat/agent-conversation-runtime.ts
@@ -1,20 +1,19 @@
 import type { WebChatPlanLimitError } from '../api';
 import { NovuError } from '../utils/errors';
-import type { WebChat } from './web-chat';
-import { createLocalConversationKey } from './web-chat-store';
 import type { AgentToolApprovalDecision } from './agent-message.types';
 import { derivePendingActions } from './agent-message.types';
 import type {
-  AgentConversationPaginationSnapshot,
   AgentConversationPublicationMeta,
   AgentConversationRunSnapshot,
   AgentConversationSessionStatus,
   AgentConversationSnapshot,
   ConversationArgs,
-  ConversationResult,
   SendMessageInput,
 } from './conversation-runtime.types';
 import { runtimeCacheKey } from './runtime-cache-key';
+import type { WebChatPagination } from './types';
+import type { WebChat } from './web-chat';
+import { createLocalConversationKey } from './web-chat-store';
 
 const EMPTY_RUN: AgentConversationRunSnapshot = Object.freeze({ isRunning: false });
 
@@ -82,16 +81,17 @@ function normalizeSendMessageInput(input: SendMessageInput): { text: string; met
   return { text: input.text, metadata: input.metadata };
 }
 
-function storePagination(hasMore: boolean, status: AgentConversationPaginationSnapshot['status'] = 'idle') {
+function storePagination(hasMore: boolean, status: WebChatPagination['status'] = 'idle') {
   return { hasMore, status };
 }
 
 /**
- * Framework-independent conversation runtime for one agent thread.
- * Owns identity, immutable snapshots, and bound actions.
+ * One conversation thread. Get this from {@link WebChat.conversation}. Do not construct it yourself.
+ * Call {@link AgentConversationRuntime.dispose} when the chat unmounts.
  */
 export class AgentConversationRuntime {
   readonly agentId: string;
+  /** @internal */
   readonly key: string;
 
   #webChat: WebChat;
@@ -146,14 +146,20 @@ export class AgentConversationRuntime {
     }
   }
 
+  /** Current immutable snapshot. */
   getSnapshot(): AgentConversationSnapshot {
     return this.#snapshot;
   }
 
+  /** Empty snapshot for SSR hydration. Stable across the server render. */
   getServerSnapshot(): AgentConversationSnapshot {
     return SERVER_SNAPSHOT;
   }
 
+  /**
+   * Call `listener` on every snapshot, including the current one.
+   * Returns a function that stops listening.
+   */
   subscribe(
     listener: (snapshot: AgentConversationSnapshot, meta?: AgentConversationPublicationMeta) => void
   ): () => void {
@@ -165,6 +171,7 @@ export class AgentConversationRuntime {
     };
   }
 
+  /** Stop listeners and release the socket. */
   dispose(): void {
     if (this.#disposed) {
       return;
@@ -178,6 +185,7 @@ export class AgentConversationRuntime {
     this.#listeners.clear();
   }
 
+  /** Reload the newest history page. Runs on resume when `conversationId` is set. */
   async load(): Promise<{
     data?: { conversationId: string; messages: AgentConversationSnapshot['messages']; hasMore: boolean };
     error?: NovuError;
@@ -232,6 +240,7 @@ export class AgentConversationRuntime {
     return response;
   }
 
+  /** Load the next older history page. Overlapping calls do not run. */
   async fetchMore(): Promise<{
     data?: { messages: AgentConversationSnapshot['messages']; hasMore: boolean };
     error?: NovuError;
@@ -274,6 +283,7 @@ export class AgentConversationRuntime {
     return response;
   }
 
+  /** Send a user message. `input` is a string, or `{ text, metadata }`. Creates a conversation when `conversationId` is omitted. */
   async sendMessage(
     input: SendMessageInput
   ): Promise<{ data?: { conversationId: string; messageId: string }; error?: NovuError | WebChatPlanLimitError }> {
@@ -302,6 +312,7 @@ export class AgentConversationRuntime {
     return response;
   }
 
+  /** Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. */
   async respondToAction(args: {
     actionId: string;
     decision: AgentToolApprovalDecision;
@@ -322,6 +333,7 @@ export class AgentConversationRuntime {
     return response;
   }
 
+  /** Click a Card button. Do not use this for tool approval. */
   async sendAction(args: {
     actionId: string;
     sourceMessageId: string;
@@ -344,6 +356,7 @@ export class AgentConversationRuntime {
     return response;
   }
 
+  /** Resend a message whose `status` is `failed`. Reuses the original idempotency key. */
   async retryMessage(
     messageId: string
   ): Promise<{ data?: { conversationId: string; messageId: string }; error?: NovuError | WebChatPlanLimitError }> {
@@ -360,13 +373,6 @@ export class AgentConversationRuntime {
     }
 
     return response;
-  }
-
-  cancelRun(): ConversationResult<void> {
-    return {
-      ok: false,
-      error: new NovuError('Run cancellation is not supported yet', new Error('cancelRun is not implemented')),
-    };
   }
 
   /** @internal */
@@ -417,7 +423,7 @@ export class AgentConversationRuntime {
       isRunning: boolean;
       typing?: AgentConversationRunSnapshot['typing'];
       status: AgentConversationSnapshot['conversationStatus'];
-      pagination: AgentConversationPaginationSnapshot;
+      pagination: WebChatPagination;
       isRecovering: boolean;
       catchUpError?: NovuError;
       conversationId?: string;

--- a/packages/js/src/web-chat/agent-message.types.ts
+++ b/packages/js/src/web-chat/agent-message.types.ts
@@ -2,23 +2,32 @@ import type { AgentMessageRole, AgentToolResultContent, AgentToolSource } from '
 
 export type { AgentMessageRole };
 
+/** Delivery state of a local user send. */
 export type AgentMessageStatus = 'sending' | 'sent' | 'failed';
 
+/** Text is still arriving (`streaming`) or complete (`done`). */
 export type AgentTextPartState = 'streaming' | 'done';
 
+/** Lifecycle of a tool-call part. */
 export type AgentToolPartState = 'input-streaming' | 'input-available' | 'output-available' | 'output-error';
 
+/** Lifecycle of a gated tool-approval part. */
 export type AgentApprovalPartState = 'pending' | 'approved' | 'denied';
+
+/** Lifecycle of an MCP connect card. */
 export type AgentMcpConnectionPartState = 'pending' | 'connected' | 'failed';
 
+/** Subscriber decision for a pending tool approval. */
 export type AgentToolApprovalDecision = 'approved' | 'denied' | 'trust-tool' | 'trust-server';
 
+/** Visible message text. */
 export type AgentTextPart = {
   type: 'text';
   text: string;
   state: AgentTextPartState;
 };
 
+/** Agent reasoning text while the turn is in progress. */
 export type AgentThinkingPart = {
   type: 'thinking';
   thinkingId: string;
@@ -26,6 +35,7 @@ export type AgentThinkingPart = {
   state: AgentTextPartState;
 };
 
+/** Tool call and its result. */
 export type AgentToolPart = {
   type: 'tool';
   toolUseId: string;
@@ -36,6 +46,7 @@ export type AgentToolPart = {
   state: AgentToolPartState;
 };
 
+/** Gated tool that waits for the subscriber. */
 export type AgentApprovalPart = {
   type: 'approval';
   approvalId: string;
@@ -44,16 +55,17 @@ export type AgentApprovalPart = {
   input?: Record<string, unknown>;
   source?: AgentToolSource;
   state: AgentApprovalPartState;
-  /** Server-minted; echo via respondToAction. Do not invent client-side. */
+  /** Server-generated. Pass this id to `respondToAction`. Do not create it on the client. */
   approveActionId?: string;
-  /** Server-minted; echo via respondToAction. Do not invent client-side. */
+  /** Server-generated. Pass this id to `respondToAction`. Do not create it on the client. */
   denyActionId?: string;
-  /** Server-minted always-allow-this-tool action id. Present for managed tools with trust support. */
+  /** Server-generated always-allow-this-tool action id. Present for managed tools that support trust. */
   trustToolActionId?: string;
-  /** Server-minted always-allow-MCP-server action id. Present for MCP tools only. */
+  /** Server-generated always-allow-MCP-server action id. Present for MCP tools only. */
   trustServerActionId?: string;
 };
 
+/** MCP server connect card. Open `authorizeUrl` in the browser. */
 export type AgentMcpConnectionPart = {
   type: 'mcp-connection';
   actionId: string;
@@ -65,17 +77,21 @@ export type AgentMcpConnectionPart = {
   message?: string;
 };
 
+/** Pending tool-approval item. Pass `id` to `respondToAction`. */
 export type AgentToolApprovalAction = Omit<AgentApprovalPart, 'type' | 'state'> & {
   type: 'tool-approval';
   id: string;
 };
 
+/** Pending MCP connect item. Open `authorizeUrl`. */
 export type AgentMcpConnectionAction = Omit<AgentMcpConnectionPart, 'state' | 'message'> & {
   id: string;
 };
 
+/** One item the UI must handle: a tool approval or an MCP connect card. */
 export type AgentPendingAction = AgentToolApprovalAction | AgentMcpConnectionAction;
 
+/** Citation. */
 export type AgentSourcePart = {
   type: 'source';
   sourceType: 'url' | 'document';
@@ -84,6 +100,7 @@ export type AgentSourcePart = {
   filename?: string;
 };
 
+/** File attachment metadata. */
 export type AgentFilePart = {
   type: 'file';
   fileId: string;
@@ -91,17 +108,20 @@ export type AgentFilePart = {
   mediaType?: string;
 };
 
+/** Structured Card. Button clicks call `sendAction`. */
 export type AgentCardPart = {
   type: 'card';
   card: Record<string, unknown>;
 };
 
+/** Custom payload. The UI decides how to render it. */
 export type AgentDataPart = {
   type: 'data';
   name: string;
   data: unknown;
 };
 
+/** One content block in a message. */
 export type AgentMessagePart =
   | AgentTextPart
   | AgentThinkingPart
@@ -113,19 +133,18 @@ export type AgentMessagePart =
   | AgentCardPart
   | AgentDataPart;
 
+/** One message in the conversation timeline. */
 export type AgentMessage = {
   id: string;
   role: AgentMessageRole;
   parts: AgentMessagePart[];
   createdAt: string;
   status: AgentMessageStatus;
-  /**
-   * Stable client-minted idempotency key for outbound user messages.
-   * Persisted from optimistic append through server reconciliation (`msg_*`).
-   */
+  /** Client-generated idempotency key for outbound user messages (`msg_*`). */
   idempotencyKey?: string;
 };
 
+/** `'active'` or `'resolved'`. The agent sets `resolved` with `ctx.resolve()`. */
 export type AgentConversationStatus = 'active' | 'resolved';
 
 export type AgentConversationError = {
@@ -133,12 +152,12 @@ export type AgentConversationError = {
   code?: string;
 };
 
-/** Ephemeral typing indicator. Absent when not typing. */
+/** Typing indicator. Absent when the agent is not typing. */
 export type AgentConversationTyping = {
   status?: string;
 };
 
-/** Timeline state produced by folding `AgentEventEnvelope`s. */
+/** Timeline produced by applying event envelopes. */
 export type AgentConversationState = {
   messages: AgentMessage[];
   isRunning: boolean;
@@ -146,10 +165,7 @@ export type AgentConversationState = {
   status: AgentConversationStatus;
   lastSequence: number;
   error?: AgentConversationError;
-  /**
-   * Fold-internal: assistant message that receives tool/thinking parts when events
-   * omit `messageId`. Cleared on `run-finish` / `run-error`.
-   */
+  /** Assistant message that receives tool and thinking parts when events omit `messageId`. */
   activeAssistantMessageId?: string;
 };
 

--- a/packages/js/src/web-chat/apply-envelope.ts
+++ b/packages/js/src/web-chat/apply-envelope.ts
@@ -1,6 +1,5 @@
 /**
- * Folds `AgentEventEnvelope` streams into a parts-based `AgentMessage[]` timeline.
- * Runs on clients only (live WS + durable history); the server append-only stores envelopes.
+ * Apply agent event envelopes to a parts-based message timeline.
  */
 import type { AgentEventEnvelope, AgentFileRef, AgentMessageContent } from '@novu/agent-event-protocol';
 import type {
@@ -595,13 +594,7 @@ function editMessage(
   return { ...state, messages: nextMessages };
 }
 
-/**
- * Clears ephemeral typing. Call sites are intentional and small:
- * - `channel.typing` state `off`
- * - assistant `message-start` / durable assistant `message` (content replaced waiting)
- * - `tool-approval-request` (human input replaced waiting)
- * Do not clear on `run-finish` / `run-error` here — that lifecycle stays separate.
- */
+/** Remove the typing indicator. Do not call on `run-finish` or `run-error`. */
 function clearTyping(state: AgentConversationState): AgentConversationState {
   if (state.typing === undefined) {
     return state;

--- a/packages/js/src/web-chat/conversation-runtime.types.ts
+++ b/packages/js/src/web-chat/conversation-runtime.types.ts
@@ -1,99 +1,61 @@
 import type { WebChatPlanLimitError } from '../api';
 import type { NovuError } from '../utils/errors';
 import type {
-  AgentConversationError,
   AgentConversationStatus,
   AgentConversationTyping,
   AgentMessage,
   AgentPendingAction,
-  AgentToolApprovalDecision,
 } from './agent-message.types';
-import type {
-  WebChatChange,
-  WebChatPaginationStatus,
-  FetchMoreResult,
-  LoadConversationResult,
-  RespondToActionResult,
-  RetryMessageResult,
-  SendActionResult,
-  SendMessageResult,
-} from './types';
+import type { WebChatChange, WebChatPagination } from './types';
 
-/** Session lifecycle for history loads on this runtime. */
+/** History load state for this runtime: idle (`ready`), first page (`loading`), or older pages (`fetching`). */
 export type AgentConversationSessionStatus = 'ready' | 'loading' | 'fetching';
 
+/** Whether the agent turn is in progress, plus an optional typing indicator. */
 export type AgentConversationRunSnapshot = {
   isRunning: boolean;
   typing?: AgentConversationTyping;
 };
 
-export type AgentConversationPaginationSnapshot = {
-  hasMore: boolean;
-  status: WebChatPaginationStatus;
-};
-
-/** Extra context for one snapshot publication. Omitted on the initial subscribe replay. */
+/** Extra context for one snapshot update. Omitted on the first `subscribe` call. */
 export type AgentConversationPublicationMeta = {
   change?: WebChatChange;
-  /** Resume history finished loading for this runtime. */
+  /** True after resume history finishes loading. */
   historyLoaded?: boolean;
 };
 
 /**
- * Immutable published view of one agent conversation thread.
- * `getSnapshot()` returns the same object reference until the next publication.
+ * Immutable view of one conversation. `getSnapshot()` returns the same object
+ * until the next update.
  */
 export type AgentConversationSnapshot = {
-  /** Holder key for this runtime session. Stable for the life of the runtime. */
+  /** @internal Stable session key for this runtime. */
   key: string;
+  /** Server conversation id after create or resume. */
   conversationId?: string;
-  /** History load / pagination state for this runtime. */
+  /** History load state. Not the conversation lifecycle. See {@link AgentConversationSnapshot.conversationStatus}. */
   status: AgentConversationSessionStatus;
   run: AgentConversationRunSnapshot;
+  /** `'active'` or `'resolved'`. The agent sets `resolved` with `ctx.resolve()`. */
   conversationStatus: AgentConversationStatus;
-  pagination: AgentConversationPaginationSnapshot;
+  pagination: WebChatPagination;
   messages: readonly AgentMessage[];
   pendingActions: readonly AgentPendingAction[];
-  error?: NovuError | WebChatPlanLimitError | AgentConversationError;
-  /** True while reconnect catch-up is in flight for this conversation. */
+  error?: NovuError | WebChatPlanLimitError;
+  /** True while reconnect recovery is in progress. */
   isRecovering: boolean;
-  /** Set when reconnect catch-up fails. Separate from send/fetch `error`. */
+  /** Set when reconnect recovery fails. Separate from send and fetch `error`. */
   catchUpError?: NovuError;
 };
 
-export type ConversationOk<T> = { ok: true; data: T };
-export type ConversationErr = { ok: false; error: NovuError };
-export type ConversationResult<T> = ConversationOk<T> | ConversationErr;
-
 export type ConversationArgs = {
+  /** Public agent identifier from the dashboard. */
   agentId: string;
+  /** Resume this conversation. Omit to start a new chat. */
   conversationId?: string;
+  /** HMAC-SHA256 of `agentId`. Required when Security HMAC is on for the Web Chat integration. */
   agentHash?: string;
 };
 
+/** Plain text, or text plus optional metadata for the agent. */
 export type SendMessageInput = string | { text: string; metadata?: Record<string, unknown> };
-
-export type AgentConversationRuntimeActions = {
-  getSnapshot(): AgentConversationSnapshot;
-  getServerSnapshot(): AgentConversationSnapshot;
-  subscribe(
-    listener: (snapshot: AgentConversationSnapshot, meta?: AgentConversationPublicationMeta) => void
-  ): () => void;
-  dispose(): void;
-  load(): Promise<{ data?: LoadConversationResult; error?: NovuError }>;
-  fetchMore(): Promise<{ data?: FetchMoreResult; error?: NovuError }>;
-  sendMessage(
-    input: SendMessageInput
-  ): Promise<{ data?: SendMessageResult; error?: NovuError | WebChatPlanLimitError }>;
-  respondToAction(args: {
-    actionId: string;
-    decision: AgentToolApprovalDecision;
-  }): Promise<{ data?: RespondToActionResult; error?: NovuError | WebChatPlanLimitError }>;
-  sendAction(args: {
-    actionId: string;
-    sourceMessageId: string;
-    value?: string;
-  }): Promise<{ data?: SendActionResult; error?: NovuError | WebChatPlanLimitError }>;
-  retryMessage(messageId: string): Promise<{ data?: RetryMessageResult; error?: NovuError | WebChatPlanLimitError }>;
-  cancelRun(): ConversationResult<void>;
-};

--- a/packages/js/src/web-chat/derive-pending-actions.ts
+++ b/packages/js/src/web-chat/derive-pending-actions.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage, AgentPendingAction } from './agent-message.types';
 
+/** Pending tool-approval and MCP-connect actions in `messages`. */
 export function derivePendingActions(messages: AgentMessage[]): AgentPendingAction[] {
   const pending: AgentPendingAction[] = [];
 

--- a/packages/js/src/web-chat/idempotency.ts
+++ b/packages/js/src/web-chat/idempotency.ts
@@ -13,7 +13,7 @@ export function mintClientId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36).slice(-12)}`;
 }
 
-/** Client-minted message idempotency key (`msg_*`). Sent as `messageId` on accept. */
+/** Client-generated message idempotency key (`msg_*`). Sent as `messageId` on accept. */
 export function createMessageIdempotencyKey(): string {
   return mintClientId('msg');
 }

--- a/packages/js/src/web-chat/index.ts
+++ b/packages/js/src/web-chat/index.ts
@@ -1,17 +1,8 @@
-export { WebChat } from './web-chat';
-export type {
-  WebChatDefinition,
-  WebChatToolsDefinition,
-  AgentToolDefinition,
-  AgentToolPartFor,
-} from './web-chat-definition.types';
-export { AgentConversationRuntime } from './agent-conversation-runtime';
+export type { AgentConversationRuntime } from './agent-conversation-runtime';
 export type {
   AgentApprovalPart,
   AgentApprovalPartState,
   AgentCardPart,
-  AgentConversationError,
-  AgentConversationState,
   AgentConversationStatus,
   AgentConversationTyping,
   AgentDataPart,
@@ -34,36 +25,29 @@ export type {
   AgentToolPartState,
 } from './agent-message.types';
 export type {
-  AgentConversationPaginationSnapshot,
   AgentConversationPublicationMeta,
   AgentConversationRunSnapshot,
-  AgentConversationRuntimeActions,
   AgentConversationSessionStatus,
   AgentConversationSnapshot,
   ConversationArgs,
-  ConversationErr,
-  ConversationOk,
-  ConversationResult,
   SendMessageInput,
 } from './conversation-runtime.types';
-export { derivePendingActions } from './derive-pending-actions';
 export type {
-  WebChatChange,
-  WebChatMessagesUpdated,
-  WebChatPagination,
-  WebChatPaginationStatus,
   AgentEventEnvelope,
   AgentHashFields,
-  FetchMoreArgs,
   FetchMoreResult,
-  LoadConversationArgs,
   LoadConversationResult,
-  RespondToActionArgs,
   RespondToActionResult,
-  RetryMessageArgs,
   RetryMessageResult,
-  SendActionArgs,
   SendActionResult,
-  SendMessageArgs,
   SendMessageResult,
+  WebChatPagination,
+  WebChatPaginationStatus,
 } from './types';
+export { WebChat } from './web-chat';
+export type {
+  AgentToolDefinition,
+  AgentToolPartFor,
+  WebChatDefinition,
+  WebChatToolsDefinition,
+} from './web-chat-definition.types';

--- a/packages/js/src/web-chat/types.ts
+++ b/packages/js/src/web-chat/types.ts
@@ -23,8 +23,8 @@ export type {
 };
 
 /**
- * HMAC-SHA256(env secret, agentId) hex. Required when the env's `novu-web-chat`
- * integration has Security HMAC enabled.
+ * HMAC-SHA256 of `agentId` with the environment secret.
+ * Required when Security HMAC is on for the Web Chat integration.
  */
 export type AgentHashFields = {
   agentHash?: string;
@@ -36,17 +36,15 @@ export type SendMessageArgs = AgentHashFields & {
   metadata?: Record<string, unknown>;
   /**
    * Existing conversation to append to.
-   * Omit this field to create a new conversation. The client does not reuse a prior chat.
+   * Omit this field to create a new conversation.
    * After create, pass the returned `conversationId` on later sends.
    */
   conversationId?: string;
-  /**
-   * Immutable holder key for the local store and emit subscription.
-   * Defaults to `conversationId` on resume, or a minted `local_*` key on create.
-   */
+  /** @internal Session key for the local cache. */
   key?: string;
 };
 
+/** Result of a successful send or retry. */
 export type SendMessageResult = {
   conversationId: string;
   messageId: string;
@@ -56,6 +54,7 @@ export type RetryMessageArgs = AgentHashFields & {
   agentId: string;
   messageId: string;
   conversationId?: string;
+  /** @internal Session key for the local cache. */
   key?: string;
 };
 
@@ -66,6 +65,7 @@ export type LoadConversationArgs = {
   conversationId: string;
 };
 
+/** Newest history page for a resumed conversation. */
 export type LoadConversationResult = {
   conversationId: string;
   messages: AgentMessage[];
@@ -75,9 +75,11 @@ export type LoadConversationResult = {
 export type FetchMoreArgs = {
   agentId: string;
   conversationId?: string;
+  /** @internal Session key for the local cache. */
   key?: string;
 };
 
+/** Next older history page. */
 export type FetchMoreResult = {
   messages: AgentMessage[];
   hasMore: boolean;
@@ -96,9 +98,11 @@ export type RespondToActionArgs = AgentHashFields & {
   actionId: string;
   decision: AgentToolApprovalDecision;
   conversationId?: string;
+  /** @internal Session key for the local cache. */
   key?: string;
 };
 
+/** Result of a tool-approval decision. */
 export type RespondToActionResult = {
   conversationId: string;
 };
@@ -107,14 +111,16 @@ export type SendActionArgs = AgentHashFields & {
   agentId: string;
   /** `id` of the clicked Card button. */
   actionId: string;
-  /** Platform message id of the message that carries the Card. */
+  /** `id` of the message that carries the Card. */
   sourceMessageId: string;
   /** `value` of the clicked Card button, if set. */
   value?: string;
   conversationId?: string;
+  /** @internal Session key for the local cache. */
   key?: string;
 };
 
+/** Result of a Card button click. */
 export type SendActionResult = {
   conversationId: string;
 };

--- a/packages/js/src/web-chat/web-chat-definition.types.ts
+++ b/packages/js/src/web-chat/web-chat-definition.types.ts
@@ -1,7 +1,7 @@
 import type { AgentToolResultContent } from '@novu/agent-event-protocol';
 import type { AgentToolPart } from './agent-message.types';
 
-/** Per-tool input/output shapes for compile-time narrowing on `AgentToolPart`. */
+/** Input and output shapes used to narrow `AgentToolPart` at compile time. */
 export type AgentToolDefinition = {
   input?: unknown;
   output?: unknown;
@@ -10,7 +10,7 @@ export type AgentToolDefinition = {
 export type WebChatToolsDefinition = Record<string, AgentToolDefinition>;
 
 /**
- * Optional integrator-defined tool catalog for narrowing `AgentToolPart` by `toolName`.
+ * Optional tool catalog. Use it to narrow `AgentToolPart` by `toolName`.
  *
  * @example
  * type MyChat = WebChatDefinition<{

--- a/packages/js/src/web-chat/web-chat-plan-limit-error.ts
+++ b/packages/js/src/web-chat/web-chat-plan-limit-error.ts
@@ -1,5 +1,10 @@
+/** Which plan limit blocked the request. */
 export type WebChatPlanLimitReason = 'agents' | 'channels' | 'conversations';
 
+/**
+ * Thrown when a Web Chat request is blocked by a plan limit (HTTP 402).
+ * Check `reason` to see which limit was hit.
+ */
 export class WebChatPlanLimitError extends Error {
   readonly reason: WebChatPlanLimitReason;
 

--- a/packages/js/src/web-chat/web-chat-store.ts
+++ b/packages/js/src/web-chat/web-chat-store.ts
@@ -16,26 +16,25 @@ type McpConnectionResult = {
 };
 
 /**
- * Stable local identity for one conversation holder.
+ * Stable local identity for one conversation session.
  * The object reference does not change. Timeline fields are overwritten in place.
- * This store is an in-memory UI cache. It is not a synchronized server timeline.
  */
 export type ConversationEntry = AgentConversationState & {
   agentId: string;
   /** Public conversation id after create, or when the session resumes. */
   conversationId?: string;
   /**
-   * Map key for this holder. The key does not change for the life of the holder.
-   * Create sessions use `local_*`. Resume sessions use the `conv_*` id.
+   * Map key for this session. The key does not change.
+   * New chats use `local_*`. Resume uses the `conv_*` id.
    */
   key: string;
   /**
    * Cursor toward older history (`before` on the next page). Null when unknown,
-   * exhausted, or on a create-only holder before any history load.
+   * exhausted, or before any history load.
    */
   olderCursor: string | null;
   /**
-   * Actions already reported as new. Add-only: an action id is never raised twice,
+   * Actions already reported as new. An action id is never raised twice,
    * so a resolved action must not fall out and be reported again.
    */
   reportedActionIds: Set<string>;
@@ -43,21 +42,21 @@ export type ConversationEntry = AgentConversationState & {
   mcpConnectionResults: Map<string, McpConnectionResult>;
   /**
    * Latest `channel.edit` / `channel.delete` per message id.
-   * History pages fold in isolation, so a mutation on a newer page must still
-   * apply when `fetchMore` prepends the original `MESSAGE`.
+   * History pages apply in isolation, so a mutation on a newer page must still
+   * apply when `fetchMore` prepends the original message.
    */
   messageMutations: Map<string, AgentEventEnvelope>;
-  /** True while reconnect catch-up is in flight for this holder. */
+  /** True while reconnect recovery is in progress. */
   isRecovering: boolean;
-  /** Set when catch-up hits the safety page limit or HTTP fails. Cleared on success. */
+  /** Set when reconnect recovery hits the page limit or HTTP fails. Cleared on success. */
   catchUpError?: NovuError;
-  /** One create at a time on this holder until a conversation id exists. */
+  /** One create at a time on this session until a conversation id exists. */
   pendingCreate?: Promise<void>;
   /** History pagination state for `fetchMore`. */
   paginationStatus: WebChatPaginationStatus;
   /** Invalidates in-flight `fetchMore` status updates after history reload. */
   paginationEpoch: number;
-  /** Coalesces overlapping `fetchMore` calls on this holder. */
+  /** Coalesces overlapping `fetchMore` calls on this session. */
   pendingFetchMore?: Promise<{ data?: FetchMoreResult; error?: NovuError }>;
 };
 
@@ -88,9 +87,8 @@ function applyState(entry: ConversationEntry, next: AgentConversationState): voi
 }
 
 /**
- * In-memory store for web-chat conversations.
- * `WebChat` updates this store around HTTP calls. The hook listens on `onUpdate`.
- * The map key is the immutable holder `key`.
+ * In-memory cache for Web Chat conversations.
+ * `WebChat` writes here around HTTP calls. The map key is the session `key`.
  */
 export class WebChatStore {
   #byKey = new Map<string, ConversationEntry>();
@@ -101,9 +99,8 @@ export class WebChatStore {
   }
 
   /**
-   * Notify listeners with the folded snapshot and what the fold added.
-   * Only this store can tell the three sources apart, so it reports them instead of
-   * leaving each consumer to guess from the snapshot alone.
+   * Notify listeners with the snapshot and what this update added.
+   * Only this store can tell live, history, and local updates apart.
    */
   #publish(entry: ConversationEntry, source: WebChatChangeSource, addedMessages: AgentMessage[]): void {
     const newActions = derivePendingActions(entry.messages).filter((action) => !entry.reportedActionIds.has(action.id));
@@ -116,8 +113,7 @@ export class WebChatStore {
 
   /**
    * Mark a backfilled page's actions as already reported.
-   * An older page can carry a request whose response is on a page already folded, which
-   * leaves it looking pending. Paging backwards is never new activity.
+   * Paging backwards is never new activity.
    */
   #suppressActions(entry: ConversationEntry, messages: AgentMessage[]): void {
     for (const action of derivePendingActions(messages)) {
@@ -194,7 +190,7 @@ export class WebChatStore {
     return this.#byKey.get(key);
   }
 
-  /** Find a holder that already claimed this conversation id. */
+  /** Find a session that already claimed this conversation id. */
   getByConversationId(agentId: string, conversationId: string): ConversationEntry | undefined {
     for (const entry of this.#byKey.values()) {
       if (entry.agentId === agentId && entry.conversationId === conversationId) {
@@ -205,7 +201,7 @@ export class WebChatStore {
     return undefined;
   }
 
-  /** All holders that already claimed this conversation id (create + resume can both exist). */
+  /** All sessions that already claimed this conversation id (create and resume can both exist). */
   findByConversationId(agentId: string, conversationId: string): ConversationEntry[] {
     const matches: ConversationEntry[] = [];
     for (const entry of this.#byKey.values()) {
@@ -217,7 +213,7 @@ export class WebChatStore {
     return matches;
   }
 
-  /** Holders that already have a public conversation id (eligible for reconnect catch-up). */
+  /** Sessions that already have a public conversation id (eligible for reconnect recovery). */
   listClaimed(): Array<ConversationEntry & { conversationId: string }> {
     const claimed: Array<ConversationEntry & { conversationId: string }> = [];
     for (const entry of this.#byKey.values()) {
@@ -230,8 +226,8 @@ export class WebChatStore {
   }
 
   /**
-   * Return the entry for `key`, or create an empty holder.
-   * This method does not reuse a holder that only shares `conversationId`.
+   * Return the entry for `key`, or create an empty session.
+   * This method does not reuse a session that only shares `conversationId`.
    * Resume (`key === conversationId`) stays separate from an in-flight `local_*` create.
    */
   getOrCreate(args: { agentId: string; key: string; conversationId?: string }): ConversationEntry {
@@ -338,8 +334,8 @@ export class WebChatStore {
   }
 
   /**
-   * Merge a history page into this holder.
-   * Server message ids win. Local-only messages stay on the holder.
+   * Merge a history page into this session.
+   * Server message ids win. Local-only messages stay on the session.
    */
   absorbHistoryPage(
     entry: ConversationEntry,
@@ -368,10 +364,8 @@ export class WebChatStore {
   }
 
   /**
-   * Run one history page fetch for this holder.
+   * Run one history page fetch for this session.
    * Overlapping calls reuse the same in-flight promise.
-   * Message-id filtering in `prependOlderPage` prevents duplicate-message corruption when
-   * overlapping pagination wastes network or cursor work.
    */
   withFetchMoreClaim(
     entry: ConversationEntry,
@@ -412,7 +406,7 @@ export class WebChatStore {
   }
 
   /**
-   * Fold an older history page into this holder without resetting live timeline fields.
+   * Apply an older history page without resetting live timeline fields.
    * Preserves `lastSequence` so the live sequence gate stays valid after pagination.
    */
   prependOlderPage(
@@ -438,10 +432,7 @@ export class WebChatStore {
     return entry;
   }
 
-  /**
-   * Apply one live envelope onto this holder and notify listeners.
-   * Drops envelopes at or behind `lastSequence` so catch-up HTTP + buffered WS overlap is safe.
-   */
+  /** Update reconnect recovery flags and notify listeners. */
   setRecoveryState(
     entry: ConversationEntry,
     state: { isRecovering: boolean; catchUpError?: NovuError | undefined }
@@ -455,6 +446,10 @@ export class WebChatStore {
     return entry;
   }
 
+  /**
+   * Apply one live envelope and notify listeners.
+   * Drops envelopes at or behind `lastSequence` so recovery HTTP and buffered socket overlap is safe.
+   */
   applyLiveEnvelope(entry: ConversationEntry, envelope: AgentEventEnvelope): ConversationEntry {
     if (envelope.sequence <= entry.lastSequence) {
       return entry;
@@ -474,12 +469,9 @@ export class WebChatStore {
   }
 
   /**
-   * Run an HTTP post for this entry.
-   * If the holder has no conversation id, only one create runs at a time.
-   * Waiters read `entry.conversationId` again after the prior create finishes.
+   * Run an HTTP post for this session.
+   * If there is no conversation id, only one create runs at a time.
    * If a create succeeds, later waiters reuse that id.
-   * If a create fails, the next attempt still waits in line.
-   * If the conversation id is already known, the post runs with no gate.
    */
   withCreateClaim<T>(
     entry: ConversationEntry,

--- a/packages/js/src/web-chat/web-chat.test.ts
+++ b/packages/js/src/web-chat/web-chat.test.ts
@@ -1749,7 +1749,7 @@ describe('WebChat', () => {
         'act_page0001'
       )
     );
-    await agentChat.loadConversation({
+    await webChat.loadConversation({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
@@ -1758,14 +1758,14 @@ describe('WebChat', () => {
       historyPage([{ sequence: 1, messageId: 'msg_gone0000001', role: 'user', markdown: 'deleted later' }], null)
     );
 
-    const result = await agentChat.fetchMore({
+    const result = await webChat.fetchMore({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
 
     expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_keep0000001']);
     expect(
-      agentChat
+      webChat
         .getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' })
         ?.messages.map((message) => message.id)
     ).toEqual(['msg_keep0000001']);
@@ -1796,7 +1796,7 @@ describe('WebChat', () => {
         'act_page0001'
       )
     );
-    await agentChat.loadConversation({
+    await webChat.loadConversation({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
@@ -1805,7 +1805,7 @@ describe('WebChat', () => {
       historyPage([{ sequence: 1, messageId: 'msg_edit0000001', role: 'user', markdown: 'original' }], null)
     );
 
-    const result = await agentChat.fetchMore({
+    const result = await webChat.fetchMore({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
@@ -1821,13 +1821,13 @@ describe('WebChat', () => {
     getEvents.mockResolvedValueOnce(
       historyPage([{ sequence: 2, messageId: 'msg_keep0000001', role: 'user', markdown: 'keep' }], 'act_page0001')
     );
-    await agentChat.loadConversation({
+    await webChat.loadConversation({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
 
     emitter.emit(
-      'agent_chat.agent_event',
+      'web_chat.agent_event',
       liveEnvelope({ sequence: 3, event: { type: 'channel.delete', messageId: 'msg_gone0000001' } })
     );
 
@@ -1835,7 +1835,7 @@ describe('WebChat', () => {
       historyPage([{ sequence: 1, messageId: 'msg_gone0000001', role: 'user', markdown: 'deleted later' }], null)
     );
 
-    const result = await agentChat.fetchMore({
+    const result = await webChat.fetchMore({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
@@ -1847,20 +1847,20 @@ describe('WebChat', () => {
     getEvents.mockResolvedValueOnce(
       historyPage([{ sequence: 1, messageId: 'msg_asst0000001', role: 'assistant', markdown: 'original' }], null)
     );
-    await agentChat.loadConversation({
+    await webChat.loadConversation({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
 
     emitter.emit(
-      'agent_chat.agent_event',
+      'web_chat.agent_event',
       liveEnvelope({
         sequence: 2,
         event: { type: 'channel.edit', messageId: 'msg_asst0000001', content: { markdown: 'edited' } },
       })
     );
     emitter.emit(
-      'agent_chat.agent_event',
+      'web_chat.agent_event',
       liveEnvelope({
         sequence: 3,
         event: {
@@ -1874,7 +1874,7 @@ describe('WebChat', () => {
     );
 
     expect(
-      agentChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' })?.messages[0]?.parts
+      webChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' })?.messages[0]?.parts
     ).toMatchObject([
       { type: 'text', text: 'edited', state: 'done' },
       { type: 'source', sourceType: 'url', url: 'https://example.com', title: 'Example' },
@@ -1891,7 +1891,7 @@ describe('WebChat', () => {
         null
       )
     );
-    await agentChat.loadConversation({
+    await webChat.loadConversation({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
@@ -1904,14 +1904,14 @@ describe('WebChat', () => {
         })
     );
 
-    const reload = agentChat.loadConversation({
+    const reload = webChat.loadConversation({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
     await waitForGetEventsCalls(2);
 
     emitter.emit(
-      'agent_chat.agent_event',
+      'web_chat.agent_event',
       liveEnvelope({ sequence: 3, event: { type: 'channel.delete', messageId: 'msg_gone0000001' } })
     );
 

--- a/packages/js/src/web-chat/web-chat.ts
+++ b/packages/js/src/web-chat/web-chat.ts
@@ -1,20 +1,16 @@
 import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
-import { WebChatPlanLimitError, WebChatService, InboxService } from '../api';
+import { InboxService, WebChatPlanLimitError, WebChatService } from '../api';
 import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
 import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
 import type { BaseSocketInterface } from '../ws/base-socket';
-import { WebChatStore, type ConversationEntry, createLocalConversationKey } from './web-chat-store';
 import { AgentConversationRuntime } from './agent-conversation-runtime';
 import { type AgentConversationError, type AgentMessage, derivePendingActions } from './agent-message.types';
-import type { ConversationArgs, ConversationResult } from './conversation-runtime.types';
+import type { ConversationArgs } from './conversation-runtime.types';
 import { createActionIdempotencyKeyForScope, createMessageIdempotencyKey } from './idempotency';
 import { runtimeCacheKey } from './runtime-cache-key';
 import type {
-  WebChatChange,
-  WebChatMessagesUpdated,
-  WebChatPagination,
   FetchMoreArgs,
   FetchMoreResult,
   LoadConversationArgs,
@@ -27,8 +23,12 @@ import type {
   SendActionResult,
   SendMessageArgs,
   SendMessageResult,
+  WebChatChange,
+  WebChatMessagesUpdated,
+  WebChatPagination,
 } from './types';
 import { parseAgentEventEnvelope } from './validate-envelope';
+import { type ConversationEntry, createLocalConversationKey, WebChatStore } from './web-chat-store';
 
 function conversationErrorToNovuError(error: AgentConversationError): NovuError {
   return new NovuError(error.message, new Error(error.code ?? error.message));
@@ -41,9 +41,13 @@ function entryPagination(entry: ConversationEntry): WebChatPagination {
   };
 }
 
-/** Safety cap on reconnect catch-up HTTP pages when a sequence checkpoint exists. Exceeding this sets a public error. */
+/** Max HTTP pages for reconnect recovery when a sequence checkpoint exists. */
 const CATCH_UP_PAGE_LIMIT = 20;
 
+/**
+ * Headless Web Chat client. Load it with `await novu.loadWebChat()` or `loadWebChat(novu)`,
+ * then call {@link WebChat.conversation} for each thread.
+ */
 export class WebChat extends BaseModule {
   #webChatService: WebChatService;
   #store: WebChatStore;
@@ -86,10 +90,7 @@ export class WebChat extends BaseModule {
     });
   }
 
-  /**
-   * Keep the socket connected while at least one consumer wants live events.
-   * Call from hook mount / vanilla open. Pair with `unsubscribe`.
-   */
+  /** @internal Keep the live socket connected while at least one consumer is active. */
   subscribe(): void {
     this.#liveSubscriberCount += 1;
     if (this.#liveSubscriberCount === 1) {
@@ -97,6 +98,7 @@ export class WebChat extends BaseModule {
     }
   }
 
+  /** @internal */
   unsubscribe(): void {
     if (this.#liveSubscriberCount === 0) {
       return;
@@ -105,6 +107,7 @@ export class WebChat extends BaseModule {
     this.#liveSubscriberCount -= 1;
   }
 
+  /** Drop all local conversation state and runtimes. */
   clearCache(): void {
     for (const runtime of [...this.#runtimes.values()]) {
       runtime.dispose();
@@ -116,15 +119,16 @@ export class WebChat extends BaseModule {
   }
 
   /**
-   * Return a stable conversation runtime for one agent thread.
-   * Resume sessions (`conversationId` set) are reused across calls with the same identity.
+   * Return a runtime for one conversation.
+   * Calls with the same `agentId` and `conversationId` reuse the same runtime.
+   * Omit `conversationId` to start a new chat. Call {@link AgentConversationRuntime.dispose} when the chat unmounts.
    */
-  conversation(args: ConversationArgs): ConversationResult<AgentConversationRuntime> {
+  conversation(args: ConversationArgs): AgentConversationRuntime {
     const cacheKey = args.conversationId ? runtimeCacheKey(args.agentId, args.conversationId) : undefined;
     if (cacheKey) {
       const existing = this.#runtimes.get(cacheKey);
       if (existing) {
-        return { ok: true, data: existing };
+        return existing;
       }
     }
 
@@ -133,7 +137,7 @@ export class WebChat extends BaseModule {
       this.#runtimes.set(cacheKey, runtime);
     }
 
-    return { ok: true, data: runtime };
+    return runtime;
   }
 
   /** @internal */
@@ -162,6 +166,7 @@ export class WebChat extends BaseModule {
     }
   }
 
+  /** @internal */
   getConversation({ agentId, conversationId, key }: { agentId: string; conversationId?: string; key?: string }):
     | {
         conversationId?: string;
@@ -202,6 +207,7 @@ export class WebChat extends BaseModule {
     };
   }
 
+  /** @internal Prefer {@link AgentConversationRuntime.respondToAction}. */
   async respondToAction(args: RespondToActionArgs): Result<RespondToActionResult, NovuError | WebChatPlanLimitError> {
     return this.#withConversationAction(
       args,
@@ -242,6 +248,7 @@ export class WebChat extends BaseModule {
     );
   }
 
+  /** @internal Prefer {@link AgentConversationRuntime.sendAction}. */
   async sendAction(args: SendActionArgs): Result<SendActionResult, NovuError | WebChatPlanLimitError> {
     return this.#withConversationAction(
       args,
@@ -273,10 +280,7 @@ export class WebChat extends BaseModule {
     );
   }
 
-  /**
-   * Load the newest history page into the local holder.
-   * The holder key is the public conversation id.
-   */
+  /** @internal Prefer {@link AgentConversationRuntime.load}. */
   async loadConversation(args: LoadConversationArgs): Result<LoadConversationResult> {
     return this.callWithSession(async () => {
       try {
@@ -304,6 +308,7 @@ export class WebChat extends BaseModule {
     });
   }
 
+  /** @internal Prefer {@link AgentConversationRuntime.fetchMore}. */
   async fetchMore(args: FetchMoreArgs): Result<FetchMoreResult> {
     return this.callWithSession(async () => {
       const entry = this.#resolveFetchEntry(args);
@@ -359,8 +364,8 @@ export class WebChat extends BaseModule {
   }
 
   /**
-   * Send a user message. Overlapping send while a run is active is rejected.
-   * Cancel-previous is NV-8643.
+   * @internal Prefer {@link AgentConversationRuntime.sendMessage}.
+   * Rejected while an agent turn is in progress.
    */
   async sendMessage(args: SendMessageArgs): Result<SendMessageResult, NovuError | WebChatPlanLimitError> {
     return this.callWithSession<SendMessageResult, NovuError | WebChatPlanLimitError>(async () => {
@@ -388,15 +393,15 @@ export class WebChat extends BaseModule {
   }
 
   /**
-   * Resubmit a failed outbound message using its original idempotency identity.
-   * Does not append a new optimistic bubble or mint a new key.
+   * @internal Prefer {@link AgentConversationRuntime.retryMessage}.
+   * Resends a failed message with the original idempotency key. Does not create a second message.
    */
   async retryMessage(args: RetryMessageArgs): Result<RetryMessageResult, NovuError | WebChatPlanLimitError> {
     return this.callWithSession<RetryMessageResult, NovuError | WebChatPlanLimitError>(async () => {
       const entry = this.#resolveFetchEntry(args);
       if (!entry) {
         return {
-          error: new NovuError('Cannot retry message without a conversation holder', new Error('missing entry')),
+          error: new NovuError('Cannot retry message without a conversation', new Error('missing entry')),
         };
       }
 
@@ -518,10 +523,7 @@ export class WebChat extends BaseModule {
     };
   }
 
-  /**
-   * Shared session + conversation + plan-limit wrapper for `respondToAction` and `sendAction`.
-   * The two public methods stay separate: they take different ids and extra fields.
-   */
+  /** Shared session and plan-limit wrapper for `respondToAction` and `sendAction`. */
   async #withConversationAction(
     args: { agentId: string; conversationId?: string; key?: string },
     missingConversationMessage: string,
@@ -573,10 +575,7 @@ export class WebChat extends BaseModule {
     return undefined;
   }
 
-  /**
-   * Find the holder for a send.
-   * Reject a key when the holder belongs to another agent or another claimed conversation.
-   */
+  /** Resolve the local session for a send. Reject a key that belongs to another agent or conversation. */
   #resolveSendEntry(args: SendMessageArgs, key: string): ConversationEntry {
     const byKey = this.#store.get(key);
     if (byKey && this.#isUsableSendEntry(byKey, args)) {
@@ -594,7 +593,7 @@ export class WebChat extends BaseModule {
       );
     }
 
-    // If the key is stale, do not call getOrCreate with that key. That returns the wrong holder.
+    // If the key is stale, do not call getOrCreate with that key. That returns the wrong session.
     const createKey = byKey ? createLocalConversationKey() : key;
 
     return this.#store.getOrCreate({
@@ -620,9 +619,8 @@ export class WebChat extends BaseModule {
   }
 
   /**
-   * Live WS path: apply envelopes into open conversations only.
-   * Unknown conversations are dropped — mount/resume creates the entry.
-   * During reconnect catch-up for a conversation, only that conversation's envelopes buffer.
+   * Apply live envelopes to open conversations only.
+   * Unknown conversations are dropped. During reconnect recovery, only that conversation buffers.
    */
   #handleAgentEvent(raw: unknown): void {
     const parsed = parseAgentEventEnvelope(raw);

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -16,7 +16,8 @@
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "removeComments": false
+    "removeComments": false,
+    "stripInternal": true
   },
   "include": ["src/**/*", "src/**/*.d.ts"],
   "exclude": ["node_modules", "**/node_modules/*"]

--- a/packages/js/tsup.config.ts
+++ b/packages/js/tsup.config.ts
@@ -59,6 +59,9 @@ const baseModuleConfig: Options = {
   treeshake: true,
   dts: {
     resolve: ['@novu/agent-event-protocol'],
+    compilerOptions: {
+      stripInternal: true,
+    },
   },
   noExternal: ['@novu/agent-event-protocol'],
   entry: {

--- a/packages/react/src/hooks/useWebChat.ts
+++ b/packages/react/src/hooks/useWebChat.ts
@@ -1,6 +1,4 @@
 import type {
-  WebChatPagination,
-  WebChatPlanLimitError,
   AgentConversationPublicationMeta,
   AgentConversationRunSnapshot,
   AgentConversationRuntime,
@@ -14,7 +12,10 @@ import type {
   LoadConversationResult,
   RespondToActionResult,
   SendActionResult,
+  SendMessageInput,
   SendMessageResult,
+  WebChatPagination,
+  WebChatPlanLimitError,
 } from '@novu/js';
 import { NovuError } from '@novu/js';
 import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
@@ -25,27 +26,26 @@ type UseWebChatCallbacks = {
   onSuccess?: (data: LoadConversationResult) => void;
   onError?: (error: NovuError | WebChatPlanLimitError) => void;
   /**
-   * Fires once per message, when the message id first appears on the conversation.
-   * History pages are silent: only new activity fires.
-   * An agent message can still be empty at this point, because the first envelope of a
-   * turn creates the message before any text is folded into it.
-   * A send that never reaches the server does not fire: the message flips to `failed` instead.
+   * Fires once when a message id first appears. History pages do not fire.
+   * The first event of a turn can create an empty assistant message before text arrives.
+   * A send that never reaches the server does not fire. The message status becomes `failed` instead.
    */
   onMessage?: (message: AgentMessage) => void;
   /**
-   * Fires once per pending action, including actions still pending on mount, so a
-   * resumed conversation reports what it is blocked on. Paging backwards is silent.
+   * Fires once per pending action, including actions still pending on mount.
+   * Paging backwards does not fire.
    */
   onActionRequested?: (action: AgentPendingAction) => void;
   /**
-   * Raw envelopes for this conversation, before the derived callbacks for the same fold.
-   * A duplicate envelope that the store drops does not fire. Neither does an envelope that
-   * arrives before a newly created conversation claims its id.
-   * The store folds the envelope before this callback runs, so `messages` here is one render old.
+   * Live event envelopes for this conversation.
+   * Duplicates that the client drops do not fire.
+   * Envelopes that arrive before the conversation id exists do not fire.
+   * The message list in this render does not include this envelope yet.
    */
   onEvent?: (envelope: AgentEventEnvelope) => void;
 };
 
+/** Arguments for {@link useWebChat}. Pass `agentId`, or pass `conversation`. Do not mix the two. */
 export type UseWebChatProps = UseWebChatCallbacks &
   AgentHashFields &
   (
@@ -54,7 +54,6 @@ export type UseWebChatProps = UseWebChatCallbacks &
         /**
          * Resume this conversation. The hook loads history on mount.
          * Omit this prop to start a new chat. The first send creates a conversation.
-         * Later sends pass the returned id. Remount or clear this prop to start another chat.
          */
         conversationId?: string;
         conversation?: never;
@@ -68,51 +67,62 @@ export type UseWebChatProps = UseWebChatCallbacks &
       }
   );
 
+/** State and actions returned by {@link useWebChat}. */
 export type UseWebChatResult = {
+  /** Conversation timeline. */
   messages: AgentMessage[];
+  /** Tool approvals and MCP connect items that are still pending. */
   pendingActions: AgentPendingAction[];
+  /** Server conversation id after create or resume. */
   conversationId?: string;
+  /** Last error from load, send, retry, or action. */
   error?: NovuError | WebChatPlanLimitError;
   /** True while Web Chat loads and, for an existing conversation, until the first history fetch completes. */
   isLoading: boolean;
+  /** True while the agent turn is in progress. Same as `run.isRunning`. */
   isRunning: boolean;
+  /** Typing indicator. Same as `run.typing`. Absent when the agent is not typing. */
   typing?: AgentConversationRunSnapshot['typing'];
-  /** Conversation lifecycle status (`active`, etc.). */
-  status: AgentConversationStatus;
-  /** Explicit alias for `status`. */
+  /** `'active'` or `'resolved'`. The agent sets `resolved` with `ctx.resolve()`. Not a loading flag. */
   conversationStatus: AgentConversationStatus;
-  /** Current agent run snapshot. */
+  /** Current agent-run snapshot. */
   run: AgentConversationRunSnapshot;
+  /** Older-history control. Not a top-level `hasMore` or `fetchMore`. */
   pagination: WebChatPagination & {
     fetchMore: () => Promise<{
       data?: { messages: AgentMessage[]; hasMore: boolean };
       error?: NovuError;
     }>;
   };
-  /** True while reconnect catch-up is in flight for this conversation. */
+  /** True while reconnect recovery is in progress. */
   isRecovering: boolean;
-  /** Set when reconnect catch-up fails. Separate from send/fetch `error`. */
+  /** Set when reconnect recovery fails. Separate from send and fetch `error`. */
   catchUpError?: NovuError;
+  /** Reload the newest history page. No-op when there is no conversation id. */
   refetch: () => Promise<void>;
-  sendMessage: (text: string) => Promise<{
+  /** Send a user message. `input` is a string, or `{ text, metadata }`. Creates a conversation when `conversationId` is omitted. */
+  sendMessage: (input: SendMessageInput) => Promise<{
     data?: SendMessageResult;
     error?: NovuError | WebChatPlanLimitError;
   }>;
+  /** Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. */
   respondToAction: (args: { actionId: string; decision: AgentToolApprovalDecision }) => Promise<{
     data?: RespondToActionResult;
     error?: NovuError | WebChatPlanLimitError;
   }>;
+  /** Click a Card button. Do not use this for tool approval. */
   sendAction: (args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{
     data?: SendActionResult;
     error?: NovuError | WebChatPlanLimitError;
   }>;
+  /** Resend a message whose `status` is `failed`. Reuses the original idempotency key. */
   retryMessage: (messageId: string) => Promise<{
     data?: SendMessageResult;
     error?: NovuError | WebChatPlanLimitError;
   }>;
 };
 
-const EMPTY_SERVER_SNAPSHOT: AgentConversationSnapshot = {
+const EMPTY_SERVER_SNAPSHOT = {
   key: 'ssr',
   status: 'loading',
   run: { isRunning: false },
@@ -121,7 +131,7 @@ const EMPTY_SERVER_SNAPSHOT: AgentConversationSnapshot = {
   messages: [],
   pendingActions: [],
   isRecovering: false,
-};
+} as AgentConversationSnapshot;
 
 type RuntimeActionResult<T> = {
   data?: T;
@@ -219,14 +229,9 @@ function resolveOwnedRuntime(args: {
 
   current?.runtime.dispose();
 
-  const result = args.novu.webChat.conversation({ agentId: args.agentId, agentHash: args.agentHash });
-  if (!result.ok) {
-    args.ownedRuntimeRef.current = null;
-    return null;
-  }
-
-  args.ownedRuntimeRef.current = { key, novu: args.novu, runtime: result.data };
-  return result.data;
+  const runtime = args.novu.webChat.conversation({ agentId: args.agentId, agentHash: args.agentHash });
+  args.ownedRuntimeRef.current = { key, novu: args.novu, runtime };
+  return runtime;
 }
 
 type WebChatLoadState =
@@ -246,6 +251,16 @@ function toNovuError(error: unknown): NovuError {
   return new NovuError('Failed to load Web Chat', new Error(String(error)));
 }
 
+/**
+ * Headless Web Chat client. Use it inside `NovuProvider`.
+ *
+ * @example
+ * ```tsx
+ * const { messages, sendMessage, isRunning, isLoading, error } = useWebChat({
+ *   agentId: 'YOUR_AGENT_IDENTIFIER',
+ * });
+ * ```
+ */
 export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
   const novu = useNovu();
   const propsRef = useDataRef(props);
@@ -315,13 +330,11 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
       return null;
     }
 
-    const result = novu.webChat.conversation({
+    return novu.webChat.conversation({
       agentId,
       conversationId: conversationIdProp,
       agentHash,
     });
-
-    return result.ok ? result.data : null;
   }, [webChatReady, sharedRuntime, novu, agentId, conversationIdProp, agentHash]);
 
   if (sharedRuntime || conversationIdProp) {
@@ -457,7 +470,10 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
     [snapshot.pagination.status, snapshot.pagination.hasMore, fetchMore]
   );
 
-  const sendMessage = useCallback((text: string) => callRuntime((target) => target.sendMessage(text)), [callRuntime]);
+  const sendMessage = useCallback(
+    (input: SendMessageInput) => callRuntime((target) => target.sendMessage(input)),
+    [callRuntime]
+  );
   const respondToAction = useCallback(
     (args: { actionId: string; decision: AgentToolApprovalDecision }) =>
       callRuntime((target) => target.respondToAction(args)),
@@ -481,7 +497,6 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
     isLoading: !webChatLoadError && (isWebChatLoading || snapshot.status === 'loading'),
     isRunning: snapshot.run.isRunning,
     typing: snapshot.run.typing,
-    status: snapshot.conversationStatus,
     conversationStatus: snapshot.conversationStatus,
     run: snapshot.run,
     pagination: paginationWithFetch,

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -84,7 +84,6 @@ export function useWebChat(_: UseWebChatProps): UseWebChatResult {
     isLoading: true,
     isRunning: false,
     typing: undefined,
-    status: 'active',
     conversationStatus: 'active',
     run: { isRunning: false },
     pagination: {

--- a/playground/web-chat/src/app/playground.tsx
+++ b/playground/web-chat/src/app/playground.tsx
@@ -54,7 +54,7 @@ function PlaygroundApp() {
               isRunning={chat.isRunning}
               runOrigin={chat.runOrigin}
               lastRunTransition={chat.lastRunTransition}
-              status={chat.status}
+              conversationStatus={chat.conversationStatus}
               socketStatus={socketStatus}
               pendingApprovalCount={chat.pendingApprovalCount}
               conversations={conversations.items}

--- a/playground/web-chat/src/components/session-sidebar.tsx
+++ b/playground/web-chat/src/components/session-sidebar.tsx
@@ -67,7 +67,7 @@ type SessionSidebarProps = {
   isRunning: boolean;
   runOrigin: RunOrigin;
   lastRunTransition?: RunTransition;
-  status: AgentConversationStatus;
+  conversationStatus: AgentConversationStatus;
   socketStatus: SocketStatus;
   pendingApprovalCount: number;
   conversations: ConversationSummary[];
@@ -90,7 +90,7 @@ export function SessionSidebar({
   isRunning,
   runOrigin,
   lastRunTransition,
-  status,
+  conversationStatus,
   socketStatus,
   pendingApprovalCount,
   conversations,
@@ -190,7 +190,7 @@ export function SessionSidebar({
               <dl className="session-stats">
                 <div className="session-stat">
                   <dt>Status</dt>
-                  <dd>{status}</dd>
+                  <dd>{conversationStatus}</dd>
                 </div>
                 <div className="session-stat">
                   <dt>Approvals</dt>

--- a/playground/web-chat/src/components/web-chat.tsx
+++ b/playground/web-chat/src/components/web-chat.tsx
@@ -32,7 +32,7 @@ import { ChatPanel } from './chat-panel';
 export type WebChatSession = {
   conversationId?: string;
   isRunning: boolean;
-  status: AgentConversationStatus;
+  conversationStatus: AgentConversationStatus;
   pendingApprovalCount: number;
   runOrigin: RunOrigin;
   lastRunTransition?: RunTransition;
@@ -70,7 +70,7 @@ export function WebChat({ conversationId, onAssistantMessage, sidebar }: WebChat
     conversationId: activeConversationId,
     error,
     isRunning,
-    status,
+    conversationStatus,
     isLoading,
     pagination,
     typing,
@@ -99,7 +99,7 @@ export function WebChat({ conversationId, onAssistantMessage, sidebar }: WebChat
   const session: WebChatSession = {
     conversationId: activeConversationId,
     isRunning,
-    status,
+    conversationStatus,
     pendingApprovalCount: pendingActions.filter((action) => action.type === 'tool-approval').length,
     runOrigin: runOrigin(isRunning, lastTransition),
     lastRunTransition: lastTransition,

--- a/playground/web-chat/src/lib/debug-events.ts
+++ b/playground/web-chat/src/lib/debug-events.ts
@@ -26,7 +26,6 @@ export function createDebugEvent(event: Omit<DebugEvent, 'id' | 'ts'> & { ts?: n
 export const SDK_DEBUG_EVENTS = [
   'session.initialize.pending',
   'session.initialize.resolved',
-  'web_chat.messages.updated',
   'socket.connect.pending',
   'socket.connect.resolved',
 ] as const;


### PR DESCRIPTION
## Summary
- Shrink the `@novu/js` / `@novu/react` Web Chat barrel to the integrator path: `loadWebChat` → `conversation()` / `useWebChat`.
- `conversation()` now returns `AgentConversationRuntime` directly. HTTP `*Args` types, store helpers, and `web_chat.messages.updated` are off the public surface; `@internal` is stripped from published `.d.ts`.
- Caller JSDoc only (no ticket ids). Hook `sendMessage` accepts `SendMessageInput`; hook lifecycle is `conversationStatus` (snapshot `status` stays history load).

## Breaking changes
- `novu.webChat.conversation()` no longer returns `{ ok, data }`.
- `useWebChat().status` removed; use `conversationStatus`.
- Named exports dropped: `SendMessageArgs`, `LoadConversationArgs`, `FetchMoreArgs`, `RetryMessageArgs`, `RespondToActionArgs`, `SendActionArgs`, `derivePendingActions`, `AgentConversationState`, `ConversationResult`, `WebChatChange`, `AgentConversationPaginationSnapshot`.

## Test plan
- [x] `pnpm exec jest src/web-chat src/novu.load-web-chat.test.ts` in `packages/js` (123 passed)
- [ ] Typecheck a JS sample: `loadWebChat` → `conversation({ agentId })` → `sendMessage` / `subscribe` / `dispose`
- [ ] Typecheck a React sample: `useWebChat({ agentId })` with `conversationStatus` and `sendMessage('hi')`
- [ ] Confirm `SendMessageArgs` / `novu.on('web_chat.messages.updated')` do not typecheck against `@novu/js`


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR narrows the public Web Chat API across `@novu/js` and `@novu/react`, changes `conversation()` to return its runtime directly, and clarifies the distinction between conversation lifecycle and history-loading status.

- Removes internal HTTP argument types, store helpers, implementation state, and the internal message-update event from public declarations.
- Adds `SendMessageInput` support to the React hook and exposes `conversationStatus` instead of the former `status` alias.
- Enables internal declaration stripping and updates tests, documentation, SSR stubs, and the Web Chat playground to match the new contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the reviewed SDK, React, declaration, documentation, and playground changes consistently implement the explicitly documented API tightening.

No concrete unacknowledged runtime, build, lifecycle, declaration, or security failure remains after checking the coordinated API migrations and internal event separation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/js/src/web-chat/web-chat.ts | Changes `conversation()` to return `AgentConversationRuntime` directly while retaining internal store, action, socket, and recovery behavior. |
| packages/js/src/web-chat/agent-conversation-runtime.ts | Documents the integrator-facing runtime, adds structured message input, and marks cache identity details internal. |
| packages/js/src/index.ts | Narrows the root Web Chat export surface to the intended integrator API and adds updated public result types. |
| packages/js/src/event-emitter/novu-event-emitter.ts | Keeps the Web Chat message-update event available internally while excluding it from the public event contract. |
| packages/react/src/hooks/useWebChat.ts | Adapts the hook to the direct runtime return, supports metadata-bearing sends, and replaces the lifecycle status alias with `conversationStatus`. |
| packages/react/src/server/index.tsx | Keeps the server-safe hook stub aligned with the revised client hook result. |
| packages/js/tsup.config.ts | Enables stripping of `@internal` declarations from bundled CommonJS and ESM type output. |
| packages/js/tsconfig.json | Enables internal-member stripping for TypeScript declaration emission. |
| docs/platform/sdks/javascript.mdx | Updates JavaScript examples and reference material for direct runtime access and structured send input. |
| docs/platform/sdks/react/hooks/use-web-chat.mdx | Documents `conversationStatus`, `SendMessageInput`, and the revised recovery terminology. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  App[Integrator application] --> Load[loadWebChat]
  Load --> Client[WebChat client]
  Client --> Conversation[conversation args]
  Conversation --> Runtime[AgentConversationRuntime]
  Runtime --> Snapshot[Immutable conversation snapshot]
  Runtime --> Actions[sendMessage / retry / actions / pagination]
  Runtime --> Socket[Live event stream]
  Runtime --> History[HTTP history and recovery]
  React[useWebChat] --> Runtime
  React --> HookState[messages / conversationStatus / run / pagination]
```

<sub>Reviews (1): Last reviewed commit: ["refactor(js,react): tighten Web Chat pub..."](https://github.com/novuhq/novu/commit/2ccf28f2ba36056ef9b937af0ff22fcd864275bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57842395)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Developer SDKs and UI packages](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/developer-sdks.md)
- Knowledge Base — [JavaScript client SDK](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/javascript-client-sdk.md)
- Knowledge Base — [Agent platform and AI integrations](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agent-platform.md)
</details>


<!-- /greptile_comment -->