### PR TITLE
feat(human): add contacts list and display names to the human CLI

### DIFF
--- a/apps/api/src/app/human/dtos/list-contacts.dto.ts
+++ b/apps/api/src/app/human/dtos/list-contacts.dto.ts
@@ -26,8 +26,8 @@ export class ListContactsQueryDto {
  * legacy `channels`, and topic membership stay out of the contract.
  */
 export class HumanContactDto {
-  @ApiProperty()
-  subscriberId: string;
+  @ApiProperty({ description: 'The subscriberId — pass it to `--to`.' })
+  id: string;
 
   @ApiPropertyOptional()
   firstName?: string;

--- a/apps/api/src/app/human/dtos/list-contacts.dto.ts
+++ b/apps/api/src/app/human/dtos/list-contacts.dto.ts
@@ -1,0 +1,64 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export const DEFAULT_CONTACTS_LIMIT = 50;
+export const MAX_CONTACTS_LIMIT = 100;
+
+export class ListContactsQueryDto {
+  @ApiPropertyOptional({ default: DEFAULT_CONTACTS_LIMIT, maximum: MAX_CONTACTS_LIMIT })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(MAX_CONTACTS_LIMIT)
+  limit?: number;
+
+  @ApiPropertyOptional({ description: 'Cursor from a previous page’s `next` — returns contacts after it.' })
+  @IsOptional()
+  @IsString()
+  after?: string;
+}
+
+/**
+ * A contact is a subscriber, viewed as "someone an agent can talk to".
+ * Only the human-facing subset of the subscriber is exposed — internal ids,
+ * legacy `channels`, and topic membership stay out of the contract.
+ */
+export class HumanContactDto {
+  @ApiProperty()
+  subscriberId: string;
+
+  @ApiPropertyOptional()
+  firstName?: string;
+
+  @ApiPropertyOptional()
+  lastName?: string;
+
+  @ApiPropertyOptional()
+  email?: string;
+
+  @ApiPropertyOptional()
+  phone?: string;
+
+  @ApiPropertyOptional({
+    description: 'Free-form custom data on the subscriber (e.g. role notes).',
+    type: 'object',
+    additionalProperties: true,
+  })
+  data?: Record<string, unknown>;
+
+  @ApiProperty()
+  createdAt: string;
+
+  @ApiProperty()
+  updatedAt: string;
+}
+
+export class ListContactsResponseDto {
+  @ApiProperty({ type: [HumanContactDto] })
+  data: HumanContactDto[];
+
+  @ApiProperty({ nullable: true, description: 'Cursor for the next page, or null when this is the last page.' })
+  next: string | null;
+}

--- a/apps/api/src/app/human/dtos/setup-human-relay.dto.ts
+++ b/apps/api/src/app/human/dtos/setup-human-relay.dto.ts
@@ -21,6 +21,20 @@ export class SetupHumanRelayRequestDto {
   @IsOptional()
   @IsEmail()
   email?: string;
+
+  @ApiPropertyOptional({
+    description: 'The human’s first name (display name shown to agents and in reply attribution).',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  firstName?: string;
+
+  @ApiPropertyOptional({ description: 'The human’s last name.' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  lastName?: string;
 }
 
 export class SetupHumanRelayResponseDto {

--- a/apps/api/src/app/human/e2e/human-contacts.e2e.ts
+++ b/apps/api/src/app/human/e2e/human-contacts.e2e.ts
@@ -66,7 +66,7 @@ describe('Human contacts (setup names → list) #novu-v2', () => {
       expect(res.status).to.equal(200, JSON.stringify(res.body));
 
       const rows = res.body.data as Array<Record<string, unknown>>;
-      const byId = new Map(rows.map((row) => [row.subscriberId as string, row]));
+      const byId = new Map(rows.map((row) => [row.id as string, row]));
       expect(byId.has(`alice-${stamp}`)).to.equal(true);
       expect(byId.has(`bob-${stamp}`)).to.equal(true);
       expect(byId.has(`carol-${stamp}`)).to.equal(true);
@@ -82,16 +82,7 @@ describe('Human contacts (setup names → list) #novu-v2', () => {
       expect(carol?.createdAt).to.be.a('string');
       expect(carol?.updatedAt).to.be.a('string');
 
-      const allowedKeys = new Set([
-        'subscriberId',
-        'firstName',
-        'lastName',
-        'email',
-        'phone',
-        'data',
-        'createdAt',
-        'updatedAt',
-      ]);
+      const allowedKeys = new Set(['id', 'firstName', 'lastName', 'email', 'phone', 'data', 'createdAt', 'updatedAt']);
       for (const row of rows) {
         for (const key of Object.keys(row)) {
           expect(allowedKeys.has(key), `unexpected contact field "${key}"`).to.equal(true);
@@ -112,7 +103,7 @@ describe('Human contacts (setup names → list) #novu-v2', () => {
       const second = await session.testAgent.get('/v1/human/contacts').query({ limit: 1, after: first.body.next });
       expect(second.status).to.equal(200);
       expect(second.body.data).to.have.length(1);
-      expect(second.body.data[0].subscriberId).to.not.equal(first.body.data[0].subscriberId);
+      expect(second.body.data[0].id).to.not.equal(first.body.data[0].id);
     });
 
     it('returns an empty page for a malformed cursor', async () => {

--- a/apps/api/src/app/human/e2e/human-contacts.e2e.ts
+++ b/apps/api/src/app/human/e2e/human-contacts.e2e.ts
@@ -1,0 +1,125 @@
+import { SubscriberRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+const subscriberRepository = new SubscriberRepository();
+
+describe('Human contacts (setup names → list) #novu-v2', () => {
+  let session: UserSession;
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  async function setup(body: Record<string, unknown>) {
+    const res = await session.testAgent.post('/v1/human/setup').send(body);
+    expect(res.status).to.equal(200, JSON.stringify(res.body));
+
+    return res.body.data as { subscriberId: string };
+  }
+
+  async function findSubscriber(subscriberId: string) {
+    return subscriberRepository.findOne({ subscriberId, _environmentId: session.environment._id });
+  }
+
+  describe('POST /v1/human/setup names', () => {
+    it('creates the subscriber with firstName and lastName', async () => {
+      const subscriberId = `contact-${Date.now()}`;
+      await setup({ subscriberId, firstName: 'Alice', lastName: 'Chen' });
+
+      const subscriber = await findSubscriber(subscriberId);
+      expect(subscriber?.firstName).to.equal('Alice');
+      expect(subscriber?.lastName).to.equal('Chen');
+    });
+
+    it('replaces the name on re-setup and keeps it when omitted', async () => {
+      const subscriberId = `contact-${Date.now()}`;
+      await setup({ subscriberId, firstName: 'Alice' });
+      await setup({ subscriberId, firstName: 'Alicia', lastName: 'Chen' });
+
+      let subscriber = await findSubscriber(subscriberId);
+      expect(subscriber?.firstName).to.equal('Alicia');
+      expect(subscriber?.lastName).to.equal('Chen');
+
+      await setup({ subscriberId });
+      subscriber = await findSubscriber(subscriberId);
+      expect(subscriber?.firstName).to.equal('Alicia');
+      expect(subscriber?.lastName).to.equal('Chen');
+    });
+  });
+
+  describe('GET /v1/human/contacts', () => {
+    it('lists every subscriber in the environment with only contact fields', async () => {
+      const stamp = Date.now();
+      await setup({ subscriberId: `alice-${stamp}`, firstName: 'Alice', lastName: 'Chen' });
+      await setup({ subscriberId: `bob-${stamp}`, email: 'bob@example.com' });
+      await subscriberRepository.create({
+        subscriberId: `carol-${stamp}`,
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+        phone: '+15550000000',
+        data: { role: 'on-call' },
+      });
+
+      const res = await session.testAgent.get('/v1/human/contacts');
+      expect(res.status).to.equal(200, JSON.stringify(res.body));
+
+      const rows = res.body.data as Array<Record<string, unknown>>;
+      const byId = new Map(rows.map((row) => [row.subscriberId as string, row]));
+      expect(byId.has(`alice-${stamp}`)).to.equal(true);
+      expect(byId.has(`bob-${stamp}`)).to.equal(true);
+      expect(byId.has(`carol-${stamp}`)).to.equal(true);
+
+      const alice = byId.get(`alice-${stamp}`);
+      expect(alice?.firstName).to.equal('Alice');
+      expect(alice?.lastName).to.equal('Chen');
+      expect(byId.get(`bob-${stamp}`)?.email).to.equal('bob@example.com');
+
+      const carol = byId.get(`carol-${stamp}`);
+      expect(carol?.phone).to.equal('+15550000000');
+      expect(carol?.data).to.deep.equal({ role: 'on-call' });
+      expect(carol?.createdAt).to.be.a('string');
+      expect(carol?.updatedAt).to.be.a('string');
+
+      const allowedKeys = new Set([
+        'subscriberId',
+        'firstName',
+        'lastName',
+        'email',
+        'phone',
+        'data',
+        'createdAt',
+        'updatedAt',
+      ]);
+      for (const row of rows) {
+        for (const key of Object.keys(row)) {
+          expect(allowedKeys.has(key), `unexpected contact field "${key}"`).to.equal(true);
+        }
+      }
+    });
+
+    it('pages with limit and after', async () => {
+      const stamp = Date.now();
+      await setup({ subscriberId: `p1-${stamp}` });
+      await setup({ subscriberId: `p2-${stamp}` });
+
+      const first = await session.testAgent.get('/v1/human/contacts').query({ limit: 1 });
+      expect(first.status).to.equal(200);
+      expect(first.body.data).to.have.length(1);
+      expect(first.body.next).to.be.a('string');
+
+      const second = await session.testAgent.get('/v1/human/contacts').query({ limit: 1, after: first.body.next });
+      expect(second.status).to.equal(200);
+      expect(second.body.data).to.have.length(1);
+      expect(second.body.data[0].subscriberId).to.not.equal(first.body.data[0].subscriberId);
+    });
+
+    it('returns an empty page for a malformed cursor', async () => {
+      const res = await session.testAgent.get('/v1/human/contacts').query({ after: 'not-a-cursor' });
+      expect(res.status).to.equal(200);
+      expect(res.body.data).to.deep.equal([]);
+      expect(res.body.next).to.equal(null);
+    });
+  });
+});

--- a/apps/api/src/app/human/human-interactions.controller.ts
+++ b/apps/api/src/app/human/human-interactions.controller.ts
@@ -20,6 +20,7 @@ import { KeylessAccessible } from '../shared/framework/swagger/keyless.security'
 import { UserSession } from '../shared/framework/user.decorator';
 import { CreateInteractionRequestDto } from './dtos/create-interaction-request.dto';
 import { InteractionResponseDto } from './dtos/interaction-response.dto';
+import { ListContactsQueryDto, ListContactsResponseDto } from './dtos/list-contacts.dto';
 import { ListInteractionsQueryDto } from './dtos/list-interactions-query.dto';
 import { SetupHumanRelayRequestDto, SetupHumanRelayResponseDto } from './dtos/setup-human-relay.dto';
 import { CancelInteractionCommand } from './usecases/cancel-interaction/cancel-interaction.command';
@@ -28,6 +29,8 @@ import { CreateInteractionCommand } from './usecases/create-interaction/create-i
 import { CreateInteraction } from './usecases/create-interaction/create-interaction.usecase';
 import { GetInteractionCommand } from './usecases/get-interaction/get-interaction.command';
 import { GetInteraction } from './usecases/get-interaction/get-interaction.usecase';
+import { ListContactsCommand } from './usecases/list-contacts/list-contacts.command';
+import { ListContacts } from './usecases/list-contacts/list-contacts.usecase';
 import { ListInteractionsCommand } from './usecases/list-interactions/list-interactions.command';
 import { ListInteractions } from './usecases/list-interactions/list-interactions.usecase';
 import { SetupHumanRelayCommand } from './usecases/setup-human-relay/setup-human-relay.command';
@@ -44,7 +47,8 @@ export class HumanInteractionsController {
     private readonly getInteractionUsecase: GetInteraction,
     private readonly listInteractionsUsecase: ListInteractions,
     private readonly cancelInteractionUsecase: CancelInteraction,
-    private readonly setupHumanRelayUsecase: SetupHumanRelay
+    private readonly setupHumanRelayUsecase: SetupHumanRelay,
+    private readonly listContactsUsecase: ListContacts
   ) {}
 
   @Post('/interactions')
@@ -130,6 +134,30 @@ export class HumanInteractionsController {
     );
   }
 
+  /**
+   * Contacts are the environment's subscribers — the people an agent can
+   * address with `--to`. Deliberately a thin subscriber list today; filters
+   * and a per-contact `channels` field are the intended extension points.
+   */
+  @Get('/contacts')
+  @KeylessAccessible()
+  @ExternalApiAccessible()
+  @RequirePermissions(PermissionsEnum.AGENT_READ)
+  listContacts(
+    @UserSession() user: UserSessionData,
+    @Query() query: ListContactsQueryDto
+  ): Promise<ListContactsResponseDto> {
+    return this.listContactsUsecase.execute(
+      ListContactsCommand.create({
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        userId: user._id,
+        limit: query.limit,
+        after: query.after,
+      })
+    );
+  }
+
   @Post('/setup')
   @HttpCode(HttpStatus.OK)
   @KeylessAccessible()
@@ -147,6 +175,8 @@ export class HumanInteractionsController {
         subscriberId: body.subscriberId,
         agentIdentifier: body.agentIdentifier,
         email: body.email,
+        firstName: body.firstName,
+        lastName: body.lastName,
       })
     );
   }

--- a/apps/api/src/app/human/human.module.ts
+++ b/apps/api/src/app/human/human.module.ts
@@ -14,6 +14,7 @@ import { HumanDeliveryService } from './services/human-delivery.service';
 import { CancelInteraction } from './usecases/cancel-interaction/cancel-interaction.usecase';
 import { CreateInteraction } from './usecases/create-interaction/create-interaction.usecase';
 import { GetInteraction } from './usecases/get-interaction/get-interaction.usecase';
+import { ListContacts } from './usecases/list-contacts/list-contacts.usecase';
 import { ListInteractions } from './usecases/list-interactions/list-interactions.usecase';
 import { SetupHumanRelay } from './usecases/setup-human-relay/setup-human-relay.usecase';
 
@@ -37,6 +38,7 @@ import { SetupHumanRelay } from './usecases/setup-human-relay/setup-human-relay.
     ListInteractions,
     CancelInteraction,
     SetupHumanRelay,
+    ListContacts,
   ],
 })
 export class HumanModule {}

--- a/apps/api/src/app/human/usecases/list-contacts/list-contacts.command.ts
+++ b/apps/api/src/app/human/usecases/list-contacts/list-contacts.command.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+import { MAX_CONTACTS_LIMIT } from '../../dtos/list-contacts.dto';
+
+export class ListContactsCommand extends EnvironmentWithUserCommand {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(MAX_CONTACTS_LIMIT)
+  limit?: number;
+
+  @IsOptional()
+  @IsString()
+  after?: string;
+}

--- a/apps/api/src/app/human/usecases/list-contacts/list-contacts.usecase.ts
+++ b/apps/api/src/app/human/usecases/list-contacts/list-contacts.usecase.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { InstrumentUsecase } from '@novu/application-generic';
+import { BaseRepository, SubscriberEntity, SubscriberRepository } from '@novu/dal';
+import { DirectionEnum } from '../../../shared/dtos/base-responses';
+import { DEFAULT_CONTACTS_LIMIT, HumanContactDto, ListContactsResponseDto } from '../../dtos/list-contacts.dto';
+import { ListContactsCommand } from './list-contacts.command';
+
+/**
+ * Lists the environment's subscribers as contacts. Backed by the same
+ * repository pagination as `GET /v2/subscribers`, but exposed under
+ * `/v1/human` so it is keyless-reachable by the `human` CLI and can grow
+ * human-specific filters (and a per-contact `channels` field) later.
+ */
+@Injectable()
+export class ListContacts {
+  constructor(private readonly subscriberRepository: SubscriberRepository) {}
+
+  @InstrumentUsecase()
+  async execute(command: ListContactsCommand): Promise<ListContactsResponseDto> {
+    // A cursor that is not an internal id can never match a row; return an
+    // empty page instead of letting the repository throw on a bad ObjectId.
+    if (command.after && !BaseRepository.isInternalId(command.after)) {
+      return { data: [], next: null };
+    }
+
+    const page = await this.subscriberRepository.listSubscribers({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      limit: command.limit ?? DEFAULT_CONTACTS_LIMIT,
+      after: command.after,
+      sortBy: '_id',
+      sortDirection: DirectionEnum.DESC,
+    });
+
+    return {
+      data: page.subscribers.map(toContact),
+      next: page.next,
+    };
+  }
+}
+
+function toContact(subscriber: SubscriberEntity): HumanContactDto {
+  return {
+    subscriberId: subscriber.subscriberId,
+    ...(subscriber.firstName ? { firstName: subscriber.firstName } : {}),
+    ...(subscriber.lastName ? { lastName: subscriber.lastName } : {}),
+    ...(subscriber.email ? { email: subscriber.email } : {}),
+    ...(subscriber.phone ? { phone: subscriber.phone } : {}),
+    ...(subscriber.data ? { data: subscriber.data } : {}),
+    createdAt: subscriber.createdAt,
+    updatedAt: subscriber.updatedAt,
+  };
+}

--- a/apps/api/src/app/human/usecases/list-contacts/list-contacts.usecase.ts
+++ b/apps/api/src/app/human/usecases/list-contacts/list-contacts.usecase.ts
@@ -41,7 +41,7 @@ export class ListContacts {
 
 function toContact(subscriber: SubscriberEntity): HumanContactDto {
   return {
-    subscriberId: subscriber.subscriberId,
+    id: subscriber.subscriberId,
     ...(subscriber.firstName ? { firstName: subscriber.firstName } : {}),
     ...(subscriber.lastName ? { lastName: subscriber.lastName } : {}),
     ...(subscriber.email ? { email: subscriber.email } : {}),

--- a/apps/api/src/app/human/usecases/setup-human-relay/setup-human-relay.command.ts
+++ b/apps/api/src/app/human/usecases/setup-human-relay/setup-human-relay.command.ts
@@ -13,4 +13,12 @@ export class SetupHumanRelayCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsString()
   email?: string;
+
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  lastName?: string;
 }

--- a/apps/api/src/app/human/usecases/setup-human-relay/setup-human-relay.usecase.ts
+++ b/apps/api/src/app/human/usecases/setup-human-relay/setup-human-relay.usecase.ts
@@ -1,6 +1,6 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { InstrumentUsecase } from '@novu/application-generic';
-import { AgentEntity, AgentRepository, SubscriberRepository } from '@novu/dal';
+import { AgentEntity, AgentRepository, SubscriberEntity, SubscriberRepository } from '@novu/dal';
 import { AgentSubscriberAccessEnum } from '@novu/shared';
 import type { SetupHumanRelayResponseDto } from '../../dtos/setup-human-relay.dto';
 import { SetupHumanRelayCommand } from './setup-human-relay.command';
@@ -71,6 +71,8 @@ export class SetupHumanRelay {
 
   private async ensureSubscriber(command: SetupHumanRelayCommand): Promise<void> {
     const email = command.email?.trim().toLowerCase();
+    const firstName = command.firstName?.trim() || undefined;
+    const lastName = command.lastName?.trim() || undefined;
 
     const existing = await this.subscriberRepository.findOne({
       subscriberId: command.subscriberId,
@@ -80,10 +82,17 @@ export class SetupHumanRelay {
     if (existing) {
       // Email identity powers the email channel (delivery target + inbound
       // reply resolution live on Subscriber.email — no ChannelEndpoint).
-      if (email && existing.email !== email) {
+      // Names are only ever set or replaced, never cleared: an invite that
+      // omits `--name` must not wipe a name captured earlier.
+      const updates: Partial<Pick<SubscriberEntity, 'email' | 'firstName' | 'lastName'>> = {};
+      if (email && existing.email !== email) updates.email = email;
+      if (firstName && existing.firstName !== firstName) updates.firstName = firstName;
+      if (lastName && existing.lastName !== lastName) updates.lastName = lastName;
+
+      if (Object.keys(updates).length > 0) {
         await this.subscriberRepository.update(
           { subscriberId: command.subscriberId, _environmentId: command.environmentId },
-          { $set: { email } }
+          { $set: updates }
         );
       }
 
@@ -95,6 +104,8 @@ export class SetupHumanRelay {
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
       ...(email ? { email } : {}),
+      ...(firstName ? { firstName } : {}),
+      ...(lastName ? { lastName } : {}),
     });
   }
 }

--- a/packages/human/README.md
+++ b/packages/human/README.md
@@ -16,15 +16,20 @@ human choose "Pick a release strategy" --option canary --option blue-green
 human tell "Nightly build finished — 0 failures."
 
 # Link another human (they open the URL; does not change your local identity):
-human invite alice --via slack
+human invite alice --via slack --name "Alice Chen"
 human invite bob --via telegram --async
 human invite carol --via email --email carol@acme.com
+
+# See who agents can reach (subscribers in the environment; `(you)` marks the operator):
+human contacts
+human contacts --json
 ```
 
 ## How it works
 
 - `setup` provisions a keyless Novu environment (no account needed), a hidden relay agent, and links **your** channel — Telegram via QR, Slack via app install, Email by registering your address (approvals arrive as button emails; answer asks by replying). Run it again with another channel to add more. Linked channels live on the server; `human channels --default slack` sets a local preference for where interactions land when you don't pass `--via`.
-- `invite` links a **different** subscriber the same way Slack/Telegram connect does (OAuth or a deep link → channel endpoint). Send them the URL; your `~/.novu/human.json` subscriberId stays yours. Then `--to alice` can reach them.
+- `invite` links a **different** subscriber the same way Slack/Telegram connect does (OAuth or a deep link → channel endpoint). Send them the URL; your `~/.novu/human.json` subscriberId stays yours. Then `--to alice` can reach them. Pass `--name "Alice Chen"` so they show up by name.
+- `contacts` lists the environment's subscribers — every person `--to` can address — so an agent can check who exists before coordinating between people. It's a directory, not a reachability check: if delivery fails with "no linked endpoint", `invite` them on that channel.
 - Agents stay channel-blind: routing is the human's preference. `--via telegram|slack|email` on ask/approve is a rare per-call **delivery** override, not how you onboard someone.
 - Each command delivers a one-off message (with action buttons where relevant) and **blocks** until the human answers, the `--ttl` expires, or `--timeout` elapses.
 - Answers flow back through button clicks or plain replies; the CLI resolves and your agent continues.
@@ -46,7 +51,7 @@ human invite carol --via email --email carol@acme.com
 - `--timeout 10m` — max time this invocation blocks; on timeout it prints the id so `human wait <id>` can resume.
 - `--async` — don't block; print the interaction id immediately.
 - `--json` — full interaction object for programmatic parsing.
-- `--to <humanId>` — address a human who is already linked (`human invite` first), or comma-separated humans (`alice,bob`, max 50) so any listed person can settle.
+- `--to <humanId>` — address a human who is already linked (`human contacts` to find them, `human invite` to add them), or comma-separated humans (`alice,bob`, max 50) so any listed person can settle.
 - `--via <platform>` — deliver on a specific linked channel instead of the default.
 
 ## Auth & headless use

--- a/packages/human/site/index.html
+++ b/packages/human/site/index.html
@@ -51,6 +51,9 @@ HOW IT WORKS
     --timeout elapses.
   - Answers flow back through button clicks or plain replies; the CLI
     resolves and your agent continues.
+  - `contacts` lists every subscriber `--to` can address so an agent
+    can check who exists before coordinating. It's a directory, not a
+    reachability check.
 
 EXIT CODES (stable contract for agents)
 ----------------------------------------

--- a/packages/human/site/index.html
+++ b/packages/human/site/index.html
@@ -34,6 +34,8 @@ USAGE (forever after, by any agent on the machine)
   human approve "Delete 342 stale records from prod?"
   human choose "Pick a release strategy" --option canary --option blue-green
   human tell "Nightly build finished — 0 failures."
+  human contacts                       # who --to can address
+  human contacts --json
 
 HOW IT WORKS
 ------------
@@ -67,18 +69,31 @@ FLAGS
   --async                don't block; print the interaction id immediately
   --json                 full interaction object for programmatic parsing
   --to <humanId>         address a linked human, or comma-separated humans
-                          (link others first with `human invite`)
+                          (find them with `human contacts`; link others
+                          first with `human invite`)
   --via <platform>       deliver on a specific linked channel instead of default
 
 INVITE (link another human)
 ---------------------------
-  human invite alice --via slack
+  human invite alice --via slack --name "Alice Chen"
   human invite bob --via telegram --async
-  human invite carol --via email --email carol@acme.com
+  human invite carol --via email --email carol@acme.com --name "Carol Diaz"
 
   Prints a connect URL for that person (same OAuth / Telegram deep-link
   as setup). Does not change your local subscriberId. After they connect,
-  address them with --to.
+  address them with --to. Pass --name so they show up by name in contacts.
+
+CONTACTS (who agents can reach)
+-------------------------------
+  human contacts
+  human contacts --json
+  human contacts --limit 20 --after <cursor>
+
+  Lists every subscriber in the environment — the directory `--to`
+  addresses. The operator's row is marked (you) / self: true. A directory,
+  not a reachability check: if delivery fails with "no linked endpoint",
+  invite them on that channel. Pages are 50 by default (max 100); when
+  next is set, continue with --after.
 
 AUTH
 ----

--- a/packages/human/site/sapien.html
+++ b/packages/human/site/sapien.html
@@ -405,32 +405,6 @@
     padding: 1px 5px;
   }
 
-  /* ---------- exit codes ---------- */
-
-  .codes {
-    border-top: 1px solid var(--line);
-    padding: clamp(64px, 9vw, 110px) clamp(20px, 4vw, 48px);
-  }
-
-  .codes-table {
-    margin-top: 44px;
-    border-top: 1px solid var(--line);
-    font-family: "Geist Mono", monospace;
-    font-size: 0.8rem;
-  }
-
-  .code-row {
-    display: grid;
-    grid-template-columns: 72px 1fr;
-    gap: 20px;
-    padding: 13px 4px;
-    border-bottom: 1px solid var(--line);
-    color: var(--text-dim);
-  }
-
-  .code-row .n { color: var(--text); font-weight: 500; }
-  .code-row.ember .n { color: var(--ember); }
-
   /* ---------- quote ---------- */
 
   .quote {
@@ -547,8 +521,8 @@
     <div class="session-copy">
       <h2>The agent waits.<br /><em>You decide.</em></h2>
       <p>Every blocking call delivers a message with buttons to wherever you
-      already are, then holds the process until you tap one. Exit codes carry
-      the verdict — your scripts branch on the answer, not on hope.</p>
+      already are, then holds the process until you tap one. Your scripts
+      branch on the answer, not on hope.</p>
       <p>Timeouts, retries and resumption are the agent's problem.
       Yours is a five-second decision from your phone.</p>
     </div>
@@ -574,7 +548,7 @@
     </div>
     <div class="verb">
       <span class="name">approve</span>
-      <p>Approve / Deny buttons for anything irreversible. Exit 0 or 10. An audit trail of who said yes.</p>
+      <p>Approve / Deny buttons for anything irreversible. An audit trail of who said yes.</p>
     </div>
     <div class="verb">
       <span class="name">choose</span>
@@ -632,17 +606,6 @@
         <p>The question lands where you already read messages, with buttons.
         Tap one, or just reply. The agent picks it up and keeps going.</p>
       </div>
-    </div>
-  </section>
-
-  <section class="codes">
-    <h2 class="section-title">Exit codes are <em>the contract.</em></h2>
-    <div class="codes-table">
-      <div class="code-row"><span class="n">0</span><span>answered / approved / chosen / delivered</span></div>
-      <div class="code-row ember"><span class="n">10</span><span>denied — the human said no</span></div>
-      <div class="code-row"><span class="n">11</span><span>timed out waiting — still pending, resume with <span style="color:var(--text)">human wait &lt;id&gt;</span></span></div>
-      <div class="code-row"><span class="n">12</span><span>expired or canceled</span></div>
-      <div class="code-row"><span class="n">1</span><span>error</span></div>
     </div>
   </section>
 

--- a/packages/human/site/sapien.html
+++ b/packages/human/site/sapien.html
@@ -256,6 +256,17 @@
     margin: 0 0 12px;
   }
 
+  .session-copy code {
+    font-family: "Geist Mono", monospace;
+    font-size: 0.8em;
+    color: var(--text);
+    background: var(--bg-raise);
+    border: 1px solid var(--line);
+    padding: 1px 5px;
+  }
+
+  .session.rule { border-top: 1px solid var(--line); }
+
   .terminal {
     border: 1px solid var(--line-strong);
     background: var(--bg-raise);
@@ -332,6 +343,9 @@
     font-size: 0.86rem;
     color: var(--text-dim);
   }
+
+  .terminal-body .you { color: #7eb8d4; }
+  .terminal-body .hdr { color: var(--text-faint); }
 
   /* ---------- steps ---------- */
 
@@ -569,6 +583,31 @@
     <div class="verb">
       <span class="name">tell</span>
       <p>One-way. Delivered and done — for the "it finished" message nobody should have to poll for.</p>
+    </div>
+  </section>
+
+  <section class="session rule" id="contacts">
+    <div class="session-copy">
+      <h2>More than one human.<br /><em>Look first.</em></h2>
+      <p>Agents can list everyone they can address with
+      <code>human contacts</code> — a directory of people in the
+      environment, not a guarantee they have a channel linked yet.</p>
+      <p>Your row is marked <em>(you)</em>. Invite someone new with
+      <code>human invite alice --via slack --name "Alice Chen"</code>,
+      then pass their id to <code>--to</code>.</p>
+    </div>
+    <div class="terminal" aria-label="Contacts directory">
+      <div class="terminal-bar"><span>agent — who can I reach</span><span>tty</span></div>
+      <div class="terminal-body">
+        <div class="line"><span class="p">$</span> <span class="c">human contacts</span></div>
+        <div class="line"><span class="hdr">ID     NAME         EMAIL</span></div>
+        <div class="line"><span class="c">dima   Dima Groza   dima@novu.co</span><span class="you"> (you)</span></div>
+        <div class="line"><span class="c">alice  Alice Chen   alice@acme.com</span></div>
+        <div class="line"><span class="c">bob    Bob          —</span></div>
+        <div class="line">&nbsp;</div>
+        <div class="line"><span class="p">$</span> <span class="c">human approve <span class="d">"Ship the pricing change?"</span> --to alice</span></div>
+        <div class="line"><span class="cursor"></span></div>
+      </div>
     </div>
   </section>
 

--- a/packages/human/src/api/human.ts
+++ b/packages/human/src/api/human.ts
@@ -74,7 +74,7 @@ export async function cancelInteraction(client: HumanApiClient, id: string): Pro
 
 export async function setupHumanRelay(
   client: HumanApiClient,
-  input: { subscriberId: string; agentIdentifier?: string; email?: string }
+  input: { subscriberId: string; agentIdentifier?: string; email?: string; firstName?: string; lastName?: string }
 ): Promise<{ agentId: string; agentIdentifier: string; subscriberId: string }> {
   const res = await client.axios.post<
     | { data?: { agentId: string; agentIdentifier: string; subscriberId: string } }
@@ -86,4 +86,31 @@ export async function setupHumanRelay(
   >('/v1/human/setup', input);
 
   return unwrap(res.data);
+}
+
+/** A contact is a subscriber in the environment — someone `--to` can address. */
+export interface Contact {
+  subscriberId: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  data?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ContactsPage {
+  data: Contact[];
+  next: string | null;
+}
+
+export async function listContacts(
+  client: HumanApiClient,
+  params: { limit?: number; after?: string } = {}
+): Promise<ContactsPage> {
+  const res = await client.axios.get<{ data?: Contact[]; next?: string | null }>('/v1/human/contacts', { params });
+  const body = res.data;
+
+  return { data: Array.isArray(body?.data) ? body.data : [], next: body?.next ?? null };
 }

--- a/packages/human/src/api/human.ts
+++ b/packages/human/src/api/human.ts
@@ -88,9 +88,9 @@ export async function setupHumanRelay(
   return unwrap(res.data);
 }
 
-/** A contact is a subscriber in the environment — someone `--to` can address. */
+/** A contact is a subscriber in the environment — `id` is the subscriberId `--to` addresses. */
 export interface Contact {
-  subscriberId: string;
+  id: string;
   firstName?: string;
   lastName?: string;
   email?: string;

--- a/packages/human/src/commands/contacts.spec.ts
+++ b/packages/human/src/commands/contacts.spec.ts
@@ -27,7 +27,7 @@ const config: HumanCliConfig = {
   subscriberId: 'human_me',
 };
 
-function contact(overrides: Partial<Contact> & { subscriberId: string }): Contact {
+function contact(overrides: Partial<Contact> & { id: string }): Contact {
   return { createdAt: '2026-09-01T00:00:00.000Z', updatedAt: '2026-09-01T00:00:00.000Z', ...overrides };
 }
 
@@ -43,21 +43,21 @@ describe('parseContactsLimit', () => {
 
 describe('markSelf', () => {
   it('flags only the operator row', () => {
-    const rows = markSelf([contact({ subscriberId: 'alice' }), contact({ subscriberId: 'human_me' })], 'human_me');
+    const rows = markSelf([contact({ id: 'alice' }), contact({ id: 'human_me' })], 'human_me');
     expect(rows.map((row) => row.self)).toEqual([false, true]);
   });
 
   it('flags nothing when the config has no subscriberId', () => {
-    const rows = markSelf([contact({ subscriberId: 'alice' })], undefined);
+    const rows = markSelf([contact({ id: 'alice' })], undefined);
     expect(rows[0].self).toBe(false);
   });
 });
 
 describe('displayName', () => {
   it('joins first and last name and tolerates either missing', () => {
-    expect(displayName(contact({ subscriberId: 'a', firstName: 'Alice', lastName: 'Chen' }))).toBe('Alice Chen');
-    expect(displayName(contact({ subscriberId: 'a', firstName: 'Alice' }))).toBe('Alice');
-    expect(displayName(contact({ subscriberId: 'a' }))).toBe('');
+    expect(displayName(contact({ id: 'a', firstName: 'Alice', lastName: 'Chen' }))).toBe('Alice Chen');
+    expect(displayName(contact({ id: 'a', firstName: 'Alice' }))).toBe('Alice');
+    expect(displayName(contact({ id: 'a' }))).toBe('');
   });
 });
 
@@ -69,10 +69,7 @@ describe('renderContactsTable', () => {
   it('marks (you) and hints when more pages exist', () => {
     const out = renderContactsTable(
       markSelf(
-        [
-          contact({ subscriberId: 'alice', firstName: 'Alice', email: 'a@x.co' }),
-          contact({ subscriberId: 'human_me' }),
-        ],
+        [contact({ id: 'alice', firstName: 'Alice', email: 'a@x.co' }), contact({ id: 'human_me' })],
         'human_me'
       ),
       'cursor-1',
@@ -87,7 +84,7 @@ describe('renderContactsTable', () => {
   });
 
   it('omits the hint on the last page', () => {
-    expect(renderContactsTable(markSelf([contact({ subscriberId: 'alice' })], 'human_me'), null, 50)).not.toContain(
+    expect(renderContactsTable(markSelf([contact({ id: 'alice' })], 'human_me'), null, 50)).not.toContain(
       'More contacts'
     );
   });
@@ -113,7 +110,7 @@ describe('contactsCommand', () => {
 
   it('prints { data, next } JSON with self markers', async () => {
     listContacts.mockResolvedValue({
-      data: [contact({ subscriberId: 'human_me', firstName: 'Dima' }), contact({ subscriberId: 'alice' })],
+      data: [contact({ id: 'human_me', firstName: 'Dima' }), contact({ id: 'alice' })],
       next: 'cursor-2',
     });
 
@@ -122,14 +119,14 @@ describe('contactsCommand', () => {
     expect(listContacts).toHaveBeenCalledWith({}, { limit: 10 });
     const parsed = JSON.parse(stdout);
     expect(parsed.next).toBe('cursor-2');
-    expect(parsed.data.map((row: { subscriberId: string; self: boolean }) => [row.subscriberId, row.self])).toEqual([
+    expect(parsed.data.map((row: { id: string; self: boolean }) => [row.id, row.self])).toEqual([
       ['human_me', true],
       ['alice', false],
     ]);
   });
 
   it('renders the table by default', async () => {
-    listContacts.mockResolvedValue({ data: [contact({ subscriberId: 'alice', firstName: 'Alice' })], next: null });
+    listContacts.mockResolvedValue({ data: [contact({ id: 'alice', firstName: 'Alice' })], next: null });
 
     await expect(contactsCommand({})).rejects.toThrow('exit:0');
 

--- a/packages/human/src/commands/contacts.spec.ts
+++ b/packages/human/src/commands/contacts.spec.ts
@@ -63,7 +63,7 @@ describe('displayName', () => {
 
 describe('renderContactsTable', () => {
   it('prints an empty-state hint', () => {
-    expect(renderContactsTable([], null, 50)).toContain('No contacts found');
+    expect(renderContactsTable([], null)).toContain('No contacts found');
   });
 
   it('marks (you) and hints when more pages exist', () => {
@@ -72,21 +72,18 @@ describe('renderContactsTable', () => {
         [contact({ id: 'alice', firstName: 'Alice', email: 'a@x.co' }), contact({ id: 'human_me' })],
         'human_me'
       ),
-      'cursor-1',
-      50
+      'cursor-1'
     );
     expect(out).toContain('alice');
     expect(out).toContain('Alice');
     expect(out).toContain('a@x.co');
     expect(out).toContain('(you)');
     expect(out).toContain('More contacts');
-    expect(out).toContain('--limit 100');
+    expect(out).toContain('--after cursor-1');
   });
 
   it('omits the hint on the last page', () => {
-    expect(renderContactsTable(markSelf([contact({ id: 'alice' })], 'human_me'), null, 50)).not.toContain(
-      'More contacts'
-    );
+    expect(renderContactsTable(markSelf([contact({ id: 'alice' })], 'human_me'), null)).not.toContain('More contacts');
   });
 });
 
@@ -133,5 +130,15 @@ describe('contactsCommand', () => {
     expect(stdout).toContain('alice');
     expect(stdout).toContain('Alice');
     expect(listContacts).toHaveBeenCalledWith({}, { limit: 50 });
+  });
+
+  it('passes --after through as the page cursor', async () => {
+    listContacts.mockResolvedValue({ data: [contact({ id: 'bob' })], next: null });
+
+    await expect(contactsCommand({ after: 'cursor-2', limit: '25' })).rejects.toThrow('exit:0');
+
+    expect(listContacts).toHaveBeenCalledWith({}, { limit: 25, after: 'cursor-2' });
+    expect(stdout).toContain('bob');
+    expect(stdout).not.toContain('More contacts');
   });
 });

--- a/packages/human/src/commands/contacts.spec.ts
+++ b/packages/human/src/commands/contacts.spec.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Contact } from '../api/human';
+import type { HumanCliConfig } from '../config';
+
+const listContacts = vi.fn();
+const clientFromConfig = vi.fn();
+
+vi.mock('../api/human', () => ({
+  listContacts: (...args: unknown[]) => listContacts(...args),
+}));
+
+vi.mock('./interact', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./interact')>();
+
+  return {
+    ...original,
+    clientFromConfig: (...args: unknown[]) => clientFromConfig(...args),
+  };
+});
+
+const { contactsCommand, markSelf, parseContactsLimit, renderContactsTable, displayName } = await import('./contacts');
+
+const config: HumanCliConfig = {
+  apiUrl: 'https://api.novu.co',
+  auth: { mode: 'apiKey', secretKey: 'key' },
+  relayAgentIdentifier: 'human-relay',
+  subscriberId: 'human_me',
+};
+
+function contact(overrides: Partial<Contact> & { subscriberId: string }): Contact {
+  return { createdAt: '2026-09-01T00:00:00.000Z', updatedAt: '2026-09-01T00:00:00.000Z', ...overrides };
+}
+
+describe('parseContactsLimit', () => {
+  it('defaults to 50 and rejects out-of-range values', () => {
+    expect(parseContactsLimit(undefined)).toBe(50);
+    expect(parseContactsLimit('5')).toBe(5);
+    expect(() => parseContactsLimit('0')).toThrow('--limit');
+    expect(() => parseContactsLimit('101')).toThrow('--limit');
+    expect(() => parseContactsLimit('abc')).toThrow('--limit');
+  });
+});
+
+describe('markSelf', () => {
+  it('flags only the operator row', () => {
+    const rows = markSelf([contact({ subscriberId: 'alice' }), contact({ subscriberId: 'human_me' })], 'human_me');
+    expect(rows.map((row) => row.self)).toEqual([false, true]);
+  });
+
+  it('flags nothing when the config has no subscriberId', () => {
+    const rows = markSelf([contact({ subscriberId: 'alice' })], undefined);
+    expect(rows[0].self).toBe(false);
+  });
+});
+
+describe('displayName', () => {
+  it('joins first and last name and tolerates either missing', () => {
+    expect(displayName(contact({ subscriberId: 'a', firstName: 'Alice', lastName: 'Chen' }))).toBe('Alice Chen');
+    expect(displayName(contact({ subscriberId: 'a', firstName: 'Alice' }))).toBe('Alice');
+    expect(displayName(contact({ subscriberId: 'a' }))).toBe('');
+  });
+});
+
+describe('renderContactsTable', () => {
+  it('prints an empty-state hint', () => {
+    expect(renderContactsTable([], null, 50)).toContain('No contacts found');
+  });
+
+  it('marks (you) and hints when more pages exist', () => {
+    const out = renderContactsTable(
+      markSelf(
+        [
+          contact({ subscriberId: 'alice', firstName: 'Alice', email: 'a@x.co' }),
+          contact({ subscriberId: 'human_me' }),
+        ],
+        'human_me'
+      ),
+      'cursor-1',
+      50
+    );
+    expect(out).toContain('alice');
+    expect(out).toContain('Alice');
+    expect(out).toContain('a@x.co');
+    expect(out).toContain('(you)');
+    expect(out).toContain('More contacts');
+    expect(out).toContain('--limit 100');
+  });
+
+  it('omits the hint on the last page', () => {
+    expect(renderContactsTable(markSelf([contact({ subscriberId: 'alice' })], 'human_me'), null, 50)).not.toContain(
+      'More contacts'
+    );
+  });
+});
+
+describe('contactsCommand', () => {
+  let stdout: string;
+
+  beforeEach(() => {
+    stdout = '';
+    listContacts.mockReset();
+    clientFromConfig.mockReset();
+    clientFromConfig.mockReturnValue({ client: {}, config });
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stdout += String(chunk);
+
+      return true;
+    });
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+  });
+
+  it('prints { data, next } JSON with self markers', async () => {
+    listContacts.mockResolvedValue({
+      data: [contact({ subscriberId: 'human_me', firstName: 'Dima' }), contact({ subscriberId: 'alice' })],
+      next: 'cursor-2',
+    });
+
+    await expect(contactsCommand({ json: true, limit: '10' })).rejects.toThrow('exit:0');
+
+    expect(listContacts).toHaveBeenCalledWith({}, { limit: 10 });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.next).toBe('cursor-2');
+    expect(parsed.data.map((row: { subscriberId: string; self: boolean }) => [row.subscriberId, row.self])).toEqual([
+      ['human_me', true],
+      ['alice', false],
+    ]);
+  });
+
+  it('renders the table by default', async () => {
+    listContacts.mockResolvedValue({ data: [contact({ subscriberId: 'alice', firstName: 'Alice' })], next: null });
+
+    await expect(contactsCommand({})).rejects.toThrow('exit:0');
+
+    expect(stdout).toContain('alice');
+    expect(stdout).toContain('Alice');
+    expect(listContacts).toHaveBeenCalledWith({}, { limit: 50 });
+  });
+});

--- a/packages/human/src/commands/contacts.ts
+++ b/packages/human/src/commands/contacts.ts
@@ -1,0 +1,91 @@
+import pc from 'picocolors';
+import { type Contact, listContacts } from '../api/human';
+import { clientFromConfig, handleError } from './interact';
+
+export const DEFAULT_CONTACTS_LIMIT = 50;
+export const MAX_CONTACTS_LIMIT = 100;
+
+export interface ContactsOptions {
+  limit?: string;
+  json?: boolean;
+  apiUrl?: string;
+}
+
+export type ContactRow = Contact & { self: boolean };
+
+export function parseContactsLimit(raw: string | undefined): number {
+  if (raw === undefined || raw === '') {
+    return DEFAULT_CONTACTS_LIMIT;
+  }
+
+  const limit = Number(raw);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_CONTACTS_LIMIT) {
+    throw new Error(`--limit must be a whole number between 1 and ${MAX_CONTACTS_LIMIT}.`);
+  }
+
+  return limit;
+}
+
+/** Marks the operator's own row so agents don't page you as a third party. */
+export function markSelf(contacts: Contact[], selfSubscriberId: string | undefined): ContactRow[] {
+  return contacts.map((contact) => ({
+    ...contact,
+    self: selfSubscriberId !== undefined && contact.subscriberId === selfSubscriberId,
+  }));
+}
+
+export function displayName(contact: Contact): string {
+  return [contact.firstName, contact.lastName].filter(Boolean).join(' ');
+}
+
+export function renderContactsTable(rows: ContactRow[], next: string | null, limit: number): string {
+  if (rows.length === 0) {
+    return 'No contacts found. Run `human setup` or `human invite <id> --via <channel>` to add people.\n';
+  }
+
+  const idWidth = Math.max(...rows.map((row) => row.subscriberId.length), 'ID'.length);
+  const nameWidth = Math.max(...rows.map((row) => displayName(row).length), 'NAME'.length);
+  const lines = [pc.dim(`${'ID'.padEnd(idWidth)}  ${'NAME'.padEnd(nameWidth)}  EMAIL`)];
+
+  for (const row of rows) {
+    const name = displayName(row) || pc.dim('—');
+    const email = row.email ?? pc.dim('—');
+    const self = row.self ? pc.cyan(' (you)') : '';
+    lines.push(`${row.subscriberId.padEnd(idWidth)}  ${name.padEnd(nameWidth)}  ${email}${self}`);
+  }
+
+  if (next) {
+    lines.push(
+      pc.dim(
+        `More contacts — rerun with --limit ${Math.min(limit * 2, MAX_CONTACTS_LIMIT)} or use --json for the cursor.`
+      )
+    );
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export async function contactsCommand(options: ContactsOptions): Promise<never> {
+  let output: string;
+  try {
+    output = await renderContacts(options);
+  } catch (err) {
+    return handleError(err);
+  }
+
+  process.stdout.write(output);
+  process.exit(0);
+}
+
+async function renderContacts(options: ContactsOptions): Promise<string> {
+  const limit = parseContactsLimit(options.limit);
+  const { client, config } = clientFromConfig(options.apiUrl);
+  const page = await listContacts(client, { limit });
+  const rows = markSelf(page.data, config.subscriberId);
+
+  if (options.json) {
+    return `${JSON.stringify({ data: rows, next: page.next }, null, 2)}\n`;
+  }
+
+  return renderContactsTable(rows, page.next, limit);
+}

--- a/packages/human/src/commands/contacts.ts
+++ b/packages/human/src/commands/contacts.ts
@@ -7,6 +7,8 @@ export const MAX_CONTACTS_LIMIT = 100;
 
 export interface ContactsOptions {
   limit?: string;
+  /** `next` cursor from a previous page. */
+  after?: string;
   json?: boolean;
   apiUrl?: string;
 }
@@ -38,7 +40,7 @@ export function displayName(contact: Contact): string {
   return [contact.firstName, contact.lastName].filter(Boolean).join(' ');
 }
 
-export function renderContactsTable(rows: ContactRow[], next: string | null, limit: number): string {
+export function renderContactsTable(rows: ContactRow[], next: string | null): string {
   if (rows.length === 0) {
     return 'No contacts found. Run `human setup` or `human invite <id> --via <channel>` to add people.\n';
   }
@@ -55,11 +57,7 @@ export function renderContactsTable(rows: ContactRow[], next: string | null, lim
   }
 
   if (next) {
-    lines.push(
-      pc.dim(
-        `More contacts — rerun with --limit ${Math.min(limit * 2, MAX_CONTACTS_LIMIT)} or use --json for the cursor.`
-      )
-    );
+    lines.push(pc.dim(`More contacts — next page: human contacts --after ${next}`));
   }
 
   return `${lines.join('\n')}\n`;
@@ -80,12 +78,13 @@ export async function contactsCommand(options: ContactsOptions): Promise<never> 
 async function renderContacts(options: ContactsOptions): Promise<string> {
   const limit = parseContactsLimit(options.limit);
   const { client, config } = clientFromConfig(options.apiUrl);
-  const page = await listContacts(client, { limit });
+  const after = options.after?.trim() || undefined;
+  const page = await listContacts(client, { limit, ...(after ? { after } : {}) });
   const rows = markSelf(page.data, config.subscriberId);
 
   if (options.json) {
     return `${JSON.stringify({ data: rows, next: page.next }, null, 2)}\n`;
   }
 
-  return renderContactsTable(rows, page.next, limit);
+  return renderContactsTable(rows, page.next);
 }

--- a/packages/human/src/commands/contacts.ts
+++ b/packages/human/src/commands/contacts.ts
@@ -30,7 +30,7 @@ export function parseContactsLimit(raw: string | undefined): number {
 export function markSelf(contacts: Contact[], selfSubscriberId: string | undefined): ContactRow[] {
   return contacts.map((contact) => ({
     ...contact,
-    self: selfSubscriberId !== undefined && contact.subscriberId === selfSubscriberId,
+    self: selfSubscriberId !== undefined && contact.id === selfSubscriberId,
   }));
 }
 
@@ -43,7 +43,7 @@ export function renderContactsTable(rows: ContactRow[], next: string | null, lim
     return 'No contacts found. Run `human setup` or `human invite <id> --via <channel>` to add people.\n';
   }
 
-  const idWidth = Math.max(...rows.map((row) => row.subscriberId.length), 'ID'.length);
+  const idWidth = Math.max(...rows.map((row) => row.id.length), 'ID'.length);
   const nameWidth = Math.max(...rows.map((row) => displayName(row).length), 'NAME'.length);
   const lines = [pc.dim(`${'ID'.padEnd(idWidth)}  ${'NAME'.padEnd(nameWidth)}  EMAIL`)];
 
@@ -51,7 +51,7 @@ export function renderContactsTable(rows: ContactRow[], next: string | null, lim
     const name = displayName(row) || pc.dim('—');
     const email = row.email ?? pc.dim('—');
     const self = row.self ? pc.cyan(' (you)') : '';
-    lines.push(`${row.subscriberId.padEnd(idWidth)}  ${name.padEnd(nameWidth)}  ${email}${self}`);
+    lines.push(`${row.id.padEnd(idWidth)}  ${name.padEnd(nameWidth)}  ${email}${self}`);
   }
 
   if (next) {

--- a/packages/human/src/commands/invite.spec.ts
+++ b/packages/human/src/commands/invite.spec.ts
@@ -40,7 +40,7 @@ vi.mock('./interact', async (importOriginal) => {
   };
 });
 
-const { parseInviteHumanId, resolveInviteVia, runInvite } = await import('./invite');
+const { parseInviteHumanId, resolveInviteVia, runInvite, splitName } = await import('./invite');
 
 const operatorConfig: HumanCliConfig = {
   apiUrl: 'https://api.novu.co',
@@ -62,6 +62,19 @@ describe('parseInviteHumanId', () => {
     expect(parseInviteHumanId(' alice ')).toBe('alice');
     expect(() => parseInviteHumanId('  ')).toThrow('subscriberId');
     expect(() => parseInviteHumanId('alice,bob')).toThrow('one human at a time');
+  });
+});
+
+describe('splitName', () => {
+  it('splits on the first space and collapses whitespace', () => {
+    expect(splitName('Alice Chen')).toEqual({ firstName: 'Alice', lastName: 'Chen' });
+    expect(splitName('  Mary   Ann Smith ')).toEqual({ firstName: 'Mary', lastName: 'Ann Smith' });
+    expect(splitName('Alice')).toEqual({ firstName: 'Alice' });
+  });
+
+  it('returns undefined for blank input so no name is cleared', () => {
+    expect(splitName(undefined)).toBeUndefined();
+    expect(splitName('   ')).toBeUndefined();
   });
 });
 
@@ -151,5 +164,46 @@ describe('runInvite', () => {
 
     expect(result.via).toBe('telegram');
     expect(hasChannelEndpoint).toHaveBeenCalledWith(expect.anything(), 'tg-1', 'bob');
+  });
+
+  it('forwards --name to the relay setup for chat channels', async () => {
+    listAgentIntegrations.mockResolvedValue([telegramLink()]);
+    hasChannelEndpoint.mockResolvedValue(true);
+
+    await runInvite('alice', { via: 'telegram', name: 'Alice Chen' });
+
+    expect(setupHumanRelay).toHaveBeenCalledWith(expect.anything(), {
+      subscriberId: 'alice',
+      agentIdentifier: 'human-relay',
+      firstName: 'Alice',
+      lastName: 'Chen',
+    });
+  });
+
+  it('forwards --name alongside --email and labels an already-linked email human', async () => {
+    listAgentIntegrations.mockResolvedValue([
+      { integration: { identifier: 'email-1', providerId: 'novu-email-agent', active: true } },
+    ]);
+    getSubscriberEmail.mockResolvedValue(undefined);
+
+    await runInvite('carol', { via: 'email', email: 'carol@acme.com', name: 'Carol' });
+    expect(setupHumanRelay).toHaveBeenCalledWith(expect.anything(), {
+      subscriberId: 'carol',
+      agentIdentifier: 'human-relay',
+      email: 'carol@acme.com',
+      firstName: 'Carol',
+    });
+
+    setupHumanRelay.mockClear();
+    getSubscriberEmail.mockResolvedValue('carol@acme.com');
+
+    const result = await runInvite('carol', { via: 'email', name: 'Carol Diaz' });
+    expect(result.alreadyLinked).toBe(true);
+    expect(setupHumanRelay).toHaveBeenCalledWith(expect.anything(), {
+      subscriberId: 'carol',
+      agentIdentifier: 'human-relay',
+      firstName: 'Carol',
+      lastName: 'Diaz',
+    });
   });
 });

--- a/packages/human/src/commands/invite.ts
+++ b/packages/human/src/commands/invite.ts
@@ -22,8 +22,29 @@ import {
 export interface InviteOptions {
   via?: string;
   email?: string;
+  /** Display name, e.g. "Alice Chen" — split into firstName/lastName on the subscriber. */
+  name?: string;
   async?: boolean;
   apiUrl?: string;
+}
+
+/**
+ * `--name "Alice Chen"` → `{ firstName: 'Alice', lastName: 'Chen' }`; a single
+ * token is just a firstName. Returns undefined for blank input so callers can
+ * spread it straight into the setup payload without clearing an existing name.
+ */
+export function splitName(raw: string | undefined): { firstName: string; lastName?: string } | undefined {
+  const name = raw?.trim().replace(/\s+/g, ' ');
+  if (!name) {
+    return undefined;
+  }
+
+  const spaceAt = name.indexOf(' ');
+  if (spaceAt === -1) {
+    return { firstName: name };
+  }
+
+  return { firstName: name.slice(0, spaceAt), lastName: name.slice(spaceAt + 1) };
 }
 
 export interface InviteResult {
@@ -76,6 +97,7 @@ export async function runInvite(humanIdArg: string, options: InviteOptions): Pro
   const links = await listAgentIntegrations(client, agentIdentifier);
   const via = resolveInviteVia(links, options.via);
   const linked = findLinkedIntegration(links, via);
+  const name = splitName(options.name);
 
   if (!linked) {
     throw new Error(`No ${via} channel is linked to the relay agent. Run \`human setup ${via}\` first.`);
@@ -87,11 +109,11 @@ export async function runInvite(humanIdArg: string, options: InviteOptions): Pro
       result = await inviteEmail(client, humanId, agentIdentifier, linked.integration.sharedInboundAddress, options);
       break;
     case 'telegram':
-      await setupHumanRelay(client, { subscriberId: humanId, agentIdentifier });
+      await setupHumanRelay(client, { subscriberId: humanId, agentIdentifier, ...name });
       result = await inviteTelegram(client, humanId, linked.integration.identifier, options);
       break;
     case 'slack':
-      await setupHumanRelay(client, { subscriberId: humanId, agentIdentifier });
+      await setupHumanRelay(client, { subscriberId: humanId, agentIdentifier, ...name });
       result = await inviteSlack(client, humanId, agentIdentifier, linked.integration.identifier, options);
       break;
     default: {
@@ -106,10 +128,11 @@ export async function runInvite(humanIdArg: string, options: InviteOptions): Pro
 export async function inviteCommand(humanIdArg: string, options: InviteOptions): Promise<never> {
   try {
     const result = await runInvite(humanIdArg, options);
+    const who = options.name?.trim() ? `${result.humanId} (${options.name.trim()})` : result.humanId;
     const lead =
       options.async && !result.alreadyLinked && result.via !== 'email'
         ? 'Link issued. After they connect, address them with:'
-        : `${result.humanId} is ${result.alreadyLinked ? 'already ' : ''}linked on ${result.via}. Address them with:`;
+        : `${who} is ${result.alreadyLinked ? 'already ' : ''}linked on ${result.via}. Address them with:`;
 
     process.stdout.write(`\n${pc.green('✔')} ${lead}\n` + `  ${pc.bold(`human ask "…" --to ${result.humanId}`)}\n`);
 
@@ -193,12 +216,19 @@ async function inviteEmail(
   if (existingEmail && !options.email) {
     info(`${humanId} is already linked on email (${existingEmail}).`);
 
+    // Still honor a name passed alongside so `invite --name` is a way to label
+    // someone who was linked before names existed.
+    const name = splitName(options.name);
+    if (name) {
+      await setupHumanRelay(client, { subscriberId: humanId, agentIdentifier, ...name });
+    }
+
     return { humanId, via: 'email', alreadyLinked: true };
   }
 
   const email = options.email ? requireEmail(options.email) : await promptInviteEmail();
 
-  await setupHumanRelay(client, { subscriberId: humanId, agentIdentifier, email });
+  await setupHumanRelay(client, { subscriberId: humanId, agentIdentifier, email, ...splitName(options.name) });
 
   if (inboundAddress) {
     info(`Replies go to ${pc.bold(inboundAddress)} — answering an interaction is just replying to its email.`);

--- a/packages/human/src/commands/setup.spec.ts
+++ b/packages/human/src/commands/setup.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { resolveOperatorName } = await import('./setup');
+
+describe('resolveOperatorName', () => {
+  it('uses --name without prompting', async () => {
+    const prompt = vi.fn();
+
+    await expect(resolveOperatorName({ name: 'Dima Grossman' }, false, { isTTY: true, prompt })).resolves.toEqual({
+      firstName: 'Dima',
+      lastName: 'Grossman',
+    });
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it('prompts once on a first-run TTY and accepts an empty answer', async () => {
+    const prompt = vi.fn().mockResolvedValue('Alice');
+    await expect(resolveOperatorName({}, false, { isTTY: true, prompt })).resolves.toEqual({ firstName: 'Alice' });
+    expect(prompt).toHaveBeenCalledTimes(1);
+
+    const empty = vi.fn().mockResolvedValue('   ');
+    await expect(resolveOperatorName({}, false, { isTTY: true, prompt: empty })).resolves.toBeUndefined();
+  });
+
+  it('never prompts when already set up or when stdin is not a TTY', async () => {
+    const prompt = vi.fn();
+
+    await expect(resolveOperatorName({}, true, { isTTY: true, prompt })).resolves.toBeUndefined();
+    await expect(resolveOperatorName({}, false, { isTTY: false, prompt })).resolves.toBeUndefined();
+    expect(prompt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/human/src/commands/setup.ts
+++ b/packages/human/src/commands/setup.ts
@@ -33,6 +33,7 @@ import { pollUntil, sleep } from '../poll';
 import { renderQR } from '../qr';
 import { installHumanSkill, resolveSkillHosts } from '../skills/install-skills';
 import { handleError } from './interact';
+import { splitName } from './invite';
 import {
   CHANNEL_POLL_INTERVAL_MS,
   CHANNEL_POLL_TIMEOUT_MS,
@@ -47,12 +48,38 @@ import {
 
 const BOTFATHER_URL = 'https://t.me/botfather';
 
+/**
+ * `--name` always wins. Otherwise ask once — only on the very first setup
+ * (no subscriberId in config yet) and only on a TTY; an empty answer or a
+ * non-interactive run just leaves the name unset.
+ */
+export async function resolveOperatorName(
+  options: Pick<SetupOptions, 'name'>,
+  alreadySetUp: boolean,
+  io: { isTTY: boolean; prompt: (question: string) => Promise<string> } = {
+    isTTY: Boolean(process.stdin.isTTY),
+    prompt: promptLine,
+  }
+): Promise<{ firstName: string; lastName?: string } | undefined> {
+  if (options.name !== undefined) {
+    return splitName(options.name);
+  }
+
+  if (alreadySetUp || !io.isTTY) {
+    return undefined;
+  }
+
+  return splitName(await io.prompt('Your name (shown to agents, optional): '));
+}
+
 interface SetupOptions {
   apiUrl?: string;
   secretKey?: string;
   telegramBotToken?: string;
   slackConfigToken?: string;
   email?: string;
+  /** Your display name; skips the first-run prompt. */
+  name?: string;
   agentIdentifier?: string;
   /** Tri-state: undefined = ask (TTY) / skip (non-TTY); true/false = explicit `--skill`/`--no-skill`. */
   skill?: boolean;
@@ -87,9 +114,10 @@ export async function setupCommand(channelArg: string | undefined, options: Setu
     // 2. Provision the relay agent + the human's subscriber row.
     const subscriberId = existing?.subscriberId ?? `human_${randomBytes(6).toString('hex')}`;
     const relayIdentifier = options.agentIdentifier ?? existing?.relayAgentIdentifier ?? DEFAULT_RELAY_AGENT_IDENTIFIER;
+    const name = await resolveOperatorName(options, Boolean(existing?.subscriberId));
 
     info('Setting up your human relay...');
-    const relay = await setupHumanRelay(client, { subscriberId, agentIdentifier: relayIdentifier });
+    const relay = await setupHumanRelay(client, { subscriberId, agentIdentifier: relayIdentifier, ...name });
 
     // 3. Channel linking — linked channels live on the server; locally we only
     // remember a default preference for when the caller does not pass `--via`.
@@ -121,7 +149,7 @@ export async function setupCommand(channelArg: string | undefined, options: Setu
     // 5. Smoke test on the channel that was just linked.
     await createInteraction(client, {
       kind: 'tell',
-      prompt: 'You\'re connected. Agents can now reach you here — try `human approve "Deploy to production?"`.',
+      prompt: `${name ? `Hi ${name.firstName}, you're` : "You're"} connected. Agents can now reach you here — try \`human approve "Deploy to production?"\`.`,
       to: subscriberId,
       via: channel,
       agentIdentifier: relay.agentIdentifier,

--- a/packages/human/src/index.ts
+++ b/packages/human/src/index.ts
@@ -135,8 +135,9 @@ program
 
 program
   .command('contacts')
-  .option('--limit <n>', 'max contacts to print (default: 50, max: 100)')
-  .option('--json', 'print JSON ({ data, next }; rows carry `self: true` for you)')
+  .option('--limit <n>', 'max contacts per page (default: 50, max: 100)')
+  .option('--after <cursor>', 'continue from the `next` cursor of a previous page')
+  .option('--json', 'print JSON ({ data, next }; rows carry `self: true` for you; pass `next` to --after)')
   .option('--api-url <url>', 'Novu API URL override')
   .description('List humans (subscribers) agents can reach with --to')
   .action(contactsCommand);

--- a/packages/human/src/index.ts
+++ b/packages/human/src/index.ts
@@ -2,6 +2,7 @@
 import { Command } from 'commander';
 import { version } from '../package.json';
 import { channelsCommand } from './commands/channels';
+import { contactsCommand } from './commands/contacts';
 import { runInteraction } from './commands/interact';
 import { inviteCommand } from './commands/invite';
 import { cancelCommand, listCommand } from './commands/list';
@@ -111,6 +112,7 @@ program
   .option('--telegram-bot-token <token>', 'BotFather token (skips the interactive prompt)')
   .option('--slack-config-token <token>', 'Slack App Configuration Token (skips the interactive prompt)')
   .option('--email <address>', 'your email address for the email channel (skips the interactive prompt)')
+  .option('--name <name>', 'your name, shown to agents (skips the first-run prompt)')
   .option('--agent-identifier <identifier>', 'relay agent identifier (default: human-relay)')
   .option('--skill', 'also install the human-cli skill for coding agents (default: prompt on a TTY)')
   .option('--no-skill', 'skip the coding-agent skill install')
@@ -125,10 +127,19 @@ program
     'channel to link them on (telegram, slack, email). Required when several channels are linked.'
   )
   .option('--email <address>', 'their email address (required for --via email when not a TTY)')
+  .option('--name <name>', 'their display name, e.g. "Alice Chen" (shown in `human contacts`)')
   .option('--async', 'print the connect URL and exit instead of waiting for them to finish')
   .option('--api-url <url>', 'Novu API URL override')
   .description('Link another human to a channel (sends them a Slack/Telegram connect URL)')
   .action(inviteCommand);
+
+program
+  .command('contacts')
+  .option('--limit <n>', 'max contacts to print (default: 50, max: 100)')
+  .option('--json', 'print JSON ({ data, next }; rows carry `self: true` for you)')
+  .option('--api-url <url>', 'Novu API URL override')
+  .description('List humans (subscribers) agents can reach with --to')
+  .action(contactsCommand);
 
 program
   .command('channels')

--- a/packages/human/src/skills/content/human-cli/SKILL.md
+++ b/packages/human/src/skills/content/human-cli/SKILL.md
@@ -86,10 +86,10 @@ else a job finished — look before you ask:
 human contacts --json
 ```
 
-Each row is a subscriber the environment knows about: `subscriberId`,
+Each row is a subscriber the environment knows about: `id` (the subscriberId),
 `firstName`/`lastName`, `email`, `phone`, free-form `data`, and `self: true`
 on the person who ran setup (the default `--to` when you pass nothing).
-Pick by name or id and pass the `subscriberId` to `--to`:
+Pick by name or id and pass the `id` to `--to`:
 
 ```bash
 human approve "Ship the pricing change?" --to alice
@@ -99,7 +99,7 @@ human tell "Deploy is done." --to alice,bob
 Contacts is a directory, not a reachability guarantee. If delivery fails with
 "no linked <channel> endpoint", that person exists but hasn't connected the
 channel yet — run `human invite <id> --via <channel> --name "…"`, send them
-the URL, and retry. Never invent a subscriberId that isn't in the list, and
+the URL, and retry. Never invent an id that isn't in the list, and
 never page `self` as if they were a third party.
 
 ## The four commands

--- a/packages/human/src/skills/content/human-cli/SKILL.md
+++ b/packages/human/src/skills/content/human-cli/SKILL.md
@@ -89,6 +89,8 @@ human contacts --json
 Each row is a subscriber the environment knows about: `id` (the subscriberId),
 `firstName`/`lastName`, `email`, `phone`, free-form `data`, and `self: true`
 on the person who ran setup (the default `--to` when you pass nothing).
+Pages are 50 rows by default; when `next` is non-null, fetch the rest with
+`human contacts --after <next>` before concluding someone isn't there.
 Pick by name or id and pass the `id` to `--to`:
 
 ```bash

--- a/packages/human/src/skills/content/human-cli/SKILL.md
+++ b/packages/human/src/skills/content/human-cli/SKILL.md
@@ -65,14 +65,42 @@ To reach a *different* person than the one who ran setup, they need a linked
 channel too:
 
 ```bash
-human invite alice --via slack
-human invite bob --via telegram --async
-human invite carol --via email --email carol@acme.com
+human invite alice --via slack --name "Alice Chen"
+human invite bob --via telegram --async --name "Bob"
+human invite carol --via email --email carol@acme.com --name "Carol Diaz"
 ```
 
 Send them the printed URL (Slack authorize or Telegram Start). `--async`
 prints the URL and returns immediately. This does **not** change
 `~/.novu/human.json`. After they connect, address them with `--to alice`.
+`--name` is what `human contacts` shows next to the id, so always pass it
+when you know who the person is.
+
+## Who can I reach: check contacts before coordinating between people
+
+When a task involves more than the one human who ran setup — routing a
+question to the right owner, getting a second approval, telling someone
+else a job finished — look before you ask:
+
+```bash
+human contacts --json
+```
+
+Each row is a subscriber the environment knows about: `subscriberId`,
+`firstName`/`lastName`, `email`, `phone`, free-form `data`, and `self: true`
+on the person who ran setup (the default `--to` when you pass nothing).
+Pick by name or id and pass the `subscriberId` to `--to`:
+
+```bash
+human approve "Ship the pricing change?" --to alice
+human tell "Deploy is done." --to alice,bob
+```
+
+Contacts is a directory, not a reachability guarantee. If delivery fails with
+"no linked <channel> endpoint", that person exists but hasn't connected the
+channel yet — run `human invite <id> --via <channel> --name "…"`, send them
+the URL, and retry. Never invent a subscriberId that isn't in the list, and
+never page `self` as if they were a third party.
 
 ## The four commands
 
@@ -137,9 +165,9 @@ other useful work to do while you wait.
   is asking. Set this whenever you have a stable identity (skip it for
   one-off ad hoc runs).
 - `--to <humanId>` / `--via <telegram|slack|email>` — `--to` addresses humans
-  who are already linked. Link someone else first with
-  `human invite alice --via slack` (prints a connect URL for them; does not
-  change your local identity). `--to alice,bob` lets any listed human settle
+  who are already linked. Find them with `human contacts --json` first; link
+  someone new with `human invite alice --via slack --name "Alice Chen"`
+  (prints a connect URL for them; does not change your local identity). `--to alice,bob` lets any listed human settle
   (first valid answer wins, max 50). `--via` on ask/approve is only a delivery
   override when that person has several channels; don't guess — if you need
   a specific one, pass `--via`. If they have no endpoint yet, the API tells


### PR DESCRIPTION
### What changed? Why was the change needed?

`@novu/human` lets an agent ask, approve, choose, or tell a human, but an agent had no way to discover **who** it can reach. `human invite` writes no local state, the CLI never read subscriber names, and the only enumeration primitive returned channel endpoints rather than people. Coordinating between several humans meant knowing subscriberIds out of band.

This PR adds a contacts directory and display names. Design decisions (agreed in a grilling session):

- A **contact is a subscriber**. Contacts are all subscribers in the environment: no marker, no reachability filter. Auto-provisioned platform senders show up too.
- Rows carry **subscriber fields only** (`id, firstName, lastName, email, phone, data, createdAt, updatedAt`; `id` is the subscriberId that `--to` addresses). A per-contact `channels` field is a deliberate future extension, not in v1.
- Served by a **new `GET /v1/human/contacts`** endpoint (keyless-accessible, like the rest of `/v1/human`) instead of opening the v2 subscriber search to keyless, so human-specific filters can be added later.

**API (`apps/api/src/app/human`)**
- `POST /v1/human/setup` accepts optional `firstName` / `lastName`. Set on create, replaced on re-run when provided, never cleared when omitted (same rule as `email`).
- New `GET /v1/human/contacts` with `limit` (1–100, default 50) and `after` cursor, returning `{ data, next }`. Backed by the same `subscriberRepository.listSubscribers` pagination as `GET /v2/subscribers`, mapped to a narrow DTO that does not leak `_id`, `_environmentId`, legacy `channels`, or topics.
- New e2e suite `human-contacts.e2e.ts`: name create/replace/keep, full listing with only DTO fields, paging, malformed-cursor empty page.

**CLI (`packages/human`)**
- New flat `human contacts` command: table view (`ID / NAME / EMAIL`), `--json` returning `{ data, next }`, `--limit`. The operator's own row is marked `(you)` / `self: true` by comparing to `config.subscriberId`, so agents don't page the operator as a third party. Prints a "more" hint when another page exists.
- `--name "Alice Chen"` on `human invite` and `human setup`, split on the first space into `firstName` / `lastName`. Setup prompts once for your name on a first-run TTY (`--name` skips, non-TTY skips silently). The smoke-test `tell` greets by name.
- `invite --via email --name` on an already-linked email human still writes the name, so people linked before names existed can be labeled.
- Bundled SKILL.md gains a "Who can I reach" workflow section telling agents to run `human contacts --json` before coordinating between people, and that contacts is a directory, not a reachability guarantee. README updated.

**Verification**
- `pnpm --filter @novu/human test`: 58 tests / 7 files pass (new specs for `contacts`, `splitName`, `--name` forwarding, `resolveOperatorName`). `pnpm build` succeeds.
- API e2e for `human-contacts.e2e.ts` + `human-interactions.e2e.ts`: 26 passing (run in CE mode locally, since `@novu/ee-auth` isn't built here).
- Biome clean on changed files apart from the repo's `Record` "verify" reminder, which also fires on the existing base subscriber DTO.

### Screenshots

N/A (CLI + API).

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

- Names are split on the first whitespace (`"Mary Ann Smith"` → `Mary` / `Ann Smith`). Inbound reply attribution already reads `subscriber.firstName`, so replies now show a name instead of a raw id.
- `contacts` is deliberately unfiltered; if a real environment is used via `--secret-key`, it lists that environment's whole subscriber base. Filters are the intended follow-up on the new endpoint.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a subscriber-backed contacts directory to the Human API and CLI, along with subscriber display-name support during setup and invitation.
- Adds the paginated `GET /v1/human/contacts` endpoint with a restricted contact DTO.
- Adds `human contacts`, JSON/table output, self markers, limits, and continuation-cursor support.
- Captures and updates names through `human setup` and `human invite`.
- Updates tests, documentation, bundled skill guidance, and the Human website.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/human/usecases/list-contacts/list-contacts.usecase.ts | Implements environment-scoped subscriber pagination, cursor validation, and narrow contact DTO mapping. |
| apps/api/src/app/human/human-interactions.controller.ts | Exposes the contacts endpoint and forwards optional subscriber names during relay setup. |
| apps/api/src/app/human/usecases/setup-human-relay/setup-human-relay.usecase.ts | Creates or selectively updates normalized subscriber email and display-name fields without clearing omitted values. |
| packages/human/src/commands/contacts.ts | Implements contacts pagination, table and JSON rendering, self identification, and continuation instructions. |
| packages/human/src/index.ts | Registers the contacts command, including the continuation-cursor option required to access later pages. |
| packages/human/src/commands/invite.ts | Splits display names and forwards them while inviting new or already-linked contacts. |
| packages/human/src/commands/setup.ts | Adds optional first-run name collection and forwards the resolved name during operator setup. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Agent
  participant CLI as human CLI
  participant API as Human API
  participant DAL as Subscriber repository
  Agent->>CLI: human contacts [--limit] [--after]
  CLI->>API: GET /v1/human/contacts
  API->>DAL: listSubscribers(environment, limit, after)
  DAL-->>API: subscribers + next cursor
  API-->>CLI: restricted contact DTOs + next
  CLI-->>Agent: table or JSON with self markers
  Agent->>CLI: human contacts --after next
  CLI->>API: GET contacts with continuation cursor
```

<sub>Reviews (4): Last reviewed commit: ["docs(human): drop the exit-codes table f..."](https://github.com/novuhq/novu/commit/d16a666827efe8e2dfa83e96acd0b5f7e53e4f48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59559103)</sub>

<!-- /greptile_comment -->