### PR TITLE
feat(api-service,human): cap keyless human interactions and push the claim link

### DIFF
--- a/apps/api/src/app/connect/connect.module.ts
+++ b/apps/api/src/app/connect/connect.module.ts
@@ -8,6 +8,7 @@ import {
   ConversationActivityRepository,
   ConversationRepository,
   EnvironmentRepository,
+  HumanInteractionRepository,
   IntegrationRepository,
   McpConnectionRepository,
   SubscriberRepository,
@@ -35,6 +36,7 @@ import { ClaimKeylessConnect } from './usecases/claim-keyless-connect/claim-keyl
     AgentMcpServerRepository,
     McpConnectionRepository,
     EnvironmentRepository,
+    HumanInteractionRepository,
   ],
   exports: [ConnectClaimTokenService],
 })

--- a/apps/api/src/app/connect/services/connect-claim-token.service.ts
+++ b/apps/api/src/app/connect/services/connect-claim-token.service.ts
@@ -84,6 +84,30 @@ export class ConnectClaimTokenService {
     return issued;
   }
 
+  /**
+   * True once the claim token issued for this keyless environment has been
+   * consumed — i.e. its assets now live in a real organization. Best-effort:
+   * cache outages and missing tokens read as "not claimed".
+   */
+  async isEnvironmentClaimed(environmentId: string): Promise<boolean> {
+    if (!this.cacheService.cacheEnabled()) {
+      return false;
+    }
+
+    try {
+      const token = await this.cacheService.get(`${ENV_TOKEN_KEY_PREFIX}{${environmentId}}`);
+      if (!token || !isConnectClaimTokenFormat(token)) {
+        return false;
+      }
+
+      return await this.tokens.isTokenUsed(token);
+    } catch (error) {
+      this.logger.warn({ err: error, environmentId }, 'Failed to read connect claim state for environment');
+
+      return false;
+    }
+  }
+
   async isSignupCtaPosted(conversationId: string): Promise<boolean> {
     if (!this.cacheService.cacheEnabled()) {
       return false;

--- a/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
+++ b/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
@@ -16,6 +16,7 @@ import {
   ConversationRepository,
   EnvironmentEntity,
   EnvironmentRepository,
+  HumanInteractionRepository,
   IntegrationRepository,
   McpConnectionRepository,
   SubscriberRepository,
@@ -49,6 +50,7 @@ export class ClaimKeylessConnect {
     private readonly subscriberRepository: SubscriberRepository,
     private readonly agentMcpServerRepository: AgentMcpServerRepository,
     private readonly mcpConnectionRepository: McpConnectionRepository,
+    private readonly humanInteractionRepository: HumanInteractionRepository,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -106,6 +108,7 @@ export class ClaimKeylessConnect {
         await this.conversationActivityRepository.update(sourceScope, { $set: target }, { session });
         await this.agentMcpServerRepository.update(sourceScope, { $set: target }, { session });
         await this.mcpConnectionRepository.update(sourceScope, { $set: target }, { session });
+        await this.humanInteractionRepository.update(sourceScope, { $set: target }, { session });
         await this.subscriberRepository.update(
           { ...sourceScope, subscriberId: { $ne: KEYLESS_SUBSCRIBER_ID } },
           { $set: target },

--- a/apps/api/src/app/human/e2e/human-interactions.e2e.ts
+++ b/apps/api/src/app/human/e2e/human-interactions.e2e.ts
@@ -16,6 +16,7 @@ import { ChatInstanceRegistry } from '../../agents/conversation-runtime/ingress/
 import { AgentInboundHandler } from '../../agents/conversation-runtime/ingress/inbound-turn.handler';
 import { startTelegramApiStub, type TelegramApiStub } from '../../agents/e2e/helpers/telegram-api-stub';
 import { AgentEventEnum } from '../../agents/shared/enums/agent-event.enum';
+import { ConnectClaimTokenService } from '../../connect/services/connect-claim-token.service';
 
 const integrationRepository = new IntegrationRepository();
 const agentIntegrationRepository = new AgentIntegrationRepository();
@@ -583,6 +584,100 @@ describe('Human interactions (create → deliver → resolve) #novu-v2', () => {
       const listRes = await session.testAgent.get('/v1/human/interactions?status=pending');
       expect(listRes.status).to.equal(200);
       expect(listRes.body.data.length).to.be.greaterThan(0);
+    });
+  });
+
+  describe('keyless demo cap', () => {
+    let originalKeylessOrgId: string | undefined;
+    let originalCap: string | undefined;
+
+    beforeEach(() => {
+      originalKeylessOrgId = process.env.KEYLESS_ORGANIZATION_ID;
+      originalCap = process.env.KEYLESS_HUMAN_INTERACTION_CAP;
+      process.env.KEYLESS_ORGANIZATION_ID = session.organization._id;
+      process.env.KEYLESS_HUMAN_INTERACTION_CAP = '2';
+    });
+
+    afterEach(() => {
+      restoreEnv('KEYLESS_ORGANIZATION_ID', originalKeylessOrgId);
+      restoreEnv('KEYLESS_HUMAN_INTERACTION_CAP', originalCap);
+    });
+
+    function restoreEnv(name: string, value: string | undefined) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+
+    function telegramSends() {
+      return telegramApiStub.calls.filter((call) => call.method === 'sendMessage');
+    }
+
+    it('replaces delivery with the sign-up card once the cap is reached, and only sends it once', async () => {
+      expect((await createInteraction({ kind: 'tell', prompt: 'One.' })).status).to.equal(201);
+      expect((await createInteraction({ kind: 'tell', prompt: 'Two.' })).status).to.equal(201);
+      const sendsBefore = telegramSends().length;
+
+      const third = await createInteraction({ kind: 'ask', prompt: 'Three?' });
+      expect(third.status).to.equal(429, JSON.stringify(third.body));
+      expect(third.body.code).to.equal('KEYLESS_HUMAN_CAP_REACHED');
+      expect(third.body.cap).to.equal(2);
+      expect(third.body.claimUrl).to.match(/\/connect\/claim\?token=/);
+      expect(third.body.message).to.include(third.body.claimUrl);
+
+      // The human got the CTA card on the channel the prompt would have used — not the prompt itself.
+      const sends = telegramSends();
+      expect(sends.length).to.equal(sendsBefore + 1);
+      const cta = JSON.stringify(sends[sends.length - 1].payload);
+      expect(cta).to.include('connect/claim');
+      expect(cta).to.include('Sign up');
+      expect(cta).to.not.include('Three?');
+
+      // Nothing was persisted for the blocked call.
+      expect(await humanInteractionRepository.count({ _environmentId: session.environment._id })).to.equal(2);
+
+      // A retrying agent keeps getting the 429 + link, but the human is not spammed again.
+      const fourth = await createInteraction({ kind: 'ask', prompt: 'Four?' });
+      expect(fourth.status).to.equal(429);
+      expect(fourth.body.claimUrl).to.equal(third.body.claimUrl);
+      expect(telegramSends().length).to.equal(sendsBefore + 1);
+    });
+
+    it('does not apply to non-keyless organizations', async () => {
+      process.env.KEYLESS_ORGANIZATION_ID = 'some-other-org';
+
+      expect((await createInteraction({ kind: 'tell', prompt: 'One.' })).status).to.equal(201);
+      expect((await createInteraction({ kind: 'tell', prompt: 'Two.' })).status).to.equal(201);
+      expect((await createInteraction({ kind: 'tell', prompt: 'Three.' })).status).to.equal(201);
+    });
+
+    it('moves interactions with the claim and points a stale keyless credential at re-auth', async () => {
+      const created = await createInteraction({ kind: 'approve', prompt: 'Keep me?' });
+      expect(created.status).to.equal(201, JSON.stringify(created.body));
+
+      const tokenService = testServer.getService(ConnectClaimTokenService);
+      const { token } = await tokenService.issueOrGetForEnvironment({
+        env: session.environment._id,
+        org: session.organization._id,
+      });
+
+      const claimer = new UserSession();
+      await claimer.initialize();
+      const claimRes = await claimer.testAgent.post('/v1/connect/claim').send({ token });
+      expect(claimRes.status).to.equal(200, JSON.stringify(claimRes.body));
+      const targetEnvironmentId = claimRes.body.data.environmentId as string;
+
+      const row = await humanInteractionRepository.findByIdentifier(targetEnvironmentId, created.body.data.id);
+      expect(row?._organizationId).to.equal(claimer.organization._id);
+      expect(await humanInteractionRepository.count({ _environmentId: session.environment._id })).to.equal(0);
+
+      // The keyless env is now empty; the CLI must be told to re-auth, not to run setup again.
+      const after = await createInteraction({ kind: 'tell', prompt: 'Still here?' });
+      expect(after.status).to.equal(403, JSON.stringify(after.body));
+      expect(after.body.message).to.match(/claimed into your Novu account/);
+      expect(after.body.message).to.include('human setup --secret-key');
     });
   });
 });

--- a/apps/api/src/app/human/human.module.ts
+++ b/apps/api/src/app/human/human.module.ts
@@ -8,6 +8,7 @@ import {
 } from '@novu/dal';
 import { AgentsModule } from '../agents/agents.module';
 import { AuthModule } from '../auth/auth.module';
+import { ConnectModule } from '../connect/connect.module';
 import { SharedModule } from '../shared/shared.module';
 import { HumanInteractionsController } from './human-interactions.controller';
 import { HumanDeliveryService } from './services/human-delivery.service';
@@ -23,7 +24,7 @@ import { SetupHumanRelay } from './usecases/setup-human-relay/setup-human-relay.
  * Framework `ctx.*` helpers create in-thread cards via `CreateConversationInteraction`.
  */
 @Module({
-  imports: [SharedModule, AuthModule, AgentsModule],
+  imports: [SharedModule, AuthModule, AgentsModule, ConnectModule],
   controllers: [HumanInteractionsController],
   providers: [
     HumanInteractionRepository,

--- a/apps/api/src/app/human/services/human-delivery.service.ts
+++ b/apps/api/src/app/human/services/human-delivery.service.ts
@@ -17,6 +17,7 @@ import {
 } from '@novu/shared';
 import { OutboundGateway } from '../../agents/conversation-runtime/egress/outbound.gateway';
 import { buildPendingContent } from '../../agents/human-relay/human-card.builder';
+import type { ReplyContentDto } from '../../agents/shared/dtos/agent-reply-payload.dto';
 
 export interface ResolvedHumanTarget {
   platform: string;
@@ -140,11 +141,20 @@ export class HumanDeliveryService {
     interaction: HumanInteractionEntity,
     target: ResolvedHumanTarget
   ): Promise<{ platformMessageId: string; platformThreadId: string }> {
+    return this.deliverContent(interaction._agentId, target, buildPendingContent(interaction));
+  }
+
+  /** One-off DM of arbitrary content (e.g. the keyless sign-up CTA) to an already-resolved target. */
+  async deliverContent(
+    agentId: string,
+    target: ResolvedHumanTarget,
+    content: ReplyContentDto
+  ): Promise<{ platformMessageId: string; platformThreadId: string }> {
     const sent = await this.outboundGateway.sendDirectMessage(
-      interaction._agentId,
+      agentId,
       target.integrationIdentifier,
       target.platformUserId,
-      buildPendingContent(interaction)
+      content
     );
 
     return { platformMessageId: sent.messageId, platformThreadId: sent.platformThreadId };

--- a/apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.spec.ts
+++ b/apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.spec.ts
@@ -19,6 +19,7 @@ describe('CreateInteraction', () => {
     };
     const humanInteractionRepository = {
       countPendingForSubscriber: sinon.stub().resolves(0),
+      count: sinon.stub().resolves(0),
       create: sinon.stub().resolves(created),
       stampDelivery: sinon.stub().resolves(undefined),
       markDeliveredIfPending: sinon.stub().resolves({ ...created, status: HumanInteractionStatusEnum.DELIVERED }),
@@ -34,12 +35,20 @@ describe('CreateInteraction', () => {
         platformUserId: '777',
       }),
       deliver: sinon.stub().resolves({ platformMessageId: 'msg-1', platformThreadId: 'thread-1' }),
+      deliverContent: sinon.stub().resolves({ platformMessageId: 'cta-1', platformThreadId: 'thread-1' }),
+    };
+    const connectClaimTokenService = {
+      isEnvironmentClaimed: sinon.stub().resolves(false),
+      issueOrGetForEnvironment: sinon.stub().resolves({ token: 'tok', expiresAt: '2026-01-08T00:00:00.000Z' }),
+      isSignupCtaPosted: sinon.stub().resolves(false),
+      tryMarkSignupCtaPosted: sinon.stub().resolves(true),
     };
     const logger = { setContext: sinon.stub(), warn: sinon.stub() };
     const usecase = new CreateInteraction(
       humanInteractionRepository as any,
       agentRepository as any,
       deliveryService as any,
+      connectClaimTokenService as any,
       logger as any
     );
     const command = {
@@ -59,6 +68,7 @@ describe('CreateInteraction', () => {
       agentRepository,
       deliveryService,
       humanInteractionRepository,
+      connectClaimTokenService,
     };
   }
 
@@ -270,5 +280,153 @@ describe('CreateInteraction', () => {
     expect(humanInteractionRepository.stampDelivery.firstCall.args[2].subscriberIds).to.deep.equal(['sub-2']);
     expect(result.to).to.deep.equal(['sub-2']);
     expect(result.failedTo).to.deep.equal(['sub-1']);
+  });
+
+  describe('keyless demo cap', () => {
+    let originalKeylessOrgId: string | undefined;
+    let originalCap: string | undefined;
+
+    beforeEach(() => {
+      originalKeylessOrgId = process.env.KEYLESS_ORGANIZATION_ID;
+      originalCap = process.env.KEYLESS_HUMAN_INTERACTION_CAP;
+      process.env.KEYLESS_ORGANIZATION_ID = 'org1';
+      process.env.KEYLESS_HUMAN_INTERACTION_CAP = '2';
+    });
+
+    afterEach(() => {
+      restoreEnv('KEYLESS_ORGANIZATION_ID', originalKeylessOrgId);
+      restoreEnv('KEYLESS_HUMAN_INTERACTION_CAP', originalCap);
+    });
+
+    function restoreEnv(name: string, value: string | undefined) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+
+    it('creates normally while under the cap', async () => {
+      const { usecase, command, agentRepository, humanInteractionRepository, deliveryService } = setup();
+      agentRepository.findOne.resolves({ _id: 'agent-hitl', identifier: 'human-hitl' });
+      humanInteractionRepository.count.resolves(1);
+
+      await usecase.execute(command as any);
+
+      expect(humanInteractionRepository.create.calledOnce).to.equal(true);
+      expect(deliveryService.deliverContent.called).to.equal(false);
+    });
+
+    it('sends the sign-up card instead of the prompt and returns 429 with the claim link once capped', async () => {
+      const {
+        usecase,
+        command,
+        agentRepository,
+        humanInteractionRepository,
+        deliveryService,
+        connectClaimTokenService,
+      } = setup();
+      agentRepository.findOne.resolves({ _id: 'agent-hitl', identifier: 'human-hitl' });
+      humanInteractionRepository.count.resolves(2);
+
+      let thrown: unknown;
+      try {
+        await usecase.execute(command as any);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).to.be.instanceOf(HttpException);
+      const response = (thrown as HttpException).getResponse() as Record<string, unknown>;
+      expect((thrown as HttpException).getStatus()).to.equal(429);
+      expect(response.code).to.equal('KEYLESS_HUMAN_CAP_REACHED');
+      expect(response.cap).to.equal(2);
+      expect(response.claimUrl).to.match(/\/connect\/claim\?token=tok$/);
+      expect(response.message).to.include(response.claimUrl as string);
+
+      expect(humanInteractionRepository.create.called).to.equal(false);
+      expect(deliveryService.deliver.called).to.equal(false);
+      expect(deliveryService.deliverContent.calledOnce).to.equal(true);
+      expect(deliveryService.deliverContent.firstCall.args[0]).to.equal('agent-hitl');
+      expect(JSON.stringify(deliveryService.deliverContent.firstCall.args[2])).to.include('Sign up');
+      expect(connectClaimTokenService.tryMarkSignupCtaPosted.calledOnceWith('human:env1')).to.equal(true);
+    });
+
+    it('does not resend the card when the CTA was already posted for the environment', async () => {
+      const {
+        usecase,
+        command,
+        agentRepository,
+        humanInteractionRepository,
+        deliveryService,
+        connectClaimTokenService,
+      } = setup();
+      agentRepository.findOne.resolves({ _id: 'agent-hitl', identifier: 'human-hitl' });
+      humanInteractionRepository.count.resolves(5);
+      connectClaimTokenService.isSignupCtaPosted.resolves(true);
+
+      let status: number | undefined;
+      try {
+        await usecase.execute(command as any);
+      } catch (error) {
+        status = (error as HttpException).getStatus();
+      }
+
+      expect(status).to.equal(429);
+      expect(deliveryService.deliverContent.called).to.equal(false);
+    });
+
+    it('still returns 429 when the claim link cannot be issued', async () => {
+      const {
+        usecase,
+        command,
+        agentRepository,
+        humanInteractionRepository,
+        deliveryService,
+        connectClaimTokenService,
+      } = setup();
+      agentRepository.findOne.resolves({ _id: 'agent-hitl', identifier: 'human-hitl' });
+      humanInteractionRepository.count.resolves(2);
+      connectClaimTokenService.issueOrGetForEnvironment.rejects(new Error('cache down'));
+
+      let thrown: HttpException | undefined;
+      try {
+        await usecase.execute(command as any);
+      } catch (error) {
+        thrown = error as HttpException;
+      }
+
+      expect(thrown?.getStatus()).to.equal(429);
+      expect((thrown?.getResponse() as Record<string, unknown>).claimUrl).to.equal(undefined);
+      expect(deliveryService.deliverContent.called).to.equal(false);
+    });
+
+    it('rejects a claimed keyless environment with a re-auth hint before looking up the agent', async () => {
+      const { usecase, command, agentRepository, connectClaimTokenService } = setup();
+      connectClaimTokenService.isEnvironmentClaimed.resolves(true);
+
+      let thrown: HttpException | undefined;
+      try {
+        await usecase.execute(command as any);
+      } catch (error) {
+        thrown = error as HttpException;
+      }
+
+      expect(thrown?.getStatus()).to.equal(403);
+      expect(thrown?.message).to.include('human setup --secret-key');
+      expect(agentRepository.findOne.called).to.equal(false);
+    });
+
+    it('ignores the cap for non-keyless organizations', async () => {
+      process.env.KEYLESS_ORGANIZATION_ID = 'some-other-org';
+      const { usecase, command, agentRepository, humanInteractionRepository, connectClaimTokenService } = setup();
+      agentRepository.findOne.resolves({ _id: 'agent-hitl', identifier: 'human-hitl' });
+      humanInteractionRepository.count.resolves(50);
+
+      await usecase.execute(command as any);
+
+      expect(humanInteractionRepository.create.calledOnce).to.equal(true);
+      expect(connectClaimTokenService.isEnvironmentClaimed.called).to.equal(false);
+    });
   });
 });

--- a/apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.ts
+++ b/apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.ts
@@ -1,7 +1,12 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, HttpException, Injectable, NotFoundException } from '@nestjs/common';
 import { InstrumentUsecase, PinoLogger } from '@novu/application-generic';
 import { AgentEntity, AgentRepository, HumanInteractionRepository } from '@novu/dal';
 import { normalizeHumanTo } from '@novu/shared';
+import type { ReplyContentDto } from '../../../agents/shared/dtos/agent-reply-payload.dto';
+import { ConnectClaimTokenService } from '../../../connect/services/connect-claim-token.service';
+import { resolveKeylessHumanInteractionCap } from '../../../keyless/keyless-abuse.constants';
+import { isKeylessOrganization } from '../../../keyless/keyless-organization.helpers';
+import { buildConnectClaimUrl, buildKeylessHumanSignupCard } from '../../../keyless/keyless-signup.helpers';
 import { type InteractionResponseDto, toInteractionResponse } from '../../dtos/interaction-response.dto';
 import { HumanDeliveryService } from '../../services/human-delivery.service';
 import {
@@ -14,12 +19,19 @@ import {
 import { DEFAULT_HUMAN_RELAY_IDENTIFIER } from '../setup-human-relay/setup-human-relay.usecase';
 import { CreateInteractionCommand } from './create-interaction.command';
 
+/** Machine-readable code on the 429 body so `@novu/human` can branch without parsing prose. */
+export const KEYLESS_HUMAN_CAP_REACHED_CODE = 'KEYLESS_HUMAN_CAP_REACHED';
+
+export const KEYLESS_HUMAN_CLAIMED_MESSAGE =
+  'This demo workspace was claimed into your Novu account. Run `human setup --secret-key <your Development environment key>` (or set NOVU_SECRET_KEY) to continue.';
+
 @Injectable()
 export class CreateInteraction {
   constructor(
     private readonly humanInteractionRepository: HumanInteractionRepository,
     private readonly agentRepository: AgentRepository,
     private readonly deliveryService: HumanDeliveryService,
+    private readonly connectClaimTokenService: ConnectClaimTokenService,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -29,10 +41,22 @@ export class CreateInteraction {
   async execute(command: CreateInteractionCommand): Promise<InteractionResponseDto> {
     assertHumanChooseOptions(command.kind, command.options);
 
+    const isKeyless = isKeylessOrganization(command.organizationId);
+
+    // Once claimed, the relay agent and channels live in the user's own
+    // environment; a stale keyless credential must not read as "run setup".
+    if (isKeyless && (await this.connectClaimTokenService.isEnvironmentClaimed(command.environmentId))) {
+      throw new ForbiddenException(KEYLESS_HUMAN_CLAIMED_MESSAGE);
+    }
+
     const agent = await this.resolveAgent(command);
     const subscriberIds = normalizeHumanTo(command.to);
     if (subscriberIds.length === 0) {
       throw new BadRequestException('`to` must include at least one subscriberId');
+    }
+
+    if (isKeyless) {
+      await this.assertKeylessHumanCap(command, agent, subscriberIds);
     }
 
     await assertHumanPendingCap(this.humanInteractionRepository, {
@@ -43,18 +67,7 @@ export class CreateInteraction {
         `Human "${subscriberId}" already has ${pendingCount} pending interactions (cap ${cap}). Wait for answers or cancel stale ones with \`human list\`.`,
     });
 
-    const resolved = await Promise.all(
-      subscriberIds.map(async (subscriberId) => ({
-        subscriberId,
-        target: await this.deliveryService.resolveChannel({
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-          agentId: agent._id,
-          subscriberId,
-          via: command.via,
-        }),
-      }))
-    );
+    const resolved = await this.resolveTargets(command, agent, subscriberIds);
 
     const interaction = await this.humanInteractionRepository.create(
       buildPendingHumanInteraction({
@@ -82,6 +95,112 @@ export class CreateInteraction {
     });
 
     return toInteractionResponse(delivered.interaction, delivered.failedSubscriberIds);
+  }
+
+  private async resolveTargets(command: CreateInteractionCommand, agent: AgentEntity, subscriberIds: string[]) {
+    return Promise.all(
+      subscriberIds.map(async (subscriberId) => ({
+        subscriberId,
+        target: await this.deliveryService.resolveChannel({
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          agentId: agent._id,
+          subscriberId,
+          via: command.via,
+        }),
+      }))
+    );
+  }
+
+  /**
+   * Keyless demo cap (`KEYLESS_HUMAN_INTERACTION_CAP`, counted across every
+   * interaction the environment ever created). Past it, the human gets the
+   * sign-up card on the channel the prompt would have used — once per
+   * environment, so a retrying agent does not spam them — and the caller gets
+   * a 429 carrying the same claim link.
+   */
+  private async assertKeylessHumanCap(
+    command: CreateInteractionCommand,
+    agent: AgentEntity,
+    subscriberIds: string[]
+  ): Promise<void> {
+    const cap = resolveKeylessHumanInteractionCap();
+    const used = await this.humanInteractionRepository.count({ _environmentId: command.environmentId });
+
+    if (used < cap) {
+      return;
+    }
+
+    const claimUrl = await this.resolveClaimUrl(command);
+    await this.postKeylessSignupCta(command, agent, subscriberIds, claimUrl);
+
+    const message = claimUrl
+      ? `You've used the ${cap} free messages of this keyless demo. Sign up for a free Novu account to keep your channels and continue: ${claimUrl}`
+      : `You've used the ${cap} free messages of this keyless demo. Sign up for a free Novu account to keep your channels and continue.`;
+
+    throw new HttpException(
+      { statusCode: 429, message, code: KEYLESS_HUMAN_CAP_REACHED_CODE, cap, ...(claimUrl ? { claimUrl } : {}) },
+      429
+    );
+  }
+
+  private async resolveClaimUrl(command: CreateInteractionCommand): Promise<string | undefined> {
+    try {
+      const { token } = await this.connectClaimTokenService.issueOrGetForEnvironment({
+        env: command.environmentId,
+        org: command.organizationId,
+      });
+
+      return buildConnectClaimUrl(token);
+    } catch (err) {
+      this.logger.warn({ err, environmentId: command.environmentId }, 'Failed to issue keyless claim token');
+
+      return undefined;
+    }
+  }
+
+  private async postKeylessSignupCta(
+    command: CreateInteractionCommand,
+    agent: AgentEntity,
+    subscriberIds: string[],
+    claimUrl: string | undefined
+  ): Promise<void> {
+    if (!claimUrl) {
+      return;
+    }
+
+    const ctaKey = `human:${command.environmentId}`;
+
+    try {
+      if (await this.connectClaimTokenService.isSignupCtaPosted(ctaKey)) {
+        return;
+      }
+
+      const content = { card: buildKeylessHumanSignupCard(claimUrl) } as ReplyContentDto;
+      let deliveredCount = 0;
+
+      for (const subscriberId of subscriberIds) {
+        try {
+          const target = await this.deliveryService.resolveChannel({
+            environmentId: command.environmentId,
+            organizationId: command.organizationId,
+            agentId: agent._id,
+            subscriberId,
+            via: command.via,
+          });
+          await this.deliveryService.deliverContent(agent._id, target, content);
+          deliveredCount += 1;
+        } catch (err) {
+          this.logger.warn({ err, subscriberId }, 'Failed to deliver keyless signup CTA to one human');
+        }
+      }
+
+      if (deliveredCount > 0) {
+        await this.connectClaimTokenService.tryMarkSignupCtaPosted(ctaKey);
+      }
+    } catch (err) {
+      this.logger.warn({ err, environmentId: command.environmentId }, 'Failed to post keyless signup CTA');
+    }
   }
 
   private async resolveAgent(command: CreateInteractionCommand): Promise<AgentEntity> {

--- a/apps/api/src/app/keyless/keyless-abuse.constants.ts
+++ b/apps/api/src/app/keyless/keyless-abuse.constants.ts
@@ -24,6 +24,17 @@ export const KEYLESS_GENERATE_CAP_PER_IP_PER_DAY = parsePositiveIntEnv(
 
 export const KEYLESS_MAX_AGENTS_PER_ENV = parsePositiveIntEnv(process.env.KEYLESS_MAX_AGENTS_PER_ENV, 2);
 
+/**
+ * How many `@novu/human` interactions a keyless environment may create before
+ * delivery is replaced by the sign-up CTA. Read at call time (not module load)
+ * so the value can change per process/test without a restart.
+ */
+export const KEYLESS_HUMAN_INTERACTION_CAP_DEFAULT = 5;
+
+export function resolveKeylessHumanInteractionCap(): number {
+  return parsePositiveIntEnv(process.env.KEYLESS_HUMAN_INTERACTION_CAP, KEYLESS_HUMAN_INTERACTION_CAP_DEFAULT);
+}
+
 export const KEYLESS_DAILY_COUNTER_TTL_SECONDS = 86_400;
 
 export const INCR_WITH_EXPIRE_SCRIPT = `

--- a/apps/api/src/app/keyless/keyless-signup.helpers.ts
+++ b/apps/api/src/app/keyless/keyless-signup.helpers.ts
@@ -68,3 +68,33 @@ export function buildKeylessSignupCard(claimUrl: string): CardElement {
     ],
   };
 }
+
+/**
+ * Sent on the human's linked channel *instead of* the agent's message once a
+ * keyless `@novu/human` environment hits its interaction cap.
+ */
+export function buildKeylessHumanSignupCard(claimUrl: string): CardElement {
+  return {
+    type: 'card',
+    children: [
+      {
+        type: 'text',
+        content:
+          "You've reached the limit of this free `human` demo. Sign up for a free Novu account to keep this " +
+          'channel and your setup — your agents pick up right where they left off.',
+      },
+      { type: 'divider' },
+      {
+        type: 'actions',
+        children: [
+          {
+            type: 'link-button',
+            label: 'Sign up & keep this setup',
+            url: claimUrl,
+            style: 'primary',
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/packages/human/README.md
+++ b/packages/human/README.md
@@ -53,6 +53,8 @@ human invite carol --via email --email carol@acme.com
 
 `setup` stores credentials in `~/.novu/human.json`. Alternatively set `NOVU_SECRET_KEY` (and optionally `NOVU_API_URL`) for an existing Novu environment.
 
+The keyless environment `setup` creates is a free demo with a small message allowance. Once it's used up, the next command exits `1` with a sign-up link (the same link is sent to you on your linked channel) instead of delivering the message. Sign up, claim the demo — your channels and relay move into your own Development environment — then point the CLI at it: `human setup --secret-key <key>` or `NOVU_SECRET_KEY`.
+
 In containers, sandboxes, and CI — anywhere no config file exists — the CLI is fully operational from environment variables alone:
 
 ```bash

--- a/packages/human/src/commands/interact.spec.ts
+++ b/packages/human/src/commands/interact.spec.ts
@@ -11,7 +11,9 @@ vi.mock('../output', async (importOriginal) => {
   };
 });
 
-const { parseDuration, parseHumanToOption, resolveTo } = await import('./interact');
+const { formatKeylessCapMessage, getKeylessCapDetails, handleError, parseDuration, parseHumanToOption, resolveTo } =
+  await import('./interact');
+const { HumanApiError } = await import('../api/client');
 const { exitCodeFor, EXIT_DENIED, EXIT_GONE, EXIT_OK, EXIT_TIMEOUT } = await import('../output');
 
 type HumanCliConfig = import('../config').HumanCliConfig;
@@ -106,5 +108,38 @@ describe('exit code contract', () => {
     expect(exitCodeFor({ ...base, status: 'expired' })).toBe(EXIT_GONE);
     expect(exitCodeFor({ ...base, status: 'canceled' })).toBe(EXIT_GONE);
     expect(exitCodeFor({ ...base, status: 'pending' })).toBe(EXIT_TIMEOUT);
+  });
+});
+
+describe('keyless cap errors', () => {
+  const capError = (body: unknown, status = 429, message = 'limit') =>
+    new HumanApiError(message, status, 'POST https://api.novu.co/v1/human/interactions', body);
+
+  it('detects the structured 429 body and extracts the claim link', () => {
+    const err = capError({ code: 'KEYLESS_HUMAN_CAP_REACHED', claimUrl: 'https://dash/connect/claim?token=t', cap: 5 });
+    expect(getKeylessCapDetails(err)).toEqual({ claimUrl: 'https://dash/connect/claim?token=t', cap: 5 });
+  });
+
+  it('falls back to the message wording when the body has no code', () => {
+    const err = capError({}, 429, "You've used the 5 free messages of this keyless demo.");
+    expect(getKeylessCapDetails(err)).toEqual({ claimUrl: undefined, cap: undefined });
+  });
+
+  it('ignores other 429s and non-API errors', () => {
+    expect(getKeylessCapDetails(capError({}, 429, 'already has 25 pending interactions'))).toBeNull();
+    expect(getKeylessCapDetails(capError({ code: 'KEYLESS_HUMAN_CAP_REACHED' }, 400))).toBeNull();
+    expect(getKeylessCapDetails(new Error('boom'))).toBeNull();
+  });
+
+  it('prints the claim link and the recovery command', () => {
+    const text = formatKeylessCapMessage({ claimUrl: 'https://dash/connect/claim?token=t', cap: 5 });
+    expect(text).toContain('5 free messages');
+    expect(text).toContain('https://dash/connect/claim?token=t');
+    expect(text).toContain('human setup --secret-key');
+  });
+
+  it('routes the cap error through fail with the claim link', () => {
+    const err = capError({ code: 'KEYLESS_HUMAN_CAP_REACHED', claimUrl: 'https://dash/connect/claim?token=t' });
+    expect(() => handleError(err)).toThrow('https://dash/connect/claim?token=t');
   });
 });

--- a/packages/human/src/commands/interact.ts
+++ b/packages/human/src/commands/interact.ts
@@ -174,7 +174,64 @@ export function parseDuration(value: string): number {
   return amount * multiplier;
 }
 
+/** Matches the API's `KEYLESS_HUMAN_CAP_REACHED_CODE`. The CLI cannot import `apps/api`. */
+const KEYLESS_CAP_CODE = 'KEYLESS_HUMAN_CAP_REACHED';
+
+export interface KeylessCapDetails {
+  claimUrl?: string;
+  cap?: number;
+}
+
+/**
+ * The keyless demo cap: a 429 whose body carries `code: KEYLESS_HUMAN_CAP_REACHED`
+ * (falling back to the message wording for older APIs). The human already got
+ * the same claim link on their channel; the agent just needs to stop retrying.
+ */
+export function getKeylessCapDetails(err: unknown): KeylessCapDetails | null {
+  if (!(err instanceof HumanApiError) || err.status !== 429) {
+    return null;
+  }
+
+  const body = (err.body && typeof err.body === 'object' ? err.body : {}) as {
+    code?: unknown;
+    claimUrl?: unknown;
+    cap?: unknown;
+  };
+
+  if (body.code !== KEYLESS_CAP_CODE && !/keyless demo/i.test(err.message)) {
+    return null;
+  }
+
+  return {
+    claimUrl: typeof body.claimUrl === 'string' ? body.claimUrl : undefined,
+    cap: typeof body.cap === 'number' ? body.cap : undefined,
+  };
+}
+
+export function formatKeylessCapMessage(details: KeylessCapDetails): string {
+  const count = details.cap ? `${details.cap} free messages` : 'free messages';
+  const lines = [`You've used the ${count} of this keyless demo.`];
+
+  if (details.claimUrl) {
+    lines.push(`Sign up to keep your channels and continue: ${details.claimUrl}`);
+  } else {
+    lines.push('Sign up for a free Novu account to keep your channels and continue.');
+  }
+
+  lines.push(
+    '(We also sent this link to you on your linked channel.)',
+    'After signing up, run: human setup --secret-key <key>   or set NOVU_SECRET_KEY'
+  );
+
+  return lines.join('\n');
+}
+
 export function handleError(err: unknown): never {
+  const keylessCap = getKeylessCapDetails(err);
+  if (keylessCap) {
+    fail(formatKeylessCapMessage(keylessCap));
+  }
+
   if (err instanceof HumanApiError) {
     fail(err.status ? `${err.message} (${err.status})` : err.message);
   }

--- a/packages/human/src/skills/content/human-cli/SKILL.md
+++ b/packages/human/src/skills/content/human-cli/SKILL.md
@@ -56,6 +56,18 @@ reachable (chat, PR description, logs) rather than silently giving up or
 looping. Never attempt to configure it on the human's behalf — you don't have
 their Telegram/Slack/email credentials, and setup is interactive by design.
 
+The no-account (keyless) setup is a free demo with a small message allowance.
+When it runs out, commands exit 1 with a message containing a sign-up link:
+
+```
+You've used the 5 free messages of this keyless demo.
+Sign up to keep your channels and continue: https://dashboard.novu.co/connect/claim?token=...
+```
+
+The human already received that link on their channel. Stop retrying, surface
+the link where the human will see it, and wait — the human signs up and then
+re-points the CLI with `human setup --secret-key <key>` (or `NOVU_SECRET_KEY`).
+
 In sandboxes and containers with no config file, the CLI is fully operational
 when `NOVU_SECRET_KEY` and `HUMAN_TO` are set in the environment
 (optionally `HUMAN_VIA` for the channel). `--to`/`--via` flags still


### PR DESCRIPTION
### What changed? Why was the change needed?

A keyless `@novu/human` environment (`npx @novu/human setup` without an account) could create interactions forever. The 24h keyless expiry is only enforced on the Inbox session path, and the existing `KEYLESS_DEMO_REPLY_CAP` gate lives in the agents inbound-turn handler, which `POST /v1/human/interactions` never goes through.

This adds a server-side cap to the human interactions path and pushes the connect claim link, mirroring the `novu connect` keyless CTA:

**API**
- `CreateInteraction` counts every interaction row in a keyless environment (including `tell` and the setup smoke test). Past `KEYLESS_HUMAN_INTERACTION_CAP` (default 5) it does **not** deliver the prompt. It sends a "Sign up & keep this setup" card with the claim link on the channel the prompt would have used, once per environment so a retrying agent does not spam the human, and returns a 429 with a structured body: `code: KEYLESS_HUMAN_CAP_REACHED`, `claimUrl`, `cap`, plus a message that includes the link.
- `ClaimKeylessConnect` now also moves `HumanInteraction` rows, so `human wait <id>` / `human list` keep working after the claim.
- A keyless credential for an already-claimed environment gets a 403 pointing at `human setup --secret-key <key>` / `NOVU_SECRET_KEY`, instead of the misleading "Relay agent not found. Run `human setup`" (which would mint a fresh keyless env).
- New `ConnectClaimTokenService.isEnvironmentClaimed`, `HumanDeliveryService.deliverContent`, `buildKeylessHumanSignupCard`, and `resolveKeylessHumanInteractionCap` (read at call time so it is testable and tunable).

**CLI (`packages/human`)**
- Detects the cap 429 (by `code`, falling back to the message wording) and prints the claim link plus the recovery command. Exit code stays `1` per the existing contract.
- README and the agent `SKILL.md` describe the limit and tell agents to stop retrying and surface the link.

Out of scope, as discussed: a `human login` device-auth flow so the CLI can switch to the claimed environment without pasting a key; a "N free messages left" hint; enforcing the 24h keyless expiry in `KeylessStrategy`.

### Screenshots

N/A (API + CLI).

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

- Tests: 3 new e2e cases in `human-interactions.e2e.ts` (cap + card once + no rows persisted, non-keyless untouched, claim moves rows and stale credential gets 403) and 6 new unit cases in `create-interaction.usecase.spec.ts`. Full human e2e file (24) and the human CLI vitest suite (47) pass.
- Two pre-existing unit tests in `create-interaction.usecase.spec.ts` ("keeps the row, stamps successful deliveries…" and "moves the primary subscriber…") fail on `next` without this change: they assert a top-level `subscriberId` on the stamp call that the lifecycle stopped writing in #12478. Not touched here.
- The cap covers only `POST /v1/human/interactions`. In-thread `ctx.ask`-style interactions from framework agents already sit behind the existing keyless reply cap.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caps keyless human interactions, sends a claim CTA when the allowance is exhausted, migrates human-interaction rows during claim, and teaches the CLI how to present recovery guidance.
- Adds server-side keyless usage enforcement and structured cap errors.
- Adds direct CTA-card delivery and claimed-environment detection.
- Moves human interaction ownership during keyless claims.
- Updates CLI error handling, tests, README guidance, and the installed agent skill.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until the keyless cap and CTA deduplication are made concurrency-safe and claimed environments can be recognized after transient claim-token state disappears.

Concurrent interaction requests can exceed the configured allowance and duplicate the supposedly one-time CTA, while cache expiry causes stale claimed credentials to revert to the misleading setup path.

**Files Needing Attention:** apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.ts; apps/api/src/app/connect/services/connect-claim-token.service.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.ts | Adds the cap and CTA flow, but its count-before-create enforcement and post-delivery deduplication are vulnerable to concurrent requests. |
| apps/api/src/app/connect/services/connect-claim-token.service.ts | Adds best-effort claimed-state detection whose cache-only state expires and therefore cannot reliably identify claimed environments. |
| apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts | Correctly includes HumanInteraction rows in the transactional ownership migration, but does not persist durable claimed state for the source environment. |
| packages/human/src/commands/interact.ts | Recognizes the structured cap response, preserves compatibility with older message-based responses, and prints recovery guidance. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[POST human interaction] --> B{Keyless organization?}
  B -->|No| G[Resolve and deliver interaction]
  B -->|Yes| C{Claim cache says claimed?}
  C -->|Yes| D[Return 403 re-auth guidance]
  C -->|No| E[Count environment interactions]
  E -->|Below cap| G
  E -->|At cap| F[Issue claim link and send CTA]
  F --> H[Return structured 429]
  I[Connect claim] --> J[Move agents, channels, and human interactions]
  J --> K[Consume claim token]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312544%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12544&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fhuman%2Fusecases%2Fcreate-interaction%2Fcreate-interaction.usecase.ts%3A128-131%0A**Interaction%20cap%20check%20races**%0A%0AIf%20multiple%20interaction%20requests%20arrive%20concurrently%20when%20a%20keyless%20environment%20is%20just%20below%20its%20cap%2C%20each%20request%20can%20observe%20%60used%20%3C%20cap%60%20before%20separately%20creating%20and%20delivering%20its%20interaction%2C%20causing%20the%20configured%20allowance%20to%20be%20exceeded.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fhuman%2Fusecases%2Fcreate-interaction%2Fcreate-interaction.usecase.ts%3A191-199%0A**CTA%20reservation%20happens%20too%20late**%0A%0AIf%20capped%20requests%20execute%20concurrently%2C%20each%20can%20read%20the%20CTA%20marker%20as%20absent%20and%20deliver%20the%20card%20before%20either%20calls%20%60tryMarkSignupCtaPosted%60%3B%20only%20one%20request%20wins%20the%20marker%20afterward%2C%20but%20the%20human%20has%20already%20received%20duplicate%20signup%20cards.%0A%0A%23%23%23%20Issue%203%0Aapps%2Fapi%2Fsrc%2Fapp%2Fconnect%2Fservices%2Fconnect-claim-token.service.ts%3A98-103%0A**Claimed%20state%20expires%20from%20cache**%0A%0AWhen%20the%20seven-day%20environment-token%20mapping%20or%20used-token%20marker%20expires%2C%20this%20lookup%20reports%20the%20claimed%20source%20environment%20as%20unclaimed.%20A%20stale%20keyless%20credential%20then%20searches%20the%20emptied%20source%20environment%20and%20receives%20the%20misleading%20%60Run%20human%20setup%60%20error%20instead%20of%20the%20new%20re-authentication%20guidance.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12544&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.ts:128-131
**Interaction cap check races**

If multiple interaction requests arrive concurrently when a keyless environment is just below its cap, each request can observe `used < cap` before separately creating and delivering its interaction, causing the configured allowance to be exceeded.

### Issue 2
apps/api/src/app/human/usecases/create-interaction/create-interaction.usecase.ts:191-199
**CTA reservation happens too late**

If capped requests execute concurrently, each can read the CTA marker as absent and deliver the card before either calls `tryMarkSignupCtaPosted`; only one request wins the marker afterward, but the human has already received duplicate signup cards.

### Issue 3
apps/api/src/app/connect/services/connect-claim-token.service.ts:98-103
**Claimed state expires from cache**

When the seven-day environment-token mapping or used-token marker expires, this lookup reports the claimed source environment as unclaimed. A stale keyless credential then searches the emptied source environment and receives the misleading `Run human setup` error instead of the new re-authentication guidance.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api-service,human): cap keyless hum..."](https://github.com/novuhq/novu/commit/8e1e7e00845abe1aee013b195e2c676aaa6b12c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59613617)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->