### PR TITLE
fix(js): stop MCP connect cards merging on history runId fixes NV-8752

### DIFF
--- a/packages/js/src/web-chat/apply-envelope.test.ts
+++ b/packages/js/src/web-chat/apply-envelope.test.ts
@@ -14,7 +14,11 @@ const BASE_IDS = {
   turnId: 'turn-1',
 } as const;
 
-function envelope(sequence: number, event: AgentEvent, overrides: Partial<typeof BASE_IDS> = {}): AgentEventEnvelope {
+function envelope(
+  sequence: number,
+  event: AgentEvent,
+  overrides: Partial<{ conversationId: string; agentId: string; runId: string; turnId: string }> = {}
+): AgentEventEnvelope {
   return {
     version: AGENT_EVENT_PROTOCOL_VERSION,
     sequence,
@@ -374,6 +378,63 @@ describe('applyEnvelope', () => {
       authorizeUrl: 'https://example.com/authorize',
       state: 'connected',
     });
+  });
+
+  it('does not merge a later MCP connection into an earlier one after run-finish', () => {
+    const historyRun = { runId: 'history' };
+    const state = applyEnvelopes(createInitialAgentConversationState(), [
+      envelope(1, {
+        type: 'message',
+        role: 'user',
+        messageId: 'u1',
+        content: { markdown: 'Find a Notion page' },
+      }),
+      envelope(
+        2,
+        {
+          type: 'mcp-connection-request',
+          actionId: 'sevt_notion',
+          mcpId: 'notion',
+          displayName: 'Notion',
+          authorizeUrl: 'https://example.com/notion',
+        },
+        historyRun
+      ),
+      envelope(3, {
+        type: 'message',
+        role: 'assistant',
+        messageId: 'm1',
+        content: { markdown: 'I do not have Notion connected yet.' },
+      }),
+      envelope(4, { type: 'run-finish', outcome: 'completed' }),
+      envelope(5, {
+        type: 'message',
+        role: 'user',
+        messageId: 'u2',
+        content: { markdown: 'retrieve last Linear task' },
+      }),
+      envelope(
+        6,
+        {
+          type: 'mcp-connection-request',
+          actionId: 'sevt_linear',
+          mcpId: 'linear',
+          displayName: 'Linear',
+          authorizeUrl: 'https://example.com/linear',
+        },
+        historyRun
+      ),
+    ]);
+
+    const notionMessage = state.messages.find((message) =>
+      message.parts.some((part) => part.type === 'mcp-connection' && part.mcpId === 'notion')
+    );
+    const linearMessage = state.messages.find((message) =>
+      message.parts.some((part) => part.type === 'mcp-connection' && part.mcpId === 'linear')
+    );
+
+    expect(linearMessage?.id).not.toBe(notionMessage?.id);
+    expect(linearMessage?.parts.filter((part) => part.type === 'mcp-connection')).toHaveLength(1);
   });
 
   it('folds durable user messages when role is user', () => {

--- a/packages/js/src/web-chat/apply-envelope.ts
+++ b/packages/js/src/web-chat/apply-envelope.ts
@@ -161,9 +161,11 @@ function applyEvent(state: AgentConversationState, envelope: AgentEventEnvelope)
     case 'tool-approval-response':
       return applyApprovalResponse(state, event.approvalId, event.decision);
 
-    case 'mcp-connection-request':
+    case 'mcp-connection-request': {
+      const messageId = state.activeAssistantMessageId ?? event.actionId;
+
       return clearTyping(
-        withActiveAssistantMessage(state, envelope, (message) => ({
+        withMessage(state, envelope, messageId, 'assistant', (message) => ({
           ...message,
           parts: [
             ...message.parts,
@@ -179,6 +181,7 @@ function applyEvent(state: AgentConversationState, envelope: AgentEventEnvelope)
           ],
         }))
       );
+    }
 
     case 'mcp-connection-result':
       return applyMcpConnectionResult(state, event.actionId, event.status, event.message);


### PR DESCRIPTION
## Summary
- Fix `apply-envelope` so orphan `mcp-connection-request` events use unique `actionId` as the message hang key instead of shared `runId: 'history'`
- Add regression test: Notion connect → `run-finish` → Linear connect must stay in separate assistant messages

## Context
After `run-finish`, `activeAssistantMessageId` is cleared. History envelopes from GET `/events` all use `runId: 'history'`, so later MCP connect cards were appended onto the first orphan connect message.

## Test plan
- [x] `pnpm exec jest src/web-chat/apply-envelope.test.ts -t "does not merge a later MCP"`
- [ ] Hard-refresh playground web-chat, request Notion then Linear — each connect card in its own message bubble

Linear: https://linear.app/novu/issue/NV-8752

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents orphan MCP connection requests from sharing the history run ID, keeping connection cards from separate runs in separate assistant messages.
- Uses each orphan request's unique action ID as its fallback message ID.
- Preserves grouping into the active assistant message when one exists.
- Adds regression coverage for MCP requests separated by a completed run.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the targeted history grouping defect corrected and covered by a regression test.

Orphan MCP requests now receive stable per-action message identities, while requests emitted during an active assistant message retain the existing grouping behavior; no concrete regression remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/js/src/web-chat/apply-envelope.ts | Changes orphan MCP request grouping from the shared run ID to the request action ID while preserving active-message grouping and action-based result updates. |
| packages/js/src/web-chat/apply-envelope.test.ts | Adds focused regression coverage proving that MCP connection cards on opposite sides of run completion remain in distinct messages. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    E[MCP connection request] --> A{Active assistant message?}
    A -->|Yes| M[Append card to active message]
    A -->|No| I[Use actionId as message ID]
    I --> N[Create or update independent assistant message]
    M --> C[Clear typing state]
    N --> C
```

<sub>Reviews (1): Last reviewed commit: ["fix(js): stop MCP connect cards merging ..."](https://github.com/novuhq/novu/commit/466b54750e7be7bf4f26f5cc313fa7804e2bddb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59035927)</sub>

<!-- /greptile_comment -->