### PR TITLE
fix(root): playground - hide sibling-tool Allow/Deny without dropping the part fixes NV-8761

### DIFF
--- a/playground/web-chat/src/components/assistant-ui/elements/tool-fallback.aui.tsx
+++ b/playground/web-chat/src/components/assistant-ui/elements/tool-fallback.aui.tsx
@@ -400,14 +400,9 @@ const approvalOptionLabel = (option: ToolApprovalOption) =>
   option.id;
 
 const offersInterruptAction = (
-  status: ToolCallMessagePartStatus | undefined,
   approval: ToolCallMessagePart["approval"],
   interrupt: ToolCallMessagePart["interrupt"],
-) =>
-  status?.type !== "requires-action" ||
-  status.reason !== "interrupt" ||
-  approval != null ||
-  interrupt != null;
+) => approval != null || interrupt != null;
 
 function ToolFallbackApproval({
   className,
@@ -437,7 +432,7 @@ function ToolFallbackApproval({
   )
     return null;
 
-  if (!offersInterruptAction(status, approval, interrupt)) return null;
+  if (!offersInterruptAction(approval, interrupt)) return null;
 
   // A declared option list is a host constraint: render only what the host
   // exposes; do not invent actions the runtime cannot execute.
@@ -624,7 +619,7 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
     status?.type === "incomplete" && status.reason === "cancelled";
   const isRequiresAction = status?.type === "requires-action";
   const shouldRenderApproval =
-    isRequiresAction && offersInterruptAction(status, approval, interrupt);
+    isRequiresAction && offersInterruptAction(approval, interrupt);
 
   const [open, setOpen] = useState(isRequiresAction);
   const [prevRequiresAction, setPrevRequiresAction] =

--- a/playground/web-chat/src/components/assistant-ui/elements/tool-fallback.aui.tsx
+++ b/playground/web-chat/src/components/assistant-ui/elements/tool-fallback.aui.tsx
@@ -155,7 +155,7 @@ function ToolFallbackTrigger({
   const Icon = isDeniedApproval ? XCircleIcon : statusIconMap[statusType];
   const label = isCancelled
     ? "Cancelled tool"
-    : isPendingApproval || statusType === "requires-action"
+    : isPendingApproval
       ? "Tool approval"
       : isDeniedApproval
         ? "Denied tool"
@@ -621,12 +621,12 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   const shouldRenderApproval =
     isRequiresAction && offersInterruptAction(approval, interrupt);
 
-  const [open, setOpen] = useState(isRequiresAction);
-  const [prevRequiresAction, setPrevRequiresAction] =
-    useState(isRequiresAction);
-  if (isRequiresAction !== prevRequiresAction) {
-    setPrevRequiresAction(isRequiresAction);
-    if (isRequiresAction) setOpen(true);
+  const [open, setOpen] = useState(shouldRenderApproval);
+  const [prevShouldRenderApproval, setPrevShouldRenderApproval] =
+    useState(shouldRenderApproval);
+  if (shouldRenderApproval !== prevShouldRenderApproval) {
+    setPrevShouldRenderApproval(shouldRenderApproval);
+    if (shouldRenderApproval) setOpen(true);
   }
 
   return (

--- a/playground/web-chat/src/lib/agent-message-to-thread-message.ts
+++ b/playground/web-chat/src/lib/agent-message-to-thread-message.ts
@@ -97,6 +97,9 @@ export function agentMessageToThreadMessage(message: AgentMessage): ThreadMessag
   const isStreaming = message.parts.some(
     (part) => (part.type === 'text' || part.type === 'thinking') && part.state === 'streaming'
   );
+  const hasPendingApproval = message.parts.some(
+    (part) => part.type === 'approval' && part.state === 'pending'
+  );
 
   for (const part of message.parts) {
     switch (part.type) {
@@ -176,11 +179,6 @@ export function agentMessageToThreadMessage(message: AgentMessage): ThreadMessag
         break;
     }
   }
-
-  const hasPendingApproval = message.parts.some(
-    (part): part is Extract<AgentMessage['parts'][number], { type: 'approval' }> =>
-      part.type === 'approval' && part.state === 'pending'
-  );
 
   if (message.role === 'user') {
     // Stable assistant-ui identity across optimistic opt_* → server msg_* reconciliation.


### PR DESCRIPTION
## Summary

- `ToolFallback` paints Allow/Deny only when `approval` or `interrupt` is present.
- A sibling `tool` part in the same `AgentMessage` as a pending approval stays visible.
- The converter no longer drops that part. The real approval stays on `NovuApprovalCard`.

```mermaid
flowchart LR
  A["AgentMessage: sibling tool + pending approval"] --> B["message status requires-action"]
  B --> C["assistant-ui copies status onto resultless tool-calls"]
  C --> D["NovuToolFallback"]
  D --> E["approval present: NovuApprovalCard"]
  D --> F["no approval: ToolFallback without Allow/Deny"]
```

## Test plan

- [ ] Send a turn that has one pending approval and a second tool in the same message
- [ ] Confirm the sibling tool shows name/args (and spinner or error)
- [ ] Confirm the sibling has no Allow/Deny
- [ ] Confirm the real approval card still works


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR scopes approval presentation to tool parts carrying approval or interrupt metadata while preserving sibling tool parts in messages awaiting approval.
- Removes the message-level `requires-action` status as a reason to label a tool as an approval.
- Shows and auto-expands approval controls only when approval or interrupt metadata is present.
- Computes pending-approval state before converting message parts so sibling tools remain available.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| playground/web-chat/src/components/assistant-ui/elements/tool-fallback.aui.tsx | Scopes approval labeling, controls, and automatic expansion to tool parts with explicit approval or interrupt metadata. |
| playground/web-chat/src/lib/agent-message-to-thread-message.ts | Moves pending-approval detection ahead of part conversion so sibling tool parts remain represented. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Agent message] --> B{Pending approval present?}
  B -- Yes --> C[Message requires action]
  C --> D{Tool part has approval or interrupt metadata?}
  D -- Yes --> E[Render approval card and actions]
  D -- No --> F[Render ordinary tool fallback]
  B -- No --> G[Render parts normally]
```

<sub>Reviews (2): Last reviewed commit: ["fix(playground): do not label sibling to..."](https://github.com/novuhq/novu/commit/ecba68cdbd509e3779c1397d3ac0ecce0e8ba0a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59514266)</sub>

<!-- /greptile_comment -->