### PR TITLE
refactor(js): unify pendingActions with message part shapes fixes NV-8748

### DIFF
--- a/apps/dashboard/src/components/agents/web-chat-panel/web-chat-parts.tsx
+++ b/apps/dashboard/src/components/agents/web-chat-panel/web-chat-parts.tsx
@@ -133,7 +133,7 @@ export function ChatMessageRow({
   showAvatar: boolean;
   onCardAction?: CardActionHandler;
   cardActionsDisabled?: boolean;
-  onRespondToAction?: (args: { actionId: string; decision: ToolApprovalDecision }) => void;
+  onRespondToAction?: (args: { approvalId: string; decision: ToolApprovalDecision }) => void;
   onRetry?: (messageId: string) => void;
 }) {
   const isUser = message.role === 'user';
@@ -242,7 +242,7 @@ export function ChatMessageRow({
             trustServerActionId={part.trustServerActionId}
             disabled={cardActionsDisabled}
             onRespond={
-              onRespondToAction ? (decision) => onRespondToAction({ actionId: part.approvalId, decision }) : undefined
+              onRespondToAction ? (decision) => onRespondToAction({ approvalId: part.approvalId, decision }) : undefined
             }
           />
         ))}

--- a/docs/agents/channels/web-chat/chat-ui.mdx
+++ b/docs/agents/channels/web-chat/chat-ui.mdx
@@ -90,7 +90,7 @@ The first event of a turn can create an empty assistant message before any text 
 
 | `action.type` | What to do |
 | --- | --- |
-| `tool-approval` | Call `respondToAction` with `action.id` and `approved` or `denied`. |
+| `approval` | Call `respondToAction` with `action.approvalId` and `approved` or `denied`. |
 | `mcp-connection` | Open `action.authorizeUrl` in the browser. Do not call `respondToAction`. |
 
 ### Tool approval
@@ -101,15 +101,15 @@ const { pendingActions, respondToAction } = useWebChat({
 });
 
 {pendingActions.map((action) => {
-  if (action.type !== 'tool-approval') {
+  if (action.type !== 'approval') {
     return null;
   }
 
   return (
     <button
-      key={action.id}
+      key={action.approvalId}
       type="button"
-      onClick={() => void respondToAction({ actionId: action.id, decision: 'approved' })}
+      onClick={() => void respondToAction({ approvalId: action.approvalId, decision: 'approved' })}
     >
       Approve {action.toolName}
     </button>
@@ -117,7 +117,7 @@ const { pendingActions, respondToAction } = useWebChat({
 })}
 ```
 
-Pass `action.id` from `pendingActions`. Do not invent approve or deny ids.
+Pass `action.approvalId` from `pendingActions`. Do not invent approve or deny ids.
 
 ### MCP connect
 
@@ -132,7 +132,7 @@ const { pendingActions } = useWebChat({
   }
 
   return (
-    <a key={action.id} href={action.authorizeUrl} target="_blank" rel="noreferrer">
+    <a key={action.actionId} href={action.authorizeUrl} target="_blank" rel="noreferrer">
       Connect {action.displayName}
     </a>
   );

--- a/docs/platform/sdks/javascript.mdx
+++ b/docs/platform/sdks/javascript.mdx
@@ -803,7 +803,7 @@ conversation.dispose();
 | `subscribe(listener)` | Call `listener` on every snapshot. Returns a stop function. |
 | `sendMessage(input)` | Send a user message. `input` is a string, or `{ text, metadata }`. Creates a conversation when `conversationId` is omitted. |
 | `retryMessage(messageId)` | Resend a message whose `status` is `failed`. Reuses the original idempotency key. |
-| `respondToAction({ actionId, decision })` | Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. |
+| `respondToAction({ approvalId, decision })` | Resolve a pending `approval`. Pass `approvalId` from `pendingActions` or message parts. |
 | `sendAction({ actionId, sourceMessageId, value })` | Click a Card button. Do not use this for tool approval. |
 | `fetchMore()` | Load the next older history page. |
 | `load()` | Reload the newest history page. Runs on resume when `conversationId` is set. |

--- a/docs/platform/sdks/react/hooks/use-web-chat.mdx
+++ b/docs/platform/sdks/react/hooks/use-web-chat.mdx
@@ -43,7 +43,7 @@ Pass `agentId` (and optional `conversationId` and `agentHash`), or pass `convers
 | `refetch` | `() => Promise<void>` | Reload the newest history page. No-op when there is no conversation id. |
 | `sendMessage` | `(input: SendMessageInput) => Promise<{ data?: SendMessageResult; error?: NovuError \| WebChatPlanLimitError }>` | Send a user message. `input` is a string, or `{ text, metadata }`. Creates a conversation when `conversationId` is omitted. |
 | `retryMessage` | `(messageId: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| WebChatPlanLimitError }>` | Resend a message whose `status` is `failed`. Reuses the original idempotency key. Does not create a second message. See [Retry a failed send](/agents/channels/web-chat/chat-ui#retry-a-failed-send). |
-| `respondToAction` | `(args: { actionId: string; decision: AgentToolApprovalDecision }) => Promise<{ data?: RespondToActionResult; error?: NovuError \| WebChatPlanLimitError }>` | Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. Typical decisions: `'approved'` or `'denied'`. |
+| `respondToAction` | `(args: { approvalId: string; decision: AgentToolApprovalDecision }) => Promise<{ data?: RespondToActionResult; error?: NovuError \| WebChatPlanLimitError }>` | Resolve a pending `approval`. Pass `approvalId` from `pendingActions` or message parts. Typical decisions: `'approved'` or `'denied'`. |
 | `sendAction` | `(args: { actionId: string; sourceMessageId: string; value?: string }) => Promise<{ data?: SendActionResult; error?: NovuError \| WebChatPlanLimitError }>` | Click a Card button. Pass `id` / `value` from the button and `message.id` as `sourceMessageId`. Do not use this for tool approval. See [Cards](/agents/channels/web-chat/chat-ui#cards). |
 
 ## Pagination
@@ -99,7 +99,7 @@ See [Reconnect](/agents/channels/web-chat/chat-ui#reconnect).
 
 | `type` | What to do |
 | --- | --- |
-| `tool-approval` | Call `respondToAction({ actionId: action.id, decision: 'approved' \| 'denied' })`. |
+| `approval` | Call `respondToAction({ approvalId: action.approvalId, decision: 'approved' \| 'denied' })`. |
 | `mcp-connection` | Open `authorizeUrl` in the browser. Do not invent action ids. |
 
 ## Plan limit error

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -34,7 +34,6 @@ export type {
   AgentEventEnvelope,
   AgentFilePart,
   AgentHashFields,
-  AgentMcpConnectionAction,
   AgentMcpConnectionPart,
   AgentMcpConnectionPartState,
   AgentMessage,
@@ -46,7 +45,6 @@ export type {
   AgentTextPart,
   AgentTextPartState,
   AgentThinkingPart,
-  AgentToolApprovalAction,
   AgentToolApprovalDecision,
   AgentToolDefinition,
   AgentToolPart,
@@ -70,6 +68,7 @@ export type {
   WebChatToolsDefinition,
 } from './web-chat';
 export { WebChatPlanLimitError, type WebChatPlanLimitReason } from './web-chat/web-chat-plan-limit-error';
+export { pendingActionKey } from './web-chat/derive-pending-actions';
 
 /**
  * Load Web Chat on a {@link Novu} instance. Safe to call more than one time.

--- a/packages/js/src/web-chat/agent-conversation-runtime.ts
+++ b/packages/js/src/web-chat/agent-conversation-runtime.ts
@@ -315,9 +315,9 @@ export class AgentConversationRuntime {
     return response;
   }
 
-  /** Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`. */
+  /** Resolve a pending `approval`. Pass `approvalId` from `pendingActions` or message parts. */
   async respondToAction(args: {
-    actionId: string;
+    approvalId: string;
     decision: AgentToolApprovalDecision;
   }): Promise<{ data?: { conversationId: string }; error?: NovuError | WebChatPlanLimitError }> {
     const response = await this.#webChat.respondToAction({
@@ -325,7 +325,7 @@ export class AgentConversationRuntime {
       agentHash: this.#agentHash,
       key: this.key,
       conversationId: this.#conversationId,
-      actionId: args.actionId,
+      approvalId: args.approvalId,
       decision: args.decision,
     });
 

--- a/packages/js/src/web-chat/agent-message.types.ts
+++ b/packages/js/src/web-chat/agent-message.types.ts
@@ -66,9 +66,9 @@ export type AgentApprovalPart = {
   input?: Record<string, unknown>;
   source?: AgentToolSource;
   state: AgentApprovalPartState;
-  /** Server-generated. Pass this id to `respondToAction`. Do not create it on the client. */
+  /** Server-generated approve action id. Mapped internally when `decision` is `'approved'`. */
   approveActionId?: string;
-  /** Server-generated. Pass this id to `respondToAction`. Do not create it on the client. */
+  /** Server-generated deny action id. Mapped internally when `decision` is `'denied'`. */
   denyActionId?: string;
   /** Server-generated always-allow-this-tool action id. Present for managed tools that support trust. */
   trustToolActionId?: string;
@@ -88,19 +88,10 @@ export type AgentMcpConnectionPart = {
   message?: string;
 };
 
-/** Pending tool-approval item. Pass `id` to `respondToAction`. */
-export type AgentToolApprovalAction = Omit<AgentApprovalPart, 'type' | 'state'> & {
-  type: 'tool-approval';
-  id: string;
-};
-
-/** Pending MCP connect item. Open `authorizeUrl`. */
-export type AgentMcpConnectionAction = Omit<AgentMcpConnectionPart, 'state' | 'message'> & {
-  id: string;
-};
-
-/** One item the UI must handle: a tool approval or an MCP connect card. */
-export type AgentPendingAction = AgentToolApprovalAction | AgentMcpConnectionAction;
+/** One pending item the UI must handle. Same shape as the message part. */
+export type AgentPendingAction =
+  | (AgentApprovalPart & { state: 'pending' })
+  | (AgentMcpConnectionPart & { state: 'pending' });
 
 /** Citation. */
 export type AgentSourcePart = {

--- a/packages/js/src/web-chat/derive-pending-actions.ts
+++ b/packages/js/src/web-chat/derive-pending-actions.ts
@@ -1,25 +1,21 @@
 import type { AgentMessage, AgentPendingAction } from './agent-message.types';
 
-/** Pending tool-approval and MCP-connect actions in `messages`. */
+/** Stable dedup and lookup key for a pending action derived from message parts. */
+export function pendingActionKey(action: AgentPendingAction): string {
+  return action.type === 'approval' ? action.approvalId : action.actionId;
+}
+
+/** Pending approval and MCP-connect parts in `messages`. */
 export function derivePendingActions(messages: AgentMessage[]): AgentPendingAction[] {
   const pending: AgentPendingAction[] = [];
 
   for (const message of messages) {
     for (const part of message.parts) {
       if (part.type === 'approval' && part.state === 'pending') {
-        const { state: _state, ...action } = part;
-        pending.push({
-          ...action,
-          type: 'tool-approval',
-          id: part.approvalId,
-        });
+        pending.push({ ...part, state: 'pending' });
       }
       if (part.type === 'mcp-connection' && part.state === 'pending') {
-        const { state: _state, message: _message, ...action } = part;
-        pending.push({
-          ...action,
-          id: part.actionId,
-        });
+        pending.push({ ...part, state: 'pending' });
       }
     }
   }

--- a/packages/js/src/web-chat/index.ts
+++ b/packages/js/src/web-chat/index.ts
@@ -9,7 +9,6 @@ export type {
   AgentConversationTyping,
   AgentDataPart,
   AgentFilePart,
-  AgentMcpConnectionAction,
   AgentMcpConnectionPart,
   AgentMcpConnectionPartState,
   AgentMessage,
@@ -21,7 +20,6 @@ export type {
   AgentTextPart,
   AgentTextPartState,
   AgentThinkingPart,
-  AgentToolApprovalAction,
   AgentToolApprovalDecision,
   AgentToolPart,
   AgentToolPartState,
@@ -49,6 +47,7 @@ export type {
   WebChatPagination,
   WebChatPaginationStatus,
 } from './types';
+export { derivePendingActions, pendingActionKey } from './derive-pending-actions';
 export { WebChat } from './web-chat';
 export type {
   AgentToolDefinition,

--- a/packages/js/src/web-chat/types.ts
+++ b/packages/js/src/web-chat/types.ts
@@ -2,11 +2,9 @@ import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import type {
   AgentConversationStatus,
   AgentConversationTyping,
-  AgentMcpConnectionAction,
   AgentMcpConnectionPart,
   AgentMessage,
   AgentPendingAction,
-  AgentToolApprovalAction,
   AgentToolApprovalDecision,
 } from './agent-message.types';
 
@@ -14,11 +12,9 @@ export type {
   AgentConversationStatus,
   AgentConversationTyping,
   AgentEventEnvelope,
-  AgentMcpConnectionAction,
   AgentMcpConnectionPart,
   AgentMessage,
   AgentPendingAction,
-  AgentToolApprovalAction,
   AgentToolApprovalDecision,
 };
 
@@ -95,7 +91,7 @@ export type {
 
 export type RespondToActionArgs = AgentHashFields & {
   agentId: string;
-  actionId: string;
+  approvalId: string;
   decision: AgentToolApprovalDecision;
   conversationId?: string;
   /** @internal Session key for the local cache. */

--- a/packages/js/src/web-chat/web-chat-store.ts
+++ b/packages/js/src/web-chat/web-chat-store.ts
@@ -4,8 +4,8 @@ import {
   type AgentConversationState,
   type AgentMessage,
   createInitialAgentConversationState,
-  derivePendingActions,
 } from './agent-message.types';
+import { derivePendingActions, pendingActionKey } from './derive-pending-actions';
 import { appendUserMessage, applyEnvelope, applyEnvelopes } from './apply-envelope';
 import { mintClientId } from './idempotency';
 import type { WebChatChange, WebChatChangeSource, WebChatPaginationStatus, FetchMoreResult } from './types';
@@ -103,9 +103,11 @@ export class WebChatStore {
    * Only this store can tell live, history, and local updates apart.
    */
   #publish(entry: ConversationEntry, source: WebChatChangeSource, addedMessages: AgentMessage[]): void {
-    const newActions = derivePendingActions(entry.messages).filter((action) => !entry.reportedActionIds.has(action.id));
+    const newActions = derivePendingActions(entry.messages).filter(
+      (action) => !entry.reportedActionIds.has(pendingActionKey(action))
+    );
     for (const action of newActions) {
-      entry.reportedActionIds.add(action.id);
+      entry.reportedActionIds.add(pendingActionKey(action));
     }
 
     this.#onUpdate(entry, { ...source, addedMessages, newActions });
@@ -117,7 +119,7 @@ export class WebChatStore {
    */
   #suppressActions(entry: ConversationEntry, messages: AgentMessage[]): void {
     for (const action of derivePendingActions(messages)) {
-      entry.reportedActionIds.add(action.id);
+      entry.reportedActionIds.add(pendingActionKey(action));
     }
   }
 

--- a/packages/js/src/web-chat/web-chat.test.ts
+++ b/packages/js/src/web-chat/web-chat.test.ts
@@ -4,6 +4,7 @@ import { NovuEventEmitter } from '../event-emitter';
 import { NovuError } from '../utils/errors';
 import { WebChat } from './web-chat';
 import { derivePendingActions } from './agent-message.types';
+import { pendingActionKey } from './derive-pending-actions';
 import { createActionIdempotencyKeyForScope } from './idempotency';
 import type { WebChatChange } from './types';
 
@@ -2079,12 +2080,12 @@ describe('WebChat', () => {
 
     expect(derivePendingActions(snapshot?.messages ?? [])).toEqual([
       {
-        type: 'tool-approval',
-        id: 'approval_000001',
+        type: 'approval',
         approvalId: 'approval_000001',
         toolUseId: 'tu_0000001',
         toolName: 'deleteOrder',
         input: { orderId: '123' },
+        state: 'pending',
         approveActionId: 'tool-approval:approve:approval_000001',
         denyActionId: 'tool-approval:deny:approval_000001',
       },
@@ -2105,7 +2106,7 @@ describe('WebChat', () => {
     const result = await webChat.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
-      actionId: 'approval_000001',
+      approvalId: 'approval_000001',
       decision: 'approved',
     });
 
@@ -2123,7 +2124,7 @@ describe('WebChat', () => {
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(derivePendingActions(snapshot?.messages ?? [])[0]?.type).toBe('tool-approval');
+    expect(derivePendingActions(snapshot?.messages ?? [])[0]?.type).toBe('approval');
   });
 
   it('respondToAction POSTs trust-server action id when decision is trust-server', async () => {
@@ -2150,7 +2151,7 @@ describe('WebChat', () => {
     const result = await webChat.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
-      actionId: 'approval_000001',
+      approvalId: 'approval_000001',
       decision: 'trust-server',
     });
 
@@ -2179,7 +2180,7 @@ describe('WebChat', () => {
     await webChat.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
-      actionId: 'approval_000001',
+      approvalId: 'approval_000001',
       decision: 'approved',
     });
 
@@ -2223,7 +2224,7 @@ describe('WebChat', () => {
     const result = await webChat.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
-      actionId: 'approval_missing',
+      approvalId: 'approval_missing',
       decision: 'denied',
     });
 
@@ -2250,7 +2251,7 @@ describe('WebChat', () => {
     const result = await webChat.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
-      actionId: 'approval_000001',
+      approvalId: 'approval_000001',
       decision: 'denied',
     });
 
@@ -2499,7 +2500,7 @@ describe('WebChat', () => {
     await webChat.loadConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
     await webChat.loadConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
 
-    expect(changes[0]?.newActions.map((action) => action.id)).toEqual(['approval_000001']);
+    expect(changes[0]?.newActions.map(pendingActionKey)).toEqual(['approval_000001']);
     expect(changes[1]?.newActions).toEqual([]);
   });
 
@@ -2530,7 +2531,7 @@ describe('WebChat', () => {
     expect(changes[0]?.newActions).toEqual([]);
     expect(changes[1]?.kind).toBe('live');
     expect(changes[1]?.addedMessages).toEqual([]);
-    expect(changes[1]?.newActions.map((action) => action.id)).toEqual(['approval_000001']);
+    expect(changes[1]?.newActions.map(pendingActionKey)).toEqual(['approval_000001']);
   });
 
   it('stays silent for an approval discovered by paging backwards', async () => {
@@ -2544,7 +2545,7 @@ describe('WebChat', () => {
     await webChat.fetchMore({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
 
     const snapshot = webChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
-    expect(derivePendingActions(snapshot?.messages ?? []).map((action) => action.id)).toEqual(['approval_000001']);
+    expect(derivePendingActions(snapshot?.messages ?? []).map(pendingActionKey)).toEqual(['approval_000001']);
     const historyChange = changes.find((change) => change.kind === 'history');
     expect(historyChange?.newActions).toEqual([]);
   });
@@ -2897,13 +2898,13 @@ describe('WebChat', () => {
       await webChat.respondToAction({
         agentId: 'agent_1',
         conversationId: 'conv_abcdefghijkl',
-        actionId: 'approval_000001',
+        approvalId: 'approval_000001',
         decision: 'approved',
       });
       await webChat.respondToAction({
         agentId: 'agent_1',
         conversationId: 'conv_abcdefghijkl',
-        actionId: 'approval_000001',
+        approvalId: 'approval_000001',
         decision: 'approved',
       });
 
@@ -2924,13 +2925,13 @@ describe('WebChat', () => {
       await webChat.respondToAction({
         agentId: 'agent_1',
         conversationId: 'conv_aaaaaaaaaaaa',
-        actionId: 'approval_000001',
+        approvalId: 'approval_000001',
         decision: 'approved',
       });
       await webChat.respondToAction({
         agentId: 'agent_1',
         conversationId: 'conv_bbbbbbbbbbbb',
-        actionId: 'approval_000001',
+        approvalId: 'approval_000001',
         decision: 'approved',
       });
 
@@ -2950,13 +2951,13 @@ describe('WebChat', () => {
       const failed = await webChat.respondToAction({
         agentId: 'agent_1',
         conversationId: 'conv_abcdefghijkl',
-        actionId: 'approval_000001',
+        approvalId: 'approval_000001',
         decision: 'approved',
       });
       const retried = await webChat.respondToAction({
         agentId: 'agent_1',
         conversationId: 'conv_abcdefghijkl',
-        actionId: 'approval_000001',
+        approvalId: 'approval_000001',
         decision: 'approved',
       });
 

--- a/packages/js/src/web-chat/web-chat.ts
+++ b/packages/js/src/web-chat/web-chat.ts
@@ -6,7 +6,7 @@ import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
 import type { BaseSocketInterface } from '../ws/base-socket';
 import { AgentConversationRuntime } from './agent-conversation-runtime';
-import { type AgentConversationError, type AgentMessage, derivePendingActions } from './agent-message.types';
+import { type AgentApprovalPart, type AgentConversationError, type AgentMessage, derivePendingActions } from './agent-message.types';
 import type { ConversationArgs } from './conversation-runtime.types';
 import { createActionIdempotencyKeyForScope, createMessageIdempotencyKey } from './idempotency';
 import { runtimeCacheKey } from './runtime-cache-key';
@@ -229,8 +229,11 @@ export class WebChat extends BaseModule {
       'Cannot respond to action without a conversation id',
       'Failed to respond to action',
       async (entry, conversationId) => {
-        const pending = derivePendingActions(entry.messages).find((action) => action.id === args.actionId);
-        if (!pending || pending.type !== 'tool-approval') {
+        const pending = derivePendingActions(entry.messages).find(
+          (action): action is AgentApprovalPart & { state: 'pending' } =>
+            action.type === 'approval' && action.approvalId === args.approvalId
+        );
+        if (!pending) {
           return { error: new NovuError('Pending action not found', new Error('pending action not found')) };
         }
 
@@ -249,7 +252,7 @@ export class WebChat extends BaseModule {
           };
         }
 
-        const scope = `respond:${conversationId}:${args.actionId}:${args.decision}`;
+        const scope = `respond:${conversationId}:${args.approvalId}:${args.decision}`;
         const idempotencyKey = createActionIdempotencyKeyForScope(scope);
 
         return this.#webChatService.respondToAction({

--- a/packages/novu/src/commands/connect/templates/web-chat/ts/pending-action-card.tsx
+++ b/packages/novu/src/commands/connect/templates/web-chat/ts/pending-action-card.tsx
@@ -206,7 +206,7 @@ export function ToolApprovalCard({
     setFailure(undefined);
 
     try {
-      const result = await onRespond({ actionId: part.approvalId, decision });
+      const result = await onRespond({ approvalId: part.approvalId, decision });
       if (result.error) setFailure(result.error.message);
     } finally {
       setBusy(undefined);

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,5 +1,5 @@
 export type * from '@novu/js';
-export { PreferenceLevel, SeverityLevelEnum, WorkflowCriticalityEnum } from '@novu/js';
+export { pendingActionKey, PreferenceLevel, SeverityLevelEnum, WorkflowCriticalityEnum } from '@novu/js';
 export { NovuProvider, useNovu } from './NovuProvider';
 export * from './useWebChat';
 export * from './useChannelConnection';

--- a/packages/react/src/hooks/useWebChat.ts
+++ b/packages/react/src/hooks/useWebChat.ts
@@ -113,10 +113,10 @@ export type UseWebChatResult = {
     error?: NovuError | WebChatPlanLimitError;
   }>;
   /**
-   * Resolve a pending `tool-approval`. Pass `action.id` from `pendingActions`.
+   * Resolve a pending `approval`. Pass `approvalId` from `pendingActions` or message parts.
    * Does not throw. Resolves `{ data, error }`. Inspect `error` on the result, or show hook `error`.
    */
-  respondToAction: (args: { actionId: string; decision: AgentToolApprovalDecision }) => Promise<{
+  respondToAction: (args: { approvalId: string; decision: AgentToolApprovalDecision }) => Promise<{
     data?: RespondToActionResult;
     error?: NovuError | WebChatPlanLimitError;
   }>;
@@ -493,7 +493,7 @@ export const useWebChat = (props: UseWebChatProps): UseWebChatResult => {
     [callRuntime]
   );
   const respondToAction = useCallback(
-    (args: { actionId: string; decision: AgentToolApprovalDecision }) =>
+    (args: { approvalId: string; decision: AgentToolApprovalDecision }) =>
       callRuntime((target) => target.respondToAction(args)),
     [callRuntime]
   );

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,5 @@
 export type * from '@novu/js';
-export { PreferenceLevel, SeverityLevelEnum, WorkflowCriticalityEnum } from '@novu/js';
+export { pendingActionKey, PreferenceLevel, SeverityLevelEnum, WorkflowCriticalityEnum } from '@novu/js';
 
 export type {
   AllLocalization,

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -181,7 +181,7 @@ export function useSubscriptions(_: UseSubscriptionsProps): UseSubscriptionsResu
 }
 
 export type * from '@novu/js';
-export { PreferenceLevel, SeverityLevelEnum, WorkflowCriticalityEnum } from '@novu/js';
+export { pendingActionKey, PreferenceLevel, SeverityLevelEnum, WorkflowCriticalityEnum } from '@novu/js';
 
 export type {
   AllLocalization,

--- a/playground/web-chat/src/components/assistant-ui/web-chat-runtime.tsx
+++ b/playground/web-chat/src/components/assistant-ui/web-chat-runtime.tsx
@@ -61,7 +61,7 @@ export function WebChatRuntimeProvider({
   const onRespondToToolApproval = useCallback(
     async (options: { approvalId: string; approved: boolean; optionId?: string }) => {
       await chat.respondToAction({
-        actionId: options.approvalId,
+        approvalId: options.approvalId,
         decision: decisionFromApprovalOption(options.optionId, options.approved),
       });
     },

--- a/playground/web-chat/src/components/web-chat.tsx
+++ b/playground/web-chat/src/components/web-chat.tsx
@@ -119,7 +119,7 @@ export function WebChat({
     conversationId: activeConversationId,
     isRunning,
     conversationStatus,
-    pendingApprovalCount: pendingActions.filter((action) => action.type === 'tool-approval').length,
+    pendingApprovalCount: pendingActions.filter((action) => action.type === 'approval').length,
     runOrigin: runOrigin(isRunning, lastTransition),
     lastRunTransition: lastTransition,
   };

--- a/playground/web-chat/src/lib/approval-alert.ts
+++ b/playground/web-chat/src/lib/approval-alert.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AgentPendingAction } from '@novu/react';
+import { pendingActionKey, type AgentPendingAction } from '@novu/react';
 import { useCallback, useEffect, useRef } from 'react';
 import { emitDebugEvent } from './debug-events';
 
@@ -34,11 +34,12 @@ export function useApprovalAlert(): (action: AgentPendingAction) => void {
   }, []);
 
   return useCallback((action: AgentPendingAction) => {
-    const label = action.type === 'tool-approval' ? action.toolName : action.displayName;
+    const label = action.type === 'approval' ? action.toolName : action.displayName;
+    const key = pendingActionKey(action);
     emitDebugEvent({
       source: 'sdk',
       name: `onActionRequested ${label}`,
-      payload: { actionId: action.id, type: action.type },
+      payload: { actionId: key, type: action.type },
     });
 
     if (document.visibilityState === 'visible') return;
@@ -50,7 +51,7 @@ export function useApprovalAlert(): (action: AgentPendingAction) => void {
     if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
       new Notification('Action needed', {
         body: label,
-        tag: action.id,
+        tag: key,
       });
     }
   }, []);


### PR DESCRIPTION
## Summary

- `pendingActions` is now a filtered list of pending message parts (`approval` | `mcp-connection`) with the same shape as timeline parts — no parallel `tool-approval` type or synthetic `id`.
- `respondToAction({ approvalId, decision })` replaces `actionId`; HTTP wire `actionId` is unchanged.
- Export `pendingActionKey()` from `@novu/js` / `@novu/react` for dedup across consumers.

## Breaking changes

- Removed `AgentToolApprovalAction`, `AgentMcpConnectionAction`, and `'tool-approval'` discriminant.
- `respondToAction` param renamed: `actionId` → `approvalId`.
- First-party consumers (dashboard, playground, CLI template, docs) updated.

## Test plan

- [x] `packages/js` web-chat tests pass (87 tests)
- [ ] Approve a tool approval end-to-end in playground
- [ ] Verify MCP connection pending action shows correct debug payload / notification tag
- [ ] Dashboard web chat panel renders approval buttons and responds correctly


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR unifies pending actions with their underlying message-part shapes and renames the approval response parameter while preserving the HTTP wire contract.
- Exposes `pendingActionKey` across the JavaScript and React SDK entry points.
- Updates Web Chat state derivation, action handling, first-party consumers, tests, and documentation.
- Adds the missing server-safe React re-export required by Node and SSR consumers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/server/index.tsx | Adds the missing server runtime re-export of `pendingActionKey`, aligning it with the browser and declaration surfaces. |
| packages/js/src/web-chat/derive-pending-actions.ts | Returns pending message parts directly and provides a stable key helper for approval and MCP actions. |
| packages/js/src/web-chat/web-chat.ts | Resolves approval actions by `approvalId` while retaining server-provided decision action IDs and scoped idempotency. |
| packages/js/src/web-chat/web-chat-store.ts | Uses `pendingActionKey` consistently when suppressing and deduplicating pending-action notifications. |
| packages/react/src/index.ts | Exposes `pendingActionKey` from the React browser entry point. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(react): export pendingActionKey from..."](https://github.com/novuhq/novu/commit/902948f1572d564e8b09ff0aa8adff42322a4814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59497686)</sub>

**Context used:**

- Knowledge Base — [Developer SDKs and UI packages](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/developer-sdks.md)
- Knowledge Base — [JavaScript client SDK](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/javascript-client-sdk.md)

<!-- /greptile_comment -->