### PR TITLE
docs(react): document that useWebChat mutations never throw fixes NV-8751

### DIFF
--- a/docs/agents/channels/web-chat/chat-ui.mdx
+++ b/docs/agents/channels/web-chat/chat-ui.mdx
@@ -22,6 +22,22 @@ Use these fields to drive the UI. See [`useWebChat`](/platform/sdks/react/hooks/
 
 See [Reconnect](#reconnect) (`isRecovering`, `catchUpError`). See [Older messages](#older-messages) (`pagination`).
 
+## Errors
+
+`error` in the table above is the last failure (load, send, retry, or action). Show that message.
+
+`sendMessage`, `respondToAction`, `sendAction`, and `retryMessage` do not throw. A `try/catch` around them will not run.
+
+To react to one call, wait for the result and read `error`:
+
+```tsx
+const result = await sendMessage(text);
+
+if (result.error) {
+  // this send failed
+}
+```
+
 ## Parts
 
 Start with `type === 'text'`. Then handle the other part types. See [`useWebChat`](/platform/sdks/react/hooks/use-web-chat) for part types.

--- a/docs/agents/channels/web-chat/quickstart.mdx
+++ b/docs/agents/channels/web-chat/quickstart.mdx
@@ -151,10 +151,6 @@ export default function App() {
 
 Omit `conversationId` to start a new chat. The first successful send creates the conversation.
 
-<Note>
-  `sendMessage` does not throw. Failures show in the `error` paragraph above the list. See [Errors](/agents/channels/web-chat/chat-ui#errors) to handle one send.
-</Note>
-
 See [Chat UI](/agents/channels/web-chat/chat-ui) for parts, retry, resume, and reconnect.
 
 ## Next steps

--- a/docs/agents/channels/web-chat/quickstart.mdx
+++ b/docs/agents/channels/web-chat/quickstart.mdx
@@ -151,6 +151,10 @@ export default function App() {
 
 Omit `conversationId` to start a new chat. The first successful send creates the conversation.
 
+<Note>
+  `sendMessage` does not throw. Failures show in the `error` paragraph above the list. See [Errors](/agents/channels/web-chat/chat-ui#errors) to handle one send.
+</Note>
+
 See [Chat UI](/agents/channels/web-chat/chat-ui) for parts, retry, resume, and reconnect.
 
 ## Next steps

--- a/packages/react/src/hooks/useWebChat.ts
+++ b/packages/react/src/hooks/useWebChat.ts
@@ -67,7 +67,11 @@ export type UseWebChatProps = UseWebChatCallbacks &
       }
   );
 
-/** State and actions returned by {@link useWebChat}. */
+/**
+ * State and actions returned by {@link useWebChat}.
+ * `sendMessage`, `respondToAction`, `sendAction`, and `retryMessage` resolve `{ data, error }` and never reject.
+ * Inspect `error` on the result, or show hook `error`.
+ */
 export type UseWebChatResult = {
   /** Conversation timeline. */
   messages: AgentMessage[];
@@ -75,7 +79,7 @@ export type UseWebChatResult = {
   pendingActions: AgentPendingAction[];
   /** Server conversation id after create or resume. */
   conversationId?: string;
-  /** Last error from load, send, retry, or action. */
+  /** Last error from load, send, retry, or action. Mutations also return `{ error }` for that call. */
   error?: NovuError | WebChatPlanLimitError;
   /** True while Web Chat loads and, for an existing conversation, until the first history fetch completes. */
   isLoading: boolean;
@@ -100,22 +104,34 @@ export type UseWebChatResult = {
   catchUpError?: NovuError;
   /** Reload the newest history page. No-op when there is no conversation id. */
   refetch: () => Promise<void>;
-  /** Send a user message. `input` is a string, or `{ text, metadata }`. Creates a conversation when `conversationId` is omitted. */
+  /**
+   * Send a user message. `input` is a string, or `{ text, metadata }`. Creates a conversation when `conversationId` is omitted.
+   * Does not throw. Resolves `{ data, error }`. Inspect `error` on the result, or show hook `error`.
+   */
   sendMessage: (input: SendMessageInput) => Promise<{
     data?: SendMessageResult;
     error?: NovuError | WebChatPlanLimitError;
   }>;
-  /** Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. */
+  /**
+   * Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`.
+   * Does not throw. Resolves `{ data, error }`. Inspect `error` on the result, or show hook `error`.
+   */
   respondToAction: (args: { actionId: string; decision: AgentToolApprovalDecision }) => Promise<{
     data?: RespondToActionResult;
     error?: NovuError | WebChatPlanLimitError;
   }>;
-  /** Click a Card button. Do not use this for tool approval. */
+  /**
+   * Click a Card button. Do not use this for tool approval.
+   * Does not throw. Resolves `{ data, error }`. Inspect `error` on the result, or show hook `error`.
+   */
   sendAction: (args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{
     data?: SendActionResult;
     error?: NovuError | WebChatPlanLimitError;
   }>;
-  /** Resend a message whose `status` is `failed`. Reuses the original idempotency key. */
+  /**
+   * Resend a message whose `status` is `failed`. Reuses the original idempotency key.
+   * Does not throw. Resolves `{ data, error }`. Inspect `error` on the result, or show hook `error`.
+   */
   retryMessage: (messageId: string) => Promise<{
     data?: SendMessageResult;
     error?: NovuError | WebChatPlanLimitError;


### PR DESCRIPTION
## Summary
- `sendMessage`, `respondToAction`, `sendAction`, and `retryMessage` already resolve `{ data, error }` and never reject. TSDoc on `UseWebChatResult` and each mutation now says that, so hover/go-to-type shows callers they must inspect `error`.
- Chat UI gets a new `## Errors` section after `## State` with one `await` + `if (result.error)` example. Quickstart keeps the install path and adds a `<Note>` that points there.
- No signature change. Playground fire-and-forget call sites stay as-is.

Fixes [NV-8751](https://linear.app/novu/issue/NV-8751/usewebchat-make-it-obvious-that-mutations-return-data-error-and-never)

## Test plan
- [ ] Hover `sendMessage`, `respondToAction`, `sendAction`, and `retryMessage` in `packages/react/src/hooks/useWebChat.ts` — tooltip says they do not throw and to inspect `error`
- [ ] Open Chat UI docs: `## Errors` sits after `## State` and shows `await sendMessage` + `if (result.error)`
- [ ] Open Quickstart: no `### If send fails`; one `<Note>` links to Chat UI `#errors`
- [ ] Confirm playground still compiles / `void retryMessage(...)` is unchanged


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR documents the result-based error handling contract for Web Chat mutations.
- Adds an Errors section showing callers how to inspect a mutation result.
- Updates `UseWebChatResult` and each mutation’s TSDoc with the documented behavior.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the documented never-reject contract remains false when a consumer’s `onError` callback throws.

The mutation wrapper invokes the consumer-provided error callback without containing its exceptions, allowing every documented mutation promise to reject rather than return the promised `{ data, error }` result.

**Files Needing Attention:** packages/react/src/hooks/useWebChat.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/hooks/useWebChat.ts | Adds public TSDoc for the result-based error handling behavior of all four Web Chat mutations. |
| docs/agents/channels/web-chat/chat-ui.mdx | Adds an Errors section with an awaited `sendMessage` example that checks `result.error`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(react): drop error-handling note fr..."](https://github.com/novuhq/novu/commit/0e4507f6c377b8d97f1e136a99f3c6cbf3fad8fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59464081)</sub>

<!-- /greptile_comment -->