### PR TITLE
fix(shared): slugify contraction collapse ignores the custom separator

### DIFF
--- a/packages/shared/src/utils/slugify/slugify.spec.ts
+++ b/packages/shared/src/utils/slugify/slugify.spec.ts
@@ -47,6 +47,17 @@ describe('slugify', () => {
     expect(slugify('foo bar baz', { separator: '' }), 'foobarbaz');
   });
 
+  it('collapses trailing -s/-t contractions with the default separator', () => {
+    expect(slugify("it's")).toBe('its');
+    expect(slugify("cat's toy")).toBe('cats-toy');
+  });
+
+  it('collapses trailing -s/-t contractions with a custom separator', () => {
+    expect(slugify("it's", { separator: '_' })).toBe('its');
+    expect(slugify("cat's toy", { separator: '_' })).toBe('cats_toy');
+    expect(slugify("that's it", { separator: '.' })).toBe('thats.it');
+  });
+
   it('lowercases the string', () => {
     expect(slugify('Foo bAr baZ'), 'foo-bar-baz');
   });

--- a/packages/shared/src/utils/slugify/slugify.ts
+++ b/packages/shared/src/utils/slugify/slugify.ts
@@ -262,13 +262,19 @@ export const slugify = (string: string, options?: Options) => {
   string = string.replace(patternSlug, options.separator ?? '-');
   string = string.replace(/\\/g, '');
 
-  /*
-   * Detect contractions/possessives by looking for any word followed by a `-t`
-   * or `-s` in isolation and then remove it.
-   */
-  string = string.replace(/([a-zA-Z\d]+)-([ts])(-|$)/g, '$1$2$3');
-
   if (options.separator) {
+    /*
+     * Detect contractions/possessives by looking for any word followed by a `-t`
+     * or `-s` in isolation and then remove it. Use the configured separator so the
+     * collapse also works for custom separators (with the default `-` this is
+     * unchanged); an empty separator already strips these characters entirely.
+     */
+    const escapedSeparator = escapeStringRegexp(options.separator);
+    string = string.replace(
+      new RegExp(`([a-zA-Z\\d]+)${escapedSeparator}([ts])(${escapedSeparator}|$)`, 'g'),
+      '$1$2$3',
+    );
+
     string = removeMootSeparators(string, options.separator);
   }
 


### PR DESCRIPTION
## What

`slugify` (`@novu/shared`) collapses trailing `-s`/`-t` contractions/possessives (e.g. `it's` → `its`), but that collapse regex is **hardcoded to `-`**. With a custom `separator` the fragments survive:

| Input | Options | Before | After |
|---|---|---|---|
| `it's` | default | `its` | `its` (unchanged) |
| `it's` | `{ separator: '_' }` | `it_s` | `its` |
| `cat's toy` | `{ separator: '_' }` | `cat_s_toy` | `cats_toy` |
| `that's it` | `{ separator: '.' }` | `that.s.it` | `thats.it` |

## Fix

Build the collapse regex from the configured `separator` (regex-escaped), and only run it when a separator is set — an empty separator already strips these characters. With the default `-` separator the regex is identical, so existing behavior is unchanged.

## Testing

- Added spec cases for the default and custom-separator (`_`, `.`) contraction behavior.
- `vitest run` on `slugify.spec.ts`: **29 passed**, no regressions (existing cases unchanged; the new custom-separator cases now collapse correctly).


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates contraction and possessive collapsing to use the configured slug separator instead of a hardcoded hyphen.
- Preserves contraction behavior for the default separator.
- Adds coverage for `_` and `.` separators.
- The generalized expression currently corrupts words when an alphanumeric separator occurs naturally within the input.

<h3>Confidence Score: 4/5</h3>

This PR is not safe to merge until custom alphanumeric separators no longer corrupt ordinary input words.

The new expression treats every occurrence of the configured separator as normalization-generated; with a valid separator such as `a`, an input like `that` is incorrectly transformed to `tht`.

**Files Needing Attention:** packages/shared/src/utils/slugify/slugify.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/slugify/slugify.ts | Builds the contraction-collapse expression from the configured separator, but cannot distinguish alphanumeric separators from matching characters already present in words. |
| packages/shared/src/utils/slugify/slugify.spec.ts | Adds default and punctuation-separator contraction cases, but does not cover valid alphanumeric separator values. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312572%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12572&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fshared%2Fsrc%2Futils%2Fslugify%2Fslugify.ts%3A274%0A**Alphanumeric%20separators%20corrupt%20words**%0A%0AWhen%20the%20separator%20is%20a%20word%20character%2C%20this%20regex%20can%20match%20characters%20from%20the%20original%20input%20rather%20than%20only%20separators%20introduced%20during%20normalization.%20For%20example%2C%20%60slugify%28'that'%2C%20%7B%20separator%3A%20'a'%20%7D%29%60%20constructs%20%60%28%5Ba-zA-Z%5Cd%5D%2B%29a%28%5Bts%5D%29%28a%7C%24%29%60%20and%20changes%20%60that%60%20to%20%60tht%60.%20Because%20%60separator%60%20accepts%20any%20string%2C%20supported%20values%20such%20as%20%60a%60%2C%20%60s%60%2C%20or%20%60t%60%20can%20produce%20incorrect%20slugs.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12572&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/utils/slugify/slugify.ts:274
**Alphanumeric separators corrupt words**

When the separator is a word character, this regex can match characters from the original input rather than only separators introduced during normalization. For example, `slugify('that', { separator: 'a' })` constructs `([a-zA-Z\d]+)a([ts])(a|$)` and changes `that` to `tht`. Because `separator` accepts any string, supported values such as `a`, `s`, or `t` can produce incorrect slugs.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): slugify contraction collaps..."](https://github.com/novuhq/novu/commit/950c3ab073efbf4bf85bb53fa76c1f0b68137257) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60742707)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->