### PR TITLE
fix(framework): escape all control characters in Liquid output

### DIFF
--- a/packages/framework/src/utils/liquid.utils.test.ts
+++ b/packages/framework/src/utils/liquid.utils.test.ts
@@ -385,6 +385,19 @@ describe('defaultOutputEscape', () => {
     expect(result).toBe('line1\\nline2');
   });
 
+  it('should escape all control characters so the output is valid JSON', () => {
+    const cc = String.fromCharCode;
+    // Only \n, \r and \t were escaped before, leaving other control characters
+    // (backspace, form feed, NUL, ...) to produce invalid JSON.
+    expect(defaultOutputEscape(`a${cc(8)}b`)).toBe('a\\bb'); // backspace
+    expect(defaultOutputEscape(`a${cc(12)}b`)).toBe('a\\fb'); // form feed
+    expect(defaultOutputEscape(`a${cc(0)}b`)).toBe('a\\u0000b'); // NUL
+    expect(defaultOutputEscape(`a${cc(31)}b`)).toBe('a\\u001fb'); // unit separator
+
+    const escaped = defaultOutputEscape(`hi${cc(1)}there`);
+    expect(() => JSON.parse(`"${escaped}"`)).not.toThrow();
+  });
+
   it('should convert primitives to strings', () => {
     expect(defaultOutputEscape(123)).toBe('123');
     expect(defaultOutputEscape(true)).toBe('true');

--- a/packages/framework/src/utils/liquid.utils.ts
+++ b/packages/framework/src/utils/liquid.utils.ts
@@ -13,14 +13,30 @@ export function defaultOutputEscape(output: unknown): string {
   if (Array.isArray(output) || (typeof output === 'object' && output !== null)) {
     return stringifyDataStructureWithSingleQuotes(output);
   }
-  // For strings, escape special JSON characters: backslashes, double quotes, and newlines
+  // For strings, escape special JSON characters: backslash, double quote, and
+  // every control character (U+0000–U+001F). JSON requires all control
+  // characters to be escaped, so only handling \n, \r and \t left a value
+  // containing e.g. a backspace, form feed or NUL producing invalid JSON.
   else if (typeof output === 'string') {
     return output
       .replace(/\\/g, '\\\\')
       .replace(/"/g, '\\"')
-      .replace(/\n/g, '\\n')
-      .replace(/\r/g, '\\r')
-      .replace(/\t/g, '\\t');
+      .replace(/[\u0000-\u001f]/g, (char) => {
+        switch (char) {
+          case '\n':
+            return '\\n';
+          case '\r':
+            return '\\r';
+          case '\t':
+            return '\\t';
+          case '\b':
+            return '\\b';
+          case '\f':
+            return '\\f';
+          default:
+            return `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`;
+        }
+      });
   } else {
     return output === undefined || output === null ? '' : String(output as unknown);
   }


### PR DESCRIPTION
## What / Why

`defaultOutputEscape` in `@novu/framework` is the Liquid engine's `outputEscape` — it runs on every `{{ variable }}` to make interpolated values safe inside the JSON that templates render into. It escaped backslash, double quote, newline, carriage return, and tab.

But JSON (RFC 8259) requires **every** control character U+0000–U+001F to be escaped inside a string. So a rendered value containing e.g. a backspace, form feed, or NUL byte produced **invalid JSON** — `JSON.parse` on the surrounding document throws.

Only newline/carriage-return/tab were handled; backspace, form feed, and the rest of U+0000–U+001F slipped through. These reach the output whenever a subscriber or payload variable happens to contain a control character.

## Fix

Escape the full control-character range, matching `JSON.stringify`: newline, carriage return, tab, backspace, and form feed get their short escapes and any other control character gets a `\uXXXX` escape. Backslash and double-quote handling is unchanged, and existing behavior for normal strings and the already-handled whitespace escapes is preserved.

## Testing

Added a `defaultOutputEscape` test asserting backspace / form feed / NUL / unit-separator escape correctly and that the output parses as valid JSON. I verified the new escape produces byte-for-byte the same result as `JSON.stringify` across control characters, quotes, backslashes, and plain strings.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands Liquid variable escaping so every JSON control character is encoded safely while preserving existing quote, backslash, and common whitespace handling.
- Adds short escapes for backspace and form feed.
- Encodes remaining U+0000–U+001F characters as `\uXXXX`.
- Adds tests covering representative control characters and valid JSON parsing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or compatibility issues identified.

The changed escape order preserves literal backslashes and quotes, emits valid JSON escapes for every control character, and the relevant default rendering paths consume JSON-safe output.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/framework/src/utils/liquid.utils.ts | Broadens JSON-safe Liquid output escaping to cover the complete control-character range without introducing a confirmed regression. |
| packages/framework/src/utils/liquid.utils.test.ts | Adds focused regression coverage for short escapes, Unicode escapes, and successful JSON parsing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(framework): escape all control chara..."](https://github.com/novuhq/novu/commit/1bb9a71950540a9315b708ebef4126d2e5a80ac8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58167398)</sub>

**Context used:**

- Knowledge Base — [Framework integrations](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/framework-integrations.md)

<!-- /greptile_comment -->