### PR TITLE
feat(api-service): make Better Auth org limit configurable

### DIFF
--- a/apps/api/src/.example.env
+++ b/apps/api/src/.example.env
@@ -120,6 +120,10 @@ CLICK_HOUSE_USER=default
 CLICK_HOUSE_PASSWORD=
 CLICK_HOUSE_DATABASE=novu-local
 
+# Self-hosted EE (Better Auth): max organizations a user can create. Default 10, minimum 1.
+# Invalid values log an error and fall back to 10.
+# BETTER_AUTH_ORGANIZATION_LIMIT=10
+
 # When using `pnpm dev:portless`, scripts/portless-dev-env.mjs resolves these at
 # runtime via `portless get` (worktree-prefixed and proxy-port aware):
 #   API_ROOT_URL, FRONT_BASE_URL, DASHBOARD_URL, BETTER_AUTH_BASE_URL


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Self-hosted enterprise Better Auth hardcoded a 10-organization cap per user. Operators can now raise (or lower) that cap with `BETTER_AUTH_ORGANIZATION_LIMIT`.

- Unset or blank → keep the existing default of **10**
- Valid integer ≥ **1** → use that value
- `0`, negative, or non-integer → print an error and fall back to **10**

The minimum allowed value is always 1. Invalid input does not prevent API boot.

```mermaid
flowchart TD
  A["BETTER_AUTH_ORGANIZATION_LIMIT"] --> B{"set and non-blank?"}
  B -->|no| C["use 10"]
  B -->|yes| D{"integer >= 1?"}
  D -->|yes| E["use parsed value"]
  D -->|no| F["log error"]
  F --> C
```

### Related enterprise PR

The matching change is on `novuhq/packages-enterprise` branch `cursor/better-auth-org-limit-7724`:
https://github.com/novuhq/packages-enterprise/compare/next...cursor/better-auth-org-limit-7724

This environment cannot open that PR (`Resource not accessible by integration`). Please open it from the compare link and cross-link the two PRs.

The Validate Submodule Sync test is expected to fail until the enterprise PR is merged and the submodule SHA is updated.

### Screenshots

Not visual. Unit tests for the parser:

[organization-limit-tests.log](https://cursor.com/artifacts/c/art-3d2ea8f9-556f-48e7-9e2c-7a3126cec624)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- Logic lives in `@novu/ee-auth` (`getBetterAuthOrganizationLimit`).
- Documented as a commented optional var in `apps/api/src/.example.env`.
- Not added to `env.validators` so a bad value logs and falls back instead of crashing boot.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b41a6d1e-ce90-40fa-be99-f78e754f7724?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b41a6d1e-ce90-40fa-be99-f78e754f7724&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the self-hosted Better Auth per-user organization limit configurable through `BETTER_AUTH_ORGANIZATION_LIMIT`.
- Advances the enterprise submodule to the implementation commit.
- Documents the optional environment variable, its default of 10, and fallback behavior for invalid values.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .source | Advances the enterprise packages submodule to the commit implementing the configurable organization limit. |
| apps/api/src/.example.env | Documents the optional organization-limit variable and its validation and fallback semantics. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Env[BETTER_AUTH_ORGANIZATION_LIMIT] --> Set{Non-blank value?}
  Set -->|No| Default[Use default: 10]
  Set -->|Yes| Valid{Integer at least 1?}
  Valid -->|Yes| Limit[Use configured limit]
  Valid -->|No| Log[Log validation error]
  Log --> Default
  Limit --> Auth[Configure Better Auth organization cap]
  Default --> Auth
```

<sub>Reviews (2): Last reviewed commit: ["chore(submodule): update subproject comm..."](https://github.com/novuhq/novu/commit/1aaf8df4f4b8f8e711012055984bd2655ebe6370) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59687536)</sub>

<!-- /greptile_comment -->