### PR TITLE
fix(worker): expose inbound BCC recipient fixes NV-8723

### DIFF
--- a/apps/api/src/app/outbound-webhooks/webhooks.const.ts
+++ b/apps/api/src/app/outbound-webhooks/webhooks.const.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { MessageWebhookResponseDto, WorkflowResponseDto } from '@novu/application-generic';
 import { WebhookEventEnum, WebhookObjectTypeEnum } from '@novu/shared';
 import { InboxPreference } from '../inbox/utils/types';
@@ -106,6 +106,12 @@ export class WebhookInboundEmailMailDto {
 
   @ApiProperty({ description: 'Recipient address info', type: [WebhookInboundEmailAddressDto] })
   to: WebhookInboundEmailAddressDto[];
+
+  @ApiPropertyOptional({
+    description: 'Matched SMTP envelope recipient when it is absent from the To and Cc headers',
+    type: [WebhookInboundEmailAddressDto],
+  })
+  bcc?: WebhookInboundEmailAddressDto[];
 
   @ApiProperty({ description: 'Email subject' })
   subject: string;

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.spec.ts
@@ -135,6 +135,23 @@ describe('DomainRouteStrategy', () => {
     expect(agentCall.args[0].toAddress).to.equal(`support@${DOMAIN_NAME}`);
     expect(agentCall.args[0].mail.to).to.deep.equal(command.to);
     expect(agentCall.args[0].mail.cc).to.deep.equal(command.cc);
+    expect(agentCall.args[0].mail.bcc).to.be.undefined;
+  });
+
+  it('should expose an envelope-only route recipient as BCC without changing To', async () => {
+    const routes = makeRoutes([{ address: 'support', type: DomainRouteTypeEnum.WEBHOOK }]);
+    const command = makeCommand('customer');
+    command.to = [{ address: 'customer@other.com', name: 'Customer' }];
+    command.cc = [];
+    domainRepository.findByName.resolves(makeVerifiedDomain() as any);
+    domainRouteRepository.findByDomainAndAddresses.resolves(routes as any);
+
+    await strategy.execute(command, `support@${DOMAIN_NAME}`);
+
+    const webhookCall = inboundDomainRouteDelivery.deliverToWebhook.getCall(0);
+    expect(webhookCall.args[0].mail.to).to.deep.equal(command.to);
+    expect(webhookCall.args[0].mail.cc).to.deep.equal([]);
+    expect(webhookCall.args[0].mail.bcc).to.deep.equal([{ address: `support@${DOMAIN_NAME}`, name: '' }]);
   });
 
   it('should strip a +nv reply token and prefer exact then stripped custom-domain routes', async () => {

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
@@ -121,7 +121,7 @@ export class DomainRouteStrategy {
       return { ...baseResolved, strategy: 'domain-route', status: 422, message: INBOUND_UNMATCHED_ROUTE_MESSAGE };
     }
 
-    const mail = this.commandToMail(command);
+    const mail = this.commandToMail(command, toAddress);
 
     if (route.type === DomainRouteTypeEnum.WEBHOOK) {
       const resolved: ResolvedDomainRouteContext = { ...baseResolved, strategy: 'domain-route' };
@@ -334,7 +334,7 @@ export class DomainRouteStrategy {
       await this.inboundDomainRouteDelivery.deliverToAgent({
         domain: syntheticDomain,
         route: syntheticRoute,
-        mail: this.commandToMail(command),
+        mail: this.commandToMail(command, toAddress),
         toAddress,
         originToken: originToken ?? undefined,
       });
@@ -363,7 +363,7 @@ export class DomainRouteStrategy {
     }
   }
 
-  private commandToMail(command: InboundEmailParseCommand) {
+  private commandToMail(command: InboundEmailParseCommand, recipientAddress: string) {
     return {
       from: command.from,
       to: command.to,
@@ -377,6 +377,7 @@ export class DomainRouteStrategy {
       references: command.references,
       date: command.date,
       cc: command.cc,
+      bcc: getBccRecipients(command, recipientAddress),
       // Forward the inbound-mail DKIM/SPF verdicts so the agent runtime can
       // reject identity resolution for spoofed (unverified) senders.
       dkim: command.dkim,
@@ -388,4 +389,23 @@ export class DomainRouteStrategy {
     this.logger.error({ err: error }, 'Error processing domain-route email');
     throw new BadRequestException(error);
   }
+}
+
+function getBccRecipients(command: InboundEmailParseCommand, recipientAddress: string) {
+  const normalizedRecipientAddress = recipientAddress.trim().toLowerCase();
+  const visibleRecipients = [...(command.to ?? []), ...(command.cc ?? [])];
+  const isVisibleRecipient = visibleRecipients.some(
+    (recipient) =>
+      recipient &&
+      typeof recipient === 'object' &&
+      'address' in recipient &&
+      typeof recipient.address === 'string' &&
+      recipient.address.trim().toLowerCase() === normalizedRecipientAddress
+  );
+
+  if (isVisibleRecipient) {
+    return undefined;
+  }
+
+  return [{ address: recipientAddress, name: '' }];
 }

--- a/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.spec.ts
+++ b/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.spec.ts
@@ -225,6 +225,38 @@ describe('InboundDomainRouteDelivery.previewAgentMailPayload', () => {
     expect(payload.date).to.equal(new Date('2024-01-01T00:00:00.000Z').toISOString());
   });
 
+  it('includes the resolved BCC recipient in domain-route webhook payloads', () => {
+    const payload = usecase.buildDomainRouteWebhookPayload(
+      {
+        _id: 'domain-1',
+        name: 'inbox.example.com',
+        status: DomainStatusEnum.VERIFIED,
+        mxRecordConfigured: true,
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        data: {},
+      },
+      {
+        _id: 'route-1',
+        _domainId: 'domain-1',
+        address: 'support',
+        type: DomainRouteTypeEnum.WEBHOOK,
+        data: {},
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+      } as DomainRouteEntity,
+      {
+        ...baseMail,
+        to: [],
+        bcc: [{ address: 'support@inbox.example.com', name: '' }],
+      },
+      []
+    );
+
+    expect(payload.mail.to).to.deep.equal([]);
+    expect(payload.mail.bcc).to.deep.equal([{ address: 'support@inbox.example.com', name: '' }]);
+  });
+
   it('includes normalized headers with a size cap', () => {
     const payload = usecase.previewAgentMailPayload({
       ...baseMail,

--- a/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.ts
+++ b/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.ts
@@ -78,6 +78,7 @@ export interface InboundDomainRouteMailInput {
   references?: string | string[];
   date: Date;
   cc?: unknown[];
+  bcc?: ITo[];
   /**
    * Sender-authentication verdicts (`'pass'` / `'failed'`) computed by the
    * inbound-mail service. Forwarded to the agent webhook so the agent runtime
@@ -113,6 +114,7 @@ export interface DomainRouteWebhookPayload {
     references?: string | string[];
     date: Date;
     cc?: unknown[];
+    bcc?: ITo[];
   };
 }
 
@@ -159,6 +161,7 @@ export class InboundDomainRouteDelivery {
         references: mail.references,
         date: mail.date,
         cc: mail.cc,
+        bcc: mail.bcc,
       },
     };
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

- Preserve the matched SMTP envelope recipient as `mail.bcc` when it is absent from the message `To` and `Cc` headers.
- Keep the original `mail.to` value unchanged so BCC delivery does not rewrite visible recipients.
- Document the optional BCC address list in the inbound webhook schema.
- Add worker mapping and webhook payload coverage.

[Linear NV-8723](https://linear.app/novu/issue/NV-8723/expose-bcc-recipient-in-inbound-email-webhook-payload)

```mermaid
flowchart LR
  SMTP[SMTP RCPT TO] --> Route[Matched inbound route]
  Route --> Visible{Present in To or Cc?}
  Visible -->|Yes| Headers[Keep header recipients]
  Visible -->|No| BCC[Add matched address to mail.bcc]
  Headers --> Webhook[email.received webhook]
  BCC --> Webhook
```

### Test plan

- [x] Targeted worker and application-generic unit tests: 36 passing
- [x] Focused BCC behavior tests: 2 passing
- [x] Application-generic build
- [x] Worker build
- [x] API build
- [x] Biome check on all changed files

### Screenshots

![Inbound BCC focused unit tests passing](https://cursor.com/artifacts/c/art-0652577d-1b53-4af9-973d-f0b1a5694944)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

`mail.bcc` contains only the matched envelope-only inbound recipient. It never exposes other SMTP envelope recipients.

Whole-package Biome checks still report unrelated pre-existing violations; the changed-file check passes.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1787978066485259?thread_ts=1787978066.485259&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-4f400f95-1507-5e1e-b719-8daa739684f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f400f95-1507-5e1e-b719-8daa739684f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves an envelope-only matched SMTP recipient as `mail.bcc` in inbound `email.received` webhook payloads without rewriting visible `To` or `Cc` recipients.

- Adds case-insensitive detection of whether the matched route recipient is already visible.
- Propagates the optional BCC list through the domain-route webhook payload.
- Documents the new optional field in the outbound webhook OpenAPI schema.
- Adds worker routing and payload-builder coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intended envelope-only recipient propagated through the inbound webhook contract without changing visible recipients.

The matched recipient is compared against both To and Cc using normalized addresses, added only when absent, and explicitly forwarded through the documented domain-route webhook payload; no blocking or independently actionable issue remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts | Adds normalized visibility checking and preserves an envelope-only matched route recipient as BCC while leaving header recipients unchanged. |
| libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.ts | Extends the domain-route mail and webhook contracts and forwards the optional BCC list into the emitted webhook payload. |
| apps/api/src/app/outbound-webhooks/webhooks.const.ts | Documents the optional BCC recipient list in the inbound-email webhook OpenAPI schema. |
| apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.spec.ts | Covers both visible-recipient suppression and envelope-only BCC exposure without mutating To or Cc. |
| libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.spec.ts | Verifies that the domain-route webhook payload retains BCC independently from the visible To list. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  SMTP[SMTP envelope recipient] --> Route[Worker resolves inbound route]
  Route --> Visible{Recipient present in To or Cc?}
  Visible -->|Yes| Existing[Preserve visible recipients]
  Visible -->|No| BCC[Set matched recipient in mail.bcc]
  Existing --> Payload[email.received webhook payload]
  BCC --> Payload
```

<sub>Reviews (1): Last reviewed commit: ["fix(worker): expose inbound BCC recipien..."](https://github.com/novuhq/novu/commit/0054565417ac092217cf80dff11529fc0ec9648d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58227146)</sub>

**Context used:**

- Knowledge Base — [Inbound email processing](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/inbound-email-processing.md)
- Knowledge Base — [Real-time and webhook services](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/real-time-and-webhooks.md)

<!-- /greptile_comment -->