### PR TITLE
fix(api-service): prevent bulk preference CPU exhaustion fixes NV-8766

### DIFF
--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
@@ -379,6 +379,7 @@ describe('BulkUpdatePreferences', () => {
   });
 
   it('should update multiple workflow preferences in parallel', async () => {
+    const environment = { _id: 'env-1' } as any;
     const command = BulkUpdatePreferencesCommand.create({
       environmentId: 'env-1',
       organizationId: 'org-1',
@@ -399,7 +400,7 @@ describe('BulkUpdatePreferences', () => {
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
     notificationTemplateRepositoryMock.findForBulkPreferences.resolves([mockedWorkflow1, mockedWorkflow2]);
-    environmentRepositoryMock.findOne.resolves({ _id: 'env-1' } as any);
+    environmentRepositoryMock.findOne.resolves(environment);
 
     updatePreferencesUsecaseMock.execute.onFirstCall().resolves(mockedInboxPreference1);
     updatePreferencesUsecaseMock.execute.onSecondCall().resolves(mockedInboxPreference2);
@@ -418,6 +419,9 @@ describe('BulkUpdatePreferences', () => {
       in_app: true,
       email: false,
     });
+    expect(firstCallArgs.workflow).to.equal(mockedWorkflow1);
+    expect(firstCallArgs.subscriber).to.equal(mockedSubscriber);
+    expect(firstCallArgs.environment).to.equal(environment);
 
     const secondCallArgs = updatePreferencesUsecaseMock.execute.secondCall.args[0];
     expect(secondCallArgs).to.include({
@@ -431,6 +435,59 @@ describe('BulkUpdatePreferences', () => {
     });
 
     expect(result).to.deep.equal([mockedInboxPreference1, mockedInboxPreference2]);
+  });
+
+  it('should update at most five workflow preferences concurrently', async () => {
+    const workflows = Array.from({ length: 6 }, (_, index) => ({
+      ...mockedWorkflow1,
+      _id: index.toString(16).padStart(24, '0'),
+      triggers: [{ identifier: `test-trigger-${index}` }],
+    }));
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences: workflows.map((workflow) => ({
+        workflowId: workflow._id,
+        in_app: true,
+      })),
+    });
+    let activeUpdates = 0;
+    let maxActiveUpdates = 0;
+    let releaseFirstBatch: () => void = () => {};
+    const firstBatchGate = new Promise<void>((resolve) => {
+      releaseFirstBatch = resolve;
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    notificationTemplateRepositoryMock.findForBulkPreferences.resolves(workflows);
+    environmentRepositoryMock.findOne.resolves({ _id: 'env-1' } as any);
+    updatePreferencesUsecaseMock.execute.callsFake(async () => {
+      activeUpdates += 1;
+      maxActiveUpdates = Math.max(maxActiveUpdates, activeUpdates);
+
+      if (updatePreferencesUsecaseMock.execute.callCount <= 5) {
+        await firstBatchGate;
+      }
+
+      activeUpdates -= 1;
+
+      return mockedInboxPreference1;
+    });
+
+    const execution = bulkUpdatePreferences.execute(command);
+
+    while (updatePreferencesUsecaseMock.execute.callCount < 5) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    expect(updatePreferencesUsecaseMock.execute.callCount).to.equal(5);
+    releaseFirstBatch();
+    const result = await execution;
+
+    expect(updatePreferencesUsecaseMock.execute.callCount).to.equal(6);
+    expect(maxActiveUpdates).to.equal(5);
+    expect(result).to.have.length(6);
   });
 
   it('should support lookup by workflow identifier', async () => {

--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
@@ -17,6 +17,7 @@ import { UpdatePreferences } from '../update-preferences/update-preferences.usec
 import { BulkUpdatePreferencesCommand } from './bulk-update-preferences.command';
 
 const MAX_BULK_LIMIT = 100;
+const UPDATE_BATCH_SIZE = 5;
 
 @Injectable()
 export class BulkUpdatePreferences {
@@ -101,44 +102,54 @@ export class BulkUpdatePreferences {
       _id: command.environmentId,
     });
 
-    const updatePromises = Array.from(workflowPreferencesMap.entries()).map(
-      async ([workflowId, { preference, workflow }]) => {
-        const isUpdatingSubscriptionPreference =
-          preference.subscriptionIdentifier &&
-          (typeof preference.enabled !== 'undefined' || typeof preference.condition !== 'undefined');
+    const workflowPreferenceEntries = Array.from(workflowPreferencesMap.entries());
+    const updatedPreferences: InboxPreference[] = [];
 
-        return this.updatePreferencesUsecase.execute(
-          UpdatePreferencesCommand.create({
-            organizationId: command.organizationId,
-            subscriberId: command.subscriberId,
-            environmentId: command.environmentId,
-            contextKeys,
-            level: PreferenceLevelEnum.TEMPLATE,
-            subscriptionIdentifier: preference.subscriptionIdentifier,
-            ...(isUpdatingSubscriptionPreference && {
-              all: {
-                ...(typeof preference.enabled !== 'undefined' && { enabled: preference.enabled }),
-                ...(typeof preference.condition !== 'undefined' && { condition: preference.condition }),
+    for (let batchStart = 0; batchStart < workflowPreferenceEntries.length; batchStart += UPDATE_BATCH_SIZE) {
+      const batch = workflowPreferenceEntries.slice(batchStart, batchStart + UPDATE_BATCH_SIZE);
+      const batchResults = await Promise.all(
+        batch.map(async ([workflowId, { preference, workflow }]) => {
+          const isUpdatingSubscriptionPreference =
+            preference.subscriptionIdentifier &&
+            (typeof preference.enabled !== 'undefined' || typeof preference.condition !== 'undefined');
+
+          return this.updatePreferencesUsecase.execute(
+            UpdatePreferencesCommand.create(
+              {
+                organizationId: command.organizationId,
+                subscriberId: command.subscriberId,
+                environmentId: command.environmentId,
+                contextKeys,
+                level: PreferenceLevelEnum.TEMPLATE,
+                subscriptionIdentifier: preference.subscriptionIdentifier,
+                ...(isUpdatingSubscriptionPreference && {
+                  all: {
+                    ...(typeof preference.enabled !== 'undefined' && { enabled: preference.enabled }),
+                    ...(typeof preference.condition !== 'undefined' && { condition: preference.condition }),
+                  },
+                }),
+                chat: preference.chat,
+                email: preference.email,
+                in_app: preference.in_app,
+                push: preference.push,
+                sms: preference.sms,
+                tool: preference.tool,
+                workflowIdOrIdentifier: workflowId,
+                includeInactiveChannels: false,
               },
-            }),
-            chat: preference.chat,
-            email: preference.email,
-            in_app: preference.in_app,
-            push: preference.push,
-            sms: preference.sms,
-            tool: preference.tool,
-            workflowIdOrIdentifier: workflowId,
-            workflow,
-            includeInactiveChannels: false,
-            subscriber,
-            // biome-ignore lint/style/noNonNullAssertion: environment is always found
-            environment: environment!,
-          })
-        );
-      }
-    );
+              {
+                workflow,
+                subscriber,
+                // biome-ignore lint/style/noNonNullAssertion: environment is always found
+                environment: environment!,
+              }
+            )
+          );
+        })
+      );
 
-    const updatedPreferences = await Promise.all(updatePromises);
+      updatedPreferences.push(...batchResults);
+    }
 
     return updatedPreferences;
   }

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
@@ -154,6 +154,7 @@ describe('UpdatePreferences', () => {
     getWorkflowByIdsUsecase.execute.resolves(mockedWorkflow);
 
     const result = await updatePreferences.execute(command);
+    const templatePreferenceCommand = getSubscriberTemplatePreferenceUsecase.execute.firstCall.args[0];
 
     expect(result).to.deep.equal({
       level: command.level,
@@ -168,6 +169,8 @@ describe('UpdatePreferences', () => {
         severity: mockedWorkflow.severity,
       },
     });
+    expect(templatePreferenceCommand.template).to.equal(mockedWorkflow);
+    expect(templatePreferenceCommand.subscriber).to.equal(mockedSubscriber);
   });
 
   it('should throw NotFoundException when the subscriptionIdentifier is not owned by the authenticated subscriber', async () => {

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -261,15 +261,19 @@ export class UpdatePreferences {
 
     if (command.level === PreferenceLevelEnum.TEMPLATE && command.workflowIdOrIdentifier && workflow) {
       const { preference } = await this.getSubscriberTemplatePreferenceUsecase.execute(
-        GetSubscriberTemplatePreferenceCommand.create({
-          organizationId: command.organizationId,
-          subscriberId: command.subscriberId,
-          environmentId: command.environmentId,
-          template: workflow,
-          subscriber,
-          includeInactiveChannels: command.includeInactiveChannels,
-          contextKeys: command.contextKeys,
-        } as GetSubscriberTemplatePreferenceCommand)
+        GetSubscriberTemplatePreferenceCommand.create(
+          {
+            organizationId: command.organizationId,
+            subscriberId: command.subscriberId,
+            environmentId: command.environmentId,
+            includeInactiveChannels: command.includeInactiveChannels,
+            contextKeys: command.contextKeys,
+          } as GetSubscriberTemplatePreferenceCommand,
+          {
+            template: workflow,
+            subscriber,
+          }
+        )
       );
 
       return {

--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -10,7 +10,6 @@ import {
   Patch,
   Post,
   Query,
-  ServiceUnavailableException,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiExcludeEndpoint, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
@@ -28,7 +27,6 @@ import {
   ApiRateLimitCategoryEnum,
   ButtonTypeEnum,
   DirectionEnum,
-  FeatureFlagsKeysEnum,
   MessageActionStatusEnum,
   PermissionsEnum,
   SubscriberCustomData,
@@ -67,6 +65,7 @@ import {
   GetSubscriberGlobalPreferenceCommand,
 } from '../subscribers/usecases/get-subscriber-global-preference';
 import { assertGetPreferencesEnabled } from '../subscribers/utils/assert-get-preferences-enabled';
+import { assertPreferencesUpdateEnabled } from '../subscribers/utils/assert-preferences-update-enabled';
 import { ListSubscriberSubscriptionsQueryDto } from '../topics-v2/dtos/list-subscriber-subscriptions-query.dto';
 import { ListTopicSubscriptionsResponseDto } from '../topics-v2/dtos/list-topic-subscriptions-response.dto';
 import { ListSubscriberSubscriptionsCommand } from '../topics-v2/usecases/list-subscriber-subscriptions/list-subscriber-subscriptions.command';
@@ -373,17 +372,7 @@ export class SubscribersController {
     @Param('subscriberId') subscriberId: string,
     @Body() body: BulkUpdateSubscriberPreferencesDto
   ): Promise<GetPreferencesResponseDto[]> {
-    const isPreferencesDisabled = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_ORG_KILLSWITCH_FLAG_ENABLED,
-      defaultValue: false,
-      organization: { _id: user.organizationId },
-      environment: { _id: user.environmentId },
-      component: 'preferences',
-    });
-
-    if (isPreferencesDisabled) {
-      throw new ServiceUnavailableException('Service temporarily unavailable for this organization');
-    }
+    await assertPreferencesUpdateEnabled(this.featureFlagsService, user.organizationId, user.environmentId);
 
     const preferences = body.preferences.map((preference) => ({
       workflowId: preference.workflowId,

--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -10,6 +10,7 @@ import {
   Patch,
   Post,
   Query,
+  ServiceUnavailableException,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiExcludeEndpoint, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
@@ -27,6 +28,7 @@ import {
   ApiRateLimitCategoryEnum,
   ButtonTypeEnum,
   DirectionEnum,
+  FeatureFlagsKeysEnum,
   MessageActionStatusEnum,
   PermissionsEnum,
   SubscriberCustomData,
@@ -371,6 +373,18 @@ export class SubscribersController {
     @Param('subscriberId') subscriberId: string,
     @Body() body: BulkUpdateSubscriberPreferencesDto
   ): Promise<GetPreferencesResponseDto[]> {
+    const isPreferencesDisabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_ORG_KILLSWITCH_FLAG_ENABLED,
+      defaultValue: false,
+      organization: { _id: user.organizationId },
+      environment: { _id: user.environmentId },
+      component: 'preferences',
+    });
+
+    if (isPreferencesDisabled) {
+      throw new ServiceUnavailableException('Service temporarily unavailable for this organization');
+    }
+
     const preferences = body.preferences.map((preference) => ({
       workflowId: preference.workflowId,
       ...preference.channels,

--- a/apps/api/src/app/subscribers/utils/assert-preferences-update-enabled.spec.ts
+++ b/apps/api/src/app/subscribers/utils/assert-preferences-update-enabled.spec.ts
@@ -14,15 +14,17 @@ describe('assertPreferencesUpdateEnabled', () => {
     const featureFlagsService = sinon.createStubInstance(FeatureFlagsService);
     featureFlagsService.getFlag.resolves(false);
 
-    await assertPreferencesUpdateEnabled(featureFlagsService, 'org-1', 'env-1');
+    await assertPreferencesUpdateEnabled(featureFlagsService as any, 'org-1', 'env-1');
 
-    expect(featureFlagsService.getFlag.calledOnceWithExactly({
-      key: FeatureFlagsKeysEnum.IS_ORG_KILLSWITCH_FLAG_ENABLED,
-      defaultValue: false,
-      organization: { _id: 'org-1' },
-      environment: { _id: 'env-1' },
-      component: 'preferences',
-    })).to.be.true;
+    expect(
+      featureFlagsService.getFlag.calledOnceWithExactly({
+        key: FeatureFlagsKeysEnum.IS_ORG_KILLSWITCH_FLAG_ENABLED,
+        defaultValue: false,
+        organization: { _id: 'org-1' },
+        environment: { _id: 'env-1' },
+        component: 'preferences',
+      })
+    ).to.be.true;
   });
 
   it('should reject preference updates when the organization killswitch is enabled', async () => {
@@ -30,7 +32,7 @@ describe('assertPreferencesUpdateEnabled', () => {
     featureFlagsService.getFlag.resolves(true);
 
     try {
-      await assertPreferencesUpdateEnabled(featureFlagsService, 'org-1', 'env-1');
+      await assertPreferencesUpdateEnabled(featureFlagsService as any, 'org-1', 'env-1');
       expect.fail('Should throw an exception');
     } catch (error) {
       expect(error).to.be.instanceOf(ServiceUnavailableException);

--- a/apps/api/src/app/subscribers/utils/assert-preferences-update-enabled.spec.ts
+++ b/apps/api/src/app/subscribers/utils/assert-preferences-update-enabled.spec.ts
@@ -1,0 +1,40 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { FeatureFlagsService } from '@novu/application-generic';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { assertPreferencesUpdateEnabled } from './assert-preferences-update-enabled';
+
+describe('assertPreferencesUpdateEnabled', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should allow preference updates when the organization killswitch is disabled', async () => {
+    const featureFlagsService = sinon.createStubInstance(FeatureFlagsService);
+    featureFlagsService.getFlag.resolves(false);
+
+    await assertPreferencesUpdateEnabled(featureFlagsService, 'org-1', 'env-1');
+
+    expect(featureFlagsService.getFlag.calledOnceWithExactly({
+      key: FeatureFlagsKeysEnum.IS_ORG_KILLSWITCH_FLAG_ENABLED,
+      defaultValue: false,
+      organization: { _id: 'org-1' },
+      environment: { _id: 'env-1' },
+      component: 'preferences',
+    })).to.be.true;
+  });
+
+  it('should reject preference updates when the organization killswitch is enabled', async () => {
+    const featureFlagsService = sinon.createStubInstance(FeatureFlagsService);
+    featureFlagsService.getFlag.resolves(true);
+
+    try {
+      await assertPreferencesUpdateEnabled(featureFlagsService, 'org-1', 'env-1');
+      expect.fail('Should throw an exception');
+    } catch (error) {
+      expect(error).to.be.instanceOf(ServiceUnavailableException);
+      expect(error.message).to.equal('Service temporarily unavailable for this organization');
+    }
+  });
+});

--- a/apps/api/src/app/subscribers/utils/assert-preferences-update-enabled.ts
+++ b/apps/api/src/app/subscribers/utils/assert-preferences-update-enabled.ts
@@ -1,0 +1,21 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { FeatureFlagsService } from '@novu/application-generic';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+
+export async function assertPreferencesUpdateEnabled(
+  featureFlagsService: FeatureFlagsService,
+  organizationId: string,
+  environmentId: string
+): Promise<void> {
+  const isPreferencesDisabled = await featureFlagsService.getFlag({
+    key: FeatureFlagsKeysEnum.IS_ORG_KILLSWITCH_FLAG_ENABLED,
+    defaultValue: false,
+    organization: { _id: organizationId },
+    environment: { _id: environmentId },
+    component: 'preferences',
+  });
+
+  if (isPreferencesDisabled) {
+    throw new ServiceUnavailableException('Service temporarily unavailable for this organization');
+  }
+}

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.command.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.command.ts
@@ -1,11 +1,9 @@
 import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
 import { ITenantDefine } from '@novu/shared';
-import { IsBoolean, IsDefined, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsBoolean, IsDefined, IsOptional } from 'class-validator';
 import { EnvironmentWithSubscriber } from '../../commands';
 
 export class GetSubscriberTemplatePreferenceCommand extends EnvironmentWithSubscriber {
-  @IsNotEmpty()
-  @IsDefined()
   template: NotificationTemplateEntity;
 
   @IsOptional()

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -42,6 +42,10 @@ export class GetSubscriberTemplatePreference {
 
   @InstrumentUsecase()
   async execute(command: GetSubscriberTemplatePreferenceCommand): Promise<ISubscriberPreferenceResponse> {
+    if (!command.template) {
+      throw new BadRequestException('Template is required');
+    }
+
     const subscriber: Pick<SubscriberEntity, '_id'> | null = command.subscriber ?? (await this.getSubscriber(command));
 
     const initialChannels = await this.getChannels(command);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Fixes [NV-8766](https://linear.app/novu/issue/NV-8766/prevent-bulk-preference-updates-from-exhausting-api-cpu).

High-RPS bulk preference updates recursively converted full workflow, subscriber, and environment entities for every item and started the entire batch concurrently. This caused heavy allocation, GC pressure, CPU exhaustion, and event-loop stalls.

- Pass preloaded entities through `BaseCommand.create(..., extras)` so `plainToInstance` does not recursively clone them.
- Process preference updates in sequential batches of at most five while preserving result order.
- Gate `PATCH /v2/subscribers/:subscriberId/preferences/bulk` with the org killswitch using component `preferences`.
- Preserve required-template validation with an explicit use-case guard.
- Add identity, concurrency, and killswitch unit coverage.

```mermaid
flowchart LR
  A[Bulk PATCH] --> K{preferences killswitch}
  K -->|enabled| X[503]
  K -->|disabled| B[Resolve subscriber and workflows]
  B --> C[Batch updates, max 5]
  C --> D[Commands with runtime entities in extras]
  D --> E[Persist and return ordered results]
```

### Test plan

- `19 passing` across focused bulk-update, update-preferences, and killswitch unit specs.
- `pnpm --filter @novu/api-service build` — zero TypeScript issues; API compiled successfully.
- Changed-file Biome check passes (three pre-existing warnings remain in touched legacy use cases).

### Screenshots

Not applicable; API-only change.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

Not applicable.

### Special notes for your reviewer

The killswitch targets only the v2 subscriber bulk preference route and uses LaunchDarkly component `preferences`.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b8d284f-3e29-44e1-a7ec-c7ae276ac4c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b8d284f-3e29-44e1-a7ec-c7ae276ac4c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR limits bulk preference-update concurrency and avoids recursively transforming preloaded domain entities, reducing allocation and CPU pressure. It also adds an organization-level availability gate to the v2 subscriber bulk route while retaining explicit required-template validation.
- Processes preference updates in ordered batches of at most five.
- Passes workflow, subscriber, environment, and template entities through command extras to preserve identity.
- Adds and tests the `preferences` component killswitch for the v2 subscriber bulk endpoint.
- Adds identity-preservation, concurrency-bound, and killswitch coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable changed-code defects identified.

The batching preserves result order while bounding concurrent work, command extras preserve preloaded entity identity as intended, and the explicit template guard maintains required-input validation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts | Replaces unbounded update concurrency with ordered five-item batches and passes preloaded entities through command extras. |
| apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts | Preserves workflow and subscriber identity when constructing the template-preference command. |
| apps/api/src/app/subscribers-v2/subscribers.controller.ts | Adds the organization preferences killswitch check before executing the v2 bulk update. |
| apps/api/src/app/subscribers/utils/assert-preferences-update-enabled.ts | Implements the organization/environment-scoped preferences component flag check and returns a temporary-service error when enabled. |
| libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.command.ts | Removes transform-time template validation so the preloaded template can be supplied through command extras. |
| libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts | Retains required-template enforcement at the use-case boundary with an explicit bad-request guard. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Bulk preference request] --> K{V2 subscriber route?}
  K -->|Yes| F{Preferences killswitch enabled?}
  F -->|Yes| X[Return 503]
  F -->|No| R[Resolve subscriber, workflows, and environment]
  K -->|Inbox route| R
  R --> B[Split updates into batches of five]
  B --> C[Create commands with preloaded entities in extras]
  C --> U[Execute each batch concurrently]
  U --> N{More batches?}
  N -->|Yes| B
  N -->|No| O[Return ordered results]
```

<sub>Reviews (1): Last reviewed commit: ["test(api): type preference killswitch st..."](https://github.com/novuhq/novu/commit/c1eef7597b8e201f868df67bccaefea5b2547e35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60148300)</sub>

<!-- /greptile_comment -->