### PR TITLE
fix(worker): set an explicit timeout on the telemetry HttpModule

### DIFF
--- a/apps/worker/src/app/telemetry/telemetry.module.ts
+++ b/apps/worker/src/app/telemetry/telemetry.module.ts
@@ -26,7 +26,13 @@ const REPOSITORIES = [
 
 const SERVICES = [MachineInfoService, UserInfoService];
 
-const MODULES = [ScheduleModule.forRoot(), SharedModule, HttpModule];
+const TELEMETRY_TIMEOUT_MS = 10_000;
+
+const MODULES = [
+  ScheduleModule.forRoot(),
+  SharedModule,
+  HttpModule.register({ timeout: TELEMETRY_TIMEOUT_MS }),
+];
 
 @Module({
   imports: [...MODULES],


### PR DESCRIPTION
## What

`TelemetryModule` imports `HttpModule` bare, so the `HttpService` it provides is created with
axios's own defaults. axios defaults `timeout` to `0`, meaning no application-level deadline.

This sets an explicit 10s timeout on that registration.

## Why it matters

`apps/worker/src/app/telemetry/utils/sendDataToNovuTrace.utils.ts:15` posts to
`process.env.OS_TELEMETRY_URL` with no config argument at all:

```ts
const res = await firstValueFrom(httpService.post(process.env.OS_TELEMETRY_URL as string, dataToSend));
```

The `HttpService` reaching that function comes from `MachineInfoService` and `UserInfoService`, both
providers of this module, so registering the timeout here covers it.

Telemetry is the case where an unbounded call is least likely to be noticed and least worth waiting
on: it is fire-and-forget reporting, already wrapped in a `try/catch` that logs and swallows. If the
telemetry endpoint stalls, the current code waits on a socket rather than failing fast, and it is on
a scheduled path rather than a user request, so nothing surfaces it.

## Why 10 seconds

It matches the convention already in this repository rather than introducing a new number:
`apps/api/src/app/telegram-linking/**` uses `const TELEGRAM_API_TIMEOUT_MS = 10_000` in four places,
and `file-materializer.service.ts` uses `FILE_FETCH_TIMEOUT_MS`.

Registering on the module keeps it in one place and covers services added here later. A per-call
`timeout` still overrides it.

## Scope

Deliberately narrow, and separate from the `apps/api` change in #12489 because this is a different
app and likely a different owner. The two are independent and can be merged in either order.

## How this was found

With [apiwatch](https://github.com/vishalsg42/apiwatch), a static auditor for outbound HTTP calls.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds worker telemetry HTTP requests with a 10-second module-level timeout, preventing stalled telemetry calls from waiting indefinitely.

- Registers the telemetry module’s `HttpModule` with an explicit timeout.
- Applies the deadline to machine and user telemetry posts while preserving their existing error handling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the timeout is scoped to best-effort telemetry requests whose failures are already caught and logged.

The registered HTTP client is the one injected into the telemetry services, and requests exceeding the new deadline fail through the existing non-fatal error path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/worker/src/app/telemetry/telemetry.module.ts | Replaces the default unbounded telemetry HTTP client configuration with a scoped 10-second timeout; no correctness issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): set an explicit timeout on ..."](https://github.com/novuhq/novu/commit/588c0cbadce2a231fee383c8d2065be7a8962c51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58207451)</sub>

<!-- /greptile_comment -->