### PR TITLE
fix(api): set an explicit timeout on the partner-integrations HttpModule

### DIFF
--- a/apps/api/src/app/partner-integrations/partner-integrations.module.ts
+++ b/apps/api/src/app/partner-integrations/partner-integrations.module.ts
@@ -7,8 +7,15 @@ import { SharedModule } from '../shared/shared.module';
 import { PartnerIntegrationsController } from './partner-integrations.controller';
 import { USE_CASES } from './usecases';
 
+const VERCEL_API_TIMEOUT_MS = 10_000;
+
 @Module({
-  imports: [SharedModule, HttpModule, EnvironmentsModuleV1, BridgeModule],
+  imports: [
+    SharedModule,
+    HttpModule.register({ timeout: VERCEL_API_TIMEOUT_MS }),
+    EnvironmentsModuleV1,
+    BridgeModule,
+  ],
   providers: [...USE_CASES, CommunityUserRepository, CommunityOrganizationRepository],
   controllers: [PartnerIntegrationsController],
 })


### PR DESCRIPTION
## What

`PartnerIntegrationsModule` imports `HttpModule` bare, so the `HttpService` injected into the Vercel
use cases is created with axios's own defaults. axios defaults `timeout` to `0`, which means no
application-level deadline at all.

This sets an explicit 10s timeout on the module's `HttpModule` registration, which covers every call
those use cases make through the injected `HttpService`.

## Why it matters

Six outbound calls to the Vercel API currently have no deadline of their own:

| file | line | call |
|---|---|---|
| `usecases/create-vercel-integration/create-vercel-integration.usecase.ts` | 61 | `POST /v2/oauth/access_token` |
| `usecases/get-vercel-projects/get-vercel-integration-projects.usecase.ts` | 75 | `GET /v10/projects` |
| `usecases/update-vercel-integration/update-vercel-integration.usecase.ts` | 126 | `GET /v9/projects/:id` |
| `usecases/update-vercel-integration/update-vercel-integration.usecase.ts` | 248 | `POST` |
| `usecases/update-vercel-integration/update-vercel-integration.usecase.ts` | 295 | `GET /v4/projects` |
| `usecases/update-vercel-integration/update-vercel-integration.usecase.ts` | 390 | `DELETE` |

These run inside API request handling, so a Vercel-side stall holds a Novu request open with no
bound of its own.

## Why 10 seconds, and why at the module

10s matches the convention already used elsewhere in this repository, so this adds no new number:

- `apps/api/src/app/telegram-linking/**` uses `const TELEGRAM_API_TIMEOUT_MS = 10_000` in four places
- `apps/api/src/app/domains/services/domain-connect-discovery.service.ts` uses `timeout: 5000` inline
- `apps/api/src/app/agents/conversation-runtime/egress/file-materializer.service.ts` uses `FILE_FETCH_TIMEOUT_MS`

Registering on the module rather than editing six call sites keeps the change to one place and
covers future use cases added to this module by default. A per-call `timeout` still overrides it
where a specific endpoint needs longer.

I checked each of the six for anything that would legitimately need a long deadline (streaming, long
polling, webhook delivery). They are all ordinary Vercel REST calls.

## Scope

Deliberately narrow. `apps/worker`'s telemetry module has the same gap and is a separate PR, since
it is a different app and likely a different owner.

## How this was found

With [apiwatch](https://github.com/vishalsg42/apiwatch), a static auditor for outbound HTTP calls.
Verified before and after: these six findings are the ones this change resolves, and it introduces
none.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a module-level 10-second timeout to the partner-integrations HTTP client, bounding outbound Vercel API calls made during API request handling.
- Replaces the bare `HttpModule` import with `HttpModule.register`.
- Applies the timeout to all current and future `HttpService` consumers within `PartnerIntegrationsModule`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the configured timeout is scoped to the partner-integrations HTTP client and bounds the intended Vercel requests.

SharedModule does not provide a competing Nest HttpService, so the registered configuration reaches the partner-integration use cases as intended, and no concrete regression from the 10-second deadline was established.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/partner-integrations/partner-integrations.module.ts | Registers the module-scoped Nest HTTP client with a 10-second timeout; no actionable correctness issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): set an explicit timeout on the..."](https://github.com/novuhq/novu/commit/98c8c200e81e41285f0aa8eb52ccf5fb60e70077) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58206629)</sub>

<!-- /greptile_comment -->