### PR TITLE
docs(web-chat): switch from closed beta to open Beta badge fixes DOC-438

### DIFF
--- a/docs/agents/channels/web-chat.mdx
+++ b/docs/agents/channels/web-chat.mdx
@@ -4,10 +4,6 @@ description: "Connect your agent to in-app Web Chat: a headless React hook, live
 sidebarTitle: Overview
 ---
 
-<Note>
-  Web Chat is in closed beta. Contact us at support@novu.co to get access.
-</Note>
-
 Web Chat is an ACI channel. The messaging surface is your product UI.
 
 The agent brain, conversation history, tool approval, and dashboard observability match other ACI channels. The React client is [`useWebChat`](/platform/sdks/react/hooks/use-web-chat) from `@novu/react`. You render the message list and the composer. There is no prebuilt `<WebChat />` component.

--- a/docs/agents/channels/web-chat/chat-ui.mdx
+++ b/docs/agents/channels/web-chat/chat-ui.mdx
@@ -4,10 +4,6 @@ description: "Web Chat client: state, parts, thinking, cards, approvals, custom 
 sidebarTitle: Chat UI
 ---
 
-<Note>
-  Web Chat is in closed beta. Contact us at support@novu.co to get access.
-</Note>
-
 Start from [Send a message](/agents/channels/web-chat/quickstart#send-a-message). This page covers everything after the first message.
 
 `messages` is the ordered timeline. Each message has `role` (`user` or `assistant`) and `parts`.

--- a/docs/agents/channels/web-chat/quickstart.mdx
+++ b/docs/agents/channels/web-chat/quickstart.mdx
@@ -4,10 +4,6 @@ description: "Install @novu/react, wrap NovuProvider, and use useWebChat to send
 sidebarTitle: Quickstart
 ---
 
-<Note>
-  Web Chat is in closed beta. Contact us at support@novu.co to get access.
-</Note>
-
 Build a two-way Web Chat in your React app. You supply the UI. Novu supplies conversation state, delivery, and the live socket.
 
 ## Prerequisites

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -469,6 +469,7 @@
               "agents/channels/email",
               {
                 "group": "Web Chat",
+                "tag": "Beta",
                 "root": "agents/channels/web-chat",
                 "pages": ["agents/channels/web-chat/quickstart", "agents/channels/web-chat/chat-ui"]
               }

--- a/docs/platform/sdks/react/hooks/use-web-chat.mdx
+++ b/docs/platform/sdks/react/hooks/use-web-chat.mdx
@@ -1,11 +1,8 @@
 ---
 title: "useWebChat"
 description: "API reference for the useWebChat hook: conversation state, sendMessage, retry, tool approval, live typing, and history pagination in the Novu React SDK."
+tag: Beta
 ---
-
-<Note>
-  Web Chat is in closed beta. Contact us at support@novu.co to get access.
-</Note>
 
 The `useWebChat` hook is the headless client for [Web Chat](/agents/channels/web-chat). It loads conversation history, sends messages, streams live turns over the socket, and exposes pending tool approvals.
 


### PR DESCRIPTION
## Summary
- Remove "closed beta — contact support@novu.co" callouts from Web Chat docs pages
- Add standard `Beta` sidebar tag on the Web Chat nav group and `useWebChat` hook page
- Web Chat is now documented as open beta, not private/closed beta

## Test plan
- [ ] Run Mintlify preview in `docs/` and confirm Web Chat sidebar shows **Beta**
- [ ] Confirm no "contact us for access" banner on Web Chat overview, quickstart, chat-ui, or useWebChat pages


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Web Chat documentation from closed beta to open beta.
- Removes closed-beta access notices from the overview, quickstart, Chat UI, and React hook pages.
- Adds Beta badges to the Web Chat navigation group and `useWebChat` reference page.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The changes consistently remove obsolete closed-beta notices and use supported Mintlify tag fields for the replacement Beta badges.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/agents/channels/web-chat.mdx | Removes the obsolete closed-beta access notice from the Web Chat overview. |
| docs/agents/channels/web-chat/chat-ui.mdx | Removes the obsolete closed-beta access notice from the Chat UI guide. |
| docs/agents/channels/web-chat/quickstart.mdx | Removes the obsolete closed-beta access notice from the Web Chat quickstart. |
| docs/docs.json | Adds a supported Beta tag to the Web Chat navigation group. |
| docs/platform/sdks/react/hooks/use-web-chat.mdx | Replaces the closed-beta notice with a supported Beta frontmatter tag. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(web-chat): switch from closed beta ..."](https://github.com/novuhq/novu/commit/177bfdf8b35d4848d13545aef9df360b971fd8ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58659814)</sub>

<!-- /greptile_comment -->