### PR TITLE
fix(dashboard): pin Web Chat connect copy to --runtime ai-sdk fixes NV-8722

### DIFF
--- a/apps/dashboard/src/hooks/use-web-chat-prompt.ts
+++ b/apps/dashboard/src/hooks/use-web-chat-prompt.ts
@@ -1,4 +1,8 @@
-import { buildWebChatPrompt, isNovuConnectBridgeRuntime, type NovuConnectBridgeRuntime } from '@novu/shared';
+import {
+  buildWebChatPrompt,
+  resolveWebChatConnectRuntime as resolveConnectBridgeRuntime,
+  type NovuConnectBridgeRuntime,
+} from '@novu/shared';
 import { useMemo } from 'react';
 import type { AgentResponse } from '@/api/agents';
 import type { ConnectorId } from '@/components/agents/connectors/connector-options';
@@ -8,15 +12,7 @@ export function resolveWebChatConnectRuntime(
   agent: AgentResponse,
   connectorId?: ConnectorId
 ): NovuConnectBridgeRuntime | undefined {
-  if (agent.runtime === 'managed') {
-    return undefined;
-  }
-
-  if (isNovuConnectBridgeRuntime(connectorId)) {
-    return connectorId;
-  }
-
-  return undefined;
+  return resolveConnectBridgeRuntime(agent.runtime, connectorId);
 }
 
 export function useWebChatPrompt(agent: AgentResponse, connectorId?: ConnectorId): string {

--- a/packages/shared/src/utils/web-chat-connect-prompt.spec.ts
+++ b/packages/shared/src/utils/web-chat-connect-prompt.spec.ts
@@ -4,6 +4,7 @@ import {
   buildWebChatPrompt,
   buildWebChatTuiCommand,
   buildWebChatTuiCommandForDisplay,
+  resolveWebChatConnectRuntime,
 } from './web-chat-connect-prompt';
 import { NOVU_STAGING_API_URL } from './novu-connect-cli';
 
@@ -57,6 +58,12 @@ describe('web-chat-connect-prompt', () => {
     expect(prompt).toContain('Novu staging dashboard');
     expect(prompt).toContain('npx novu@rc');
     expect(prompt).toContain('--region staging');
+  });
+
+  it('defaults missing connector to ai-sdk for self-hosted Web Chat copy', () => {
+    expect(resolveWebChatConnectRuntime('self-hosted')).toBe('ai-sdk');
+    expect(resolveWebChatConnectRuntime('self-hosted', 'langchain')).toBe('langchain');
+    expect(resolveWebChatConnectRuntime('managed')).toBeUndefined();
   });
 
   it('pins runtime and agent on the TUI command for a dashboard-created bridge agent', () => {

--- a/packages/shared/src/utils/web-chat-connect-prompt.ts
+++ b/packages/shared/src/utils/web-chat-connect-prompt.ts
@@ -18,6 +18,28 @@ export function isNovuConnectBridgeRuntime(value: string | null | undefined): va
   return value === 'ai-sdk' || value === 'langchain' || value === 'custom-code';
 }
 
+/** Same default as the dashboard handler scaffold copy when the connector is unknown. */
+export const DEFAULT_NOVU_CONNECT_BRIDGE_RUNTIME: NovuConnectBridgeRuntime = 'ai-sdk';
+
+/**
+ * CLI `--runtime` for Web Chat copy. Cloud agents store `managed` | `self-hosted`,
+ * not the bridge flavor, so missing connector defaults to AI SDK.
+ */
+export function resolveWebChatConnectRuntime(
+  agentRuntime: string | null | undefined,
+  connectorId?: string | null
+): NovuConnectBridgeRuntime | undefined {
+  if (agentRuntime === 'managed') {
+    return undefined;
+  }
+
+  if (isNovuConnectBridgeRuntime(connectorId)) {
+    return connectorId;
+  }
+
+  return DEFAULT_NOVU_CONNECT_BRIDGE_RUNTIME;
+}
+
 function bridgeRuntimeLabel(runtime: NovuConnectBridgeRuntime): string {
   switch (runtime) {
     case 'ai-sdk':


### PR DESCRIPTION
## Summary
- Self-hosted Web Chat connect copy dropped `--runtime` because create-agent does not persist `connectorId` (`managed` | `self-hosted` only).
- Default missing connector to `ai-sdk` (same as handler scaffold copy). Keep session `connectorId` when it is still on the page (LangChain / custom-code). Managed agents still omit `--runtime`.
- Linear: [NV-8722](https://linear.app/novu/issue/NV-8722/web-chat-connect-copy-omits-runtime-ai-sdk-for-self-hosted-agents)

## Test plan
- [ ] Create a self-hosted AI SDK agent → open Web Chat → copied TUI command includes `--runtime ai-sdk`
- [ ] Managed agent Web Chat copy still has no `--runtime`
- [ ] Onboarding with LangChain still copies `--runtime langchain` while `connectorId` is in session
- [ ] `pnpm exec vitest run src/utils/web-chat-connect-prompt.spec.ts` in `packages/shared`


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes Web Chat runtime resolution and defaults self-hosted agents without session connector metadata to `ai-sdk`, while continuing to omit the runtime for managed agents.
- Adds a shared runtime resolver and `ai-sdk` fallback constant.
- Updates the dashboard hook to use the shared resolver.
- Adds coverage for self-hosted defaults, retained LangChain metadata, and managed agents.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The runtime fallback matches the explicitly documented product behavior, preserves connector metadata when available, and keeps managed-agent commands unpinned.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/hooks/use-web-chat-prompt.ts | Replaces dashboard-local runtime selection with the shared resolver while preserving the hook API. |
| packages/shared/src/utils/web-chat-connect-prompt.ts | Adds centralized runtime resolution that preserves valid connector metadata, omits managed runtime flags, and otherwise defaults to `ai-sdk`. |
| packages/shared/src/utils/web-chat-connect-prompt.spec.ts | Covers the new fallback and verifies explicit LangChain and managed-agent behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): pin Web Chat connect cop..."](https://github.com/novuhq/novu/commit/c4c6a24badb69583a84dd8eba7f6dbca2e3fc686) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57924302)</sub>

<!-- /greptile_comment -->