### PR TITLE
feat(api-service): add public workflow-run stats API fixes NV-8764

### DIFF
--- a/apps/api/src/app/activity/activity.controller.ts
+++ b/apps/api/src/app/activity/activity.controller.ts
@@ -1,8 +1,10 @@
 import { ClassSerializerInterceptor, Controller, Get, Param, Query, UseInterceptors } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
-import { RequirePermissions, UserSession } from '@novu/application-generic';
-import { PermissionsEnum, UserSessionData } from '@novu/shared';
+import { ApiExcludeEndpoint, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ExternalApiAccessible, OAuthAccessible, RequirePermissions, UserSession } from '@novu/application-generic';
+import { ApiRateLimitCategoryEnum, PermissionsEnum, UserSessionData } from '@novu/shared';
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
+import { ThrottlerCategory } from '../rate-limiting/guards/throttler.decorator';
+import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
 import { GetChartsRequestDto } from './dtos/get-charts.request.dto';
 import { GetChartsResponseDto } from './dtos/get-charts.response.dto';
@@ -10,6 +12,7 @@ import { GetRequestResponseDto } from './dtos/get-request.response.dto';
 import { GetRequestsDto } from './dtos/get-requests.dto';
 import { GetRequestsResponseDto } from './dtos/get-requests.response.dto';
 import { GetWorkflowRunResponseDto } from './dtos/workflow-run-response.dto';
+import { GetWorkflowRunStatsRequestDto, GetWorkflowRunStatsResponseDto } from './dtos/workflow-run-stats.dto';
 import { GetWorkflowRunsRequestDto } from './dtos/workflow-runs-request.dto';
 import { GetWorkflowRunsResponseDto } from './dtos/workflow-runs-response.dto';
 import { GetChartsCommand } from './usecases/get-charts/get-charts.command';
@@ -20,18 +23,24 @@ import { GetRequestsCommand } from './usecases/get-requests/get-requests.command
 import { GetRequests } from './usecases/get-requests/get-requests.usecase';
 import { GetWorkflowRunCommand } from './usecases/get-workflow-run/get-workflow-run.command';
 import { GetWorkflowRun } from './usecases/get-workflow-run/get-workflow-run.usecase';
+import { GetWorkflowRunStatsCommand } from './usecases/get-workflow-run-stats/get-workflow-run-stats.command';
+import { GetWorkflowRunStats } from './usecases/get-workflow-run-stats/get-workflow-run-stats.usecase';
 import { GetWorkflowRunsCommand } from './usecases/get-workflow-runs/get-workflow-runs.command';
 import { GetWorkflowRuns } from './usecases/get-workflow-runs/get-workflow-runs.usecase';
 
+@ThrottlerCategory(ApiRateLimitCategoryEnum.CONFIGURATION)
 @Controller('/activity')
 @UseInterceptors(ClassSerializerInterceptor)
 @RequireAuthentication()
+@ApiTags('Activity')
 @SdkGroupName('Activity')
+@ApiCommonResponses()
 export class ActivityController {
   constructor(
     private getRequestsUsecase: GetRequests,
     private getWorkflowRunsUsecase: GetWorkflowRuns,
     private getWorkflowRunUsecase: GetWorkflowRun,
+    private getWorkflowRunStatsUsecase: GetWorkflowRunStats,
     private getRequestUsecase: GetRequest,
     private getChartsUsecase: GetCharts
   ) {}
@@ -74,6 +83,8 @@ export class ActivityController {
   }
 
   @Get('workflow-runs')
+  @ExternalApiAccessible()
+  @OAuthAccessible()
   @RequirePermissions(PermissionsEnum.NOTIFICATION_READ)
   @SdkGroupName('Activity.WorkflowRuns')
   @SdkMethodName('list')
@@ -81,6 +92,7 @@ export class ActivityController {
     summary: 'List workflow runs',
     description: 'Retrieve a list of workflow runs with optional filtering and pagination.',
   })
+  @ApiResponse(GetWorkflowRunsResponseDto)
   async getWorkflowRuns(
     @UserSession() user: UserSessionData,
     @Query() query: GetWorkflowRunsRequestDto
@@ -96,7 +108,36 @@ export class ActivityController {
     );
   }
 
+  @Get('workflow-runs/stats')
+  @ExternalApiAccessible()
+  @OAuthAccessible()
+  @RequirePermissions(PermissionsEnum.NOTIFICATION_READ)
+  @SdkGroupName('Activity.WorkflowRuns')
+  @SdkMethodName('stats')
+  @ApiOperation({
+    summary: 'Retrieve workflow run stats',
+    description:
+      'Retrieve aggregated workflow run counts and unique subscriber counts. Supports the same filters as the workflow-runs list plus an optional groupBy dimension.',
+  })
+  @ApiResponse(GetWorkflowRunStatsResponseDto)
+  async getWorkflowRunStats(
+    @UserSession() user: UserSessionData,
+    @Query() query: GetWorkflowRunStatsRequestDto
+  ): Promise<GetWorkflowRunStatsResponseDto> {
+    return this.getWorkflowRunStatsUsecase.execute(
+      GetWorkflowRunStatsCommand.create({
+        ...query,
+        organizationId: user.organizationId,
+        environmentId: user.environmentId,
+        userId: user._id,
+        contextKeys: query.contextKeys,
+      })
+    );
+  }
+
   @Get('workflow-runs/:workflowRunId')
+  @ExternalApiAccessible()
+  @OAuthAccessible()
   @RequirePermissions(PermissionsEnum.NOTIFICATION_READ)
   @SdkGroupName('Activity.WorkflowRuns')
   @SdkMethodName('retrieve')
@@ -104,6 +145,8 @@ export class ActivityController {
     summary: 'Retrieve workflow run',
     description: 'Retrieve detailed information for a specific workflow run by ID.',
   })
+  @ApiParam({ name: 'workflowRunId', type: String, required: true, description: 'Workflow run identifier' })
+  @ApiResponse(GetWorkflowRunResponseDto)
   async getWorkflowRun(
     @UserSession() user: UserSessionData,
     @Param('workflowRunId') workflowRunId: string
@@ -119,6 +162,7 @@ export class ActivityController {
   }
 
   @Get('charts')
+  @ApiExcludeEndpoint()
   @RequirePermissions(PermissionsEnum.NOTIFICATION_READ)
   @SdkGroupName('Activity.Charts')
   @SdkMethodName('retrieve')
@@ -126,6 +170,7 @@ export class ActivityController {
     summary: 'Retrieve activity charts',
     description: 'Retrieve chart data for activity analytics and metrics visualization.',
   })
+  @ApiResponse(GetChartsResponseDto)
   async getCharts(
     @UserSession() user: UserSessionData,
     @Query() query: GetChartsRequestDto

--- a/apps/api/src/app/activity/activity.module.ts
+++ b/apps/api/src/app/activity/activity.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { WorkflowRunService } from '@novu/application-generic';
 import { SharedModule } from '../shared/shared.module';
 import { ActivityController } from './activity.controller';
+import { ActivityRetentionService } from './shared/activity-retention.service';
 import { BuildActiveSubscribersChart } from './usecases/build-active-subscribers-chart/build-active-subscribers-chart.usecase';
 import { BuildActiveSubscribersTrendChart } from './usecases/build-active-subscribers-trend-chart/build-active-subscribers-trend-chart.usecase';
 import { BuildAvgMessagesPerSubscriberChart } from './usecases/build-avg-messages-per-subscriber-chart/build-avg-messages-per-subscriber-chart.usecase';
@@ -18,13 +19,16 @@ import { GetCharts } from './usecases/get-charts/get-charts.usecase';
 import { GetRequest } from './usecases/get-request/get-request.usecase';
 import { GetRequests } from './usecases/get-requests/get-requests.usecase';
 import { GetWorkflowRun } from './usecases/get-workflow-run/get-workflow-run.usecase';
+import { GetWorkflowRunStats } from './usecases/get-workflow-run-stats/get-workflow-run-stats.usecase';
 import { GetWorkflowRuns } from './usecases/get-workflow-runs/get-workflow-runs.usecase';
 
 const USE_CASES = [
   GetRequests,
   GetWorkflowRuns,
   GetWorkflowRun,
+  GetWorkflowRunStats,
   GetCharts,
+  ActivityRetentionService,
   BuildDeliveryTrendChart,
   BuildInteractionTrendChart,
   BuildWorkflowByVolumeChart,

--- a/apps/api/src/app/activity/dtos/shared.dto.ts
+++ b/apps/api/src/app/activity/dtos/shared.dto.ts
@@ -103,6 +103,15 @@ export class GetWorkflowRunResponseBaseDto {
   topics?: TopicResponseDto[];
 }
 
+export enum WorkflowRunStatsGroupByEnum {
+  DAY = 'day',
+  STATUS = 'status',
+  DELIVERY_LIFECYCLE_STATUS = 'deliveryLifecycleStatus',
+  DELIVERY_LIFECYCLE_DETAIL = 'deliveryLifecycleDetail',
+  WORKFLOW = 'workflow',
+  CHANNEL = 'channel',
+}
+
 export enum ReportTypeEnum {
   DELIVERY_TREND = 'delivery-trend',
   INTERACTION_TREND = 'interaction-trend',

--- a/apps/api/src/app/activity/dtos/workflow-run-stats.dto.ts
+++ b/apps/api/src/app/activity/dtos/workflow-run-stats.dto.ts
@@ -1,0 +1,56 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsArray, IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { WorkflowRunStatsGroupByEnum } from './shared.dto';
+import { WorkflowRunFiltersRequestDto } from './workflow-runs-request.dto';
+
+export class GetWorkflowRunStatsRequestDto extends WorkflowRunFiltersRequestDto {
+  @ApiPropertyOptional({
+    enum: WorkflowRunStatsGroupByEnum,
+    description: 'Optional dimension to group counts by. Omit for totals only.',
+  })
+  @IsOptional()
+  @IsEnum(WorkflowRunStatsGroupByEnum)
+  groupBy?: WorkflowRunStatsGroupByEnum;
+}
+
+export class WorkflowRunStatsBucketDto {
+  @ApiProperty({ description: 'Group key for this bucket' })
+  @IsString()
+  key: string;
+
+  @ApiProperty({ description: 'Number of workflow runs in this bucket' })
+  @IsInt()
+  @Min(0)
+  count: number;
+
+  @ApiProperty({ description: 'Number of unique subscribers in this bucket' })
+  @IsInt()
+  @Min(0)
+  uniqueSubscribers: number;
+}
+
+export class GetWorkflowRunStatsResponseDto {
+  @ApiProperty({ description: 'Total matching workflow runs after filters' })
+  @IsInt()
+  @Min(0)
+  total: number;
+
+  @ApiProperty({ description: 'Unique subscribers across matching workflow runs' })
+  @IsInt()
+  @Min(0)
+  uniqueSubscribers: number;
+
+  @ApiPropertyOptional({
+    enum: WorkflowRunStatsGroupByEnum,
+    nullable: true,
+    description: 'Dimension used to produce buckets, or null when ungrouped',
+  })
+  @IsOptional()
+  groupBy: WorkflowRunStatsGroupByEnum | null;
+
+  @ApiProperty({ description: 'Grouped counts, empty when groupBy is omitted', type: [WorkflowRunStatsBucketDto] })
+  @Type(() => WorkflowRunStatsBucketDto)
+  @IsArray()
+  buckets: WorkflowRunStatsBucketDto[];
+}

--- a/apps/api/src/app/activity/dtos/workflow-runs-request.dto.ts
+++ b/apps/api/src/app/activity/dtos/workflow-runs-request.dto.ts
@@ -1,38 +1,45 @@
-import { SeverityLevelEnum } from '@novu/shared';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { DeliveryLifecycleDetail, DeliveryLifecycleStatusEnum, SeverityLevelEnum } from '@novu/shared';
 import { Transform, Type } from 'class-transformer';
 import { IsArray, IsIn, IsInt, IsISO8601, IsOptional, IsString, Max, Min } from 'class-validator';
 import { WorkflowRunStatusDtoEnum } from './shared.dto';
 
-export class GetWorkflowRunsRequestDto {
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  @Max(100)
-  limit: number = 10;
-
-  @IsOptional()
-  @IsString()
-  cursor?: string;
-
+export class WorkflowRunFiltersRequestDto {
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Filter by workflow identifiers',
+  })
   @IsOptional()
   @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
   @IsArray()
   @IsString({ each: true })
   workflowIds?: string[];
 
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Filter by subscriber identifiers',
+  })
   @IsOptional()
   @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
   @IsArray()
   @IsString({ each: true })
   subscriberIds?: string[];
 
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Filter by transaction identifiers',
+  })
   @IsOptional()
   @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
   @IsArray()
   @IsString({ each: true })
   transactionIds?: string[];
 
+  @ApiPropertyOptional({
+    enum: WorkflowRunStatusDtoEnum,
+    isArray: true,
+    description: 'Filter by workflow run status',
+  })
   @IsOptional()
   @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
   @IsArray()
@@ -40,28 +47,53 @@ export class GetWorkflowRunsRequestDto {
   @IsIn(Object.values(WorkflowRunStatusDtoEnum), { each: true })
   statuses?: WorkflowRunStatusDtoEnum[];
 
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Filter by channel types',
+  })
   @IsOptional()
   @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
   @IsArray()
   @IsString({ each: true })
   channels?: string[];
 
+  @ApiPropertyOptional({
+    type: String,
+    description: 'Filter by topic key',
+  })
   @IsOptional()
   @IsString()
   topicKey?: string;
 
+  @ApiPropertyOptional({
+    type: String,
+    description: 'Filter by subscription identifier',
+  })
   @IsOptional()
   @IsString()
   subscriptionId?: string;
 
+  @ApiPropertyOptional({
+    type: String,
+    description: 'Filter for records created at or after this ISO-8601 timestamp',
+  })
   @IsOptional()
   @IsISO8601()
   createdGte?: string;
 
+  @ApiPropertyOptional({
+    type: String,
+    description: 'Filter for records created at or before this ISO-8601 timestamp',
+  })
   @IsOptional()
   @IsISO8601()
   createdLte?: string;
 
+  @ApiPropertyOptional({
+    enum: SeverityLevelEnum,
+    isArray: true,
+    description: 'Filter by severity',
+  })
   @IsOptional()
   @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
   @IsArray()
@@ -69,19 +101,69 @@ export class GetWorkflowRunsRequestDto {
   @IsIn(Object.values(SeverityLevelEnum), { each: true })
   severity?: SeverityLevelEnum[];
 
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Filter by exact context keys, order insensitive (format: "type:id")',
+  })
   @IsOptional()
   @Transform(({ value }) => {
-    // No parameter = no filter
     if (value === undefined) return undefined;
 
-    // Empty string = filter for records with no (default) context
     if (value === '') return [];
 
-    // Normalize to array and remove empty strings
     const array = Array.isArray(value) ? value : [value];
+
     return array.filter((v) => v !== '');
   })
   @IsArray()
   @IsString({ each: true })
   contextKeys?: string[];
+
+  @ApiPropertyOptional({
+    enum: DeliveryLifecycleStatusEnum,
+    isArray: true,
+    description: 'Filter by delivery lifecycle status',
+  })
+  @IsOptional()
+  @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
+  @IsArray()
+  @IsString({ each: true })
+  @IsIn(Object.values(DeliveryLifecycleStatusEnum), { each: true })
+  deliveryLifecycleStatus?: DeliveryLifecycleStatusEnum[];
+
+  @ApiPropertyOptional({
+    enum: DeliveryLifecycleDetail,
+    isArray: true,
+    description: 'Filter by delivery lifecycle detail (skip or failure reason)',
+  })
+  @IsOptional()
+  @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
+  @IsArray()
+  @IsString({ each: true })
+  @IsIn(Object.values(DeliveryLifecycleDetail), { each: true })
+  deliveryLifecycleDetail?: DeliveryLifecycleDetail[];
+}
+
+export class GetWorkflowRunsRequestDto extends WorkflowRunFiltersRequestDto {
+  @ApiPropertyOptional({
+    type: Number,
+    default: 10,
+    minimum: 1,
+    maximum: 100,
+    description: 'Page size for cursor pagination',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 10;
+
+  @ApiPropertyOptional({
+    type: String,
+    description: 'Cursor for the next or previous page',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
 }

--- a/apps/api/src/app/activity/e2e/get-workflow-run-stats.e2e.ts
+++ b/apps/api/src/app/activity/e2e/get-workflow-run-stats.e2e.ts
@@ -1,0 +1,277 @@
+import { ClickHouseService, WorkflowRunRepository, WorkflowRunStatusEnum } from '@novu/application-generic';
+import { NotificationEntity, NotificationRepository, NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
+import {
+  ApiServiceLevelEnum,
+  DeliveryLifecycleDetail,
+  DeliveryLifecycleStatusEnum,
+  EmailBlockTypeEnum,
+  PermissionsEnum,
+  StepTypeEnum,
+} from '@novu/shared';
+import { SubscribersService, UserSession } from '@novu/testing';
+import { expect } from 'chai';
+import { WorkflowRunStatsGroupByEnum } from '../dtos/shared.dto';
+import { GetWorkflowRunStatsResponseDto } from '../dtos/workflow-run-stats.dto';
+
+function unwrapStats(body: { data: GetWorkflowRunStatsResponseDto }): GetWorkflowRunStatsResponseDto {
+  return body.data;
+}
+
+describe('Workflow Run Stats - GET /v1/activity/workflow-runs/stats #novu-v2', () => {
+  let session: UserSession;
+  let template: NotificationTemplateEntity;
+  let subscriber: SubscriberEntity;
+  let subscriberService: SubscribersService;
+  let workflowRunRepository: WorkflowRunRepository;
+  const clickHouseService = new ClickHouseService();
+
+  async function createWorkflowRuns(options: {
+    count: number;
+    status?: WorkflowRunStatusEnum;
+    channels?: StepTypeEnum[];
+    deliveryLifecycleStatus?: DeliveryLifecycleStatusEnum;
+    deliveryLifecycleDetail?: DeliveryLifecycleDetail;
+    subscriberId?: string;
+  }) {
+    const {
+      count,
+      status = WorkflowRunStatusEnum.COMPLETED,
+      channels = [StepTypeEnum.EMAIL],
+      deliveryLifecycleStatus,
+      deliveryLifecycleDetail,
+      subscriberId = subscriber.subscriberId,
+    } = options;
+
+    const promises: Promise<void>[] = [];
+
+    for (let i = 1; i < count + 1; i += 1) {
+      const mockNotification: NotificationEntity = {
+        _id: NotificationRepository.createObjectId(),
+        _templateId: template._id,
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+        _subscriberId: subscriber._id,
+        topics: [],
+        transactionId: `stats-txn_${Date.now()}_${i}_${Math.random()}`,
+        channels,
+        to: subscriberId,
+        payload: { runNumber: i },
+        controls: undefined,
+        tags: [],
+        createdAt: new Date().toISOString(),
+      };
+
+      promises.push(
+        workflowRunRepository.create(mockNotification, template, {
+          status,
+          userId: session.user._id,
+          externalSubscriberId: subscriberId,
+          deliveryLifecycleStatus,
+          deliveryLifecycleDetail,
+        })
+      );
+    }
+
+    await Promise.all(promises);
+  }
+
+  beforeEach(async () => {
+    await clickHouseService.init();
+    (process.env as any).IS_WORKFLOW_RUN_LOGS_WRITE_ENABLED = 'true';
+
+    session = new UserSession();
+    await session.initialize();
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+    subscriber = await subscriberService.createSubscriber();
+    workflowRunRepository = session.testServer?.getService(WorkflowRunRepository);
+
+    template = await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.EMAIL,
+          subject: 'Test subject',
+          content: [{ type: EmailBlockTypeEnum.TEXT, content: 'Hello {{firstName}}' }],
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    delete (process.env as any).IS_WORKFLOW_RUN_LOGS_WRITE_ENABLED;
+  });
+
+  it('should return totals without groupBy', async () => {
+    await createWorkflowRuns({ count: 3 });
+
+    const { body } = await session.testAgent.get('/v1/activity/workflow-runs/stats').expect(200);
+    const stats = unwrapStats(body);
+
+    expect(stats.total).to.be.at.least(3);
+    expect(stats.uniqueSubscribers).to.be.at.least(1);
+    expect(stats.groupBy).to.equal(null);
+    expect(stats.buckets).to.deep.equal([]);
+  });
+
+  it('should group by status and delivery lifecycle detail', async () => {
+    await createWorkflowRuns({
+      count: 2,
+      status: WorkflowRunStatusEnum.ERROR,
+      deliveryLifecycleStatus: DeliveryLifecycleStatusEnum.SKIPPED,
+      deliveryLifecycleDetail: DeliveryLifecycleDetail.SUBSCRIBER_PREFERENCE,
+    });
+    await createWorkflowRuns({
+      count: 1,
+      status: WorkflowRunStatusEnum.COMPLETED,
+      deliveryLifecycleStatus: DeliveryLifecycleStatusEnum.DELIVERED,
+    });
+
+    const { body: byStatusBody } = await session.testAgent
+      .get('/v1/activity/workflow-runs/stats')
+      .query({ groupBy: WorkflowRunStatsGroupByEnum.STATUS })
+      .expect(200);
+    const byStatus = unwrapStats(byStatusBody);
+
+    expect(byStatus.groupBy).to.equal(WorkflowRunStatsGroupByEnum.STATUS);
+    expect(byStatus.buckets.some((bucket) => bucket.key === 'error' && bucket.count >= 2)).to.equal(true);
+    expect(byStatus.buckets.some((bucket) => bucket.key === 'completed' && bucket.count >= 1)).to.equal(true);
+
+    const { body: byDetailBody } = await session.testAgent
+      .get('/v1/activity/workflow-runs/stats')
+      .query({
+        groupBy: WorkflowRunStatsGroupByEnum.DELIVERY_LIFECYCLE_DETAIL,
+        deliveryLifecycleStatus: [DeliveryLifecycleStatusEnum.SKIPPED],
+      })
+      .expect(200);
+    const byDetail = unwrapStats(byDetailBody);
+
+    expect(byDetail.total).to.be.at.least(2);
+    expect(byDetail.buckets.some((bucket) => bucket.key === DeliveryLifecycleDetail.SUBSCRIBER_PREFERENCE)).to.equal(
+      true
+    );
+  });
+
+  it('should group by channel', async () => {
+    await createWorkflowRuns({ count: 2, channels: [StepTypeEnum.EMAIL] });
+    await createWorkflowRuns({ count: 1, channels: [StepTypeEnum.IN_APP] });
+
+    const { body } = await session.testAgent
+      .get('/v1/activity/workflow-runs/stats')
+      .query({ groupBy: WorkflowRunStatsGroupByEnum.CHANNEL })
+      .expect(200);
+    const stats = unwrapStats(body);
+
+    expect(stats.groupBy).to.equal(WorkflowRunStatsGroupByEnum.CHANNEL);
+    expect(stats.buckets.some((bucket) => bucket.key === StepTypeEnum.EMAIL)).to.equal(true);
+  });
+
+  it('should return 402 when the requested window exceeds plan retention', async () => {
+    const tooOld = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString();
+
+    const { body } = await session.testAgent
+      .get('/v1/activity/workflow-runs/stats')
+      .query({ createdGte: tooOld })
+      .expect(402);
+
+    expect(body.message).to.include("plan's retention period");
+  });
+
+  it('should allow stats with an API key', async () => {
+    const { body } = await session.testAgent
+      .get('/v1/activity/workflow-runs/stats')
+      .set('authorization', `ApiKey ${session.apiKey}`)
+      .expect(200);
+
+    expect(unwrapStats(body).total).to.be.a('number');
+  });
+
+  it('should deny stats without notification read permission', async () => {
+    const originalRbac = process.env.IS_RBAC_ENABLED;
+    (process.env as Record<string, string>).IS_RBAC_ENABLED = 'true';
+
+    const deniedSession = new UserSession();
+    await deniedSession.initialize();
+    await deniedSession.updateOrganizationServiceLevel(ApiServiceLevelEnum.BUSINESS);
+    await deniedSession.updateEETokenClaims({
+      org_permissions: [PermissionsEnum.WORKFLOW_READ],
+    });
+
+    await deniedSession.testAgent.get('/v1/activity/workflow-runs/stats').expect(403);
+
+    if (originalRbac === undefined) {
+      delete (process.env as Record<string, string | undefined>).IS_RBAC_ENABLED;
+    } else {
+      process.env.IS_RBAC_ENABLED = originalRbac;
+    }
+  });
+
+  it('should count a replaced workflow run once when querying with FINAL', async () => {
+    const notificationId = NotificationRepository.createObjectId();
+    const transactionId = `final-txn_${Date.now()}_${Math.random()}`;
+    const mockNotification: NotificationEntity = {
+      _id: notificationId,
+      _templateId: template._id,
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      _subscriberId: subscriber._id,
+      topics: [],
+      transactionId,
+      channels: [StepTypeEnum.EMAIL],
+      to: subscriber.subscriberId,
+      payload: { runNumber: 1 },
+      controls: undefined,
+      tags: [],
+      createdAt: new Date().toISOString(),
+    };
+
+    await workflowRunRepository.create(mockNotification, template, {
+      status: WorkflowRunStatusEnum.PROCESSING,
+      userId: session.user._id,
+      externalSubscriberId: subscriber.subscriberId,
+    });
+    await workflowRunRepository.create(mockNotification, template, {
+      status: WorkflowRunStatusEnum.COMPLETED,
+      userId: session.user._id,
+      externalSubscriberId: subscriber.subscriberId,
+    });
+
+    const { body } = await session.testAgent
+      .get('/v1/activity/workflow-runs/stats')
+      .query({ transactionIds: [transactionId] })
+      .expect(200);
+    const stats = unwrapStats(body);
+
+    expect(stats.total).to.equal(1);
+    expect(stats.uniqueSubscribers).to.equal(1);
+  });
+
+  it('should group by day, workflow, and delivery lifecycle status', async () => {
+    await createWorkflowRuns({
+      count: 2,
+      deliveryLifecycleStatus: DeliveryLifecycleStatusEnum.DELIVERED,
+    });
+
+    const { body: byDayBody } = await session.testAgent
+      .get('/v1/activity/workflow-runs/stats')
+      .query({ groupBy: WorkflowRunStatsGroupByEnum.DAY })
+      .expect(200);
+    const byDay = unwrapStats(byDayBody);
+    expect(byDay.groupBy).to.equal(WorkflowRunStatsGroupByEnum.DAY);
+    expect(byDay.buckets.length).to.be.greaterThan(0);
+
+    const { body: byWorkflowBody } = await session.testAgent
+      .get('/v1/activity/workflow-runs/stats')
+      .query({ groupBy: WorkflowRunStatsGroupByEnum.WORKFLOW })
+      .expect(200);
+    const byWorkflow = unwrapStats(byWorkflowBody);
+    expect(byWorkflow.buckets.some((bucket) => bucket.key === template._id && bucket.count >= 2)).to.equal(true);
+
+    const { body: byLifecycleBody } = await session.testAgent
+      .get('/v1/activity/workflow-runs/stats')
+      .query({ groupBy: WorkflowRunStatsGroupByEnum.DELIVERY_LIFECYCLE_STATUS })
+      .expect(200);
+    const byLifecycle = unwrapStats(byLifecycleBody);
+    expect(
+      byLifecycle.buckets.some((bucket) => bucket.key === DeliveryLifecycleStatusEnum.DELIVERED && bucket.count >= 2)
+    ).to.equal(true);
+  });
+});

--- a/apps/api/src/app/activity/e2e/get-workflow-runs.e2e.ts
+++ b/apps/api/src/app/activity/e2e/get-workflow-runs.e2e.ts
@@ -1,10 +1,9 @@
 import { Novu } from '@novu/api';
 import { ClickHouseService, WorkflowRunRepository, WorkflowRunStatusEnum } from '@novu/application-generic';
 import { NotificationEntity, NotificationRepository, NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
-import { EmailBlockTypeEnum, StepTypeEnum } from '@novu/shared';
+import { DeliveryLifecycleDetail, DeliveryLifecycleStatusEnum, EmailBlockTypeEnum, StepTypeEnum } from '@novu/shared';
 import { SubscribersService, UserSession } from '@novu/testing';
 import { expect } from 'chai';
-import { sleep } from '../../events/e2e/utils/sleep.util';
 import { initNovuClassSdk } from '../../shared/helpers/e2e/sdk/e2e-sdk.helper';
 import { WorkflowRunStatusDtoEnum } from '../dtos/shared.dto';
 import { GetWorkflowRunsResponseDto } from '../dtos/workflow-runs-response.dto';
@@ -21,28 +20,6 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
   let workflowRunRepository: WorkflowRunRepository;
   const clickHouseService = new ClickHouseService();
 
-  // Helper function to create multiple workflow triggers with 5ms delay between each
-  async function createMultipleWorkflowRuns(options: {
-    count: number;
-    workflowId: string;
-    subscriberId: string[];
-    payloadTemplate?: (index: number) => Record<string, any>;
-    transactionId?: string;
-  }) {
-    const { count, workflowId, subscriberId, payloadTemplate, transactionId } = options;
-
-    for (let i = 1; i < count + 1; i += 1) {
-      await novuClient.trigger({
-        workflowId,
-        to: subscriberId,
-        payload: payloadTemplate ? payloadTemplate(i) : { runNumber: i },
-        ...(transactionId && { transactionId: `${transactionId}-${i}` }),
-      });
-
-      await sleep(5);
-    }
-  }
-
   async function createMultipleWorkflowRunsByDb(options: {
     count: number;
     subscriberId: string[];
@@ -51,6 +28,9 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
     status?: WorkflowRunStatusEnum;
     channels?: StepTypeEnum[];
     workflow?: NotificationTemplateEntity;
+    deliveryLifecycleStatus?: DeliveryLifecycleStatusEnum;
+    deliveryLifecycleDetail?: DeliveryLifecycleDetail;
+    createdAt?: Date;
   }) {
     const {
       count,
@@ -60,6 +40,9 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
       status = WorkflowRunStatusEnum.COMPLETED,
       channels = [StepTypeEnum.EMAIL],
       workflow = template,
+      deliveryLifecycleStatus,
+      deliveryLifecycleDetail,
+      createdAt,
     } = options;
 
     const promises: Promise<void>[] = [];
@@ -81,7 +64,7 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
         payload,
         controls: undefined,
         tags: [],
-        createdAt: new Date().toISOString(),
+        createdAt: (createdAt ?? new Date()).toISOString(),
       };
 
       promises.push(
@@ -89,6 +72,8 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
           status,
           userId: session.user._id,
           externalSubscriberId: subscriberId[0],
+          deliveryLifecycleStatus,
+          deliveryLifecycleDetail,
         })
       );
     }
@@ -155,22 +140,9 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
   });
 
   it('should return paginated results with default limit', async () => {
-    // will generate 6 workflow runs with 2 subscribers, total of 12 workflow runs
-    await createMultipleWorkflowRuns({
-      count: 6,
-      workflowId: template.triggers[0].identifier,
-      subscriberId: [subscriber.subscriberId, '123'],
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    await session.waitForWorkflowQueueCompletion();
-    await session.waitForStandardQueueCompletion();
-    await session.waitForSubscriberQueueCompletion();
-
-    // Force ClickHouse merge to deduplicate workflow runs
-    const databaseName = process.env.CLICK_HOUSE_DATABASE || 'test_logs';
-    await clickHouseService.exec({
-      query: `OPTIMIZE TABLE ${databaseName}.workflow_runs FINAL`,
+    await createMultipleWorkflowRunsByDb({
+      count: 12,
+      subscriberId: [subscriber.subscriberId],
     });
 
     const { body: firstPage }: { body: GetWorkflowRunsResponseDto } = await session.testAgent
@@ -199,15 +171,7 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
     });
     expect(secondPageWorkflowRun, 'secondPageWorkflowRun should exist').to.not.be.null;
     expect(secondPageWorkflowRun.data, 'secondPageWorkflowRun.data should exist').to.not.be.undefined;
-    expect(JSON.parse(secondPageWorkflowRun.data.payload || '{}')?.runNumber, 'secondPage runNumber').to.be.equal(1);
-
-    expect(firstPage.data[0].steps, 'workflow run should have steps').to.be.an('array');
-    if (firstPage.data[0].steps.length > 0) {
-      const step = firstPage.data[0].steps[0];
-      expect(step.id.startsWith('sr_'), 'step id should start with sr_').to.be.true;
-      expect(step.stepType, 'step should have step type').to.be.equal('trigger');
-      expect(step.status, 'step should have status').to.be.equal('completed');
-    }
+    expect(firstPage.data.map((item) => item.id)).to.not.include(secondPage.data[0].id);
   });
 
   it('should validate cursor-based pagination collision handling', async () => {
@@ -525,50 +489,39 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
   });
 
   it('should filter results by date range', async () => {
-    await createMultipleWorkflowRuns({
+    const firstCreatedAt = new Date(Date.now() - 6 * 60 * 1000);
+    const secondCreatedAt = new Date(Date.now() - 3 * 60 * 1000);
+    const thirdCreatedAt = new Date(Date.now() - 30 * 1000);
+
+    await createMultipleWorkflowRunsByDb({
       count: 2,
-      workflowId: template.triggers[0].identifier,
       subscriberId: [subscriber.subscriberId],
       payloadTemplate: (index) => ({ testText: `first trigger ${index}` }),
+      createdAt: firstCreatedAt,
     });
-
-    await session.waitForWorkflowQueueCompletion();
-    await session.waitForSubscriberQueueCompletion();
-
-    const beforeTrigger = new Date();
-
-    await createMultipleWorkflowRuns({
+    await createMultipleWorkflowRunsByDb({
       count: 2,
-      workflowId: template.triggers[0].identifier,
       subscriberId: [subscriber.subscriberId],
       payloadTemplate: (index) => ({ testText: `second trigger ${index}` }),
+      createdAt: secondCreatedAt,
     });
-
-    await session.waitForWorkflowQueueCompletion();
-    await session.waitForSubscriberQueueCompletion();
-
-    const afterTrigger = new Date();
-
-    await createMultipleWorkflowRuns({
+    await createMultipleWorkflowRunsByDb({
       count: 2,
-      workflowId: template.triggers[0].identifier,
       subscriberId: [subscriber.subscriberId],
       payloadTemplate: (index) => ({ testText: `third trigger ${index}` }),
+      createdAt: thirdCreatedAt,
     });
-
-    await session.waitForWorkflowQueueCompletion();
-    await session.waitForSubscriberQueueCompletion();
 
     const { body } = await session.testAgent
       .get('/v1/activity/workflow-runs')
       .query({
-        createdGte: beforeTrigger.toISOString(),
-        createdLte: afterTrigger.toISOString(),
+        createdGte: new Date(Date.now() - 4 * 60 * 1000).toISOString(),
+        createdLte: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
       })
       .expect(200);
 
     expect(body.data).to.be.an('array');
-    expect(body.data.length, 'body.data.length').to.be.greaterThan(0);
+    expect(body.data.length, 'body.data.length').to.equal(2);
 
     for (const workflowRun of body.data) {
       const workflowRunEntity = await workflowRunRepository.findOne({
@@ -613,56 +566,40 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
   });
 
   it('should filter results by channels', async () => {
-    // Trigger email workflow runs
-    await createMultipleWorkflowRuns({
+    await createMultipleWorkflowRunsByDb({
       count: 2,
-      workflowId: emailTemplate.triggers[0].identifier,
       subscriberId: [subscriber.subscriberId],
+      workflow: emailTemplate,
+      channels: [StepTypeEnum.EMAIL],
+    });
+    await createMultipleWorkflowRunsByDb({
+      count: 2,
+      subscriberId: [subscriber.subscriberId],
+      workflow: inAppTemplate,
+      channels: [StepTypeEnum.IN_APP],
     });
 
-    // Trigger in-app workflow runs
-    await createMultipleWorkflowRuns({
-      count: 2,
-      workflowId: inAppTemplate.triggers[0].identifier,
-      subscriberId: [subscriber.subscriberId],
-    });
-
-    await session.waitForWorkflowQueueCompletion();
-    await session.waitForSubscriberQueueCompletion();
-
-    // Filter by EMAIL channel only
     const { body: bodyEmailFiltered } = (await session.testAgent
       .get('/v1/activity/workflow-runs')
       .query({ channels: [StepTypeEnum.EMAIL] })
       .expect(200)) as { body: GetWorkflowRunsResponseDto };
 
-    expect(bodyEmailFiltered.data.length, 'bodyEmailFiltered.data.length').to.be.greaterThan(0);
+    expect(bodyEmailFiltered.data.length, 'bodyEmailFiltered.data.length').to.equal(2);
 
     for (const workflowRun of bodyEmailFiltered.data) {
-      const stepsTypes = workflowRun.steps.map((step: any) => step.stepType);
-      expect(stepsTypes.length).to.be.greaterThan(0);
-      for (const stepType of stepsTypes) {
-        expect([StepTypeEnum.TRIGGER, StepTypeEnum.EMAIL], 'stepType should be EMAIL').to.include(stepType);
-      }
+      expect(workflowRun.workflowId).to.equal(emailTemplate._id);
     }
 
-    // Filter by EMAIL and IN_APP channels
     const { body: bodyEmailAndInAppFiltered } = (await session.testAgent
       .get('/v1/activity/workflow-runs')
       .query({ channels: [StepTypeEnum.EMAIL, StepTypeEnum.IN_APP] })
       .expect(200)) as { body: GetWorkflowRunsResponseDto };
 
-    expect(bodyEmailAndInAppFiltered.data.length, 'bodyEmailAndInAppFiltered.data.length').to.be.greaterThan(0);
+    expect(bodyEmailAndInAppFiltered.data.length, 'bodyEmailAndInAppFiltered.data.length').to.equal(4);
 
+    const allowedIds = [emailTemplate._id, inAppTemplate._id];
     for (const workflowRun of bodyEmailAndInAppFiltered.data) {
-      const stepsTypes = workflowRun.steps.map((step: any) => step.stepType);
-      expect(stepsTypes.length).to.be.greaterThan(0);
-      for (const stepType of stepsTypes) {
-        expect(
-          [StepTypeEnum.TRIGGER, StepTypeEnum.EMAIL, StepTypeEnum.IN_APP],
-          'stepType should be EMAIL or IN_APP'
-        ).to.include(stepType);
-      }
+      expect(allowedIds).to.include(workflowRun.workflowId);
     }
   });
 
@@ -676,5 +613,43 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
     expect(body.data.length).to.equal(0);
     expect(body.next).to.equal(null);
     expect(body.previous).to.equal(null);
+  });
+
+  it('should filter results by delivery lifecycle status and detail', async () => {
+    await createMultipleWorkflowRunsByDb({
+      count: 2,
+      subscriberId: [subscriber.subscriberId],
+      deliveryLifecycleStatus: DeliveryLifecycleStatusEnum.SKIPPED,
+      deliveryLifecycleDetail: DeliveryLifecycleDetail.SUBSCRIBER_PREFERENCE,
+    });
+    await createMultipleWorkflowRunsByDb({
+      count: 1,
+      subscriberId: [subscriber.subscriberId],
+      deliveryLifecycleStatus: DeliveryLifecycleStatusEnum.ERRORED,
+      deliveryLifecycleDetail: DeliveryLifecycleDetail.UNKNOWN_ERROR,
+    });
+
+    const { body } = await session.testAgent
+      .get('/v1/activity/workflow-runs')
+      .query({
+        deliveryLifecycleStatus: [DeliveryLifecycleStatusEnum.SKIPPED],
+        deliveryLifecycleDetail: [DeliveryLifecycleDetail.SUBSCRIBER_PREFERENCE],
+      })
+      .expect(200);
+
+    expect(body.data.length).to.equal(2);
+
+    for (const workflowRun of body.data) {
+      expect(workflowRun.deliveryLifecycleStatus).to.equal(DeliveryLifecycleStatusEnum.SKIPPED);
+    }
+  });
+
+  it('should allow listing workflow runs with an API key', async () => {
+    const { body } = await session.testAgent
+      .get('/v1/activity/workflow-runs')
+      .set('authorization', `ApiKey ${session.apiKey}`)
+      .expect(200);
+
+    expect(body.data).to.be.an('array');
   });
 });

--- a/apps/api/src/app/activity/shared/activity-retention.service.spec.ts
+++ b/apps/api/src/app/activity/shared/activity-retention.service.spec.ts
@@ -1,0 +1,42 @@
+import { HttpException } from '@nestjs/common';
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { expect } from 'chai';
+import { ActivityRetentionService } from './activity-retention.service';
+
+describe('ActivityRetentionService', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('clamps missing dates to the plan window and rejects explicit out-of-range dates', async () => {
+    const organization = {
+      apiServiceLevel: ApiServiceLevelEnum.FREE,
+      createdAt: new Date('2026-01-01'),
+    };
+    const service = new ActivityRetentionService({
+      findById: async () => organization,
+    } as never);
+
+    process.env.NODE_ENV = 'test';
+
+    const clamped = await service.validateRetentionLimitForTier('org-1');
+    const windowMs = new Date(clamped.before).getTime() - new Date(clamped.after).getTime();
+
+    expect(windowMs).to.be.lessThan(26 * 60 * 60 * 1000);
+    expect(windowMs).to.be.greaterThan(20 * 60 * 60 * 1000);
+
+    const buffered = service.queryWindowForWorkflowRuns(clamped);
+    expect(new Date(buffered.before).getTime() - new Date(clamped.before).getTime()).to.equal(60 * 60 * 1000);
+    expect(service.queryWindowForWorkflowRuns(clamped, clamped.before)).to.deep.equal(clamped);
+
+    try {
+      await service.validateRetentionLimitForTier('org-1', new Date('2020-01-01').toISOString());
+      expect.fail('expected 402');
+    } catch (error) {
+      expect(error).to.be.instanceOf(HttpException);
+      expect((error as HttpException).getStatus()).to.equal(402);
+    }
+  });
+});

--- a/apps/api/src/app/activity/shared/activity-retention.service.spec.ts
+++ b/apps/api/src/app/activity/shared/activity-retention.service.spec.ts
@@ -5,9 +5,16 @@ import { ActivityRetentionService } from './activity-retention.service';
 
 describe('ActivityRetentionService', () => {
   const originalNodeEnv = process.env.NODE_ENV;
+  const originalSelfHosted = process.env.IS_SELF_HOSTED;
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
+
+    if (originalSelfHosted === undefined) {
+      delete process.env.IS_SELF_HOSTED;
+    } else {
+      process.env.IS_SELF_HOSTED = originalSelfHosted;
+    }
   });
 
   it('clamps missing dates to the plan window and rejects explicit out-of-range dates', async () => {
@@ -33,6 +40,45 @@ describe('ActivityRetentionService', () => {
 
     try {
       await service.validateRetentionLimitForTier('org-1', new Date('2020-01-01').toISOString());
+      expect.fail('expected 402');
+    } catch (error) {
+      expect(error).to.be.instanceOf(HttpException);
+      expect((error as HttpException).getStatus()).to.equal(402);
+    }
+  });
+
+  it('serializes an unbounded self-hosted window instead of producing an invalid Date', async () => {
+    const service = new ActivityRetentionService({
+      findById: async () => ({
+        apiServiceLevel: ApiServiceLevelEnum.FREE,
+        createdAt: new Date('2026-01-01'),
+      }),
+    } as never);
+
+    process.env.IS_SELF_HOSTED = 'true';
+    process.env.NODE_ENV = 'test';
+
+    const window = await service.validateRetentionLimitForTier('org-1');
+
+    expect(window.after).to.equal(new Date(0).toISOString());
+    expect(Number.isNaN(new Date(window.before).getTime())).to.equal(false);
+  });
+
+  it('rejects a retrieve timestamp that is older than the plan window', async () => {
+    const service = new ActivityRetentionService({
+      findById: async () => ({
+        apiServiceLevel: ApiServiceLevelEnum.FREE,
+        createdAt: new Date('2026-01-01'),
+      }),
+    } as never);
+
+    process.env.NODE_ENV = 'test';
+    delete process.env.IS_SELF_HOSTED;
+
+    const tooOld = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString();
+
+    try {
+      await service.validateRetentionLimitForTier('org-1', tooOld, tooOld);
       expect.fail('expected 402');
     } catch (error) {
       expect(error).to.be.instanceOf(HttpException);

--- a/apps/api/src/app/activity/shared/activity-retention.service.ts
+++ b/apps/api/src/app/activity/shared/activity-retention.service.ts
@@ -1,0 +1,95 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { CommunityOrganizationRepository, OrganizationEntity } from '@novu/dal';
+import { ApiServiceLevelEnum, FeatureNameEnum, getFeatureForTierAsNumber } from '@novu/shared';
+
+export interface ValidatedRetentionWindow {
+  after: string;
+  before: string;
+}
+
+@Injectable()
+export class ActivityRetentionService {
+  constructor(private organizationRepository: CommunityOrganizationRepository) {}
+
+  async validateRetentionLimitForTier(
+    organizationId: string,
+    createdAtGte?: string,
+    createdAtLte?: string
+  ): Promise<ValidatedRetentionWindow> {
+    const organization = await this.organizationRepository.findById(organizationId);
+
+    if (!organization) {
+      throw new HttpException('Organization not found', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    const maxRetentionMs = this.getMaxRetentionPeriodByOrganization(organization);
+    const earliestAllowedDate = new Date(Date.now() - maxRetentionMs);
+    const effectiveStartDate = createdAtGte ? new Date(createdAtGte) : earliestAllowedDate;
+    const effectiveEndDate = createdAtLte ? new Date(createdAtLte) : new Date();
+
+    this.validateDateRange(earliestAllowedDate, effectiveStartDate, effectiveEndDate);
+
+    return {
+      after: effectiveStartDate.toISOString(),
+      before: effectiveEndDate.toISOString(),
+    };
+  }
+
+  queryWindowForWorkflowRuns(window: ValidatedRetentionWindow, createdAtLte?: string): ValidatedRetentionWindow {
+    if (createdAtLte) {
+      return window;
+    }
+
+    // One-hour buffer so in-flight ClickHouse writes are not excluded by clock skew
+    return {
+      after: window.after,
+      before: new Date(new Date(window.before).getTime() + 60 * 60 * 1000).toISOString(),
+    };
+  }
+
+  private validateDateRange(earliestAllowedDate: Date, startDate: Date, endDate: Date) {
+    if (startDate > endDate) {
+      throw new HttpException(
+        'Invalid date range: start date (createdAtGte) must be earlier than end date (createdAtLte)',
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    const buffer = 1 * 60 * 60 * 1000;
+    const bufferedEarliestAllowedDate = new Date(earliestAllowedDate.getTime() - buffer);
+
+    if (
+      process.env.NODE_ENV !== 'local' &&
+      (startDate < bufferedEarliestAllowedDate || endDate < bufferedEarliestAllowedDate)
+    ) {
+      throw new HttpException(
+        `Requested date range exceeds your plan's retention period. ` +
+          `The earliest accessible date for your plan is ${earliestAllowedDate.toISOString().split('T')[0]}. ` +
+          `Please upgrade your plan to access older activities.`,
+        HttpStatus.PAYMENT_REQUIRED
+      );
+    }
+  }
+
+  /**
+   * Charts and activity data follow the same retention policy as activity feed notifications.
+   * Data is automatically deleted after a certain period of time based on the organization's tier.
+   */
+  private getMaxRetentionPeriodByOrganization(organization: OrganizationEntity) {
+    if (process.env.IS_SELF_HOSTED === 'true') {
+      return Number.MAX_SAFE_INTEGER;
+    }
+
+    const { apiServiceLevel, createdAt } = organization;
+
+    if (apiServiceLevel === ApiServiceLevelEnum.FREE && new Date(createdAt) < new Date('2025-02-28')) {
+      return 30 * 24 * 60 * 60 * 1000;
+    }
+
+    return getFeatureForTierAsNumber(
+      FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
+      apiServiceLevel ?? ApiServiceLevelEnum.FREE,
+      true
+    );
+  }
+}

--- a/apps/api/src/app/activity/shared/activity-retention.service.ts
+++ b/apps/api/src/app/activity/shared/activity-retention.service.ts
@@ -22,8 +22,7 @@ export class ActivityRetentionService {
       throw new HttpException('Organization not found', HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    const maxRetentionMs = this.getMaxRetentionPeriodByOrganization(organization);
-    const earliestAllowedDate = new Date(Date.now() - maxRetentionMs);
+    const earliestAllowedDate = this.getEarliestAllowedDate(organization);
     const effectiveStartDate = createdAtGte ? new Date(createdAtGte) : earliestAllowedDate;
     const effectiveEndDate = createdAtLte ? new Date(createdAtLte) : new Date();
 
@@ -71,15 +70,19 @@ export class ActivityRetentionService {
     }
   }
 
+  private getEarliestAllowedDate(organization: OrganizationEntity): Date {
+    if (process.env.IS_SELF_HOSTED === 'true') {
+      return new Date(0);
+    }
+
+    return new Date(Date.now() - this.getMaxRetentionPeriodByOrganization(organization));
+  }
+
   /**
    * Charts and activity data follow the same retention policy as activity feed notifications.
    * Data is automatically deleted after a certain period of time based on the organization's tier.
    */
   private getMaxRetentionPeriodByOrganization(organization: OrganizationEntity) {
-    if (process.env.IS_SELF_HOSTED === 'true') {
-      return Number.MAX_SAFE_INTEGER;
-    }
-
     const { apiServiceLevel, createdAt } = organization;
 
     if (apiServiceLevel === ApiServiceLevelEnum.FREE && new Date(createdAt) < new Date('2025-02-28')) {

--- a/apps/api/src/app/activity/shared/build-workflow-run-where.ts
+++ b/apps/api/src/app/activity/shared/build-workflow-run-where.ts
@@ -1,0 +1,144 @@
+import {
+  ClickhouseOperator,
+  FieldCondition,
+  LogRepository,
+  QueryBuilder,
+  WorkflowRun,
+  WorkflowRunStatusEnum,
+} from '@novu/application-generic';
+import { TopicSubscribersRepository } from '@novu/dal';
+import { DeliveryLifecycleDetail, DeliveryLifecycleStatusEnum, SeverityLevelEnum } from '@novu/shared';
+import { WorkflowRunStatusDtoEnum } from '../dtos/shared.dto';
+
+export interface WorkflowRunFilterFields {
+  environmentId: string;
+  workflowIds?: string[];
+  subscriberIds?: string[];
+  transactionIds?: string[];
+  statuses?: WorkflowRunStatusDtoEnum[];
+  channels?: string[];
+  topicKey?: string;
+  subscriptionId?: string;
+  createdGte?: string;
+  createdLte?: string;
+  severity?: SeverityLevelEnum[];
+  contextKeys?: string[];
+  deliveryLifecycleStatus?: DeliveryLifecycleStatusEnum[];
+  deliveryLifecycleDetail?: DeliveryLifecycleDetail[];
+}
+
+function mapStatusesToStoredValues(statuses: WorkflowRunStatusDtoEnum[]): string[] {
+  return statuses.flatMap((status) => {
+    if (status === WorkflowRunStatusDtoEnum.PROCESSING) {
+      return [WorkflowRunStatusEnum.PENDING, WorkflowRunStatusEnum.PROCESSING];
+    }
+    if (status === WorkflowRunStatusDtoEnum.COMPLETED) {
+      return [WorkflowRunStatusEnum.SUCCESS, WorkflowRunStatusEnum.COMPLETED];
+    }
+    if (status === WorkflowRunStatusDtoEnum.ERROR) {
+      return [WorkflowRunStatusEnum.ERROR];
+    }
+
+    const _exhaustive: never = status;
+
+    return [_exhaustive];
+  });
+}
+
+export async function applyWorkflowRunFilters(
+  queryBuilder: QueryBuilder<WorkflowRun>,
+  command: WorkflowRunFilterFields,
+  topicSubscribersRepository: TopicSubscribersRepository
+): Promise<void> {
+  if (command.workflowIds?.length) {
+    queryBuilder.whereIn('workflow_id', command.workflowIds);
+  }
+
+  if (command.subscriberIds?.length) {
+    queryBuilder.whereIn('external_subscriber_id', command.subscriberIds);
+  }
+
+  if (command.transactionIds?.length) {
+    queryBuilder.whereIn('transaction_id', command.transactionIds);
+  }
+
+  if (command.statuses?.length) {
+    queryBuilder.whereIn('status', mapStatusesToStoredValues(command.statuses) as WorkflowRunStatusEnum[]);
+  }
+
+  if (command.createdGte) {
+    queryBuilder.whereGreaterThanOrEqual('created_at', LogRepository.formatDateTime64(new Date(command.createdGte)));
+  }
+
+  if (command.createdLte) {
+    queryBuilder.whereLessThanOrEqual('created_at', LogRepository.formatDateTime64(new Date(command.createdLte)));
+  }
+
+  if (command.channels?.length) {
+    queryBuilder.orWhere(
+      command.channels.map((channel) => ({
+        field: 'channels',
+        operator: 'LIKE',
+        value: `%"${channel}"%`,
+      }))
+    );
+  }
+
+  const severity = command.severity ?? [];
+  if (severity.length) {
+    const orConditions: Array<FieldCondition<WorkflowRun, keyof WorkflowRun, ClickhouseOperator>> = [];
+    if (severity.includes(SeverityLevelEnum.NONE)) {
+      orConditions.push({
+        field: 'severity',
+        operator: 'IS NULL',
+      });
+      orConditions.push({
+        field: 'severity',
+        operator: '=',
+        value: SeverityLevelEnum.NONE,
+      });
+    }
+    const severityWithoutNone = severity.filter((level) => level !== SeverityLevelEnum.NONE);
+    for (const level of severityWithoutNone) {
+      orConditions.push({
+        field: 'severity',
+        operator: '=',
+        value: level.toString(),
+      });
+    }
+    queryBuilder.orWhere(orConditions);
+  }
+
+  if (command.topicKey) {
+    queryBuilder.whereLike('topics', `%${command.topicKey}%`);
+  }
+
+  if (command.subscriptionId) {
+    const subscription = await topicSubscribersRepository.findOne({
+      _environmentId: command.environmentId,
+      identifier: command.subscriptionId,
+    });
+
+    if (subscription) {
+      queryBuilder.whereLike('topics', `%${subscription.topicKey}%`);
+      queryBuilder.whereLike('topics', `%${subscription.identifier}%`);
+      queryBuilder.whereEquals('external_subscriber_id', subscription.externalSubscriberId);
+    }
+  }
+
+  if (command.contextKeys !== undefined) {
+    if (command.contextKeys.length === 0) {
+      queryBuilder.whereEquals('context_keys', []);
+    } else {
+      queryBuilder.whereHasAll('context_keys', command.contextKeys);
+    }
+  }
+
+  if (command.deliveryLifecycleStatus?.length) {
+    queryBuilder.whereIn('delivery_lifecycle_status', command.deliveryLifecycleStatus);
+  }
+
+  if (command.deliveryLifecycleDetail?.length) {
+    queryBuilder.whereIn('delivery_lifecycle_detail', command.deliveryLifecycleDetail);
+  }
+}

--- a/apps/api/src/app/activity/usecases/get-charts/get-charts.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-charts/get-charts.usecase.ts
@@ -1,7 +1,5 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
-import { CommunityOrganizationRepository, OrganizationEntity } from '@novu/dal';
-import { ApiServiceLevelEnum, FeatureNameEnum, getFeatureForTierAsNumber } from '@novu/shared';
 import {
   ActiveSubscribersDataPointDto,
   ActiveSubscribersTrendDataPointDto,
@@ -18,6 +16,7 @@ import {
   WorkflowVolumeDataPointDto,
 } from '../../dtos/get-charts.response.dto';
 import { ReportTypeEnum } from '../../dtos/shared.dto';
+import { ActivityRetentionService } from '../../shared/activity-retention.service';
 import { BuildActiveSubscribersChart, BuildActiveSubscribersChartCommand } from '../build-active-subscribers-chart';
 import { BuildActiveSubscribersTrendChartCommand } from '../build-active-subscribers-trend-chart/build-active-subscribers-trend-chart.command';
 import { BuildActiveSubscribersTrendChart } from '../build-active-subscribers-trend-chart/build-active-subscribers-trend-chart.usecase';
@@ -51,7 +50,7 @@ export class GetCharts {
     private buildWorkflowRunsMetricChart: BuildWorkflowRunsMetricChart,
     private buildTotalInteractionsChart: BuildTotalInteractionsChart,
     private buildWorkflowRunsTrendChart: BuildWorkflowRunsTrendChart,
-    private organizationRepository: CommunityOrganizationRepository,
+    private activityRetentionService: ActivityRetentionService,
     private logger: PinoLogger
   ) {
     this.logger.setContext(GetCharts.name);
@@ -72,7 +71,11 @@ export class GetCharts {
       topicKey,
     } = command;
 
-    const validatedDates = await this.validateRetentionLimitForTier(organizationId, createdAtGte, createdAtLte);
+    const validatedDates = await this.activityRetentionService.validateRetentionLimitForTier(
+      organizationId,
+      createdAtGte,
+      createdAtLte
+    );
 
     const endDate = new Date(validatedDates.before);
     const startDate = new Date(validatedDates.after);
@@ -318,78 +321,5 @@ export class GetCharts {
     return {
       data,
     };
-  }
-
-  private async validateRetentionLimitForTier(organizationId: string, createdAtGte?: string, createdAtLte?: string) {
-    const organization = await this.organizationRepository.findById(organizationId);
-
-    if (!organization) {
-      throw new HttpException('Organization not found', HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    const maxRetentionMs = this.getMaxRetentionPeriodByOrganization(organization);
-
-    const earliestAllowedDate = new Date(Date.now() - maxRetentionMs);
-
-    // If no start date is provided, default to the earliest allowed date
-    const effectiveStartDate = createdAtGte ? new Date(createdAtGte) : earliestAllowedDate;
-    const effectiveEndDate = createdAtLte ? new Date(createdAtLte) : new Date();
-
-    this.validateDateRange(earliestAllowedDate, effectiveStartDate, effectiveEndDate);
-
-    return {
-      after: effectiveStartDate.toISOString(),
-      before: effectiveEndDate.toISOString(),
-    };
-  }
-
-  private validateDateRange(earliestAllowedDate: Date, startDate: Date, endDate: Date) {
-    if (startDate > endDate) {
-      throw new HttpException(
-        'Invalid date range: start date (createdAtGte) must be earlier than end date (createdAtLte)',
-        HttpStatus.BAD_REQUEST
-      );
-    }
-
-    // add buffer to account for time delay in execution
-    const buffer = 1 * 60 * 60 * 1000; // 1 hour
-    const bufferedEarliestAllowedDate = new Date(earliestAllowedDate.getTime() - buffer);
-
-    if (
-      process.env.NODE_ENV !== 'local' &&
-      (startDate < bufferedEarliestAllowedDate || endDate < bufferedEarliestAllowedDate)
-    ) {
-      throw new HttpException(
-        `Requested date range exceeds your plan's retention period. ` +
-          `The earliest accessible date for your plan is ${earliestAllowedDate.toISOString().split('T')[0]}. ` +
-          `Please upgrade your plan to access older activities.`,
-        HttpStatus.PAYMENT_REQUIRED
-      );
-    }
-  }
-
-  /**
-   * Charts data follows the same retention policy as activity feed notifications.
-   * Data is automatically deleted after a certain period of time based on the organization's tier.
-   */
-  private getMaxRetentionPeriodByOrganization(organization: OrganizationEntity) {
-    // 1. Self-hosted gets unlimited retention both community and enterprise
-    if (process.env.IS_SELF_HOSTED === 'true') {
-      return Number.MAX_SAFE_INTEGER;
-    }
-
-    const { apiServiceLevel, createdAt } = organization;
-
-    // 2. Special case: Free tier orgs created before Feb 28, 2025 get 30 days
-    if (apiServiceLevel === ApiServiceLevelEnum.FREE && new Date(createdAt) < new Date('2025-02-28')) {
-      return 30 * 24 * 60 * 60 * 1000;
-    }
-
-    // 3. Otherwise, use tier-based retention from feature flags
-    return getFeatureForTierAsNumber(
-      FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
-      apiServiceLevel ?? ApiServiceLevelEnum.FREE,
-      true
-    );
   }
 }

--- a/apps/api/src/app/activity/usecases/get-workflow-run-stats/get-workflow-run-stats.command.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run-stats/get-workflow-run-stats.command.ts
@@ -1,0 +1,9 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { WorkflowRunStatsGroupByEnum } from '../../dtos/shared.dto';
+import { WorkflowRunFiltersCommand } from '../get-workflow-runs/get-workflow-runs.command';
+
+export class GetWorkflowRunStatsCommand extends WorkflowRunFiltersCommand {
+  @IsOptional()
+  @IsEnum(WorkflowRunStatsGroupByEnum)
+  groupBy?: WorkflowRunStatsGroupByEnum;
+}

--- a/apps/api/src/app/activity/usecases/get-workflow-run-stats/get-workflow-run-stats.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run-stats/get-workflow-run-stats.usecase.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger, QueryBuilder, WorkflowRun, WorkflowRunRepository } from '@novu/application-generic';
+import { TopicSubscribersRepository } from '@novu/dal';
+import { GetWorkflowRunStatsResponseDto } from '../../dtos/workflow-run-stats.dto';
+import { ActivityRetentionService } from '../../shared/activity-retention.service';
+import { applyWorkflowRunFilters } from '../../shared/build-workflow-run-where';
+import { GetWorkflowRunStatsCommand } from './get-workflow-run-stats.command';
+
+const BUCKET_LIMIT = 50;
+
+@Injectable()
+export class GetWorkflowRunStats {
+  constructor(
+    private workflowRunRepository: WorkflowRunRepository,
+    private topicSubscribersRepository: TopicSubscribersRepository,
+    private activityRetentionService: ActivityRetentionService,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(GetWorkflowRunStats.name);
+  }
+
+  async execute(command: GetWorkflowRunStatsCommand): Promise<GetWorkflowRunStatsResponseDto> {
+    const retentionWindow = await this.activityRetentionService.validateRetentionLimitForTier(
+      command.organizationId,
+      command.createdGte,
+      command.createdLte
+    );
+    const queryWindow = this.activityRetentionService.queryWindowForWorkflowRuns(retentionWindow, command.createdLte);
+
+    const queryBuilder = new QueryBuilder<WorkflowRun>({
+      environmentId: command.environmentId,
+    });
+
+    await applyWorkflowRunFilters(
+      queryBuilder,
+      {
+        ...command,
+        createdGte: queryWindow.after,
+        createdLte: queryWindow.before,
+      },
+      this.topicSubscribersRepository
+    );
+
+    const result = await this.workflowRunRepository.getGroupedStats({
+      where: queryBuilder.build(),
+      groupBy: command.groupBy,
+      bucketLimit: BUCKET_LIMIT,
+    });
+
+    return {
+      total: result.total,
+      uniqueSubscribers: result.uniqueSubscribers,
+      groupBy: command.groupBy ?? null,
+      buckets: result.buckets,
+    };
+  }
+}

--- a/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { HttpException, Injectable, NotFoundException } from '@nestjs/common';
 import {
   PinoLogger,
   QueryBuilder,
@@ -13,6 +13,7 @@ import { JobEntity, JobRepository } from '@novu/dal';
 import { StepTypeEnum } from '@novu/shared';
 import { subDays } from 'date-fns';
 import { GetWorkflowRunResponseDto, StepRunDto } from '../../dtos/workflow-run-response.dto';
+import { ActivityRetentionService } from '../../shared/activity-retention.service';
 import { mapTraceToExecutionDetailDto, mapWorkflowRunStatusToDto } from '../../shared/mappers';
 import { GetWorkflowRunCommand } from './get-workflow-run.command';
 
@@ -81,6 +82,7 @@ export class GetWorkflowRun {
     private stepRunRepository: StepRunRepository,
     private traceLogRepository: TraceLogRepository,
     private jobRepository: JobRepository,
+    private activityRetentionService: ActivityRetentionService,
     private logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -116,6 +118,13 @@ export class GetWorkflowRun {
       }
 
       const workflowRun = workflowRunResult.data;
+      const createdAtIso = new Date(`${workflowRun.created_at} UTC`).toISOString();
+      await this.activityRetentionService.validateRetentionLimitForTier(
+        command.organizationId,
+        createdAtIso,
+        createdAtIso
+      );
+
       const [stepRuns, overrides] = await Promise.all([
         this.getStepRunsForWorkflowRun(command, workflowRun),
         this.getOverridesByTransactionId(workflowRun.transaction_id, command),
@@ -124,6 +133,10 @@ export class GetWorkflowRun {
 
       return workflowRunDto;
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       this.logger.error(
         {
           error: error.message,

--- a/apps/api/src/app/activity/usecases/get-workflow-runs/get-workflow-runs.command.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-runs/get-workflow-runs.command.ts
@@ -1,18 +1,9 @@
-import { SeverityLevelEnum } from '@novu/shared';
+import { DeliveryLifecycleDetail, DeliveryLifecycleStatusEnum, SeverityLevelEnum } from '@novu/shared';
 import { IsArray, IsIn, IsInt, IsISO8601, IsOptional, IsString, Max, Min } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { WorkflowRunStatusDtoEnum } from '../../dtos/shared.dto';
 
-export class GetWorkflowRunsCommand extends EnvironmentWithUserCommand {
-  @IsInt()
-  @Min(1)
-  @Max(100)
-  limit: number;
-
-  @IsOptional()
-  @IsString()
-  cursor?: string;
-
+export class WorkflowRunFiltersCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
@@ -64,4 +55,25 @@ export class GetWorkflowRunsCommand extends EnvironmentWithUserCommand {
   @IsArray()
   @IsString({ each: true })
   contextKeys?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @IsIn(Object.values(DeliveryLifecycleStatusEnum), { each: true })
+  deliveryLifecycleStatus?: DeliveryLifecycleStatusEnum[];
+
+  @IsOptional()
+  @IsArray()
+  @IsIn(Object.values(DeliveryLifecycleDetail), { each: true })
+  deliveryLifecycleDetail?: DeliveryLifecycleDetail[];
+}
+
+export class GetWorkflowRunsCommand extends WorkflowRunFiltersCommand {
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number;
+
+  @IsOptional()
+  @IsString()
+  cursor?: string;
 }

--- a/apps/api/src/app/activity/usecases/get-workflow-runs/get-workflow-runs.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-runs/get-workflow-runs.usecase.ts
@@ -1,7 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import {
-  ClickhouseOperator,
-  FieldCondition,
   PinoLogger,
   QueryBuilder,
   StepRun,
@@ -9,12 +7,11 @@ import {
   Where,
   WorkflowRun,
   WorkflowRunRepository,
-  WorkflowRunStatusEnum,
 } from '@novu/application-generic';
 import { TopicSubscribersRepository } from '@novu/dal';
-import { SeverityLevelEnum } from '@novu/shared';
-import { WorkflowRunStatusDtoEnum } from '../../dtos/shared.dto';
 import { GetWorkflowRunsDto, GetWorkflowRunsResponseDto } from '../../dtos/workflow-runs-response.dto';
+import { ActivityRetentionService } from '../../shared/activity-retention.service';
+import { applyWorkflowRunFilters } from '../../shared/build-workflow-run-where';
 import { mapWorkflowRunStatusToDto } from '../../shared/mappers';
 import { GetWorkflowRunsCommand } from './get-workflow-runs.command';
 
@@ -66,6 +63,7 @@ export class GetWorkflowRuns {
     private workflowRunRepository: WorkflowRunRepository,
     private stepRunRepository: StepRunRepository,
     private topicSubscribersRepository: TopicSubscribersRepository,
+    private activityRetentionService: ActivityRetentionService,
     private logger: PinoLogger
   ) {
     this.logger.setContext(GetWorkflowRuns.name);
@@ -83,108 +81,26 @@ export class GetWorkflowRuns {
     );
 
     try {
+      const retentionWindow = await this.activityRetentionService.validateRetentionLimitForTier(
+        command.organizationId,
+        command.createdGte,
+        command.createdLte
+      );
+      const queryWindow = this.activityRetentionService.queryWindowForWorkflowRuns(retentionWindow, command.createdLte);
+
       const queryBuilder = new QueryBuilder<WorkflowRun>({
         environmentId: command.environmentId,
       });
 
-      if (command.workflowIds?.length) {
-        queryBuilder.whereIn('workflow_id', command.workflowIds);
-      }
-
-      if (command.subscriberIds?.length) {
-        queryBuilder.whereIn('external_subscriber_id', command.subscriberIds);
-      }
-
-      if (command.transactionIds?.length) {
-        queryBuilder.whereIn('transaction_id', command.transactionIds);
-      }
-
-      if (command.statuses?.length) {
-        const statuses = command.statuses.map((status) => {
-          //backward compatibility: if new statuses are used, append old status until renewed in the database, nv-6562
-          if (status === WorkflowRunStatusDtoEnum.PROCESSING) {
-            return [WorkflowRunStatusEnum.PENDING, WorkflowRunStatusEnum.PROCESSING];
-          }
-          if (status === WorkflowRunStatusDtoEnum.COMPLETED) {
-            return [WorkflowRunStatusEnum.SUCCESS, WorkflowRunStatusEnum.COMPLETED];
-          }
-          if (status === WorkflowRunStatusDtoEnum.ERROR) {
-            return [WorkflowRunStatusEnum.ERROR];
-          }
-          return status;
-        });
-        queryBuilder.whereIn('status', statuses.flat());
-      }
-
-      if (command.createdGte) {
-        queryBuilder.whereGreaterThanOrEqual('created_at', new Date(command.createdGte));
-      }
-
-      if (command.createdLte) {
-        queryBuilder.whereLessThanOrEqual('created_at', new Date(command.createdLte));
-      }
-
-      if (command.channels?.length) {
-        queryBuilder.orWhere(
-          command.channels.map((channel) => ({
-            field: 'channels',
-            operator: 'LIKE',
-            value: `%"${channel}"%`,
-          }))
-        );
-      }
-
-      const severity = command.severity ?? [];
-      if (severity.length) {
-        const orConditions: Array<FieldCondition<WorkflowRun, keyof WorkflowRun, ClickhouseOperator>> = [];
-        if (severity.includes(SeverityLevelEnum.NONE)) {
-          orConditions.push({
-            field: 'severity',
-            operator: 'IS NULL',
-          });
-          orConditions.push({
-            field: 'severity',
-            operator: '=',
-            value: SeverityLevelEnum.NONE,
-          });
-        }
-        const severityWithoutNone = severity.filter((severity) => severity !== SeverityLevelEnum.NONE);
-        for (const severity of severityWithoutNone) {
-          orConditions.push({
-            field: 'severity',
-            operator: '=',
-            value: severity.toString(),
-          });
-        }
-        queryBuilder.orWhere(orConditions);
-      }
-
-      if (command.topicKey) {
-        queryBuilder.whereLike('topics', `%${command.topicKey}%`);
-      }
-
-      if (command.subscriptionId) {
-        const subscription = await this.topicSubscribersRepository.findOne({
-          _environmentId: command.environmentId,
-          identifier: command.subscriptionId,
-        });
-
-        if (subscription) {
-          queryBuilder.whereLike('topics', `%${subscription.topicKey}%`);
-          queryBuilder.whereLike('topics', `%${subscription.identifier}%`);
-          queryBuilder.whereEquals('external_subscriber_id', subscription.externalSubscriberId);
-        }
-      }
-
-      if (command.contextKeys !== undefined) {
-        if (command.contextKeys.length === 0) {
-          // Empty array = filter for records with no context (empty context_keys)
-          queryBuilder.whereEquals('context_keys', []);
-        } else {
-          // Non-empty array = filter for records containing all specified contexts
-          queryBuilder.whereHasAll('context_keys', command.contextKeys);
-        }
-      }
+      await applyWorkflowRunFilters(
+        queryBuilder,
+        {
+          ...command,
+          createdGte: queryWindow.after,
+          createdLte: queryWindow.before,
+        },
+        this.topicSubscribersRepository
+      );
 
       const safeWhere = queryBuilder.build();
 

--- a/apps/api/src/app/shared/framework/swagger/swagger.controller.ts
+++ b/apps/api/src/app/shared/framework/swagger/swagger.controller.ts
@@ -39,6 +39,11 @@ function buildBaseOptions() {
     .addSecurity(API_KEY_SWAGGER_SECURITY_NAME, API_KEY_SECURITY_DEFINITIONS)
     .addSecurityRequirements(API_KEY_SWAGGER_SECURITY_NAME)
     .addTag(
+      'Activity',
+      `Activity APIs expose workflow-run history and aggregated counts so you can inspect delivery outcomes and slice runs by status, workflow, channel, or delivery lifecycle.`,
+      { url: 'https://docs.novu.co/platform/activity-feed' }
+    )
+    .addTag(
       'Events',
       `Events represent a change in state of a subscriber. They are used to trigger workflows, and enable you to send notifications to subscribers based on their actions.`,
       { url: 'https://docs.novu.co/workflows' }

--- a/libs/application-generic/src/services/analytic-logs/workflow-run/workflow-run.repository.ts
+++ b/libs/application-generic/src/services/analytic-logs/workflow-run/workflow-run.repository.ts
@@ -622,4 +622,110 @@ export class WorkflowRunRepository extends LogRepository<typeof workflowRunSchem
 
     return result.data;
   }
+
+  async getGroupedStats(options: {
+    where: Where<WorkflowRun>;
+    groupBy?: WorkflowRunStatsGroupBy;
+    bucketLimit?: number;
+  }): Promise<{
+    total: number;
+    uniqueSubscribers: number;
+    buckets: Array<{ key: string; count: number; uniqueSubscribers: number }>;
+  }> {
+    const { where, groupBy, bucketLimit = 50 } = options;
+    const { clause, params } = this.buildWhereClause(where);
+
+    const totalsResult = await this.clickhouseService.query<{
+      total: string;
+      unique_subscribers: string;
+    }>({
+      query: `
+        SELECT
+          toInt64(count()) as total,
+          toInt64(uniqExact(external_subscriber_id)) as unique_subscribers
+        FROM ${this.table} FINAL
+        ${clause}
+      `,
+      params,
+    });
+
+    const total = parseInt(totalsResult.data[0]?.total || '0', 10);
+    const uniqueSubscribers = parseInt(totalsResult.data[0]?.unique_subscribers || '0', 10);
+
+    if (!groupBy) {
+      return { total, uniqueSubscribers, buckets: [] };
+    }
+
+    const limitedBucketCount = Math.min(Math.max(bucketLimit, 1), 50);
+    const groupExpression = resolveWorkflowRunGroupExpression(groupBy);
+    const arrayJoinClause =
+      groupBy === 'channel'
+        ? `ARRAY JOIN JSONExtract(ifNull(nullIf(channels, ''), '[]'), 'Array(String)') AS channel`
+        : '';
+
+    const bucketsResult = await this.clickhouseService.query<{
+      bucket_key: string;
+      count: string;
+      unique_subscribers: string;
+    }>({
+      query: `
+        SELECT
+          ${groupExpression} as bucket_key,
+          toInt64(count()) as count,
+          toInt64(uniqExact(external_subscriber_id)) as unique_subscribers
+        FROM ${this.table} FINAL
+        ${arrayJoinClause}
+        ${clause}
+        GROUP BY bucket_key
+        ORDER BY count DESC
+        LIMIT ${limitedBucketCount}
+      `,
+      params,
+    });
+
+    return {
+      total,
+      uniqueSubscribers,
+      buckets: bucketsResult.data.map((row) => ({
+        key: row.bucket_key ?? '',
+        count: parseInt(row.count || '0', 10),
+        uniqueSubscribers: parseInt(row.unique_subscribers || '0', 10),
+      })),
+    };
+  }
+}
+
+export type WorkflowRunStatsGroupBy =
+  | 'day'
+  | 'status'
+  | 'deliveryLifecycleStatus'
+  | 'deliveryLifecycleDetail'
+  | 'workflow'
+  | 'channel';
+
+function resolveWorkflowRunGroupExpression(groupBy: WorkflowRunStatsGroupBy): string {
+  switch (groupBy) {
+    case 'day':
+      return `toString(toDate(created_at))`;
+    case 'status':
+      return `CASE
+        WHEN status IN ('pending', 'processing') THEN 'processing'
+        WHEN status IN ('success', 'completed') THEN 'completed'
+        WHEN status = 'error' THEN 'error'
+        ELSE 'processing'
+      END`;
+    case 'deliveryLifecycleStatus':
+      return `delivery_lifecycle_status`;
+    case 'deliveryLifecycleDetail':
+      return `delivery_lifecycle_detail`;
+    case 'workflow':
+      return `workflow_id`;
+    case 'channel':
+      return `replaceAll(channel, '"', '')`;
+    default: {
+      const _exhaustive: never = groupBy;
+
+      throw new Error(`Unsupported workflow run stats groupBy: ${_exhaustive}`);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Expose workflow-run activity on the public API so MCP and SDK clients can inspect delivery outcomes without a dashboard session.

- Add `GET /v1/activity/workflow-runs/stats` with the same filters as the list plus optional `groupBy` (`day`, `status`, `deliveryLifecycleStatus`, `deliveryLifecycleDetail`, `workflow`, `channel`)
- Open list, retrieve, and stats to API keys and OAuth (`@ExternalApiAccessible` + `@OAuthAccessible`)
- Share plan retention enforcement and ClickHouse filter building across charts, list, and stats
- Add delivery-lifecycle status/detail filters on the list

Charts stay internal (`@ApiExcludeEndpoint`).

```mermaid
flowchart LR
  Client["API key / OAuth / MCP"] --> List["GET /workflow-runs"]
  Client --> Stats["GET /workflow-runs/stats"]
  Client --> One["GET /workflow-runs/:id"]
  List --> Filters["applyWorkflowRunFilters"]
  Stats --> Filters
  Filters --> Retention["ActivityRetentionService"]
  Filters --> CH["WorkflowRunRepository / ClickHouse"]
  Stats --> Grouped["getGroupedStats"]
  Grouped --> CH
```

Fixes [NV-8764](https://linear.app/novu/issue/NV-8764/add-public-workflow-run-stats-api-and-open-activity-listretrieve)

## Test plan

- [ ] `GET /v1/activity/workflow-runs/stats` returns totals without `groupBy`
- [ ] Stats `groupBy` works for day, status, channel, workflow, and delivery lifecycle
- [ ] List and stats honor delivery-lifecycle filters
- [ ] API key can call list, retrieve, and stats; missing `NOTIFICATION_READ` returns 403
- [ ] Out-of-plan date window returns 402
- [ ] ReplacingMergeTree `FINAL` counts a replaced workflow run once
- [ ] Existing list pagination and date/channel filters still pass


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR exposes workflow-run list, retrieval, and aggregated statistics through the public API while sharing retention and ClickHouse filtering behavior across activity endpoints. The previously reported self-hosted retention serialization failure is fixed by using a valid epoch lower bound.
- Adds workflow-run totals and grouped statistics.
- Adds delivery-lifecycle filters and public API/OAuth accessibility.
- Centralizes retention validation and workflow-run filter construction.
- Keeps activity charts excluded from the public OpenAPI surface.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/activity/shared/activity-retention.service.ts | Centralizes plan retention validation and safely represents unbounded self-hosted retention with the Unix epoch. |
| apps/api/src/app/activity/shared/build-workflow-run-where.ts | Consolidates workflow-run filtering for list, chart, and statistics queries. |
| apps/api/src/app/activity/usecases/get-workflow-run-stats/get-workflow-run-stats.usecase.ts | Implements aggregate and grouped workflow-run statistics using shared retention and filtering. |
| libs/application-generic/src/services/analytic-logs/workflow-run/workflow-run.repository.ts | Adds ClickHouse aggregation support for workflow-run totals and grouped buckets. |
| apps/api/src/app/activity/activity.controller.ts | Publishes workflow-run list, retrieval, and statistics endpoints while retaining internal-only chart documentation. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Client[API key or OAuth client] --> List[List workflow runs]
  Client --> Stats[Workflow-run statistics]
  Client --> Retrieve[Retrieve workflow run]
  List --> Retention[Activity retention validation]
  Stats --> Retention
  Retrieve --> Retention
  List --> Filters[Shared ClickHouse filters]
  Stats --> Filters
  Retention --> Query[Workflow-run repository]
  Filters --> Query
```

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): keep self-hosted activ..."](https://github.com/novuhq/novu/commit/e834e6d54bd3ff9f4752e79de08dbbf3308160c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59977891)</sub>

**Context used:**

- Knowledge Base — [API service and application boundary](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/api-service.md)

<!-- /greptile_comment -->