### PR TITLE
chore(api-service): lower high-volume info logs to debug fixes NV-8737

### DIFF
--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -420,7 +420,7 @@ export class ParseEventRequest {
 
     if (!command.skipQueueInsertion) {
       await this.workflowQueueService.add({ name: transactionId, data: jobData, groupId: command.organizationId });
-      this.logger.info(
+      this.logger.debug(
         { ...command, transactionId, discoveredWorkflowId: discoveredWorkflow?.workflowId },
         'Event dispatched to [Workflow] Queue'
       );

--- a/libs/application-generic/src/services/workflow-run.service.ts
+++ b/libs/application-generic/src/services/workflow-run.service.ts
@@ -911,7 +911,7 @@ export class WorkflowRunService {
     const channelJobs = jobs.filter((job) => job.type && ['in_app', 'email', 'sms', 'chat', 'push'].includes(job.type));
 
     const logResolution = (status: DeliveryLifecycleStatusEnum, extra?: Record<string, unknown>) => {
-      this.logger.info(
+      this.logger.debug(
         {
           notificationId,
           resolvedStatus: status,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

These `info` logs fire on every trigger / delivery-lifecycle resolution and were adding volume without being useful at production log level.

- `Event dispatched to [Workflow] Queue` → `debug`
- `Delivery lifecycle resolved` → `debug`

Linear: https://linear.app/novu/issue/NV-8737/lower-high-volume-info-logs-to-debug

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None. This change is main-repo only.

### Special notes for your reviewer

Billing usage logs (`Using MongoDB for billing usage query`, `MongoDB usage query cache status`) are in the enterprise submodule and are not part of this PR.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0c16ce9-7537-4b78-a982-add39ac696fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0c16ce9-7537-4b78-a982-add39ac696fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces production log volume for high-frequency workflow operations.
- Changes workflow queue-dispatch logging from info to debug.
- Changes delivery-lifecycle resolution logging from info to debug.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts | Lowers the successful workflow queue-dispatch log from info to debug without changing queue behavior. |
| libs/application-generic/src/services/workflow-run.service.ts | Lowers delivery-lifecycle resolution logs from info to debug without changing lifecycle calculation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(api-service): lower high-volume in..."](https://github.com/novuhq/novu/commit/86c2c6cf589aa5866e87612fdd9dc9865e4972ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58998470)</sub>

<!-- /greptile_comment -->