### PR TITLE
fix(novu): omit apiUrl in merged Web Chat scaffold for US Cloud fixes NV-8731

### DIFF
--- a/packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.spec.ts
@@ -42,6 +42,41 @@ describe('scaffoldWebChatProject', () => {
       })
     ).rejects.toThrow(/Invalid scaffold directory name/);
   });
+
+  it('does not hardcode localhost when merging Web Chat into an existing project', async () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'novu-web-chat-merge-'));
+    fs.writeFileSync(
+      path.join(projectDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'agent-app',
+          dependencies: {
+            '@novu/react': 'latest',
+            '@novu/js': 'latest',
+            'react-markdown': '^10.1.0',
+            'remark-gfm': '^4.0.1',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    await scaffoldWebChatProject({
+      parentDir: projectDir,
+      agentIdentifier: 'support-agent',
+      applicationIdentifier: 'app-id',
+      subscriberId: 'subscriber-id',
+      apiUrl: 'https://api.novu.co',
+      mergeIntoProjectDir: projectDir,
+      mergeAtRoot: true,
+    });
+
+    const page = fs.readFileSync(path.join(projectDir, 'app', 'page.tsx'), 'utf8');
+    expect(page).not.toContain('localhost:3000');
+    expect(page).toContain('...(apiUrl ? { apiUrl } : {})');
+    expect(page).toContain('...(socketUrl ? { socketUrl } : {})');
+  });
 });
 
 describe('resolveWebChatNovuDependencies', () => {

--- a/packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.ts
+++ b/packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.ts
@@ -246,11 +246,16 @@ const inter = Inter({ subsets: ['latin'], display: 'swap' });
 export default function WebChatPage() {
   const applicationIdentifier = process.env.NEXT_PUBLIC_NOVU_APP_ID ?? '';
   const subscriberId = process.env.NEXT_PUBLIC_NOVU_SUBSCRIBER_ID ?? '';
-  const apiUrl = process.env.NEXT_PUBLIC_NOVU_BACKEND_URL ?? 'http://localhost:3000';
+  const apiUrl = process.env.NEXT_PUBLIC_NOVU_BACKEND_URL;
   const socketUrl = process.env.NEXT_PUBLIC_NOVU_SOCKET_URL;
 
   return (
-    <NovuProvider applicationIdentifier={applicationIdentifier} subscriberId={subscriberId} apiUrl={apiUrl} socketUrl={socketUrl}>
+    <NovuProvider
+      applicationIdentifier={applicationIdentifier}
+      subscriberId={subscriberId}
+      {...(apiUrl ? { apiUrl } : {})}
+      {...(socketUrl ? { socketUrl } : {})}
+    >
       <main className={\`novu-web-chat web-chat-page \${inter.className}\`}>
         <WebChat />
       </main>


### PR DESCRIPTION
## Summary
- Fix merged Web Chat scaffold template so it no longer defaults `apiUrl` to `http://localhost:3000` when `NEXT_PUBLIC_NOVU_BACKEND_URL` is unset
- Pass `apiUrl` and `socketUrl` to `NovuProvider` only when connect wrote those env vars, matching US Cloud behavior and standalone scaffold intent
- Add regression test for merge-into-agent scaffold output

## Context
US Cloud connect intentionally omits `NEXT_PUBLIC_NOVU_BACKEND_URL`. The merge scaffold hardcoded localhost, causing inbox session init to fail with "Failed to initialize session". Standalone web-chat-only scaffold was unaffected because it bakes connect's `apiUrl` into `config.ts`.

## Test plan
- [x] `pnpm exec vitest run src/commands/connect/pipeline/web-chat/scaffold-web-chat.spec.ts`
- [ ] Publish `novu` CLI and re-scaffold agent + web chat on US Cloud; confirm session initializes without backend URL env vars


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects merged Web Chat scaffolds so absent backend and socket environment variables defer to the SDK’s US Cloud defaults instead of forcing localhost.
- Removes the generated localhost API fallback.
- Conditionally supplies custom API and socket URLs to `NovuProvider`.
- Adds regression coverage for merge-at-root scaffold output.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the generated endpoint behavior aligned to connect’s environment output and the SDK defaults.

Both merge destinations share the corrected template; US Cloud omissions resolve to the intended SDK defaults, while EU, local, and self-hosted endpoints remain explicitly forwarded.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.ts | Updates the merged page template to omit unset endpoint props, preserving explicit endpoints while allowing the SDK’s cloud defaults. |
| packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.spec.ts | Adds focused regression coverage confirming merged output no longer embeds localhost and conditionally passes endpoint props. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(novu): omit apiUrl in merged Web Cha..."](https://github.com/novuhq/novu/commit/509bef8319e3f658f0af31fb8c5d8096636a51ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58649209)</sub>

<!-- /greptile_comment -->