### PR TITLE
fix(js): deliver run-error to web chat subscribers fixes NV-8741

### DIFF
--- a/packages/js/src/web-chat/agent-conversation-runtime.test.ts
+++ b/packages/js/src/web-chat/agent-conversation-runtime.test.ts
@@ -160,6 +160,37 @@ describe('AgentConversationRuntime', () => {
     runtime.dispose();
   });
 
+  it('publishes a run-error to the snapshot and keeps it across a history load', async () => {
+    const runErrorEnvelope = {
+      version: 1,
+      conversationId: 'internal',
+      conversationIdentifier: 'conv_abcdefghijkl',
+      agentId: 'agent_1',
+      runId: 'run_1',
+      turnId: 'turn_1',
+      sequence: 1,
+      timestamp: '2026-08-07T12:00:00.000Z',
+      event: { type: 'run-error', message: 'agent handler failed', code: 'handler_failed' },
+    } as const;
+    getEvents.mockResolvedValue({ events: [], olderCursor: null });
+
+    const runtime = webChat.conversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
+    await runtime.load();
+
+    emitter.emit('web_chat.agent_event', { result: runErrorEnvelope });
+
+    expect(runtime.getSnapshot().run.isRunning).toBe(false);
+    expect(runtime.getSnapshot().error).toMatchObject({ message: 'agent handler failed' });
+
+    // A resumed runtime absorbs history into its own entry; the replayed run-error must survive.
+    getEvents.mockResolvedValue({ events: [runErrorEnvelope], olderCursor: null });
+    await runtime.load();
+
+    expect(runtime.getSnapshot().error).toMatchObject({ message: 'agent handler failed' });
+
+    runtime.dispose();
+  });
+
   it('replaces a stale resume runtime when the create-flow runtime registers', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 

--- a/packages/js/src/web-chat/agent-conversation-runtime.ts
+++ b/packages/js/src/web-chat/agent-conversation-runtime.ts
@@ -132,6 +132,7 @@ export class AgentConversationRuntime {
           isRecovering: data.isRecovering,
           catchUpError: data.catchUpError,
           conversationId: data.conversationId,
+          error: data.error,
           sessionStatus:
             this.#snapshot.status === 'loading' || this.#snapshot.status === 'fetching'
               ? this.#snapshot.status
@@ -230,6 +231,7 @@ export class AgentConversationRuntime {
           pagination: store?.pagination ?? storePagination(response.data.hasMore),
           isRecovering: store?.isRecovering ?? false,
           catchUpError: store?.catchUpError,
+          error: store?.error,
           conversationId: response.data.conversationId,
           sessionStatus: 'ready',
         },
@@ -276,6 +278,7 @@ export class AgentConversationRuntime {
         isRecovering: store?.isRecovering ?? this.#snapshot.isRecovering,
         catchUpError: store?.catchUpError,
         conversationId: store?.conversationId ?? this.#conversationId,
+        error: store?.error,
         sessionStatus: 'ready',
       });
     }
@@ -427,6 +430,7 @@ export class AgentConversationRuntime {
       isRecovering: boolean;
       catchUpError?: NovuError;
       conversationId?: string;
+      error?: NovuError;
       sessionStatus: AgentConversationSessionStatus;
     },
     meta?: AgentConversationPublicationMeta
@@ -446,7 +450,7 @@ export class AgentConversationRuntime {
         pendingActions: derivePendingActions([...args.messages]),
         isRecovering: args.isRecovering,
         catchUpError: args.catchUpError,
-        error: undefined,
+        error: args.error,
       },
       meta
     );


### PR DESCRIPTION
### What changed? Why was the change needed?

Agent run failures never reached SDK consumers.

`applyEnvelope` folds a `run-error` envelope into `state.error`, and `WebChat` emits it on `web_chat.messages.updated`. Then `AgentConversationRuntime#publishFromStore` hardcoded `error: undefined` and never read `data.error`, so the value was discarded before it reached `useWebChat`. `load()` omitted the field as well, so a history reload wiped any error that had survived.

The only way to observe a failed run today is to subscribe to raw envelopes through `onEvent`, which is exactly what `playground/web-chat` had to do.

This threads `error` through `#publishFromStore` and all three of its call sites: the live-envelope handler, `fetchMore()` and `load()`.

```mermaid
flowchart LR
  A[run-error envelope] --> B[applyEnvelope<br/>state.error]
  B --> C[WebChat emits<br/>messages.updated]
  C --> D[#publishFromStore]
  D -- before --> E[error: undefined<br/>dropped]
  D -- after --> F[error: data.error<br/>reaches useWebChat]
```

Linear: [NV-8741](https://linear.app/novu/issue/NV-8741/novujs-run-error-never-reaches-usewebchat-subscribers)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

**Test coverage.** One test in `agent-conversation-runtime.test.ts` covers both paths:

1. A live `run-error` envelope reaches `getSnapshot().error`.
2. A resumed runtime (`conversation({ agentId, conversationId })`, so `runtime.key === conversationId`) keeps that error across `load()`.

The second case is the one worth reading. For a resumed runtime, `absorbHistoryPage` folds history into the *same* store entry and `applyState` overwrites `entry.error`. History does replay `run-error` — `mapNewestFirstEventActivities` maps a `RUN_ERROR` activity to `{ type: 'run-error' }` — so the fold rebuilds it. The test pins that behaviour rather than assuming it. An earlier draft of the test created the runtime through `sendMessage`, which gives it a local key, so `load()` touched a different entry and the assertion passed for the wrong reason.

Verified by reverting the one-line `load()` fix and confirming the test goes red.

### Related work

Split out of [NV-8740](https://linear.app/novu/issue/NV-8740/playground-web-chat-drop-assistant-ui-force-fits) so the SDK fix ships on its own review. The playground PR deletes the `onEvent` workaround this fix makes unnecessary, so it should merge after this one.

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR propagates Web Chat run errors from the conversation store into runtime snapshots for live events, history loads, and pagination.
- Passes the authoritative store error through every `#publishFromStore` call site.
- Adds coverage showing a live run error reaches subscribers and survives history replay.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The changed runtime paths consistently publish the store-derived run error, while existing store reduction and pagination behavior preserve the latest conversation state without allowing older pages to overwrite it.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/js/src/web-chat/agent-conversation-runtime.ts | Consistently forwards the conversation store's error into runtime snapshots across live updates, load, and pagination. |
| packages/js/src/web-chat/agent-conversation-runtime.test.ts | Covers both live run-error publication and preservation when resumed conversation history is reloaded. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[run-error envelope] --> B[Conversation store error]
  B --> C[Messages updated event]
  C --> D[AgentConversationRuntime]
  D --> E[Subscriber snapshot error]
  B --> F[History reload]
  F --> D
```

<sub>Reviews (1): Last reviewed commit: ["fix(js): deliver run-error to web chat s..."](https://github.com/novuhq/novu/commit/5aeda42dbbe686519fe3406170b7e2d218284239) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59018607)</sub>

<!-- /greptile_comment -->