### PR TITLE
fix(docs): update broken inbox docs link and ee licence directory info

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ npx novu@latest connect
 
 ## Embeddable Inbox component
 
-Using the Novu API and admin panel, you can easily add a real-time notification center to your web app without building it yourself. You can use our [React](https://docs.novu.co/inbox/react/get-started?utm_source=github&utm_medium=readme&utm_campaign=react-starter-link), or build your own via our API and SDK. React native, Vue, and Angular are coming soon.
+Using the Novu API and admin panel, you can easily add a real-time notification center to your web app without building it yourself. You can use our [React](https://docs.novu.co/platform/quickstart/react?utm_source=github&utm_medium=readme&utm_campaign=react-starter-link), or build your own via our API and SDK. React native, Vue, and Angular are coming soon.
 
 <div align="center">
 <img width="4800" height="2700" alt="Novu's Embeddable Inbox components" src="https://github.com/user-attachments/assets/00224c75-7ed0-4e19-b6fd-2a0bdced6258" />
 
-Read more about how to add a [notification center Inbox](https://docs.novu.co/inbox/react/get-started?utm_source=github&utm_medium=readme&utm_campaign=read-more-react-link) to your app.
+Read more about how to add a [notification center Inbox](https://docs.novu.co/platform/quickstart/react?utm_source=github&utm_medium=readme&utm_campaign=read-more-react-link) to your app.
 
 </div>
 
@@ -251,7 +251,7 @@ Expand a channel below to browse supported providers.
 
 | Provider |
 | --- |
-| [Novu Inbox](https://docs.novu.co/inbox/react/get-started?utm_source=github&utm_medium=repository&utm_campaign=inbox-channel-link) |
+| [Novu Inbox](https://docs.novu.co/platform/quickstart/react?utm_source=github&utm_medium=repository&utm_campaign=inbox-channel-link) |
 
 </details>
 
@@ -275,9 +275,7 @@ Novu is a commercial open source company, which means some parts of this open so
 
 The following modules and folders are licensed under the enterprise license:
 
-- `enterprise` folder at the root of the project and all of their subfolders and modules
-- `apps/web/src/ee` folder and all of their subfolders and modules
-- `apps/dashboard/src/ee` folder and all of their subfolders and modules
+- `enterprise` folder at the root of the project and all of its subfolders and modules
 
 ## 💪 Thanks to all of our contributors
 


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs three README links to point to the canonical React Inbox quickstart and updates the enterprise-license section to reflect the current directory layout.
- Replaces obsolete `/inbox/react/get-started` links with `/platform/quickstart/react`.
- Removes references to two EE directories that no longer exist.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The new documentation route is canonical, its tracking parameters remain intact, and the revised enterprise-license directory statement matches the current tree.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | The documentation links now target the registered React quickstart page, and the license-directory list matches the current repository structure. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;next&#39; into fix/update-ee-i..."](https://github.com/novuhq/novu/commit/57a99f26cb991699ca16989c5c5b5e226e03e0fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58533560)</sub>

<!-- /greptile_comment -->