### PR TITLE
fix(api-service): send agent email replies as markdown not branding cards fixes NV-8753

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -10,7 +10,7 @@ import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { extractCardPlainText } from '../../shared/util/card-plain-text.util';
 import { toDeliveryError } from '../../shared/util/delivery-error.util';
 import { esmImport } from '../../shared/util/esm-import';
-import { buildBrandedMarkdownReply, contentHasPoweredByWatermark } from '../../shared/util/novu-powered-by-watermark';
+import { brandOutboundMarkdownReply } from '../../shared/util/novu-powered-by-watermark';
 import { splitOversizedSlackText } from '../../shared/util/slack-section-limits';
 import { type AgentActionTokenBinding, AgentActionTokenService } from '../action-token/agent-action-token.service';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
@@ -899,29 +899,6 @@ export class OutboundGateway {
   }
 
   /**
-   * Wraps outbound markdown replies with a muted "Powered by Novu" footnote for
-   * organizations that have not removed Novu branding (free plan). Pro and above
-   * can disable it via the existing `removeNovuBranding` org setting, resolved
-   * once per delivery by `AgentConfigResolver`.
-   *
-   * Only plain markdown replies are branded — cards/action messages are left
-   * untouched.
-   */
-  private applyOutboundBranding(content: ChatSdkReplyContent, branding: OutboundBrandingContext): ChatSdkReplyContent {
-    if (content.card || !content.markdown || contentHasPoweredByWatermark(content.markdown)) {
-      return content;
-    }
-
-    if (branding.removeNovuBranding) {
-      return content;
-    }
-
-    const card = buildBrandedMarkdownReply(content.markdown, branding.agentIdentifier, branding.platform);
-
-    return { ...content, card, markdown: undefined };
-  }
-
-  /**
    * Single payload-construction chokepoint for adapter deliveries (post, DM,
    * edit). Branding is applied here so no delivery path can miss the watermark.
    */
@@ -929,7 +906,7 @@ export class OutboundGateway {
     content: ChatSdkReplyContent,
     branding: OutboundBrandingContext
   ): AdapterPostableMessage {
-    const deliveryContent = this.applyOutboundBranding(content, branding);
+    const deliveryContent = brandOutboundMarkdownReply(content, branding);
 
     if (deliveryContent.card) {
       return {

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
@@ -1,13 +1,18 @@
 import { expect } from 'chai';
+import type { CardElement } from 'chat';
 
 import { AgentPlatformEnum } from '../enums/agent-platform.enum';
 import {
+  appendPoweredByWatermarkToMarkdown,
+  brandOutboundMarkdownReply,
   buildBrandedMarkdownReply,
   buildPoweredByWatermark,
   contentHasPoweredByWatermark,
   NOVU_AGENT_POWERED_URL,
   NOVU_AGENT_POWERED_WATERMARK_TEXT,
 } from './novu-powered-by-watermark';
+
+type Reply = { markdown?: string; card?: CardElement };
 
 describe('novu-powered-by-watermark', () => {
   it('returns link-less text on WhatsApp', () => {
@@ -83,5 +88,74 @@ describe('novu-powered-by-watermark', () => {
     expect(contentHasPoweredByWatermark('Hello there')).to.equal(false);
     expect(contentHasPoweredByWatermark('Powered by Novu is a great product')).to.equal(false);
     expect(contentHasPoweredByWatermark('Hello\n\nPowered by Novu is great')).to.equal(false);
+  });
+
+  it('appends an attributed markdown footnote on EMAIL without wrapping in a card', () => {
+    const content: Reply = { markdown: 'Hello there' };
+    const branded = brandOutboundMarkdownReply(content, {
+      removeNovuBranding: false,
+      agentIdentifier: 'my-agent',
+      platform: AgentPlatformEnum.EMAIL,
+    });
+
+    expect(branded.card).to.equal(undefined);
+    expect(branded.markdown).to.include('Hello there');
+    expect(branded.markdown).to.include('Powered by [Novu](');
+    expect(branded.markdown).to.include(NOVU_AGENT_POWERED_URL);
+    expect(branded.markdown).to.include('utm_channel=email');
+    expect(contentHasPoweredByWatermark(branded.markdown as string)).to.equal(true);
+  });
+
+  it('does not append a second EMAIL footnote when the watermark is already present', () => {
+    const once = appendPoweredByWatermarkToMarkdown('Hello there', 'my-agent', AgentPlatformEnum.EMAIL);
+    const twice = appendPoweredByWatermarkToMarkdown(once, 'my-agent', AgentPlatformEnum.EMAIL);
+
+    expect(twice).to.equal(once);
+  });
+
+  it('still wraps Slack markdown replies in a branding card', () => {
+    const content: Reply = { markdown: 'Hello there' };
+    const branded = brandOutboundMarkdownReply(content, {
+      removeNovuBranding: false,
+      agentIdentifier: 'my-agent',
+      platform: AgentPlatformEnum.SLACK,
+    });
+
+    expect(branded.markdown).to.equal(undefined);
+    expect(branded.card).to.deep.equal(buildBrandedMarkdownReply('Hello there', 'my-agent', AgentPlatformEnum.SLACK));
+  });
+
+  it('leaves markdown unchanged when Novu branding is removed', () => {
+    const content: Reply = { markdown: 'Hello there' };
+    const branded = brandOutboundMarkdownReply(content, {
+      removeNovuBranding: true,
+      agentIdentifier: 'my-agent',
+      platform: AgentPlatformEnum.EMAIL,
+    });
+
+    expect(branded).to.equal(content);
+  });
+
+  it('leaves explicit cards unchanged', () => {
+    const content: Reply = { card: { type: 'card', children: [{ type: 'text', content: 'Approve?' }] } };
+    const branded = brandOutboundMarkdownReply(content, {
+      removeNovuBranding: false,
+      agentIdentifier: 'my-agent',
+      platform: AgentPlatformEnum.EMAIL,
+    });
+
+    expect(branded).to.equal(content);
+  });
+
+  it('leaves already-watermarked markdown unchanged', () => {
+    const markdown = appendPoweredByWatermarkToMarkdown('Hello there', 'my-agent', AgentPlatformEnum.EMAIL);
+    const content: Reply = { markdown };
+    const branded = brandOutboundMarkdownReply(content, {
+      removeNovuBranding: false,
+      agentIdentifier: 'my-agent',
+      platform: AgentPlatformEnum.EMAIL,
+    });
+
+    expect(branded).to.equal(content);
   });
 });

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
@@ -44,6 +44,47 @@ export function buildBrandedMarkdownReply(markdown: string, agentIdentifier: str
   };
 }
 
+export function appendPoweredByWatermarkToMarkdown(
+  markdown: string,
+  agentIdentifier: string,
+  platform: string
+): string {
+  if (contentHasPoweredByWatermark(markdown)) {
+    return markdown;
+  }
+
+  return `${markdown.trimEnd()}\n\n${buildPoweredByWatermark(agentIdentifier, platform)}`;
+}
+
+type BrandableMarkdownReply = {
+  markdown?: string;
+  card?: CardElement;
+};
+
+export function brandOutboundMarkdownReply<T extends BrandableMarkdownReply>(
+  content: T,
+  branding: { removeNovuBranding: boolean; agentIdentifier: string; platform: string }
+): T {
+  if (content.card || !content.markdown || contentHasPoweredByWatermark(content.markdown)) {
+    return content;
+  }
+
+  if (branding.removeNovuBranding) {
+    return content;
+  }
+
+  if (branding.platform === AgentPlatformEnum.EMAIL) {
+    return {
+      ...content,
+      markdown: appendPoweredByWatermarkToMarkdown(content.markdown, branding.agentIdentifier, branding.platform),
+    };
+  }
+
+  const card = buildBrandedMarkdownReply(content.markdown, branding.agentIdentifier, branding.platform);
+
+  return { ...content, card, markdown: undefined };
+}
+
 export function contentHasPoweredByWatermark(markdown: string): boolean {
   if (
     markdown.includes(ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX) ||


### PR DESCRIPTION
### What changed? Why was the change needed?

Free-tier agent markdown replies were converted into a Chat SDK **branding card** before send. On email that rendered as a bordered box with unparsed markdown, so the response was hard to read.

This keeps **EMAIL** replies as markdown and appends a `Powered by [Novu](...)` footnote. Slack/Teams/etc. still wrap markdown in a branding card. Explicit `Card()` replies, Pro orgs with `removeNovuBranding`, and workflow EMAIL steps are unchanged.

Linear: [NV-8753](https://linear.app/novu/issue/NV-8753/agent-email-replies-are-wrapped-in-a-card-and-hard-to-read)

```mermaid
flowchart TD
  reply["markdown or card reply"]
  brand["brandOutboundMarkdownReply"]
  emailMd["EMAIL: markdown plus footnote"]
  otherCard["other platforms: branding card"]
  skip["card or Pro: unchanged"]
  adapter["chat-adapter-email"]

  reply --> brand
  brand --> emailMd
  brand --> otherCard
  brand --> skip
  emailMd --> adapter
  otherCard --> adapter
  skip --> adapter
```

### Screenshots

N/A — HTML email layout; no dashboard UI change.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

Change is isolated to `brandOutboundMarkdownReply` in the API agent watermark util. Do not change `packages/chat-adapter-email` or Chat SDK — those would affect all cards/platforms.

</details>

## Test plan

- [ ] Unit: `novu-powered-by-watermark.spec.ts` (EMAIL footnote, Slack still cards, Pro/card/already-watermarked unchanged)
- [ ] Send a free-tier agent markdown reply over email — readable body, no bordered card, watermark at the bottom
- [ ] Send the same reply on Slack — still wrapped in a branding card
- [ ] Explicit `ctx.reply(Card(...))` on email still renders as a card
- [ ] Workflow EMAIL step still uses the existing template path (no adapter change)


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes free-tier agent email replies to remain markdown and appends the Novu attribution as a markdown footnote, while preserving card-based branding on other platforms and leaving explicit cards and unbranded replies unchanged.

- Extracts outbound reply branding into a shared utility.
- Routes email markdown through the email adapter’s existing markdown-to-HTML rendering path.
- Adds unit coverage for email, Slack, explicit cards, branding removal, and watermark idempotency.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The email adapter already parses markdown into HTML, and the changed utility preserves the existing branding behavior for non-email platforms, explicit cards, opted-out organizations, and previously branded content.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts | Adds platform-aware outbound branding, retaining markdown with a watermark for email while preserving card branding elsewhere. |
| apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts | Replaces the gateway-local branding implementation with the shared branding utility at the existing delivery chokepoint. |
| apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts | Covers email markdown attribution, non-email cards, branding opt-out, explicit cards, and duplicate-watermark prevention. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Outbound agent reply] --> B{Card or already branded?}
  B -->|Yes| C[Leave unchanged]
  B -->|No| D{Branding removed?}
  D -->|Yes| C
  D -->|No| E{Email platform?}
  E -->|Yes| F[Keep markdown and append attribution]
  E -->|No| G[Wrap markdown in branding card]
  F --> H[Build adapter message]
  G --> H
  C --> H
```

<sub>Reviews (1): Last reviewed commit: ["Brand outbound markdown per platform (em..."](https://github.com/novuhq/novu/commit/8aad5d22e330e03c343a4f4a570b10df028ac55d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59044487)</sub>

<!-- /greptile_comment -->