### PR TITLE
fix(api-service): delete channel endpoints when subscriber is removed fixes NV-8702

### DIFF
--- a/apps/api/src/app/subscribers-v2/e2e/delete-subscriber.e2e.ts
+++ b/apps/api/src/app/subscribers-v2/e2e/delete-subscriber.e2e.ts
@@ -1,5 +1,6 @@
 import { Novu } from '@novu/api';
 import {
+  ChannelEndpointRepository,
   MessageEntity,
   MessageRepository,
   PreferencesRepository,
@@ -8,7 +9,7 @@ import {
   TopicRepository,
   TopicSubscribersRepository,
 } from '@novu/dal';
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import { randomBytes } from 'crypto';
@@ -22,6 +23,7 @@ describe('Delete Subscriber - /subscribers/:subscriberId (DELETE) #novu-v2', () 
   let topicRepository: TopicRepository;
   let topicSubscribersRepository: TopicSubscribersRepository;
   let preferencesRepository: PreferencesRepository;
+  let channelEndpointRepository: ChannelEndpointRepository;
   let subscriberId: string;
   let environmentId: string;
   let organizationId: string;
@@ -36,6 +38,7 @@ describe('Delete Subscriber - /subscribers/:subscriberId (DELETE) #novu-v2', () 
     topicRepository = new TopicRepository();
     topicSubscribersRepository = new TopicSubscribersRepository();
     preferencesRepository = new PreferencesRepository();
+    channelEndpointRepository = new ChannelEndpointRepository();
 
     subscriberId = `test-subscriber-${randomBytes(4).toString('hex')}`;
     environmentId = session.environment._id;
@@ -97,6 +100,25 @@ describe('Delete Subscriber - /subscribers/:subscriberId (DELETE) #novu-v2', () 
     });
     expect(messagesBeforeDeletion.length).to.equal(3);
 
+    await channelEndpointRepository.create({
+      identifier: `chendp-${randomBytes(4).toString('hex')}`,
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+      integrationIdentifier: 'slack-test',
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      subscriberId,
+      contextKeys: [],
+      type: ENDPOINT_TYPES.SLACK_CHANNEL,
+      endpoint: { channelId: 'C123456789' },
+    });
+
+    const endpointsBeforeDeletion = await channelEndpointRepository.find({
+      _environmentId: environmentId,
+      subscriberId,
+    });
+    expect(endpointsBeforeDeletion.length).to.equal(1);
+
     await novuClient.subscribers.delete(subscriberId);
 
     const subscriberAfterDeletion = await subscriberRepository.findOne({
@@ -117,5 +139,11 @@ describe('Delete Subscriber - /subscribers/:subscriberId (DELETE) #novu-v2', () 
       externalSubscriberId: subscriberId,
     });
     expect(topicSubscriptionsAfterDeletion.length).to.equal(0);
+
+    const endpointsAfterDeletion = await channelEndpointRepository.find({
+      _environmentId: environmentId,
+      subscriberId,
+    });
+    expect(endpointsAfterDeletion.length).to.equal(0);
   });
 });

--- a/apps/api/src/app/subscribers-v2/e2e/delete-subscriber.e2e.ts
+++ b/apps/api/src/app/subscribers-v2/e2e/delete-subscriber.e2e.ts
@@ -1,5 +1,6 @@
 import { Novu } from '@novu/api';
 import {
+  ChannelConnectionRepository,
   ChannelEndpointRepository,
   MessageEntity,
   MessageRepository,
@@ -24,6 +25,7 @@ describe('Delete Subscriber - /subscribers/:subscriberId (DELETE) #novu-v2', () 
   let topicSubscribersRepository: TopicSubscribersRepository;
   let preferencesRepository: PreferencesRepository;
   let channelEndpointRepository: ChannelEndpointRepository;
+  let channelConnectionRepository: ChannelConnectionRepository;
   let subscriberId: string;
   let environmentId: string;
   let organizationId: string;
@@ -39,6 +41,7 @@ describe('Delete Subscriber - /subscribers/:subscriberId (DELETE) #novu-v2', () 
     topicSubscribersRepository = new TopicSubscribersRepository();
     preferencesRepository = new PreferencesRepository();
     channelEndpointRepository = new ChannelEndpointRepository();
+    channelConnectionRepository = new ChannelConnectionRepository();
 
     subscriberId = `test-subscriber-${randomBytes(4).toString('hex')}`;
     environmentId = session.environment._id;
@@ -119,6 +122,37 @@ describe('Delete Subscriber - /subscribers/:subscriberId (DELETE) #novu-v2', () 
     });
     expect(endpointsBeforeDeletion.length).to.equal(1);
 
+    await channelConnectionRepository.create({
+      identifier: `chconn-${randomBytes(4).toString('hex')}`,
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+      integrationIdentifier: 'slack-test',
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      subscriberId,
+      contextKeys: [],
+      workspace: { id: 'T123' },
+      auth: { accessToken: 'xoxb-test-token' },
+    });
+
+    await channelConnectionRepository.create({
+      identifier: `chconn-shared-${randomBytes(4).toString('hex')}`,
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+      integrationIdentifier: 'slack-shared',
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      contextKeys: [],
+      workspace: { id: 'T-SHARED' },
+      auth: { accessToken: 'xoxb-shared-token' },
+    });
+
+    const connectionsBeforeDeletion = await channelConnectionRepository.find({
+      _environmentId: environmentId,
+      subscriberId,
+    });
+    expect(connectionsBeforeDeletion.length).to.equal(1);
+
     await novuClient.subscribers.delete(subscriberId);
 
     const subscriberAfterDeletion = await subscriberRepository.findOne({
@@ -145,5 +179,17 @@ describe('Delete Subscriber - /subscribers/:subscriberId (DELETE) #novu-v2', () 
       subscriberId,
     });
     expect(endpointsAfterDeletion.length).to.equal(0);
+
+    const connectionsAfterDeletion = await channelConnectionRepository.find({
+      _environmentId: environmentId,
+      subscriberId,
+    });
+    expect(connectionsAfterDeletion.length).to.equal(0);
+
+    const sharedConnectionsAfterDeletion = await channelConnectionRepository.find({
+      _environmentId: environmentId,
+      integrationIdentifier: 'slack-shared',
+    });
+    expect(sharedConnectionsAfterDeletion.length).to.equal(1);
   });
 });

--- a/apps/api/src/app/subscribers-v2/subscribers.module.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.module.ts
@@ -15,6 +15,7 @@ import {
   UpsertPreferences,
 } from '@novu/application-generic';
 import {
+  ChannelConnectionRepository,
   ChannelEndpointRepository,
   CommunityOrganizationRepository,
   ContextRepository,
@@ -76,6 +77,7 @@ const DAL_MODELS = [
   MessageRepository,
   ContextRepository,
   ChannelEndpointRepository,
+  ChannelConnectionRepository,
 ];
 
 @Module({

--- a/apps/api/src/app/subscribers-v2/subscribers.module.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.module.ts
@@ -15,6 +15,7 @@ import {
   UpsertPreferences,
 } from '@novu/application-generic';
 import {
+  ChannelEndpointRepository,
   CommunityOrganizationRepository,
   ContextRepository,
   EnvironmentRepository,
@@ -74,6 +75,7 @@ const DAL_MODELS = [
   TenantRepository,
   MessageRepository,
   ContextRepository,
+  ChannelEndpointRepository,
 ];
 
 @Module({

--- a/apps/api/src/app/subscribers-v2/usecases/remove-subscriber/remove-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/remove-subscriber/remove-subscriber.usecase.ts
@@ -6,6 +6,7 @@ import {
   InvalidateCacheService,
 } from '@novu/application-generic';
 import {
+  ChannelConnectionRepository,
   ChannelEndpointRepository,
   MessageRepository,
   PreferencesRepository,
@@ -23,7 +24,8 @@ export class RemoveSubscriber {
     private topicSubscribersRepository: TopicSubscribersRepository,
     private preferenceRepository: PreferencesRepository,
     private messageRepository: MessageRepository,
-    private channelEndpointRepository: ChannelEndpointRepository
+    private channelEndpointRepository: ChannelEndpointRepository,
+    private channelConnectionRepository: ChannelConnectionRepository
   ) {}
 
   async execute({ environmentId: _environmentId, subscriberId }: RemoveSubscriberCommand) {
@@ -51,7 +53,7 @@ export class RemoveSubscriber {
       throw new NotFoundException({ message: 'Subscriber was not found', externalSubscriberId: subscriberId });
     }
 
-    await this.subscriberRepository.withTransaction(async () => {
+    await this.subscriberRepository.withTransaction(async (session) => {
       /*
        * Note about parallelism in transactions
        *
@@ -61,29 +63,52 @@ export class RemoveSubscriber {
        *
        * Refer to https://mongoosejs.com/docs/transactions.html#note-about-parallelism-in-transactions
        */
-      await this.subscriberRepository.delete({
-        subscriberId,
-        _environmentId,
-      });
+      await this.subscriberRepository.delete(
+        {
+          subscriberId,
+          _environmentId,
+        },
+        { session }
+      );
 
-      await this.topicSubscribersRepository.delete({
-        _environmentId,
-        externalSubscriberId: subscriberId,
-      });
-      await this.preferenceRepository.delete({
-        _environmentId,
-        _subscriberId: { $in: subscriberInternalIds },
-      });
+      await this.topicSubscribersRepository.delete(
+        {
+          _environmentId,
+          externalSubscriberId: subscriberId,
+        },
+        { session }
+      );
+      await this.preferenceRepository.delete(
+        {
+          _environmentId,
+          _subscriberId: { $in: subscriberInternalIds },
+        },
+        { session }
+      );
 
-      await this.messageRepository.delete({
-        _subscriberId: { $in: subscriberInternalIds },
-        _environmentId,
-      });
+      await this.messageRepository.delete(
+        {
+          _subscriberId: { $in: subscriberInternalIds },
+          _environmentId,
+        },
+        { session }
+      );
 
-      await this.channelEndpointRepository.delete({
-        subscriberId,
-        _environmentId,
-      });
+      await this.channelEndpointRepository.delete(
+        {
+          subscriberId,
+          _environmentId,
+        },
+        { session }
+      );
+
+      await this.channelConnectionRepository.delete(
+        {
+          subscriberId,
+          _environmentId,
+        },
+        { session }
+      );
     });
 
     return {

--- a/apps/api/src/app/subscribers-v2/usecases/remove-subscriber/remove-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/remove-subscriber/remove-subscriber.usecase.ts
@@ -5,7 +5,13 @@ import {
   buildSubscriberKey,
   InvalidateCacheService,
 } from '@novu/application-generic';
-import { MessageRepository, PreferencesRepository, SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
+import {
+  ChannelEndpointRepository,
+  MessageRepository,
+  PreferencesRepository,
+  SubscriberRepository,
+  TopicSubscribersRepository,
+} from '@novu/dal';
 
 import { RemoveSubscriberCommand } from './remove-subscriber.command';
 
@@ -16,7 +22,8 @@ export class RemoveSubscriber {
     private subscriberRepository: SubscriberRepository,
     private topicSubscribersRepository: TopicSubscribersRepository,
     private preferenceRepository: PreferencesRepository,
-    private messageRepository: MessageRepository
+    private messageRepository: MessageRepository,
+    private channelEndpointRepository: ChannelEndpointRepository
   ) {}
 
   async execute({ environmentId: _environmentId, subscriberId }: RemoveSubscriberCommand) {
@@ -70,6 +77,11 @@ export class RemoveSubscriber {
 
       await this.messageRepository.delete({
         _subscriberId: { $in: subscriberInternalIds },
+        _environmentId,
+      });
+
+      await this.channelEndpointRepository.delete({
+        subscriberId,
         _environmentId,
       });
     });

--- a/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
@@ -5,7 +5,12 @@ import {
   buildSubscriberKey,
   InvalidateCacheService,
 } from '@novu/application-generic';
-import { PreferencesRepository, SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
+import {
+  ChannelEndpointRepository,
+  PreferencesRepository,
+  SubscriberRepository,
+  TopicSubscribersRepository,
+} from '@novu/dal';
 
 import { RemoveSubscriberCommand } from './remove-subscriber.command';
 
@@ -15,7 +20,8 @@ export class RemoveSubscriber {
     private invalidateCache: InvalidateCacheService,
     private subscriberRepository: SubscriberRepository,
     private topicSubscribersRepository: TopicSubscribersRepository,
-    private preferenceRepository: PreferencesRepository
+    private preferenceRepository: PreferencesRepository,
+    private channelEndpointRepository: ChannelEndpointRepository
   ) {}
 
   async execute({ environmentId: _environmentId, subscriberId }: RemoveSubscriberCommand) {
@@ -65,6 +71,11 @@ export class RemoveSubscriber {
       await this.preferenceRepository.delete({
         _environmentId,
         _subscriberId: { $in: subscriberInternalIds },
+      });
+
+      await this.channelEndpointRepository.delete({
+        subscriberId,
+        _environmentId,
       });
     });
 

--- a/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
@@ -6,6 +6,7 @@ import {
   InvalidateCacheService,
 } from '@novu/application-generic';
 import {
+  ChannelConnectionRepository,
   ChannelEndpointRepository,
   PreferencesRepository,
   SubscriberRepository,
@@ -21,7 +22,8 @@ export class RemoveSubscriber {
     private subscriberRepository: SubscriberRepository,
     private topicSubscribersRepository: TopicSubscribersRepository,
     private preferenceRepository: PreferencesRepository,
-    private channelEndpointRepository: ChannelEndpointRepository
+    private channelEndpointRepository: ChannelEndpointRepository,
+    private channelConnectionRepository: ChannelConnectionRepository
   ) {}
 
   async execute({ environmentId: _environmentId, subscriberId }: RemoveSubscriberCommand) {
@@ -49,7 +51,7 @@ export class RemoveSubscriber {
       throw new NotFoundException({ message: 'Subscriber was not found', externalSubscriberId: subscriberId });
     }
 
-    await this.subscriberRepository.withTransaction(async () => {
+    await this.subscriberRepository.withTransaction(async (session) => {
       /*
        * Note about parallelism in transactions
        *
@@ -59,24 +61,44 @@ export class RemoveSubscriber {
        *
        * Refer to https://mongoosejs.com/docs/transactions.html#note-about-parallelism-in-transactions
        */
-      await this.subscriberRepository.delete({
-        subscriberId,
-        _environmentId,
-      });
+      await this.subscriberRepository.delete(
+        {
+          subscriberId,
+          _environmentId,
+        },
+        { session }
+      );
 
-      await this.topicSubscribersRepository.delete({
-        _environmentId,
-        externalSubscriberId: subscriberId,
-      });
-      await this.preferenceRepository.delete({
-        _environmentId,
-        _subscriberId: { $in: subscriberInternalIds },
-      });
+      await this.topicSubscribersRepository.delete(
+        {
+          _environmentId,
+          externalSubscriberId: subscriberId,
+        },
+        { session }
+      );
+      await this.preferenceRepository.delete(
+        {
+          _environmentId,
+          _subscriberId: { $in: subscriberInternalIds },
+        },
+        { session }
+      );
 
-      await this.channelEndpointRepository.delete({
-        subscriberId,
-        _environmentId,
-      });
+      await this.channelEndpointRepository.delete(
+        {
+          subscriberId,
+          _environmentId,
+        },
+        { session }
+      );
+
+      await this.channelConnectionRepository.delete(
+        {
+          subscriberId,
+          _environmentId,
+        },
+        { session }
+      );
     });
 
     return {


### PR DESCRIPTION
## What changed? Why was the change needed?

Deleting a subscriber left behind `ChannelEndpoint` rows keyed by that subscriber's external id. Those orphans can still be resolved at send time and bind routing to a subscriber that no longer exists.

This PR deletes matching channel endpoints in the same subscriber-removal transaction on both the v2 and v1 `RemoveSubscriber` use cases, scoped by `subscriberId` + `_environmentId`.

Linear: [NV-8702](https://linear.app/novu/issue/NV-8702)

### Test plan

- [ ] `DELETE /subscribers/:subscriberId` removes the subscriber, messages, topic subscriptions, **and** channel endpoints
- [ ] Endpoints for other subscribers in the same environment are left untouched
- [ ] Existing delete-subscriber e2e (`apps/api/src/app/subscribers-v2/e2e/delete-subscriber.e2e.ts`) passes — it now seeds an endpoint and asserts it is gone after delete

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

Channel connections (`subscriberId` optional on `ChannelConnection`) are not deleted here. Say if those should be cleaned up in the same transaction.

The endpoint delete uses the same env-scoped `delete()` pattern as messages/preferences in this use case.

</details>

Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends subscriber removal to delete subscriber-bound channel endpoints and channel connections in both API implementations while making all related persistence operations part of the same transaction.
- Passes the active transaction session to each sequential cleanup operation.
- Registers the added repositories in the v2 subscriber module.
- Expands the v2 end-to-end test to verify subscriber-bound channel cleanup while preserving shared connections.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported transaction-boundary failure has been fixed, and no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/subscribers-v2/usecases/remove-subscriber/remove-subscriber.usecase.ts | Adds endpoint and connection cleanup and correctly forwards the active session through every sequential delete. |
| apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts | Applies the same atomic channel cleanup to the legacy subscriber-removal path with its dependencies already available from the imported channel module. |
| apps/api/src/app/subscribers-v2/subscribers.module.ts | Registers both channel repositories required by the updated v2 removal use case. |
| apps/api/src/app/subscribers-v2/e2e/delete-subscriber.e2e.ts | Covers deletion of subscriber-bound endpoint and connection records and verifies that a shared connection remains intact. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Delete subscriber request] --> B[Start transaction]
  B --> C[Delete subscriber]
  C --> D[Delete topic subscriptions]
  D --> E[Delete preferences and messages]
  E --> F[Delete subscriber channel endpoints]
  F --> G[Delete subscriber channel connections]
  G --> H[Commit transaction]
```

<sub>Reviews (2): Last reviewed commit: ["Delete subscriber channel connections"](https://github.com/novuhq/novu/commit/6a33e179b4c9222dcd19ba303754723383b87e50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58353009)</sub>

**Context used:**

- Knowledge Base — [API service and application boundary](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/api-service.md)
- Knowledge Base — [Data access layer](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/data-access-layer.md)

<!-- /greptile_comment -->