### PR TITLE
feat(react): add startNewConversation to useWebChat so new chats do not remount fixes NV-8744

### DIFF
--- a/packages/react/src/hooks/useWebChat.ts
+++ b/packages/react/src/hooks/useWebChat.ts
@@ -120,6 +120,11 @@ export type UseWebChatResult = {
     data?: SendMessageResult;
     error?: NovuError | WebChatPlanLimitError;
   }>;
+  /**
+   * Start a new empty chat for the current `agentId`. The next `sendMessage` creates the server conversation.
+   * No-op when `conversationId` or `conversation` is provided.
+   */
+  startNewConversation: () => void;
 };
 
 const EMPTY_SERVER_SNAPSHOT = {
@@ -217,13 +222,14 @@ function getCreateFlowKey(agentId: string, agentHash?: string): string {
 function getManagedRuntimeKey(
   agentId: string,
   agentHash: string | undefined,
-  conversationIdProp: string | undefined
+  conversationIdProp: string | undefined,
+  createEpoch: number
 ): string {
   if (conversationIdProp) {
     return `resume:${agentId}\0${agentHash ?? ''}\0${conversationIdProp}`;
   }
 
-  return getCreateFlowKey(agentId, agentHash);
+  return `${getCreateFlowKey(agentId, agentHash)}\0${createEpoch}`;
 }
 
 type ManagedRuntimeEntry = {
@@ -306,9 +312,10 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
 
   const ownedRuntimeRef = useRef<OwnedRuntimeEntry | null>(null);
   const [managedRuntime, setManagedRuntime] = useState<ManagedRuntimeEntry | null>(null);
+  const [createEpoch, setCreateEpoch] = useState(0);
   const managedRuntimeKey = sharedRuntime
     ? null
-    : getManagedRuntimeKey(agentId, agentHash, conversationIdProp);
+    : getManagedRuntimeKey(agentId, agentHash, conversationIdProp, createEpoch);
 
   useEffect(() => {
     if (sharedRuntime) {
@@ -319,13 +326,13 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
       return;
     }
 
-    if (!webChatReady) {
+    if (!webChatReady || !managedRuntimeKey) {
       setManagedRuntime(null);
 
       return;
     }
 
-    const key = getManagedRuntimeKey(agentId, agentHash, conversationIdProp);
+    const key = managedRuntimeKey;
     const current = ownedRuntimeRef.current;
 
     let runtime: AgentConversationRuntime;
@@ -346,7 +353,7 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
       ownedRuntimeRef.current = null;
       setManagedRuntime(null);
     };
-  }, [webChatReady, sharedRuntime, novu, agentId, conversationIdProp, agentHash]);
+  }, [webChatReady, sharedRuntime, novu, agentId, conversationIdProp, agentHash, createEpoch, managedRuntimeKey]);
 
   const runtime =
     sharedRuntime ?? (managedRuntime?.key === managedRuntimeKey ? managedRuntime.runtime : null);
@@ -483,6 +490,13 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
     (messageId: string) => callRuntime((target) => target.retryMessage(messageId)),
     [callRuntime]
   );
+  const startNewConversation = useCallback(() => {
+    if (sharedRuntime || conversationIdProp) {
+      return;
+    }
+
+    setCreateEpoch((epoch) => epoch + 1);
+  }, [sharedRuntime, conversationIdProp]);
 
   return {
     messages: [...snapshot.messages],
@@ -502,5 +516,6 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
     respondToAction,
     sendAction,
     retryMessage,
+    startNewConversation,
   };
 };

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -98,6 +98,7 @@ export function useWebChat(_: UseWebChatProps): UseWebChatResult {
     respondToAction: () => Promise.resolve({ data: undefined, error: undefined }),
     sendAction: () => Promise.resolve({ data: undefined, error: undefined }),
     retryMessage: () => Promise.resolve({ data: undefined, error: undefined }),
+    startNewConversation: () => {},
   };
 }
 

--- a/playground/web-chat/src/app/playground.tsx
+++ b/playground/web-chat/src/app/playground.tsx
@@ -37,7 +37,6 @@ function PlaygroundApp() {
       <SdkEventBridge />
       <main className="workbench">
         <WebChat
-          key={session.sessionKey}
           conversationId={session.conversationId}
           onAssistantMessage={reloadConversations}
           threadList={{

--- a/playground/web-chat/src/components/web-chat.tsx
+++ b/playground/web-chat/src/components/web-chat.tsx
@@ -106,6 +106,7 @@ export function WebChat({
     catchUpError,
     refetch,
     typing,
+    startNewConversation,
   } = useWebChat({
     agentId: config.agentId,
     conversationId,
@@ -166,9 +167,12 @@ export function WebChat({
       threads: mapConversationsToThreadData(threadList.items),
       isLoading: threadList.isLoading,
       onSwitchToThread: threadList.onSwitchToThread,
-      onSwitchToNewThread: threadList.onSwitchToNewThread,
+      onSwitchToNewThread: () => {
+        startNewConversation();
+        threadList.onSwitchToNewThread();
+      },
     };
-  }, [activeThreadId, threadList]);
+  }, [activeThreadId, threadList, startNewConversation]);
 
   return (
     <WebChatRuntimeProvider

--- a/playground/web-chat/src/hooks/use-playground-session.ts
+++ b/playground/web-chat/src/hooks/use-playground-session.ts
@@ -2,34 +2,19 @@
 
 import { useCallback, useState } from 'react';
 
-/**
- * Playground-only: which conversation the page is showing.
- *
- * `useWebChat` remounts when `sessionKey` changes so a new chat / thread switch
- * gets a fresh hook instance (the hook keys off the `conversationId` prop + mount).
- */
+/** Playground-only: which conversation the page is showing. */
 export function usePlaygroundSession() {
-  const [sessionKey, setSessionKey] = useState(0);
   const [conversationId, setConversationId] = useState<string | undefined>();
 
-  const remount = useCallback((nextId?: string) => {
-    setConversationId(nextId);
-    setSessionKey((key) => key + 1);
+  const onNewChat = useCallback(() => {
+    setConversationId(undefined);
   }, []);
 
-  const onNewChat = useCallback(() => {
-    remount(undefined);
-  }, [remount]);
-
-  const onSelectConversation = useCallback(
-    (identifier: string) => {
-      remount(identifier);
-    },
-    [remount],
-  );
+  const onSelectConversation = useCallback((identifier: string) => {
+    setConversationId(identifier);
+  }, []);
 
   return {
-    sessionKey,
     conversationId,
     onNewChat,
     onSelectConversation,


### PR DESCRIPTION
## Summary
- Add `startNewConversation()` on `useWebChat` so a create-flow hook can dispose its owned runtime and open a second empty chat without remounting.
- No-op when `conversationId` or a shared `conversation` runtime is provided.
- Playground New chat calls the method and drops `sessionKey` / `key=`. Selecting a thread still only sets `conversationId`.

```mermaid
flowchart TD
  A[startNewConversation] --> B{conversationId prop or shared runtime?}
  B -->|yes| C[no-op]
  B -->|no| D[createEpoch + 1]
  D --> E[effect rebuilds managed runtime key]
  E --> F[dispose owned runtime]
  F --> G["conversation({ agentId, agentHash })"]
```

## Test plan
- [ ] Open playground, send a message, click New chat twice. Second click is empty.
- [ ] From an existing thread, click New chat. Timeline is empty. Next send creates a server conversation.
- [ ] Select an existing conversation. History loads. `WebChat` does not remount.
- [ ] Typecheck `@novu/react` after `pnpm build` for `packages/`.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds `startNewConversation()` to the React Web Chat hook so callers can replace an owned create-flow runtime without remounting the component.
- Adds epoch-based lifecycle management for owned create-flow runtimes.
- Keeps the browser and server hook result contracts aligned.
- Updates the playground to reset or select conversations through state and runtime transitions rather than React keys.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The managed runtime key changes correctly reset owned create-flow runtimes, conversationId transitions replace resumed runtimes without remounting, and both public hook implementations expose the new method.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/hooks/useWebChat.ts | Adds the public reset action and epoch-based owned-runtime replacement while preserving shared and resumed runtime ownership. |
| packages/react/src/server/index.tsx | Keeps the server-safe hook result synchronized by providing a no-op implementation of the new action. |
| playground/web-chat/src/app/playground.tsx | Removes component remounting through the session key so conversation changes use the hook lifecycle. |
| playground/web-chat/src/components/web-chat.tsx | Connects the New Thread action to both runtime reset and playground session reset. |
| playground/web-chat/src/hooks/use-playground-session.ts | Simplifies playground session state to track only the selected conversation identifier. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[New chat selected] --> B{Shared runtime or conversationId provided?}
  B -->|Yes| C[Hook method is a no-op]
  B -->|No| D[Increment create epoch]
  C --> E[Playground clears conversationId]
  D --> F[Managed runtime key changes]
  E --> F
  F --> G[Dispose owned runtime]
  G --> H[Create empty managed runtime]
  H --> I[Next message creates server conversation]
```

<sub>Reviews (1): Last reviewed commit: ["feat(react): add startNewConversation to..."](https://github.com/novuhq/novu/commit/f33381d57ad2f69af5093cdf07240009e116edd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59444413)</sub>

<!-- /greptile_comment -->