### PR TITLE
feat(human): env var support

### DIFF
--- a/packages/human/README.md
+++ b/packages/human/README.md
@@ -49,9 +49,21 @@ human invite carol --via email --email carol@acme.com
 - `--to <humanId>` — address a human who is already linked (`human invite` first), or comma-separated humans (`alice,bob`, max 50) so any listed person can settle.
 - `--via <platform>` — deliver on a specific linked channel instead of the default.
 
-## Auth
+## Auth & headless use
 
 `setup` stores credentials in `~/.novu/human.json`. Alternatively set `NOVU_SECRET_KEY` (and optionally `NOVU_API_URL`) for an existing Novu environment.
+
+In containers, sandboxes, and CI — anywhere no config file exists — the CLI is fully operational from environment variables alone:
+
+```bash
+docker run -e NOVU_SECRET_KEY=... -e HUMAN_TO=alice -e HUMAN_VIA=slack agent \
+  npx @novu/human approve "Deploy to prod?"
+```
+
+- `HUMAN_TO` — default recipient subscriberId(s), comma-separated like `--to` (max 50).
+- `HUMAN_VIA` — default channel (`telegram`, `slack`, or `email`), like `--via`.
+
+Precedence is always **CLI flags > environment variables > `~/.novu/human.json`**, and env values are never written back to the config file.
 
 ## Teaching your coding agent to use it
 

--- a/packages/human/src/commands/channels.ts
+++ b/packages/human/src/commands/channels.ts
@@ -1,8 +1,6 @@
 import pc from 'picocolors';
-import { loadConfig, NOT_SET_UP_MESSAGE, saveConfig } from '../config';
+import { loadConfig, NOT_SET_UP_MESSAGE, saveConfig, SUPPORTED_CHANNELS } from '../config';
 import { fail } from '../output';
-
-const SUPPORTED = ['telegram', 'slack', 'email'] as const;
 
 export async function channelsCommand(options: { default?: string; json?: boolean }): Promise<never> {
   const config = loadConfig();
@@ -13,8 +11,8 @@ export async function channelsCommand(options: { default?: string; json?: boolea
 
   if (options.default) {
     const target = options.default.toLowerCase();
-    if (!(SUPPORTED as readonly string[]).includes(target)) {
-      fail(`Unknown channel "${target}". Use one of: ${SUPPORTED.join(', ')}.`);
+    if (!(SUPPORTED_CHANNELS as readonly string[]).includes(target)) {
+      fail(`Unknown channel "${target}". Use one of: ${SUPPORTED_CHANNELS.join(', ')}.`);
     }
 
     saveConfig({ ...config, defaultChannel: target });

--- a/packages/human/src/commands/interact.spec.ts
+++ b/packages/human/src/commands/interact.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../output', async (importOriginal) => {
   const original = await importOriginal<typeof import('../output')>();
@@ -11,8 +11,10 @@ vi.mock('../output', async (importOriginal) => {
   };
 });
 
-const { parseDuration, parseHumanToOption } = await import('./interact');
+const { parseDuration, parseHumanToOption, resolveTo } = await import('./interact');
 const { exitCodeFor, EXIT_DENIED, EXIT_GONE, EXIT_OK, EXIT_TIMEOUT } = await import('../output');
+
+type HumanCliConfig = import('../config').HumanCliConfig;
 
 describe('parseHumanToOption', () => {
   it('splits comma-separated humans and dedupes', () => {
@@ -25,6 +27,46 @@ describe('parseHumanToOption', () => {
     expect(() => parseHumanToOption(Array.from({ length: 51 }, (_, index) => `s${index}`).join(','))).toThrow(
       'at most 50'
     );
+  });
+});
+
+describe('resolveTo', () => {
+  const config: HumanCliConfig = {
+    apiUrl: 'https://api.novu.co',
+    auth: { mode: 'apiKey', secretKey: 'api_key_private' },
+    relayAgentIdentifier: 'human-relay',
+    subscriberId: 'dave',
+  };
+
+  afterEach(() => {
+    delete process.env.HUMAN_TO;
+  });
+
+  it('works env-only, with no subscriberId in the config', () => {
+    process.env.HUMAN_TO = 'alice';
+    expect(resolveTo({ ...config, subscriberId: undefined })).toEqual(['alice']);
+  });
+
+  it('splits, trims, and dedupes a comma list from the env', () => {
+    process.env.HUMAN_TO = ' alice , bob , alice ';
+    expect(resolveTo(config)).toEqual(['alice', 'bob']);
+  });
+
+  it('applies the recipient cap to the env list and names the source', () => {
+    process.env.HUMAN_TO = Array.from({ length: 51 }, (_, index) => `s${index}`).join(',');
+    expect(() => resolveTo(config)).toThrow('HUMAN_TO supports at most 50');
+  });
+
+  it('lets a --to flag beat HUMAN_TO, and env beat the config file', () => {
+    process.env.HUMAN_TO = 'alice';
+    expect(resolveTo(config, 'carol')).toEqual(['carol']);
+    expect(resolveTo(config)).toEqual(['alice']);
+  });
+
+  it('falls through to the config subscriberId when the env is unset or blank', () => {
+    expect(resolveTo(config)).toBe('dave');
+    process.env.HUMAN_TO = '  ';
+    expect(resolveTo(config)).toBe('dave');
   });
 });
 

--- a/packages/human/src/commands/interact.ts
+++ b/packages/human/src/commands/interact.ts
@@ -6,7 +6,7 @@ import {
   type Interaction,
   type InteractionKind,
 } from '../api/human';
-import { NOT_SET_UP_MESSAGE, resolveConfig, resolveVia } from '../config';
+import { type HumanCliConfig, NOT_SET_UP_MESSAGE, resolveConfig, resolveVia } from '../config';
 import { EXIT_TIMEOUT, emitResult, fail } from '../output';
 import { sleep } from '../poll';
 import { startWaitIndicator } from '../spinner';
@@ -42,7 +42,7 @@ export function clientFromConfig(apiUrl?: string): {
 /** Matches Novu `HUMAN_INTERACTION_MAX_RECIPIENTS`. The CLI cannot import `@novu/shared`. */
 const MAX_HUMAN_TO = 50;
 
-export function parseHumanToOption(raw: string): string[] {
+export function parseHumanToOption(raw: string, label = '`--to`'): string[] {
   const ids = [
     ...new Set(
       raw
@@ -52,14 +52,28 @@ export function parseHumanToOption(raw: string): string[] {
     ),
   ];
   if (ids.length === 0) {
-    fail('`--to` must include at least one subscriberId');
+    fail(`${label} must include at least one subscriberId`);
   }
 
   if (ids.length > MAX_HUMAN_TO) {
-    fail(`\`--to\` supports at most ${MAX_HUMAN_TO} subscriberIds`);
+    fail(`${label} supports at most ${MAX_HUMAN_TO} subscriberIds`);
   }
 
   return ids;
+}
+
+/** Recipient precedence: `--to` flag > HUMAN_TO env > config file subscriberId. */
+export function resolveTo(config: HumanCliConfig, toFlag?: string): string | string[] | undefined {
+  if (toFlag) {
+    return parseHumanToOption(toFlag);
+  }
+
+  const envTo = process.env.HUMAN_TO?.trim();
+  if (envTo) {
+    return parseHumanToOption(envTo, 'HUMAN_TO');
+  }
+
+  return config.subscriberId;
 }
 
 /** Shared engine behind ask / approve / choose / tell. */
@@ -67,14 +81,14 @@ export async function runInteraction(kind: InteractionKind, prompt: string, opti
   try {
     const { client, config } = clientFromConfig(options.apiUrl);
 
-    const to = options.to ? parseHumanToOption(options.to) : config.subscriberId;
+    const to = resolveTo(config, options.to);
 
     if (!to) {
       fail(NOT_SET_UP_MESSAGE);
     }
 
-    // `--via` or the saved defaultChannel preference; omit via and the API
-    // picks when only one channel is linked.
+    // `--via`, HUMAN_VIA, or the saved defaultChannel preference; omit
+    // via and the API picks when only one channel is linked.
     const via = resolveVia(config, options.via);
 
     const input: CreateInteractionInput = {

--- a/packages/human/src/config.spec.ts
+++ b/packages/human/src/config.spec.ts
@@ -13,6 +13,7 @@ const base: HumanCliConfig = {
 afterEach(() => {
   delete process.env.NOVU_HUMAN_CONFIG;
   delete process.env.NOVU_SECRET_KEY;
+  delete process.env.HUMAN_VIA;
 });
 
 describe('config migration', () => {
@@ -70,6 +71,26 @@ describe('resolveVia', () => {
   it('omits via when nothing is preferred so the API can pick', () => {
     expect(resolveVia({ ...base, subscriberId: 'human_abc' })).toBeUndefined();
   });
+
+  it('falls back to HUMAN_VIA over the config default, case-insensitively', () => {
+    process.env.HUMAN_VIA = 'Telegram';
+    expect(resolveVia(config)).toBe('telegram');
+  });
+
+  it('lets a --via flag beat HUMAN_VIA', () => {
+    process.env.HUMAN_VIA = 'telegram';
+    expect(resolveVia(config, 'email')).toBe('email');
+  });
+
+  it('rejects an unsupported HUMAN_VIA value', () => {
+    process.env.HUMAN_VIA = 'carrier-pigeon';
+    expect(() => resolveVia(config)).toThrow(/Invalid HUMAN_VIA/);
+  });
+
+  it('ignores an empty HUMAN_VIA', () => {
+    process.env.HUMAN_VIA = '  ';
+    expect(resolveVia(config)).toBe('slack');
+  });
 });
 
 describe('resolveConfig', () => {
@@ -91,6 +112,17 @@ describe('resolveConfig', () => {
       auth: { mode: 'apiKey', secretKey: 'api_key_private' },
       subscriberId: 'human_abc',
       defaultChannel: 'telegram',
+    });
+  });
+
+  it('works with no config file at all when NOVU_SECRET_KEY is set', () => {
+    process.env.NOVU_HUMAN_CONFIG = join(mkdtempSync(join(tmpdir(), 'human-config-')), 'missing.json');
+    process.env.NOVU_SECRET_KEY = 'api_key_private';
+
+    expect(resolveConfig()).toEqual({
+      apiUrl: 'https://api.novu.co',
+      relayAgentIdentifier: 'human-relay',
+      auth: { mode: 'apiKey', secretKey: 'api_key_private' },
     });
   });
 });

--- a/packages/human/src/config.ts
+++ b/packages/human/src/config.ts
@@ -24,8 +24,10 @@ export interface HumanCliConfig {
 export const DEFAULT_API_URL = 'https://api.novu.co';
 export const DEFAULT_RELAY_AGENT_IDENTIFIER = 'human-relay';
 
+export const SUPPORTED_CHANNELS = ['telegram', 'slack', 'email'] as const;
+
 export const NOT_SET_UP_MESSAGE =
-  'No human connected yet. Ask your human to run: npx @novu/human setup (or set NOVU_SECRET_KEY).';
+  'No human connected yet. Ask your human to run: npx @novu/human setup (or set NOVU_SECRET_KEY + HUMAN_TO).';
 
 export function configPath(): string {
   return process.env.NOVU_HUMAN_CONFIG ?? join(homedir(), '.novu', 'human.json');
@@ -97,13 +99,22 @@ export function resolveConfig(overrides?: { apiUrl?: string }): HumanCliConfig {
 }
 
 /**
- * Channel preference for create: `--via` wins, otherwise the configured
- * default. When neither is set, returns undefined and the API picks the sole
- * linked channel (or errors if several are linked).
+ * Channel preference for create: `--via` wins, then HUMAN_VIA, then the
+ * configured default. When none is set, returns undefined and the API picks
+ * the sole linked channel (or errors if several are linked).
  */
 export function resolveVia(config: HumanCliConfig, via?: string): HumanChannelPlatform | undefined {
   if (via) {
     return via.toLowerCase();
+  }
+
+  const envVia = process.env.HUMAN_VIA?.trim().toLowerCase();
+  if (envVia) {
+    if (!(SUPPORTED_CHANNELS as readonly string[]).includes(envVia)) {
+      throw new Error(`Invalid HUMAN_VIA "${envVia}". Use one of: ${SUPPORTED_CHANNELS.join(', ')}.`);
+    }
+
+    return envVia;
   }
 
   return config.defaultChannel;

--- a/packages/human/src/index.ts
+++ b/packages/human/src/index.ts
@@ -19,13 +19,27 @@ program
   )
   .version(version);
 
+program.addHelpText(
+  'after',
+  '\nEnvironment variables (headless/containerized use, no config file needed):\n' +
+    '  NOVU_SECRET_KEY    Novu API secret key (replaces `human setup` auth)\n' +
+    '  HUMAN_TO           default recipient subscriberId(s), comma-separated (as --to)\n' +
+    '  HUMAN_VIA          default channel: telegram, slack, or email (as --via)\n' +
+    '  NOVU_API_URL       Novu API URL override\n' +
+    '  NOVU_HUMAN_CONFIG  config file path override\n' +
+    'Precedence: CLI flags > environment variables > ~/.novu/human.json\n'
+);
+
 function withCommonOptions(command: Command): Command {
   return command
     .option(
       '--to <humanId>',
-      'address a linked human, or comma-separated humans (max 50; first valid answer wins; link others with `human invite`)'
+      'address a linked human, or comma-separated humans (max 50; first valid answer wins; link others with `human invite`) (env: HUMAN_TO)'
     )
-    .option('--via <platform>', 'deliver on a specific linked channel (telegram, slack, email) instead of the default')
+    .option(
+      '--via <platform>',
+      'deliver on a specific linked channel (telegram, slack, email) instead of the default (env: HUMAN_VIA)'
+    )
     .option('--from <name>', 'attribution label shown to the human (e.g. "deploy-bot")')
     .option('--ttl <duration>', 'time until the request expires (e.g. 90s, 10m, 2h; max 72h; default 24h)')
     .option('--timeout <duration>', 'max time to block waiting (default: block until answered/expired)')

--- a/packages/human/src/skills/content/human-cli/SKILL.md
+++ b/packages/human/src/skills/content/human-cli/SKILL.md
@@ -48,13 +48,18 @@ process/logs already surface.
 If it isn't configured on this machine yet, every command exits 1 with:
 
 ```
-No human connected yet. Ask your human to run: npx @novu/human setup
+No human connected yet. Ask your human to run: npx @novu/human setup (or set NOVU_SECRET_KEY + HUMAN_TO).
 ```
 
 Treat that message as the actual next step: surface it to whoever *is*
 reachable (chat, PR description, logs) rather than silently giving up or
 looping. Never attempt to configure it on the human's behalf — you don't have
 their Telegram/Slack/email credentials, and setup is interactive by design.
+
+In sandboxes and containers with no config file, the CLI is fully operational
+when `NOVU_SECRET_KEY` and `HUMAN_TO` are set in the environment
+(optionally `HUMAN_VIA` for the channel). `--to`/`--via` flags still
+override the env values.
 
 To reach a *different* person than the one who ran setup, they need a linked
 channel too:


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds headless Human CLI configuration through HUMAN_TO and HUMAN_VIA, including precedence resolution, validation, tests, help text, and usage documentation.
- Resolves interaction recipients from --to, HUMAN_TO, or saved configuration.
- Resolves channels from --via, HUMAN_VIA, or the saved default.
- Centralizes supported channel names and documents container and CI usage.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking documentation issue around mixed environment and config-file precedence.

Recipient and channel environment resolution is guarded and tested, but the advertised fallback order does not reflect resolveConfig discarding saved recipient and channel values whenever NOVU_SECRET_KEY is present.

**Files Needing Attention:** packages/human/README.md, packages/human/src/config.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/human/src/commands/interact.ts | Adds recipient resolution through HUMAN_TO while preserving flag precedence, parsing, deduplication, and recipient limits. |
| packages/human/src/config.ts | Adds supported-channel centralization and validated HUMAN_VIA resolution; existing whole-config secret-key selection does not match the newly documented field-level fallback. |
| packages/human/src/index.ts | Documents environment variables and precedence in global help, including the same overly broad fallback claim. |
| packages/human/README.md | Adds headless usage guidance, but states a precedence contract that does not hold when NOVU_SECRET_KEY is combined with saved recipient or channel values. |
| packages/human/src/commands/interact.spec.ts | Covers HUMAN_TO parsing, limits, blank values, and precedence using directly supplied configuration. |
| packages/human/src/config.spec.ts | Covers HUMAN_VIA behavior and env-only secret-key configuration, but not mixed environment and file configuration. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Flags[CLI flags] --> Recipient[Resolve recipient and channel]
  Env[HUMAN_TO / HUMAN_VIA] --> Recipient
  Config[Saved config] --> Recipient
  Recipient --> Request[Create human interaction]
  Request --> Wait[Wait for addressed human response]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312497%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12497&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fhuman%2FREADME.md%3A66%0A**Precedence%20claim%20conflicts%20with%20config**%0A%0AThe%20documented%20field-level%20fallback%20does%20not%20match%20%60resolveConfig%60%3A%20when%20%60NOVU_SECRET_KEY%60%20is%20set%2C%20it%20constructs%20a%20new%20configuration%20without%20the%20saved%20%60subscriberId%60%20or%20%60defaultChannel%60.%20As%20a%20result%2C%20leaving%20%60HUMAN_TO%60%20or%20%60HUMAN_VIA%60%20unset%20does%20not%20fall%20back%20to%20%60~%2F.novu%2Fhuman.json%60%3B%20the%20recipient%20can%20instead%20be%20reported%20as%20unconfigured%20and%20the%20saved%20default%20channel%20is%20ignored.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12497&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/human/README.md:66
**Precedence claim conflicts with config**

The documented field-level fallback does not match `resolveConfig`: when `NOVU_SECRET_KEY` is set, it constructs a new configuration without the saved `subscriberId` or `defaultChannel`. As a result, leaving `HUMAN_TO` or `HUMAN_VIA` unset does not fall back to `~/.novu/human.json`; the recipient can instead be reported as unconfigured and the saved default channel is ignored.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(human): env var support"](https://github.com/novuhq/novu/commit/a1b71ced149c6faa71f7eb1ceb6d5505c1dda108) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58387511)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->