### PR TITLE
fix(docs): restore agents page frontmatter and agent-chat redirects fixes NV-8730

### DIFF
--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -1,3 +1,4 @@
+---
 title: "Novu Connect - Agent Communication Infrastructure (ACI)"
 description: "Connect AI agents to Slack, Teams, WhatsApp, Telegram, and email. Route inbound messages, preserve conversation context, and deliver replies through Novu ACI."
 sidebarTitle: Overview

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1722,7 +1722,17 @@
       "permanent": true
     },
     {
+      "source": "/platform/integrations/chat/agent-chat",
+      "destination": "/agents/channels/web-chat",
+      "permanent": true
+    },
+    {
       "source": "/platform/integrations/chat/web-chat",
+      "destination": "/agents/channels/web-chat",
+      "permanent": true
+    },
+    {
+      "source": "/agents/agent-chat",
       "destination": "/agents/channels/web-chat",
       "permanent": true
     },
@@ -1732,8 +1742,33 @@
       "permanent": true
     },
     {
+      "source": "/agents/agent-chat/quickstart",
+      "destination": "/agents/channels/web-chat/quickstart",
+      "permanent": true
+    },
+    {
       "source": "/agents/web-chat/quickstart",
       "destination": "/agents/channels/web-chat/quickstart",
+      "permanent": true
+    },
+    {
+      "source": "/agents/channels/agent-chat",
+      "destination": "/agents/channels/web-chat",
+      "permanent": true
+    },
+    {
+      "source": "/agents/channels/agent-chat/quickstart",
+      "destination": "/agents/channels/web-chat/quickstart",
+      "permanent": true
+    },
+    {
+      "source": "/agents/channels/agent-chat/chat-ui",
+      "destination": "/agents/channels/web-chat/chat-ui",
+      "permanent": true
+    },
+    {
+      "source": "/agents/channels/agent-chat/rendering",
+      "destination": "/agents/channels/web-chat/chat-ui",
       "permanent": true
     },
     {
@@ -1742,13 +1777,28 @@
       "permanent": true
     },
     {
+      "source": "/agents/channels/agent-chat/production",
+      "destination": "/agents/channels/web-chat",
+      "permanent": true
+    },
+    {
       "source": "/agents/channels/web-chat/production",
       "destination": "/agents/channels/web-chat",
       "permanent": true
     },
     {
+      "source": "/agents/channels/agent-chat/messages",
+      "destination": "/agents/channels/web-chat/chat-ui",
+      "permanent": true
+    },
+    {
       "source": "/agents/channels/web-chat/messages",
       "destination": "/agents/channels/web-chat/chat-ui",
+      "permanent": true
+    },
+    {
+      "source": "/platform/sdks/react/hooks/use-agent-chat",
+      "destination": "/platform/sdks/react/hooks/use-web-chat",
       "permanent": true
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Fixes two docs regressions introduced by the Agent Chat → Web Chat rename in f64adeda56e862899d1949e9a87c284899b5a950 ([#12470](https://github.com/novuhq/novu/pull/12470)).

**1. `docs/agents.mdx` lost its opening `---`**

The rename commit dropped the opening frontmatter delimiter, so Mintlify never parsed the frontmatter block on https://docs.novu.co/agents. The page fell back to the file path for its title (H1 read "Agents") and rendered the `title:` / `description:` / `sidebarTitle:` lines as body prose right under the heading.

**2. `docs/docs.json` redirect *sources* were find/replaced**

The same commit rewrote `agent-chat` → `web-chat` inside existing redirect `source` values, which broke previously working public URLs and left the renamed pages without any redirect. Restored the old sources and added redirects for the renamed slugs:

| Source | Destination |
| --- | --- |
| `/platform/integrations/chat/agent-chat` | `/agents/channels/web-chat` |
| `/agents/agent-chat` | `/agents/channels/web-chat` |
| `/agents/agent-chat/quickstart` | `/agents/channels/web-chat/quickstart` |
| `/agents/channels/agent-chat` | `/agents/channels/web-chat` |
| `/agents/channels/agent-chat/quickstart` | `/agents/channels/web-chat/quickstart` |
| `/agents/channels/agent-chat/chat-ui` | `/agents/channels/web-chat/chat-ui` |
| `/agents/channels/agent-chat/rendering` | `/agents/channels/web-chat/chat-ui` |
| `/agents/channels/agent-chat/production` | `/agents/channels/web-chat` |
| `/agents/channels/agent-chat/messages` | `/agents/channels/web-chat/chat-ui` |
| `/platform/sdks/react/hooks/use-agent-chat` | `/platform/sdks/react/hooks/use-web-chat` |

The `web-chat` sources the rename commit introduced are kept as-is, so nothing that works today regresses.

## Verification

- Audited all 480 tracked `.mdx` files: every frontmatter block now opens with `---`, closes with `---`, and parses as a YAML mapping. `docs/agents.mdx` was the only broken page.
- `docs/docs.json` parses as valid JSON with no duplicate redirect sources (138 total).
- Rendered the page in a local `mint dev` preview, before and after the fix.

**Before** — raw YAML in the body, H1 is "Agents", sidebar entry is "Agents":

![docs/agents page rendering raw YAML frontmatter as body text](https://cursor.com/artifacts/c/art-508c51ca-5b2e-455c-a8d9-01756c90eee7)

**After** — H1 is the frontmatter title, description renders as the subtitle, sidebar entry is "Overview":

![docs/agents page rendering the parsed frontmatter title and description correctly](https://cursor.com/artifacts/c/art-84e6643c-56a1-4b8e-b7db-391aa2671484)

## Breaking changes

None. Docs-only.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GFC06JS3/p1788186340808059?thread_ts=1788186340.808059&cid=C06GFC06JS3)

<div><a href="https://cursor.com/agents/bc-9d4da852-35ba-5259-b43d-57ec9eaf74ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d4da852-35ba-5259-b43d-57ec9eaf74ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores valid frontmatter parsing for the agents landing page and repairs legacy Agent Chat URLs after the Web Chat rename.
- Adds the missing opening frontmatter delimiter to `docs/agents.mdx`.
- Adds permanent redirects from legacy `agent-chat` routes to existing `web-chat` documentation pages.
- Preserves the newer `web-chat` redirect sources.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The restored frontmatter delimiter is syntactically correct, and the added redirect sources are unique and point to existing documentation routes.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/agents.mdx | Restores the missing opening YAML frontmatter delimiter so Mintlify parses the page metadata correctly. |
| docs/docs.json | Adds unique legacy Agent Chat redirects whose destinations resolve to current Web Chat documentation pages. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): restore agent-chat redirect s..."](https://github.com/novuhq/novu/commit/1a15a0707196b3c82530812fb1842813301226f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58646159)</sub>

<!-- /greptile_comment -->