### PR TITLE
fix(api-service): keep agent replies as markdown so channels render tables fixes NV-8756

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.branding.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.branding.spec.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { SLACK_MARKDOWN_TEXT_LIMIT } from '../../shared/util/slack-section-limits';
+import { OutboundGateway } from './outbound.gateway';
+import { OutboundDeliveryInfo } from './outbound-delivery-info.service';
+
+describe('OutboundGateway branding', () => {
+  function makeGateway() {
+    const logger = {
+      setContext: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+    };
+
+    const gateway = new OutboundGateway(
+      {} as any,
+      {} as any,
+      {} as any,
+      { prepareContentForDelivery: sinon.stub().callsFake(async (content) => content) } as any,
+      {} as any,
+      new OutboundDeliveryInfo(),
+      logger as any
+    );
+
+    return gateway;
+  }
+
+  const brandedSlack = {
+    removeNovuBranding: false,
+    agentIdentifier: 'my-agent',
+    platform: AgentPlatformEnum.SLACK,
+  };
+
+  const unbrandedSlack = {
+    removeNovuBranding: true,
+    agentIdentifier: 'my-agent',
+    platform: AgentPlatformEnum.SLACK,
+  };
+
+  it('keeps branded text replies on the markdown path instead of converting to a card', () => {
+    const gateway = makeGateway();
+
+    const postable = (gateway as any).buildAdapterPostableMessage({ markdown: 'Hello **world**' }, brandedSlack);
+
+    expect(postable.card).to.equal(undefined);
+    expect(postable.markdown).to.be.a('string');
+    expect(postable.markdown).to.include('Hello **world**');
+    expect(postable.markdown).to.include('Powered by [Novu](');
+    expect(postable.markdown).to.include('go.novu.co/agent-powered');
+  });
+
+  it('leaves cards untouched so approval and connect cards keep their structure', () => {
+    const gateway = makeGateway();
+    const card = {
+      type: 'card',
+      children: [
+        { type: 'text', content: 'Approve tool?' },
+        {
+          type: 'actions',
+          children: [{ type: 'button', id: 'approve', label: 'Approve' }],
+        },
+      ],
+    };
+
+    const postable = (gateway as any).buildAdapterPostableMessage({ card }, brandedSlack);
+
+    expect(postable.card).to.deep.equal(card);
+    expect(postable.markdown).to.equal(undefined);
+  });
+
+  it('skips the watermark when removeNovuBranding is enabled', () => {
+    const gateway = makeGateway();
+
+    const postable = (gateway as any).buildAdapterPostableMessage({ markdown: 'Hello **world**' }, unbrandedSlack);
+
+    expect(postable).to.deep.equal({ markdown: 'Hello **world**', files: undefined });
+  });
+
+  it('falls back to a split card when Slack markdown exceeds the markdown_text limit', () => {
+    const gateway = makeGateway();
+    const oversized = `x`.repeat(SLACK_MARKDOWN_TEXT_LIMIT + 1);
+
+    const postable = (gateway as any).buildAdapterPostableMessage({ markdown: oversized }, brandedSlack);
+
+    expect(postable.markdown).to.equal(undefined);
+    expect(postable.card).to.be.an('object');
+    expect(postable.card.type).to.equal('card');
+    expect(postable.card.children.length).to.be.greaterThan(1);
+    expect(postable.card.children.every((child: { type: string }) => child.type === 'text')).to.equal(true);
+    expect(
+      postable.card.children.every((child: { content: string }) => child.content.length <= 3000)
+    ).to.equal(true);
+  });
+});

--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -10,8 +10,8 @@ import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { extractCardPlainText } from '../../shared/util/card-plain-text.util';
 import { toDeliveryError } from '../../shared/util/delivery-error.util';
 import { esmImport } from '../../shared/util/esm-import';
-import { buildBrandedMarkdownReply, contentHasPoweredByWatermark } from '../../shared/util/novu-powered-by-watermark';
-import { splitOversizedSlackText } from '../../shared/util/slack-section-limits';
+import { appendPoweredByWatermark, contentHasPoweredByWatermark } from '../../shared/util/novu-powered-by-watermark';
+import { SLACK_MARKDOWN_TEXT_LIMIT, splitOversizedSlackText } from '../../shared/util/slack-section-limits';
 import { type AgentActionTokenBinding, AgentActionTokenService } from '../action-token/agent-action-token.service';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
 import { ChatInstanceRegistry, type ChatWithAdapters, type PlatformAdapters } from '../ingress/chat-instance.registry';
@@ -899,13 +899,9 @@ export class OutboundGateway {
   }
 
   /**
-   * Wraps outbound markdown replies with a muted "Powered by Novu" footnote for
-   * organizations that have not removed Novu branding (free plan). Pro and above
-   * can disable it via the existing `removeNovuBranding` org setting, resolved
-   * once per delivery by `AgentConfigResolver`.
-   *
-   * Only plain markdown replies are branded — cards/action messages are left
-   * untouched.
+   * Appends a "Powered by Novu" markdown footer for orgs that have not removed
+   * Novu branding. Pro and above can disable it via `removeNovuBranding`.
+   * Cards and action messages are left untouched.
    */
   private applyOutboundBranding(content: ChatSdkReplyContent, branding: OutboundBrandingContext): ChatSdkReplyContent {
     if (content.card || !content.markdown || contentHasPoweredByWatermark(content.markdown)) {
@@ -916,9 +912,10 @@ export class OutboundGateway {
       return content;
     }
 
-    const card = buildBrandedMarkdownReply(content.markdown, branding.agentIdentifier, branding.platform);
-
-    return { ...content, card, markdown: undefined };
+    return {
+      ...content,
+      markdown: appendPoweredByWatermark(content.markdown, branding.agentIdentifier, branding.platform),
+    };
   }
 
   /**
@@ -941,8 +938,20 @@ export class OutboundGateway {
       } as AdapterPostableMessage;
     }
 
+    const markdown = deliveryContent.markdown ?? '';
+
+    if (branding.platform === AgentPlatformEnum.SLACK && markdown.length > SLACK_MARKDOWN_TEXT_LIMIT) {
+      return {
+        card: splitOversizedSlackText({
+          type: 'card',
+          children: [{ type: 'text', content: markdown }],
+        }),
+        ...(deliveryContent.files?.length ? { files: deliveryContent.files } : {}),
+      } as AdapterPostableMessage;
+    }
+
     return {
-      markdown: deliveryContent.markdown ?? '',
+      markdown,
       files: deliveryContent.files,
     } as AdapterPostableMessage;
   }

--- a/apps/api/src/app/agents/e2e/agent-slack-roundtrip.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-slack-roundtrip.e2e.ts
@@ -250,7 +250,7 @@ describe('Agent Slack Roundtrip - emulate.dev #novu-v2', () => {
     expect(bridgeStub.calls.length, 'bridge executor invoked').to.be.gte(1);
 
     // Plain markdown replies from orgs without `removeNovuBranding` get the
-    // free-plan "Powered by Novu" watermark appended as the last line, so the
+    // free-plan "Powered by Novu" watermark appended as a markdown footer, so the
     // delivered text is no longer exactly the bridge reply.
     const replyMessage = await pollFor(async () => {
       const replies = await getThreadReplies(channel.id, threadTs);

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { AgentPlatformEnum } from '../enums/agent-platform.enum';
 import {
-  buildBrandedMarkdownReply,
+  appendPoweredByWatermark,
   buildPoweredByWatermark,
   contentHasPoweredByWatermark,
   NOVU_AGENT_POWERED_URL,
@@ -17,37 +17,35 @@ describe('novu-powered-by-watermark', () => {
     expect(watermark.length).to.be.greaterThan(NOVU_AGENT_POWERED_WATERMARK_TEXT.length);
   });
 
-  it('returns attributed Slack mrkdwn link on Slack with only Novu linked', () => {
+  it('returns italic attributed markdown link on Slack with only Novu linked', () => {
     const watermark = buildPoweredByWatermark('my-agent', AgentPlatformEnum.SLACK);
 
-    expect(watermark.startsWith('Powered by <')).to.equal(true);
-    expect(watermark).to.include('|Novu>');
-    expect(watermark).to.not.include('[Novu](');
+    expect(watermark.startsWith('_Powered by [Novu](')).to.equal(true);
+    expect(watermark.endsWith(')_')).to.equal(true);
+    expect(watermark).to.not.include('Powered by <');
+    expect(watermark).to.not.include('|Novu>');
     expect(watermark).to.include(NOVU_AGENT_POWERED_URL);
     expect(watermark).to.include('utm_source=my-agent');
     expect(watermark).to.include('utm_channel=slack');
   });
 
-  it('returns attributed markdown link on Teams with only Novu linked', () => {
+  it('returns italic attributed markdown link on Teams with only Novu linked', () => {
     const watermark = buildPoweredByWatermark('my-agent', AgentPlatformEnum.TEAMS);
 
-    expect(watermark.startsWith('Powered by [Novu](')).to.equal(true);
+    expect(watermark.startsWith('_Powered by [Novu](')).to.equal(true);
     expect(watermark).to.not.include('[Powered by Novu](');
     expect(watermark).to.include(NOVU_AGENT_POWERED_URL);
     expect(watermark).to.include('utm_source=my-agent');
     expect(watermark).to.include('utm_channel=teams');
   });
 
-  it('wraps markdown in a card with a muted watermark footnote', () => {
-    const card = buildBrandedMarkdownReply('Hello there', 'my-agent', AgentPlatformEnum.SLACK);
+  it('appends the watermark as a markdown footer', () => {
+    const branded = appendPoweredByWatermark('Hello there', 'my-agent', AgentPlatformEnum.SLACK);
 
-    expect(card.type).to.equal('card');
-    expect(card.children).to.have.length(2);
-    expect(card.children[0]).to.deep.equal({ type: 'text', content: 'Hello there' });
-    expect(card.children[1]?.type).to.equal('text');
-    expect((card.children[1] as { style?: string }).style).to.equal('muted');
-    expect((card.children[1] as { content?: string }).content).to.include('Powered by <');
-    expect((card.children[1] as { content?: string }).content).to.include('|Novu>');
+    expect(branded.startsWith('Hello there\n\n')).to.equal(true);
+    expect(branded).to.include('_Powered by [Novu](');
+    expect(branded).to.include(NOVU_AGENT_POWERED_URL);
+    expect(contentHasPoweredByWatermark(branded)).to.equal(true);
   });
 
   it('detects Slack mrkdwn watermark in markdown', () => {
@@ -58,6 +56,12 @@ describe('novu-powered-by-watermark', () => {
 
   it('detects attributed watermark in markdown', () => {
     const markdown = `Hello\n\nPowered by [Novu](${NOVU_AGENT_POWERED_URL}?utm_campaign=agent-powered)`;
+
+    expect(contentHasPoweredByWatermark(markdown)).to.equal(true);
+  });
+
+  it('detects italic attributed watermark in markdown', () => {
+    const markdown = `Hello\n\n_Powered by [Novu](${NOVU_AGENT_POWERED_URL}?utm_campaign=agent-powered)_`;
 
     expect(contentHasPoweredByWatermark(markdown)).to.equal(true);
   });

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
@@ -1,5 +1,4 @@
-import type { CardElement } from 'chat';
-import { AgentPlatformEnum, supportsMarkdownLinks } from '../enums/agent-platform.enum';
+import { supportsMarkdownLinks } from '../enums/agent-platform.enum';
 import { buildAttributedNovuUrl } from './novu-attribution-url';
 
 export const NOVU_AGENT_POWERED_URL = 'https://go.novu.co/agent-powered';
@@ -10,17 +9,10 @@ const NOVU_POWERED_WATERMARK_MARKER = '\u200B';
 
 const ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `Powered by [Novu](${NOVU_AGENT_POWERED_URL}`;
 
+// Previous Slack card path used mrkdwn (`<url|Novu>`). Keep detecting it so we don't double-stamp.
 const SLACK_ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `Powered by <${NOVU_AGENT_POWERED_URL}`;
 
 const LEGACY_ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `[${NOVU_AGENT_POWERED_WATERMARK_TEXT}](${NOVU_AGENT_POWERED_URL}`;
-
-function formatPoweredByLink(label: string, url: string, platform: string): string {
-  if (platform === AgentPlatformEnum.SLACK) {
-    return `<${url}|${label}>`;
-  }
-
-  return `[${label}](${url})`;
-}
 
 export function buildPoweredByWatermark(agentIdentifier: string, platform: string): string {
   if (!supportsMarkdownLinks(platform)) {
@@ -29,19 +21,13 @@ export function buildPoweredByWatermark(agentIdentifier: string, platform: strin
 
   const url = buildAttributedNovuUrl(NOVU_AGENT_POWERED_URL, 'agent-powered', agentIdentifier, platform);
 
-  return `Powered by ${formatPoweredByLink('Novu', url, platform)}`;
+  return `_Powered by [Novu](${url})_`;
 }
 
-export function buildBrandedMarkdownReply(markdown: string, agentIdentifier: string, platform: string): CardElement {
+export function appendPoweredByWatermark(markdown: string, agentIdentifier: string, platform: string): string {
   const watermark = buildPoweredByWatermark(agentIdentifier, platform);
 
-  return {
-    type: 'card',
-    children: [
-      { type: 'text', content: markdown },
-      { type: 'text', content: watermark, style: 'muted' },
-    ],
-  };
+  return `${markdown}\n\n${watermark}`;
 }
 
 export function contentHasPoweredByWatermark(markdown: string): boolean {

--- a/apps/api/src/app/agents/shared/util/slack-section-limits.ts
+++ b/apps/api/src/app/agents/shared/util/slack-section-limits.ts
@@ -7,6 +7,9 @@ import type { CardElement } from 'chat';
  */
 const SLACK_SECTION_TEXT_LIMIT = 3000;
 
+/** Slack `markdown_text` limit; oversize payloads are rejected rather than truncated. */
+export const SLACK_MARKDOWN_TEXT_LIMIT = 12_000;
+
 function pack(parts: string[], separator: string, limit: number, splitPart: (part: string) => string[]): string[] {
   const chunks: string[] = [];
   let current = '';

--- a/packages/chat-adapter-sendblue/src/adapter.spec.ts
+++ b/packages/chat-adapter-sendblue/src/adapter.spec.ts
@@ -70,6 +70,16 @@ describe('SendblueAdapterImpl', () => {
       expect(postMessage).toHaveBeenNthCalledWith(2, 'sendblue:t', { markdown: 'Hello world' });
     });
 
+    it('keeps attachments when converting markdown to plain text', async () => {
+      const postMessage = spyOnVendorPostMessage();
+      const adapter = new SendblueAdapterImpl(CONFIG);
+      const files = [{ name: 'photo.png', mimeType: 'image/png', data: Buffer.from('img') }];
+
+      await adapter.postMessage('sendblue:t', { markdown: 'See **this**', files } as never);
+
+      expect(postMessage).toHaveBeenCalledWith('sendblue:t', { markdown: 'See this', files });
+    });
+
     it('converts markdown tables and links before handing off to the vendor', async () => {
       const postMessage = spyOnVendorPostMessage();
       const adapter = new SendblueAdapterImpl(CONFIG);

--- a/packages/chat-adapter-sendblue/src/adapter.spec.ts
+++ b/packages/chat-adapter-sendblue/src/adapter.spec.ts
@@ -59,7 +59,7 @@ describe('SendblueAdapterImpl', () => {
   });
 
   describe('postMessage', () => {
-    it('passes plain text and markdown through to the vendor unchanged', async () => {
+    it('passes plain text through and converts markdown to plain text for iMessage/SMS', async () => {
       const postMessage = spyOnVendorPostMessage();
       const adapter = new SendblueAdapterImpl(CONFIG);
 
@@ -67,7 +67,23 @@ describe('SendblueAdapterImpl', () => {
       await adapter.postMessage('sendblue:t', { markdown: 'Hello **world**' });
 
       expect(postMessage).toHaveBeenNthCalledWith(1, 'sendblue:t', 'hello');
-      expect(postMessage).toHaveBeenNthCalledWith(2, 'sendblue:t', { markdown: 'Hello **world**' });
+      expect(postMessage).toHaveBeenNthCalledWith(2, 'sendblue:t', { markdown: 'Hello world' });
+    });
+
+    it('converts markdown tables and links before handing off to the vendor', async () => {
+      const postMessage = spyOnVendorPostMessage();
+      const adapter = new SendblueAdapterImpl(CONFIG);
+
+      await adapter.postMessage('sendblue:t', {
+        markdown: ['See [docs](https://example.com).', '', '| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n'),
+      });
+
+      const delivered = postMessage.mock.calls[0]?.[1] as { markdown: string };
+      expect(delivered.markdown).toContain('docs (https://example.com)');
+      expect(delivered.markdown).toContain('1');
+      expect(delivered.markdown).toContain('2');
+      expect(delivered.markdown).not.toContain('| ---');
+      expect(delivered.markdown).not.toContain('[docs]');
     });
 
     it('flattens a bare card to markdown text, since the vendor adapter cannot render cards', async () => {

--- a/packages/chat-adapter-sendblue/src/adapter.spec.ts
+++ b/packages/chat-adapter-sendblue/src/adapter.spec.ts
@@ -115,6 +115,19 @@ describe('SendblueAdapterImpl', () => {
       });
     });
 
+    it('keeps attachments posted alongside a card', async () => {
+      const postMessage = spyOnVendorPostMessage();
+      const adapter = new SendblueAdapterImpl(CONFIG);
+      const files = [{ name: 'receipt.pdf', mimeType: 'application/pdf', data: Buffer.from('pdf') }];
+
+      await adapter.postMessage('sendblue:t', {
+        card: { type: 'card', children: [{ type: 'text', content: 'Your order shipped' }] },
+        files,
+      } as never);
+
+      expect(postMessage).toHaveBeenCalledWith('sendblue:t', { markdown: 'Your order shipped', files });
+    });
+
     it('prefers an explicit fallbackText over rendering the card', async () => {
       const postMessage = spyOnVendorPostMessage();
       const adapter = new SendblueAdapterImpl(CONFIG);

--- a/packages/chat-adapter-sendblue/src/adapter.ts
+++ b/packages/chat-adapter-sendblue/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { Adapter, AdapterPostableMessage, CardElement, RawMessage } from 'chat';
+import type { Adapter, AdapterPostableMessage, CardElement, FileUpload, RawMessage } from 'chat';
 import {
   type SendblueMessagePayload,
   type SendblueThreadId,
@@ -103,7 +103,8 @@ export class SendblueAdapterImpl extends VendorSendblueAdapter {
    * its buttons already stripped by `adaptApprovalContentForReplyBasedPlatform`)
    * renders to an empty string and is silently skipped. Prefer the card's own
    * `fallbackText` when the caller provided one, otherwise flatten it via
-   * `renderCardAsText`.
+   * `renderCardAsText`. Any `files` posted alongside the card are carried over,
+   * since the vendor adapter uploads them for `{ markdown }` postables too.
    */
   private flattenCard(message: AdapterPostableMessage): AdapterPostableMessage {
     if (typeof message === 'string') {
@@ -118,7 +119,11 @@ export class SendblueAdapterImpl extends VendorSendblueAdapter {
     }
 
     const fallbackText = typeof record.fallbackText === 'string' ? record.fallbackText : undefined;
+    const files = Array.isArray(record.files) ? (record.files as FileUpload[]) : undefined;
 
-    return { markdown: fallbackText ?? renderCardAsText(card) };
+    return {
+      markdown: fallbackText ?? renderCardAsText(card),
+      ...(files?.length ? { files } : {}),
+    };
   }
 }

--- a/packages/chat-adapter-sendblue/src/adapter.ts
+++ b/packages/chat-adapter-sendblue/src/adapter.ts
@@ -5,6 +5,7 @@ import {
   SendblueAdapter as VendorSendblueAdapterRuntime,
 } from 'chat-adapter-sendblue';
 import { renderCardAsText } from './card-renderer.js';
+import { markdownToPlainText } from './markdown-to-plain-text.js';
 import type { SendblueAdapterConfig } from './types.js';
 
 // iMessage-first with SMS fallback matches Sendblue's own delivery behavior;
@@ -78,7 +79,22 @@ export class SendblueAdapterImpl extends VendorSendblueAdapter {
     threadId: string,
     message: AdapterPostableMessage
   ): Promise<RawMessage<SendblueMessagePayload>> {
-    return super.postMessage(threadId, this.flattenCard(message));
+    return super.postMessage(threadId, this.preparePostable(message));
+  }
+
+  private preparePostable(message: AdapterPostableMessage): AdapterPostableMessage {
+    const flattened = this.flattenCard(message);
+
+    if (typeof flattened === 'string') {
+      return flattened;
+    }
+
+    const record = flattened as unknown as Record<string, unknown>;
+    if (typeof record.markdown === 'string') {
+      return { markdown: markdownToPlainText(record.markdown) };
+    }
+
+    return flattened;
   }
 
   /**

--- a/packages/chat-adapter-sendblue/src/adapter.ts
+++ b/packages/chat-adapter-sendblue/src/adapter.ts
@@ -91,7 +91,7 @@ export class SendblueAdapterImpl extends VendorSendblueAdapter {
 
     const record = flattened as unknown as Record<string, unknown>;
     if (typeof record.markdown === 'string') {
-      return { markdown: markdownToPlainText(record.markdown) };
+      return { ...flattened, markdown: markdownToPlainText(record.markdown) };
     }
 
     return flattened;

--- a/packages/chat-adapter-sendblue/src/markdown-to-plain-text.spec.ts
+++ b/packages/chat-adapter-sendblue/src/markdown-to-plain-text.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { markdownToPlainText } from './markdown-to-plain-text.js';
+
+describe('markdownToPlainText', () => {
+  it('converts a GFM table to an ASCII table', () => {
+    const plain = markdownToPlainText(
+      ['| Provider | Count |', '| --- | --- |', '| Slack | 61 |', '| Email | 46 |'].join('\n')
+    );
+
+    expect(plain).toContain('Provider');
+    expect(plain).toContain('Count');
+    expect(plain).toContain('Slack');
+    expect(plain).toContain('61');
+    expect(plain).toContain('Email');
+    expect(plain).toContain('46');
+    expect(plain).not.toContain('| ---');
+  });
+
+  it('converts markdown links to label (url) form', () => {
+    const plain = markdownToPlainText('See [the docs](https://example.com/path) for details.');
+
+    expect(plain).toBe('See the docs (https://example.com/path) for details.');
+  });
+
+  it('strips common markdown decorations while preserving structure', () => {
+    const plain = markdownToPlainText('## Report\n\nHello **world** and _team_.\n\nThanks!');
+
+    expect(plain).toBe('Report\n\nHello world and team.\n\nThanks!');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(markdownToPlainText('')).toBe('');
+  });
+});

--- a/packages/chat-adapter-sendblue/src/markdown-to-plain-text.ts
+++ b/packages/chat-adapter-sendblue/src/markdown-to-plain-text.ts
@@ -1,0 +1,57 @@
+import {
+  isLinkNode,
+  isTableNode,
+  parseMarkdown,
+  stringifyMarkdown,
+  tableToAscii,
+  toPlainText,
+  walkAst,
+} from 'chat';
+
+function stripMarkdownDecorators(markdown: string): string {
+  return markdown
+    .replace(/^```[^\n]*\n([\s\S]*?)^```/gm, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/__(.+?)__/g, '$1')
+    .replace(/(?<!\w)\*(?!\*)([^*\n]+?)\*(?!\*)/g, '$1')
+    .replace(/(?<!\w)_(?!_)([^_\n]+?)_(?!_)/g, '$1')
+    .replace(/~~(.+?)~~/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/^>\s?/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '• ')
+    .replace(/\\([\\`*_{}[\]()#+\-.!:|])/g, '$1')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/** Convert markdown to iMessage/SMS plain text: ASCII tables, `label (url)` links, no decorations. */
+export function markdownToPlainText(markdown: string): string {
+  if (!markdown) {
+    return '';
+  }
+
+  const ast = parseMarkdown(markdown);
+  const transformed = walkAst(structuredClone(ast), (node) => {
+    if (isTableNode(node)) {
+      return {
+        type: 'code',
+        value: tableToAscii(node),
+        lang: undefined,
+      };
+    }
+
+    if (isLinkNode(node)) {
+      const label = toPlainText({ type: 'root', children: node.children ?? [] }).trim();
+
+      return {
+        type: 'text',
+        value: label ? `${label} (${node.url})` : node.url,
+      };
+    }
+
+    return node;
+  });
+
+  return stripMarkdownDecorators(stringifyMarkdown(transformed));
+}


### PR DESCRIPTION
## Summary

- Free-tier “Powered by Novu” branding wrapped every agent markdown reply in a Chat SDK **card**. Card `text` children skip each adapter’s markdown pipeline, so Slack, email, Telegram, and others showed literal `##`, `|---|`, and `[text](url)`.
- Keep branded replies on `{ markdown }` and append the watermark as a markdown footer. Approval/connect cards are unchanged.
- Slack replies over `markdown_text`’s 12k limit fall back to the existing split-card path. Sendblue/iMessage converts markdown to plain text (ASCII tables, `label (url)` links).

Linear: [NV-8756](https://linear.app/novu/issue/NV-8756/agent-markdown-replies-render-as-raw-pipes-and-headings-on-slack-email)

```mermaid
flowchart TD
  md["Agent markdown reply"]
  brand{"removeNovuBranding?"}
  footer["Append markdown watermark footer"]
  card["Approval / connect card"]
  slackLimit{"Slack and length over 12k?"}
  adapters["Chat SDK adapters"]
  native["Native tables headings links"]
  split["Split-card fallback"]

  md --> brand
  brand -->|"no"| footer --> slackLimit
  brand -->|yes| slackLimit
  card --> adapters
  slackLimit -->|no| adapters --> native
  slackLimit -->|yes| split --> adapters
```

## Test plan

- [ ] Send a free-tier agent reply with a GFM table and headings on Slack — table should render, not raw pipes.
- [ ] Same reply over email — HTML body, not a card wrapping raw markdown.
- [ ] Telegram / Teams / WhatsApp — markdown converted by each adapter, not raw `|---|`.
- [ ] Tool-approval and connect cards still post as cards with buttons.
- [ ] Sendblue/iMessage — tables as ASCII, links as `label (url)`.
- [ ] Slack reply over 12k characters still delivers (split card) instead of being rejected.
- [ ] Unit specs: watermark, Slack 12k fallback, branding gateway, Sendblue plain-text conversion.


Made with [Cursor](https://cursor.com)





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR keeps ordinary agent replies on adapters’ native markdown paths while retaining card handling for structured interactions and Slack’s oversized-message fallback.
- Appends free-tier branding as a markdown footer instead of wrapping replies in cards.
- Converts Sendblue markdown into plain text suitable for iMessage and SMS.
- Preserves files while normalizing both markdown and card postables.
- Adds regression coverage for branding, Slack limits, Sendblue formatting, and attachment preservation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; both previously reported attachment-loss paths now preserve files and have targeted regression coverage.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts | Keeps branded replies as markdown and retains files when using Slack’s oversized split-card fallback. |
| apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts | Replaces card-based branding with an italic markdown footer while retaining legacy watermark detection. |
| packages/chat-adapter-sendblue/src/adapter.ts | Converts markdown to plain text while preserving postable fields and explicitly carries files through card flattening. |
| packages/chat-adapter-sendblue/src/markdown-to-plain-text.ts | Converts tables and links into plain-text representations and strips common markdown decoration. |
| packages/chat-adapter-sendblue/src/adapter.spec.ts | Covers both previously reported attachment-loss paths and Sendblue markdown normalization. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Agent reply] --> B{Card reply?}
  B -->|Yes| C[Preserve card structure]
  B -->|No| D[Keep markdown reply]
  D --> E{Branding enabled?}
  E -->|Yes| F[Append markdown watermark]
  E -->|No| G[Use original markdown]
  F --> H{Slack payload over 12k?}
  G --> H
  H -->|Yes| I[Split into card text sections]
  H -->|No| J[Adapter markdown pipeline]
  J --> K{Sendblue?}
  K -->|Yes| L[Convert to plain text and preserve files]
  K -->|No| M[Render channel-native markdown]
```

<sub>Reviews (3): Last reviewed commit: ["Preserve files when flattening cards for..."](https://github.com/novuhq/novu/commit/5b765bce85ee85dd64da73ba90596e0a6fb805c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59078238)</sub>

<!-- /greptile_comment -->