### PR TITLE
fix(providers): classify FCM unregistered tokens as invalid

### DIFF
--- a/packages/providers/src/lib/push/fcm/fcm.provider.spec.ts
+++ b/packages/providers/src/lib/push/fcm/fcm.provider.spec.ts
@@ -473,3 +473,40 @@ describe.skip('FcmPushProvider', () => {
     });
   });
 });
+
+describe('FcmPushProvider.isTokenInvalid', () => {
+  const provider = new FcmPushProvider({
+    secretKey: '--BEGIN PRIVATE KEY--abc',
+    projectId: 'test',
+    email: 'test@iam.firebase.google.com',
+  });
+
+  const invalidTokenMessages = [
+    'Requested entity was not found',
+    'NotRegistered',
+    'InvalidRegistration',
+    'Unregistered',
+    'UNREGISTERED',
+    'registration-token-not-registered',
+    'messaging/registration-token-not-registered',
+    'messaging/invalid-registration-token',
+    'The registration token is not a valid FCM registration token',
+    'Sending message failed due to "NotRegistered"',
+    'Sending message failed due to "messaging/registration-token-not-registered: Requested entity was not found"',
+  ];
+
+  test.each(invalidTokenMessages)('returns true for %s', (errorMessage) => {
+    expect(provider.isTokenInvalid(errorMessage)).toBe(true);
+  });
+
+  test.each([
+    'Internal server error',
+    'Connection timeout',
+    'Rate limit exceeded',
+    'MismatchSenderId',
+    'SenderId mismatch',
+    '',
+  ])('returns false for %s', (errorMessage) => {
+    expect(provider.isTokenInvalid(errorMessage)).toBe(false);
+  });
+});

--- a/packages/providers/src/lib/push/fcm/fcm.provider.ts
+++ b/packages/providers/src/lib/push/fcm/fcm.provider.ts
@@ -11,7 +11,17 @@ export class FcmPushProvider extends BaseProvider implements IPushProvider {
   channelType = ChannelTypeEnum.PUSH as ChannelTypeEnum.PUSH;
   protected casing: CasingEnum = CasingEnum.SNAKE_CASE;
 
-  private readonly INVALID_TOKEN_ERRORS = ['Requested entity was not found'];
+  private readonly INVALID_TOKEN_ERRORS = [
+    'Requested entity was not found',
+    'NotRegistered',
+    'InvalidRegistration',
+    'Unregistered',
+    'UNREGISTERED',
+    'registration-token-not-registered',
+    'messaging/registration-token-not-registered',
+    'messaging/invalid-registration-token',
+    'The registration token is not a valid FCM registration token',
+  ];
 
   private appName: string;
   private messaging: Messaging;
@@ -116,9 +126,10 @@ export class FcmPushProvider extends BaseProvider implements IPushProvider {
     await deleteApp(app);
 
     if (res.successCount === 0) {
-      throw new Error(
-        `Sending message failed due to "${res.responses.find((i) => i.success === false).error.message}"`
-      );
+      const failedError = res.responses.find((i) => i.success === false)?.error;
+      const errorDetails = [failedError?.code, failedError?.message].filter(Boolean).join(': ');
+
+      throw new Error(`Sending message failed due to "${errorDetails || failedError}"`);
     }
 
     return {


### PR DESCRIPTION
Auto-removal of stale device tokens was gated on a single FCM error substring, so NotRegistered and related codes never triggered cleanup.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands FCM invalid-token recognition so stale device tokens can be classified from standard and legacy FCM error identifiers.
- Preserves both the FCM error code and message when an entire send fails.
- Adds focused coverage for invalid-token and unrelated error messages.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/providers/src/lib/push/fcm/fcm.provider.ts | Expands invalid-token patterns and includes FCM error codes in failed-send errors; no eligible follow-up defect was established. |
| packages/providers/src/lib/push/fcm/fcm.provider.spec.ts | Adds focused positive and negative tests for FCM token-invalid classification. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;next&#39; into cursor/fcm-inva..."](https://github.com/novuhq/novu/commit/e8a868edcd6adff9ba620b5bb25393fe23c8255a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60012077)</sub>

<!-- /greptile_comment -->