### PR TITLE
fix(api-service): omit empty dynamicKey on fixed throttle steps fixes NV-8728

### DIFF
--- a/libs/application-generic/src/utils/sanitize-control-values.spec.ts
+++ b/libs/application-generic/src/utils/sanitize-control-values.spec.ts
@@ -58,4 +58,40 @@ describe('dashboardSanitizeControlValues', () => {
 
     expect(sanitized).not.toHaveProperty('editorType');
   });
+
+  it('omits an empty throttle dynamicKey for a fixed throttle', () => {
+    const sanitized = dashboardSanitizeControlValues(
+      logger,
+      { type: 'fixed', amount: 1, unit: 'hours', dynamicKey: '', threshold: 1, throttleKey: '{{payload.alertKey}}' },
+      StepTypeEnum.THROTTLE
+    );
+
+    expect(sanitized).toEqual({
+      type: 'fixed',
+      amount: 1,
+      unit: 'hours',
+      threshold: 1,
+      throttleKey: '{{payload.alertKey}}',
+    });
+  });
+
+  it('keeps an empty throttle dynamicKey for a dynamic throttle so the issue still surfaces', () => {
+    const sanitized = dashboardSanitizeControlValues(
+      logger,
+      { type: 'dynamic', dynamicKey: '', threshold: 1 },
+      StepTypeEnum.THROTTLE
+    );
+
+    expect(sanitized).toEqual({ type: 'dynamic', dynamicKey: '', threshold: 1 });
+  });
+
+  it('keeps a populated throttle dynamicKey regardless of type', () => {
+    const sanitized = dashboardSanitizeControlValues(
+      logger,
+      { type: 'fixed', amount: 1, unit: 'hours', dynamicKey: 'payload.timestamp' },
+      StepTypeEnum.THROTTLE
+    );
+
+    expect(sanitized).toEqual({ type: 'fixed', amount: 1, unit: 'hours', dynamicKey: 'payload.timestamp' });
+  });
 });

--- a/libs/application-generic/src/utils/sanitize-control-values.ts
+++ b/libs/application-generic/src/utils/sanitize-control-values.ts
@@ -16,6 +16,7 @@ import {
   LookBackWindowType,
   PushControlType,
   SmsControlType,
+  ThrottleControlType,
   ToolControlType,
 } from '../schemas/control';
 import { InAppActionType, InAppControlType } from '../schemas/control/in-app-control.schema';
@@ -253,6 +254,18 @@ function sanitizeDelay(controlValues: DelayControlType) {
   return filterNullishValues(controlValues);
 }
 
+/**
+ * A fixed throttle never reads `dynamicKey`, but the dashboard form still persists it as an empty
+ * string. The control schema keeps `dynamicKey` optional with `minLength: 1`, so a present-but-empty
+ * value fails validation and surfaces a "DynamicKey is required" issue on a correctly configured
+ * fixed throttle. Drop the unused key; a dynamic throttle keeps it so the issue still surfaces there.
+ */
+function sanitizeThrottle(controlValues: ThrottleControlType) {
+  const shouldDropDynamicKey = controlValues?.type !== 'dynamic' && isEmpty(controlValues?.dynamicKey);
+
+  return filterNullishValues(shouldDropDynamicKey ? { ...controlValues, dynamicKey: undefined } : controlValues);
+}
+
 function sanitizeLayout(controlValues: LayoutControlType) {
   return {
     email: filterNullishValues({
@@ -360,6 +373,9 @@ export function dashboardSanitizeControlValues(
         break;
       case StepTypeEnum.DELAY:
         normalizedValues = sanitizeDelay(controlValues as DelayControlType);
+        break;
+      case StepTypeEnum.THROTTLE:
+        normalizedValues = sanitizeThrottle(controlValues as ThrottleControlType);
         break;
       case 'layout':
         normalizedValues = sanitizeLayout(controlValues as LayoutControlType);


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes fixed-throttle validation by removing the dashboard’s unused empty `dynamicKey` before validating control values.
- Adds throttle-specific control-value sanitization.
- Preserves `dynamicKey` for dynamic throttles and whenever it is populated.
- Adds tests covering fixed, dynamic, empty, and populated values.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The sanitizer removes only an empty, unused field from non-dynamic throttle controls while preserving dynamic-throttle validation and populated keys.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/application-generic/src/utils/sanitize-control-values.ts | Adds narrowly scoped throttle sanitization that removes only empty dynamic keys from non-dynamic throttle controls. |
| libs/application-generic/src/utils/sanitize-control-values.spec.ts | Adds focused regression coverage for fixed and dynamic throttle control values. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): omit empty dynamicKey on fixed..."](https://github.com/novuhq/novu/commit/bc476e7ce0db78281435afef0d24008af72fa6cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58612904)</sub>

<!-- /greptile_comment -->