### PR TITLE
docs: document MCP agent and conversation tools

### DIFF
--- a/docs/agents/conversations.mdx
+++ b/docs/agents/conversations.mdx
@@ -33,6 +33,16 @@ Navigate to your agent's detail page to see all conversations, their status, and
 - **Participant details**: which subscribers and platform users are part of each conversation, with identity resolution status.
 - **Platform context**: which provider and thread the conversation is happening on.
 
+## Inspect conversations from an AI tool
+
+If you have the [Novu MCP server](/platform/build-with-ai/mcp) connected, you can list and debug conversations without opening the dashboard:
+
+1. Call `get_agents` and copy the agent's identifier (slug).
+2. Call `get_conversations` with that slug as `agentId`.
+3. Call `get_conversation_activities` with a `conv_*` identifier to inspect the timeline (messages, approvals, MCP connection rows).
+
+These tools are available on Novu Cloud and self-hosted Enterprise when Conversations is enabled. They are not available on Community Edition.
+
 ## Supported platforms
 
 Both managed agents and custom code agents support the same live channels. Capability details (typing, plan cards, buttons, approvals, edits) live in one place:

--- a/docs/platform/build-with-ai/mcp.mdx
+++ b/docs/platform/build-with-ai/mcp.mdx
@@ -1,12 +1,12 @@
 ---
 title: Novu MCP Server
-description: Connect Cursor, Claude, ChatGPT, and other AI tools to the Novu MCP server to manage notifications, workflows, and subscribers using natural language.
+description: Connect Cursor, Claude, ChatGPT, and other AI tools to the Novu MCP server to manage notifications, workflows, subscribers, agents, and conversations using natural language.
 ---
 
-The Novu MCP Server exposes Novu's notification infrastructure as tools that AI assistants can discover and use in real time. Connect your AI tool to manage subscribers, workflows, integrations, and delivery activity from natural-language prompts.
+The Novu MCP Server exposes Novu's notification and agent infrastructure as tools that AI assistants can discover and use in real time. Connect your AI tool to manage subscribers, workflows, integrations, agents, conversations, and delivery activity from natural-language prompts.
 
 <Note>
-  Novu also hosts a separate **documentation MCP server** at [docs.novu.co/mcp](https://docs.novu.co/mcp) that lets AI tools search and read this documentation site. The Novu MCP Server described on this page manages your Novu account - triggers, workflows, subscribers, and more.
+  Novu also hosts a separate **documentation MCP server** at [docs.novu.co/mcp](https://docs.novu.co/mcp) that lets AI tools search and read this documentation site. The Novu MCP Server described on this page manages your Novu account - triggers, workflows, subscribers, agents, and more.
 </Note>
 
 ## About the Novu MCP server
@@ -19,6 +19,8 @@ The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open s
 - Debug failed notifications and delivery issues
 - Analyze notification activity and logs
 - Create and manage workflows
+- Create and update [agents](/agents/managed-agent/overview), then connect a channel
+- List [agent conversations](/agents/conversations) and inspect activity timelines
 
 Some AI tools support both MCP and [Agent Skills](/platform/build-with-ai/skills). MCP gives your assistant live access to your Novu account, while skills instruct agents how to use Novu APIs and SDKs effectively. They're complementary - connect the MCP server for account operations and install skills for implementation guidance.
 
@@ -214,6 +216,16 @@ Trigger my welcome-email workflow for subscriber test-user-123 with payload cont
 Show recent failed notifications in the last 24 hours and help me debug delivery issues.
 </Prompt>
 
+### Agents and conversations
+
+<Prompt description="Create a managed agent and connect a channel" icon="bot" actions={["copy", "cursor"]}>
+Create a managed Novu agent named Support Bot with a system prompt that answers product questions briefly. After it is created, connect Slack to that agent.
+</Prompt>
+
+<Prompt description="Debug an agent conversation" icon="bot" actions={["copy", "cursor"]}>
+List my Novu agents, then show recent conversations for the support-bot agent and inspect the activity timeline of the latest thread.
+</Prompt>
+
 ## MCP tools
 
 Your AI assistant discovers these tools automatically when it connects, and calls the right one based on your prompt.
@@ -237,6 +249,13 @@ Your AI assistant discovers these tools automatically when it connects, and call
 | Workflows | `trigger_workflow` | Trigger a workflow for a subscriber |
 | Workflows | `bulk_trigger_workflow` | Trigger multiple workflows in one call |
 | Workflows | `cancel_triggered_event` | Cancel a pending triggered event |
+| Agents | `create_agent` | Create an agent |
+| Agents | `get_agents` | List agents with cursor pagination |
+| Agents | `get_agent` | Retrieve a single agent by identifier (slug) |
+| Agents | `update_agent` | Update an agent's name, status, bridge URL, or behavior |
+| Agents | `connect_agent` | Connect a channel to an existing agent |
+| Conversations | `get_conversations` | List agent conversations with optional filters |
+| Conversations | `get_conversation_activities` | Inspect a conversation timeline |
 | Notifications | `get_notification` | Get a notification with execution logs |
 | Notifications | `get_notifications` | Fetch notifications with filtering |
 | Integrations | `get_integrations` | List channel integrations |
@@ -245,7 +264,7 @@ Your AI assistant discovers these tools automatically when it connects, and call
 | Integrations | `set_primary_integration` | Set an integration as primary for its channel |
 
 <Note>
-  Every tool accepts an optional `environmentId` parameter - see [Environments](#environments).
+  Every tool accepts an optional `environmentId` parameter - see [Environments](#environments). Agent tools use the agent's identifier (slug), not the Mongo `_id`. Conversation tools are available on Novu Cloud and self-hosted Enterprise, not Community Edition.
 </Note>
 
 ## Use multiple MCP servers
@@ -254,7 +273,7 @@ You can connect both the Novu MCP server and the [Novu documentation MCP server]
 
 | Server | URL | Purpose |
 | --- | --- | --- |
-| Novu MCP | `https://mcp.novu.co/` (US) / `https://eu.mcp.novu.co/` (EU) | Manage your Novu account - workflows, subscribers, triggers |
+| Novu MCP | `https://mcp.novu.co/` (US) / `https://eu.mcp.novu.co/` (EU) | Manage your Novu account - workflows, subscribers, agents, conversations, triggers |
 | Novu Docs MCP | `https://docs.novu.co/mcp` | Search and read Novu documentation |
 
 Connected MCP servers don't consume context until the AI calls a tool. Be specific in your prompts so the assistant uses the most relevant server - for example, "trigger my welcome workflow" uses the Novu MCP, while "how do I configure digest steps?" uses the Docs MCP.
@@ -276,6 +295,10 @@ Connected MCP servers don't consume context until the AI calls a tool. Be specif
 
   <Accordion title="Empty results or authentication errors">
     Double-check you're on the endpoint for your region (`eu.dashboard.novu.co` → `https://eu.mcp.novu.co/`), and that any API key is sent as `Authorization: Bearer your-api-key` with no extra spaces.
+  </Accordion>
+
+  <Accordion title="Conversations return 404">
+    `get_conversations` and `get_conversation_activities` require Novu Cloud or self-hosted Enterprise with Conversations enabled. Community Edition and environments where the feature flag is off return `404`. Confirm you passed an agent **identifier** (slug) as `agentId`, not a Mongo `_id`.
   </Accordion>
 
   <Accordion title="Self-hosted Novu">
@@ -303,6 +326,12 @@ Connected MCP servers don't consume context until the AI calls a tool. Be specif
   </Card>
   <Card title="Agent Toolkit" href="/platform/build-with-ai/agent-toolkit">
     Embed Novu tools inside your own AI agents with the `@novu/agent-toolkit` package.
+  </Card>
+  <Card title="Managed agents" href="/agents/managed-agent/overview">
+    How managed agents, connectors, and channel connect work in Novu.
+  </Card>
+  <Card title="Agent conversations" href="/agents/conversations">
+    How conversation lifecycle and activity look in the dashboard.
   </Card>
   <Card title="Novu Docs MCP" href="https://docs.novu.co/mcp">
     Connect AI tools to search and read this documentation site.


### PR DESCRIPTION
## Summary
- Document the new agent and conversation MCP tools on the Novu MCP page (`create_agent`, `get_agents`, `get_agent`, `update_agent`, `connect_agent`, `get_conversations`, `get_conversation_activities`).
- Keep the existing catalog-table style: example prompts, a short identifier/availability note, and a 404 troubleshooting accordion.
- Cross-link from Agent Conversations to the MCP debug flow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documents the MCP tools for creating and managing agents and inspecting conversation activity.
- Adds agent and conversation tools, example prompts, availability guidance, and 404 troubleshooting to the MCP page.
- Cross-links the Agent Conversations guide with the MCP debugging workflow.

<h3>Confidence Score: 5/5</h3>

The documentation-only changes appear safe to merge, with no concrete defects identified.

The added links resolve to published documentation pages, the MDX components follow existing supported patterns, and no evidence establishes that the documented MCP workflow conflicts with its external service contract.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/agents/conversations.mdx | Adds a concise MCP-based conversation inspection flow using established internal links and valid MDX formatting. |
| docs/platform/build-with-ai/mcp.mdx | Expands the MCP catalog, examples, troubleshooting guidance, and related links for agent and conversation tools without an established defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add MCP agent &amp; conversation docs"](https://github.com/novuhq/novu/commit/53bc8dddd8f86a958edb67f94c0ee11c4a268d23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58348897)</sub>

<!-- /greptile_comment -->