### PR TITLE
fix(inbound-mail): handle envelope addresses without a domain

### DIFF
--- a/apps/inbound-mail/src/server/address-utils.spec.ts
+++ b/apps/inbound-mail/src/server/address-utils.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+
+import { extractEmailDomain } from './address-utils';
+
+describe('extractEmailDomain', () => {
+  it('returns the domain after the first @', () => {
+    expect(extractEmailDomain('user@domain.com')).to.equal('domain.com');
+  });
+
+  it('returns everything after the first @ when several @ are present', () => {
+    expect(extractEmailDomain('user@sub@domain.com')).to.equal('sub@domain.com');
+  });
+
+  it('returns null for an address with no @ instead of throwing', () => {
+    /*
+     * RFC 5321 allows a domain-less envelope address such as <postmaster>.
+     * The previous `/@(.*)/.exec(email)[1]` threw a TypeError on the null match,
+     * which surfaced as an unhandled error during address validation.
+     */
+    expect(extractEmailDomain('postmaster')).to.equal(null);
+  });
+
+  it('returns an empty string when the address ends with @', () => {
+    expect(extractEmailDomain('user@')).to.equal('');
+  });
+});

--- a/apps/inbound-mail/src/server/address-utils.ts
+++ b/apps/inbound-mail/src/server/address-utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns the domain portion of an email address (everything after the first
+ * `@`), or `null` when the address has no `@` at all.
+ *
+ * SMTP envelope addresses are attacker-controlled and RFC 5321 allows a
+ * domain-less address such as `<postmaster>`, so callers must handle the `null`
+ * case rather than assuming a match is always present.
+ */
+export function extractEmailDomain(email: string): string | null {
+  const match = /@(.*)/.exec(email);
+
+  return match ? match[1] : null;
+}

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -14,6 +14,7 @@ import { SMTPServer } from 'smtp-server';
 import util from 'util';
 import { v4 as uuidv4 } from 'uuid';
 
+import { extractEmailDomain } from './address-utils';
 import { uploadAttachmentsToS3 } from './attachment-uploader';
 import { collectClientIpSources } from './client-ip-sources';
 import { InboundMailService } from './inbound-mail.service';
@@ -134,7 +135,7 @@ class Mailin extends events.EventEmitter {
             return reject(new Error(localErrorMessage));
           }
 
-          const domain = /@(.*)/.exec(email)[1];
+          const domain = extractEmailDomain(email);
 
           const validateViaLocal = () => {
             if (_this.listeners(validateEvent).length) {
@@ -153,6 +154,11 @@ class Mailin extends events.EventEmitter {
           };
 
           const validateViaDNS = () => {
+            if (domain === null) {
+              _this.emit(validationFailedEvent, email);
+
+              return reject(new Error(dnsErrorMessage));
+            }
             try {
               dns.resolveMx(domain, (err, addresses) => {
                 if (err || !addresses || !addresses.length) {


### PR DESCRIPTION
## What

`validateAddress` in `apps/inbound-mail/src/server/index.ts` derived the domain like this:

```ts
const domain = /@(.*)/.exec(email)[1];
```

When `email` has no `@`, `exec` returns `null`, so `null[1]` throws `TypeError: Cannot read properties of null (reading '1')`. The outer `try/catch` then rejects with that raw `TypeError` instead of a normal SMTP rejection.

This is reachable from untrusted inbound SMTP traffic: envelope addresses are attacker-controlled and RFC 5321 explicitly allows a domain-less address such as `<postmaster>`. The empty-address case is already guarded above (`if (!email)`), but a non-empty address with no `@` was not. It also broke the local-validation path (`disableDNSValidation`), which does not use the domain at all, because the crash happened before that branch.

Reproduction:

```js
/@(.*)/.exec('postmaster')[1]  // TypeError: Cannot read properties of null (reading '1')
/@(.*)/.exec('user@domain.com')[1]  // 'domain.com'
```

## Fix

Extract the domain through a small helper, `extractEmailDomain`, that returns `null` when there is no `@`, and guard the DNS path:

```ts
const domain = extractEmailDomain(email);
// ...
const validateViaDNS = () => {
  if (domain === null) {
    _this.emit(validationFailedEvent, email);
    return reject(new Error(dnsErrorMessage));
  }
  // dns.resolveMx(domain, ...)
};
```

A domain-less address now gets the existing `Domain not found` rejection on the DNS path rather than a `TypeError`, and local validation keeps working for it since that path only needs `email`. Behavior for every address that contains an `@` is unchanged.

## Tests

Added `address-utils.spec.ts` covering `extractEmailDomain`: a normal address, several `@`, the no-`@` case that used to crash (`postmaster` -> `null`), and a trailing `@`. Verified the four assertions and the old crash locally; the inbound-mail integration suite needs Redis so it runs in CI.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents domain-less SMTP envelope addresses from throwing during domain extraction while preserving local validation behavior.
- Adds a null-aware `extractEmailDomain` helper and focused unit coverage.
- Rejects domain-less addresses with the existing domain-not-found error when DNS validation is enabled.
- Allows local validation to process domain-less addresses without requiring a domain.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/inbound-mail/src/server/index.ts | Replaces unsafe regex indexing with null-aware extraction and cleanly rejects missing domains only on the DNS-validation path. |
| apps/inbound-mail/src/server/address-utils.ts | Adds a small helper that preserves existing extraction semantics while returning null when no at-sign exists. |
| apps/inbound-mail/src/server/address-utils.spec.ts | Covers normal, multiple-at-sign, domain-less, and empty-domain extraction cases. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(inbound-mail): handle envelope addre..."](https://github.com/novuhq/novu/commit/e7a32b810e0ad01b9339c902bbf9937b11d9d75a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59177358)</sub>

<!-- /greptile_comment -->