### PR TITLE
docs: mention Symfony Notifier integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ Expand a channel below to browse supported providers.
 
 </details>
 
+## Community integrations
+
+- [Symfony Notifier for Novu](https://github.com/symfony/novu-notifier) - send Novu notifications from Symfony applications through the Symfony Notifier component.
+
 ## 📋 Read Our Code Of Conduct
 
 Before you begin coding and collaborating, please read our [Code of Conduct](https://github.com/novuhq/novu/blob/main/CODE_OF_CONDUCT.md) thoroughly to understand the standards (that you are required to adhere to) for community engagement. As part of our open-source community, we hold ourselves and other contributors to a high standard of communication. As a participant and contributor to this project, you agree to abide by our [Code of Conduct](https://github.com/novuhq/novu/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary
- add the Symfony Notifier for Novu community integration to the README

Closes #3632

## Validation
- git diff --check
- gh repo view symfony/novu-notifier --json nameWithOwner,url

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR documents the community-maintained Symfony Notifier integration in the root README.
- Adds a Community integrations section.
- Links to the official Symfony Novu Notifier repository and briefly describes its purpose.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The new link targets the canonical Symfony Novu Notifier repository, its description matches the integration’s purpose, and no repository documentation convention or automated README generation contract is violated.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds an accurate link and description for the Symfony Notifier community integration; no issues identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: mention Symfony Notifier integrati..."](https://github.com/novuhq/novu/commit/47979683ff50e5345a1d44cc3dcf9cc3162631a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59482154)</sub>

<!-- /greptile_comment -->