### PR TITLE
fix(react): create web chat runtime in useEffect not during render fixes NV-8743

### DIFF
--- a/packages/react/src/hooks/useWebChat.ts
+++ b/packages/react/src/hooks/useWebChat.ts
@@ -214,26 +214,6 @@ function getCreateFlowKey(agentId: string, agentHash?: string): string {
   return `${agentId}\0${agentHash ?? ''}`;
 }
 
-function resolveOwnedRuntime(args: {
-  novu: ReturnType<typeof useNovu>;
-  agentId: string;
-  agentHash?: string;
-  ownedRuntimeRef: MutableRefObject<OwnedRuntimeEntry | null>;
-}): AgentConversationRuntime | null {
-  const key = getCreateFlowKey(args.agentId, args.agentHash);
-  const current = args.ownedRuntimeRef.current;
-
-  if (current?.novu === args.novu && current.key === key) {
-    return current.runtime;
-  }
-
-  current?.runtime.dispose();
-
-  const runtime = args.novu.webChat.conversation({ agentId: args.agentId, agentHash: args.agentHash });
-  args.ownedRuntimeRef.current = { key, novu: args.novu, runtime };
-  return runtime;
-}
-
 type WebChatLoadState =
   | { novu: ReturnType<typeof useNovu>; status: 'loading' }
   | { novu: ReturnType<typeof useNovu>; status: 'ready' }
@@ -308,53 +288,60 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
   const agentHash = sharedRuntime ? undefined : props.agentHash;
 
   const ownedRuntimeRef = useRef<OwnedRuntimeEntry | null>(null);
+  const [managedRuntime, setManagedRuntime] = useState<AgentConversationRuntime | null>(null);
 
   useEffect(() => {
-    const current = ownedRuntimeRef.current;
-    if (current && current.novu !== novu) {
-      current.runtime.dispose();
-      ownedRuntimeRef.current = null;
-    }
-  }, [novu]);
-
-  const cachedRuntime = useMemo(() => {
-    if (!webChatReady) {
-      return null;
-    }
-
     if (sharedRuntime) {
-      return sharedRuntime;
+      ownedRuntimeRef.current?.runtime.dispose();
+      ownedRuntimeRef.current = null;
+      setManagedRuntime(null);
+
+      return;
     }
 
-    if (!conversationIdProp) {
-      return null;
+    if (!webChatReady) {
+      setManagedRuntime(null);
+
+      return;
     }
 
-    return novu.webChat.conversation({
-      agentId,
-      conversationId: conversationIdProp,
-      agentHash,
-    });
-  }, [webChatReady, sharedRuntime, novu, agentId, conversationIdProp, agentHash]);
+    if (conversationIdProp) {
+      ownedRuntimeRef.current?.runtime.dispose();
+      ownedRuntimeRef.current = null;
 
-  if (sharedRuntime || conversationIdProp) {
-    ownedRuntimeRef.current?.runtime.dispose();
-    ownedRuntimeRef.current = null;
-  }
+      const runtime = novu.webChat.conversation({
+        agentId,
+        conversationId: conversationIdProp,
+        agentHash,
+      });
+      setManagedRuntime(runtime);
 
-  const ownedRuntime =
-    !webChatReady || sharedRuntime || conversationIdProp
-      ? null
-      : resolveOwnedRuntime({ novu, agentId, agentHash, ownedRuntimeRef });
+      return () => {
+        setManagedRuntime(null);
+      };
+    }
 
-  const runtime = sharedRuntime ?? cachedRuntime ?? ownedRuntime;
+    const key = getCreateFlowKey(agentId, agentHash);
+    const current = ownedRuntimeRef.current;
 
-  useEffect(() => {
+    if (current?.novu === novu && current.key === key) {
+      setManagedRuntime(current.runtime);
+    } else {
+      current?.runtime.dispose();
+
+      const runtime = novu.webChat.conversation({ agentId, agentHash });
+      ownedRuntimeRef.current = { key, novu, runtime };
+      setManagedRuntime(runtime);
+    }
+
     return () => {
       ownedRuntimeRef.current?.runtime.dispose();
       ownedRuntimeRef.current = null;
+      setManagedRuntime(null);
     };
-  }, []);
+  }, [webChatReady, sharedRuntime, novu, agentId, conversationIdProp, agentHash]);
+
+  const runtime = sharedRuntime ?? managedRuntime;
 
   const loadNotifiedRef = useRef(false);
   const replayedActionsRef = useRef(false);

--- a/packages/react/src/hooks/useWebChat.ts
+++ b/packages/react/src/hooks/useWebChat.ts
@@ -325,35 +325,21 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
       return;
     }
 
-    if (conversationIdProp) {
-      ownedRuntimeRef.current?.runtime.dispose();
-      ownedRuntimeRef.current = null;
-
-      const key = getManagedRuntimeKey(agentId, agentHash, conversationIdProp);
-      const runtime = novu.webChat.conversation({
-        agentId,
-        conversationId: conversationIdProp,
-        agentHash,
-      });
-      setManagedRuntime({ key, runtime });
-
-      return () => {
-        setManagedRuntime(null);
-      };
-    }
-
-    const key = getCreateFlowKey(agentId, agentHash);
+    const key = getManagedRuntimeKey(agentId, agentHash, conversationIdProp);
     const current = ownedRuntimeRef.current;
 
+    let runtime: AgentConversationRuntime;
     if (current?.novu === novu && current.key === key) {
-      setManagedRuntime({ key, runtime: current.runtime });
+      runtime = current.runtime;
     } else {
       current?.runtime.dispose();
-
-      const runtime = novu.webChat.conversation({ agentId, agentHash });
+      runtime = conversationIdProp
+        ? novu.webChat.conversation({ agentId, conversationId: conversationIdProp, agentHash })
+        : novu.webChat.conversation({ agentId, agentHash });
       ownedRuntimeRef.current = { key, novu, runtime };
-      setManagedRuntime({ key, runtime });
     }
+
+    setManagedRuntime({ key, runtime });
 
     return () => {
       ownedRuntimeRef.current?.runtime.dispose();

--- a/packages/react/src/hooks/useWebChat.ts
+++ b/packages/react/src/hooks/useWebChat.ts
@@ -214,6 +214,23 @@ function getCreateFlowKey(agentId: string, agentHash?: string): string {
   return `${agentId}\0${agentHash ?? ''}`;
 }
 
+function getManagedRuntimeKey(
+  agentId: string,
+  agentHash: string | undefined,
+  conversationIdProp: string | undefined
+): string {
+  if (conversationIdProp) {
+    return `resume:${agentId}\0${agentHash ?? ''}\0${conversationIdProp}`;
+  }
+
+  return getCreateFlowKey(agentId, agentHash);
+}
+
+type ManagedRuntimeEntry = {
+  key: string;
+  runtime: AgentConversationRuntime;
+};
+
 type WebChatLoadState =
   | { novu: ReturnType<typeof useNovu>; status: 'loading' }
   | { novu: ReturnType<typeof useNovu>; status: 'ready' }
@@ -288,7 +305,10 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
   const agentHash = sharedRuntime ? undefined : props.agentHash;
 
   const ownedRuntimeRef = useRef<OwnedRuntimeEntry | null>(null);
-  const [managedRuntime, setManagedRuntime] = useState<AgentConversationRuntime | null>(null);
+  const [managedRuntime, setManagedRuntime] = useState<ManagedRuntimeEntry | null>(null);
+  const managedRuntimeKey = sharedRuntime
+    ? null
+    : getManagedRuntimeKey(agentId, agentHash, conversationIdProp);
 
   useEffect(() => {
     if (sharedRuntime) {
@@ -309,12 +329,13 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
       ownedRuntimeRef.current?.runtime.dispose();
       ownedRuntimeRef.current = null;
 
+      const key = getManagedRuntimeKey(agentId, agentHash, conversationIdProp);
       const runtime = novu.webChat.conversation({
         agentId,
         conversationId: conversationIdProp,
         agentHash,
       });
-      setManagedRuntime(runtime);
+      setManagedRuntime({ key, runtime });
 
       return () => {
         setManagedRuntime(null);
@@ -325,13 +346,13 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
     const current = ownedRuntimeRef.current;
 
     if (current?.novu === novu && current.key === key) {
-      setManagedRuntime(current.runtime);
+      setManagedRuntime({ key, runtime: current.runtime });
     } else {
       current?.runtime.dispose();
 
       const runtime = novu.webChat.conversation({ agentId, agentHash });
       ownedRuntimeRef.current = { key, novu, runtime };
-      setManagedRuntime(runtime);
+      setManagedRuntime({ key, runtime });
     }
 
     return () => {
@@ -341,7 +362,8 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
     };
   }, [webChatReady, sharedRuntime, novu, agentId, conversationIdProp, agentHash]);
 
-  const runtime = sharedRuntime ?? managedRuntime;
+  const runtime =
+    sharedRuntime ?? (managedRuntime?.key === managedRuntimeKey ? managedRuntime.runtime : null);
 
   const loadNotifiedRef = useRef(false);
   const replayedActionsRef = useRef(false);

--- a/playground/web-chat/src/lib/socket-status.ts
+++ b/playground/web-chat/src/lib/socket-status.ts
@@ -21,11 +21,7 @@ export function setSocketStatus(status: SocketStatus): void {
   if (status === current) return;
 
   current = status;
-  // useWebChat can connect() during render; notify after this turn so
-  // PlaygroundApp does not setState while WebChat is rendering.
-  queueMicrotask(() => {
-    listeners.forEach((listener) => listener(current));
-  });
+  listeners.forEach((listener) => listener(current));
 }
 
 export function subscribeSocketStatus(listener: Listener): () => void {


### PR DESCRIPTION
## Summary
- Move `AgentConversationRuntime` create and dispose in `useWebChat` from render into a `useEffect`, covering both create-flow and resume-flow (`conversationId` prop) paths
- Remove the playground `queueMicrotask` workaround in `socket-status.ts` now that `socket.connect.pending` no longer fires during render

## Test plan
- [x] Typecheck `@novu/react` passes
- [x] Manual: playground web-chat loads, connection pill tracks connecting → online
- [x] Manual: no React setState-during-render warning in console
- [x] Manual: send message and switch conversation still work


Made with [Cursor](https://cursor.com)





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves owned web-chat runtime creation and disposal into an effect, preventing runtime-side notifications during React rendering. It also removes the playground’s deferred socket-status notification workaround.
- Uses identity keys to prevent rendering a runtime belonging to previous conversation or agent props.
- Manages both new-conversation and resumed-conversation runtimes through one effect lifecycle.
- Restores synchronous socket-status listener notifications.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported stale-runtime render is prevented by requiring the managed runtime key to match the current props.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/hooks/useWebChat.ts | Moves runtime ownership into an effect and rejects stale runtime state immediately when conversation or agent identity changes. |
| playground/web-chat/src/lib/socket-status.ts | Removes microtask deferral because runtime connection notifications no longer occur during render. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant R as React render
  participant E as useWebChat effect
  participant C as Conversation runtime
  R->>R: Compute managed runtime key
  alt Existing runtime matches key
    E->>C: Reuse runtime
  else Identity changed
    E->>C: Dispose previous runtime
    E->>C: Create replacement runtime
  end
  E->>R: Publish managed runtime
  Note over R,C: Render accepts runtime only when keys match
  E-->>C: Dispose during cleanup
```

<sub>Reviews (3): Last reviewed commit: ["fix(react): unify runtime effect paths a..."](https://github.com/novuhq/novu/commit/65c97e744e2a92af2292fbc02ada96ca0379cfc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59047935)</sub>

<!-- /greptile_comment -->