### PR TITLE
fix(api-service): Scope environment updates to API key environment fixes NV-8729

### DIFF
--- a/apps/api/src/app/environments-v1/e2e/update-environment-api-key-scope.e2e.ts
+++ b/apps/api/src/app/environments-v1/e2e/update-environment-api-key-scope.e2e.ts
@@ -45,7 +45,9 @@ describe('Update Environment API key environment scope - PUT /environments/:envi
     const {
       body: { data: environments },
     } = await session.testAgent.get('/v1/environments');
-    const production = environments.find((environment: { name: string }) => environment.name === EnvironmentEnum.PRODUCTION);
+    const production = environments.find(
+      (environment: { name: string }) => environment.name === EnvironmentEnum.PRODUCTION
+    );
 
     expect(production?._id, 'Expected Production environment').to.exist;
     expect(production._id).to.not.equal(session.environment._id);

--- a/apps/api/src/app/environments-v1/e2e/update-environment-api-key-scope.e2e.ts
+++ b/apps/api/src/app/environments-v1/e2e/update-environment-api-key-scope.e2e.ts
@@ -1,0 +1,109 @@
+import { EnvironmentRepository } from '@novu/dal';
+import { ApiServiceLevelEnum, EnvironmentEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe('Update Environment API key environment scope - PUT /environments/:environmentId #novu-v2', () => {
+  let session: UserSession;
+  const environmentRepository = new EnvironmentRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    await session.updateOrganizationServiceLevel(ApiServiceLevelEnum.BUSINESS);
+  });
+
+  it('should forbid updating a sibling environment via API key', async () => {
+    const {
+      body: { data: createdEnv },
+    } = await session.testAgent.post('/v1/environments').send({
+      name: 'Sibling Env To Update',
+      color: '#ff0000',
+    });
+
+    expect(createdEnv._id, 'Expected custom environment to be created').to.exist;
+
+    const { body } = await session.testAgent
+      .put(`/v1/environments/${createdEnv._id}`)
+      .set('authorization', `ApiKey ${session.apiKey}`)
+      .send({
+        identifier: 'compromised-sibling',
+        color: '#0000ff',
+        bridge: { url: 'https://attacker.example/api/novu' },
+      });
+
+    expect(body.statusCode).to.equal(403);
+    expect(body.message).to.contain('is scoped to a single environment');
+
+    const stored = await environmentRepository.findOne({ _id: createdEnv._id });
+    expect(stored?.identifier).to.not.equal('compromised-sibling');
+    expect(stored?.color).to.not.equal('#0000ff');
+    expect(stored?.bridge?.url || stored?.echo?.url || '').to.not.equal('https://attacker.example/api/novu');
+  });
+
+  it('should forbid updating Production via a Development API key', async () => {
+    const {
+      body: { data: environments },
+    } = await session.testAgent.get('/v1/environments');
+    const production = environments.find((environment: { name: string }) => environment.name === EnvironmentEnum.PRODUCTION);
+
+    expect(production?._id, 'Expected Production environment').to.exist;
+    expect(production._id).to.not.equal(session.environment._id);
+
+    const original = await environmentRepository.findOne({ _id: production._id });
+
+    const { body } = await session.testAgent
+      .put(`/v1/environments/${production._id}`)
+      .set('authorization', `ApiKey ${session.apiKey}`)
+      .send({
+        identifier: 'compromised-production',
+        bridge: { url: 'https://attacker.example/api/novu' },
+      });
+
+    expect(body.statusCode).to.equal(403);
+    expect(body.message).to.contain('is scoped to a single environment');
+
+    const stored = await environmentRepository.findOne({ _id: production._id });
+    expect(stored?.identifier).to.equal(original?.identifier);
+    expect(stored?.bridge?.url || '').to.equal(original?.bridge?.url || '');
+    expect(stored?.echo?.url || '').to.equal(original?.echo?.url || '');
+  });
+
+  it('should allow an API key to update its own environment', async () => {
+    const { status } = await session.testAgent
+      .put(`/v1/environments/${session.environment._id}`)
+      .set('authorization', `ApiKey ${session.apiKey}`)
+      .send({
+        identifier: 'own-env-via-api-key',
+        color: '#3366ff',
+      });
+
+    expect(status).to.equal(200);
+
+    const stored = await environmentRepository.findOne({ _id: session.environment._id });
+    expect(stored?.identifier).to.equal('own-env-via-api-key');
+    expect(stored?.color).to.equal('#3366ff');
+  });
+
+  it('should allow bearer auth to update a sibling environment in the same org', async () => {
+    const {
+      body: { data: createdEnv },
+    } = await session.testAgent.post('/v1/environments').send({
+      name: 'Bearer Updatable Env',
+      color: '#00ff00',
+    });
+
+    expect(createdEnv._id, 'Expected custom environment to be created').to.exist;
+
+    const { status } = await session.testAgent.put(`/v1/environments/${createdEnv._id}`).send({
+      identifier: 'bearer-updated-sibling',
+      color: '#112233',
+    });
+
+    expect(status).to.equal(200);
+
+    const stored = await environmentRepository.findOne({ _id: createdEnv._id });
+    expect(stored?.identifier).to.equal('bearer-updated-sibling');
+    expect(stored?.color).to.equal('#112233');
+  });
+});

--- a/apps/api/src/app/environments-v1/environments-v1.controller.ts
+++ b/apps/api/src/app/environments-v1/environments-v1.controller.ts
@@ -36,7 +36,7 @@ import { ApiKey } from '../shared/dtos/api-key';
 import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
 import { UserSession } from '../shared/framework/user.decorator';
-import { isEnvironmentScopedAuthScheme } from '../shared/utils/auth.utils';
+import { assertEnvironmentScopedAccess, isEnvironmentScopedAuthScheme } from '../shared/utils/auth.utils';
 import { CreateEnvironmentRequestDto } from './dtos/create-environment-request.dto';
 import { EnvironmentResponseDto } from './dtos/environment-response.dto';
 import { UpdateEnvironmentRequestDto } from './dtos/update-environment-request.dto';
@@ -190,6 +190,8 @@ export class EnvironmentsControllerV1 {
     @Param('environmentId') environmentId: string,
     @Body() payload: UpdateEnvironmentRequestDto
   ) {
+    assertEnvironmentScopedAccess(user.scheme, user.environmentId, environmentId);
+
     return await this.updateEnvironmentUsecase.execute(
       UpdateEnvironmentCommand.create({
         environmentId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Confirmed a cross-environment privilege escalation on `PUT /v1/environments/:environmentId`.

API keys authenticate to a **single** environment (`user.environmentId` from the key). `DELETE /v1/environments/:environmentId` already rejects sibling-environment targets for `API_KEY` / `KEYLESS`. `PUT` only scoped the Mongo write by `_organizationId`, so a Development API key could change Production (identifier, color, inbound parse domain, **bridge URL** used for workflow execution).

**Fix:** call `assertEnvironmentScopedAccess` on update, matching workflows, integrations, env-v2 diff, and the DELETE environment-scope check.

Bearer/session auth is unchanged (dashboard can still update sibling environments in the same org). An API key can still update **its own** environment.

Credit: Wenhao Wu, Southeast University.

Linear: [NV-8729](https://linear.app/novu/issue/NV-8729)

```mermaid
flowchart LR
  apiKey["API key (Development)"]
  put["PUT /v1/environments/:id"]
  guard["assertEnvironmentScopedAccess"]
  own["Own environment: allow"]
  sibling["Sibling / Production: 403"]
  apiKey --> put --> guard
  guard --> own
  guard --> sibling
```

### Test plan

- E2E: Development API key cannot update a custom sibling env or Production (including `bridge.url`); persisted documents unchanged
- E2E: API key can update its own environment
- E2E: Bearer auth can still update a sibling environment in the same org
- Existing update-environment e2e (SSRF + identifier/color) still uses session auth

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

This is the same class of bug as the recent DELETE environment-scope fix (`restrictToUserEnvironment`). PUT uses the shared `assertEnvironmentScopedAccess` helper instead of duplicating command flags.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d928f90-d1a2-465c-b421-1ed3acd26a20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d928f90-d1a2-465c-b421-1ed3acd26a20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR closes a cross-environment authorization gap in the environment update endpoint while preserving bearer-session access and own-environment API-key updates.
- Adds an environment-scope assertion before executing environment updates.
- Adds E2E coverage for sibling, Production, own-environment, and bearer-auth scenarios.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and correctly closes the cross-environment update path without breaking the documented legitimate flows.

The scope helper applies only to environment-scoped authentication, rejects mismatched target environments, permits matching API-key environments, and remains a no-op for bearer sessions; the added tests exercise each relevant branch.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/environments-v1/environments-v1.controller.ts | Adds the environment-scope authorization assertion at the correct boundary without restricting bearer-session updates. |
| apps/api/src/app/environments-v1/e2e/update-environment-api-key-scope.e2e.ts | Covers denied cross-environment API-key updates and confirms permitted own-environment and bearer-session behavior. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[PUT environment update] --> Guard[Assert environment-scoped access]
  Guard --> Scoped{API key or keyless?}
  Scoped -->|No| Update[Execute environment update]
  Scoped -->|Yes| Match{Target equals authenticated environment?}
  Match -->|Yes| Update
  Match -->|No| Forbidden[Return 403]
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): format environment API..."](https://github.com/novuhq/novu/commit/1a2c9f9b23ade4ce591b743f980ca38bcfa74f3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58631978)</sub>

<!-- /greptile_comment -->