### PR TITLE
fix(dashboard): resolve workflow editor sidebar setup row UI inconsistencies fixes NV-8779

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -809,8 +809,9 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                       <span className="text-label-xs text-text-strong">Send & reply via agent</span>
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <span
-                            className="inline-flex shrink-0 cursor-help"
+                          <button
+                            type="button"
+                            className="text-text-soft inline-flex size-4 shrink-0 items-center justify-center"
                             onClick={(e) => {
                               e.stopPropagation();
                               e.preventDefault();
@@ -821,7 +822,8 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                             }}
                           >
                             <RiInformation2Line className="size-4 text-text-soft" />
-                          </span>
+                            <span className="sr-only">About send and reply via agent</span>
+                          </button>
                         </TooltipTrigger>
                         <TooltipContent side="left" hideWhenDetached className="max-w-xs">
                           Assign an agent so this workflow can send through the agent&apos;s connected channels and

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -801,52 +801,49 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
             )}
           />
           {isWorkflowAgentAssignmentEnabled ? (
-            <Link to={ROUTES.EDIT_WORKFLOW_AGENT} className="group block border-t border-stroke-weak">
+            <div className="group border-t border-stroke-weak">
               {workflow.agent?.identifier ? (
                 <div className="flex w-full min-w-0 flex-col gap-1.5 px-3 py-4">
                   <div className="flex w-full min-w-0 items-center gap-1.5">
-                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <Link to={ROUTES.EDIT_WORKFLOW_AGENT} className="flex min-w-0 flex-1 items-center gap-2">
                       <span className="text-label-xs text-text-strong">Send & reply via agent</span>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            className="text-text-soft inline-flex size-4 shrink-0 items-center justify-center"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              e.preventDefault();
-                            }}
-                            onPointerDown={(e) => {
-                              e.stopPropagation();
-                              e.preventDefault();
-                            }}
-                          >
-                            <RiInformation2Line className="size-4 text-text-soft" />
-                            <span className="sr-only">About send and reply via agent</span>
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent side="left" hideWhenDetached className="max-w-xs">
-                          Assign an agent so this workflow can send through the agent&apos;s connected channels and
-                          route replies back automatically.
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
-                    <RiArrowRightSLine
-                      aria-hidden
-                      className="size-4 shrink-0 text-text-sub transition-transform duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong"
-                    />
+                    </Link>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-text-soft inline-flex size-4 shrink-0 items-center justify-center"
+                        >
+                          <RiInformation2Line className="size-4 text-text-soft" />
+                          <span className="sr-only">About send and reply via agent</span>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="left" hideWhenDetached className="max-w-xs">
+                        Assign an agent so this workflow can send through the agent&apos;s connected channels and route
+                        replies back automatically.
+                      </TooltipContent>
+                    </Tooltip>
+                    <Link to={ROUTES.EDIT_WORKFLOW_AGENT} className="inline-flex shrink-0 items-center">
+                      <RiArrowRightSLine
+                        aria-hidden
+                        className="size-4 shrink-0 text-text-sub transition-transform duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong"
+                      />
+                    </Link>
                   </div>
-                  <WorkflowAgentAssignmentSummary agentIdentifier={workflow.agent.identifier} />
+                  <Link to={ROUTES.EDIT_WORKFLOW_AGENT}>
+                    <WorkflowAgentAssignmentSummary agentIdentifier={workflow.agent.identifier} />
+                  </Link>
                 </div>
               ) : (
                 <SetupRow
+                  to={ROUTES.EDIT_WORKFLOW_AGENT}
                   title="Send & reply via agent"
                   tooltipContent="Assign an agent so this workflow can send through the agent's connected channels and route replies back automatically."
                   description="Let your user reply and continue with an agent"
-                  className="px-3 py-4"
+                  className="px-3 py-4 transition-colors hover:bg-bg-weak"
                 />
               )}
-            </Link>
+            </div>
           ) : null}
         </SidebarContent>
         <Separator />

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -20,7 +20,7 @@ import {
   RiCodeSSlashLine,
   RiDeleteBin2Line,
   RiErrorWarningFill,
-  RiInformationLine,
+  RiInformation2Line,
   RiListView,
   RiMore2Fill,
   RiRobot2Line,
@@ -74,6 +74,7 @@ import { buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
 import { PayloadSchemaDrawer } from './payload-schema-drawer';
+import { SetupRow } from './setup-row';
 import { TranslationToggleSection } from './translation-toggle-section';
 
 interface ConfigureWorkflowFormProps {
@@ -800,43 +801,49 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
             )}
           />
           {isWorkflowAgentAssignmentEnabled ? (
-            <Link to={ROUTES.EDIT_WORKFLOW_AGENT} className="block border-t border-stroke-weak">
-              <div className="flex flex-col gap-0.5 px-2.5 py-3">
-                <div className="flex h-5 items-center gap-2">
-                  <div className="flex min-w-0 flex-1 items-center">
-                    <span className="text-text-strong text-label-xs font-medium whitespace-nowrap">
-                      Send & reply via agent
-                    </span>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className="text-text-soft inline-flex size-4 shrink-0 items-center justify-center"
-                          onClick={(event) => event.preventDefault()}
-                        >
-                          <RiInformationLine className="size-3.5" />
-                          <span className="sr-only">About send and reply via agent</span>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-xs">
-                        Assign an agent so this workflow can send through the agent&apos;s connected channels and route
-                        replies back automatically.
-                      </TooltipContent>
-                    </Tooltip>
+            <Link to={ROUTES.EDIT_WORKFLOW_AGENT} className="group block border-t border-stroke-weak">
+              {workflow.agent?.identifier ? (
+                <div className="flex w-full min-w-0 flex-col gap-1.5 px-3 py-4">
+                  <div className="flex w-full min-w-0 items-center gap-1.5">
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                      <span className="text-label-xs text-text-strong">Send & reply via agent</span>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            className="inline-flex shrink-0 cursor-help"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                            }}
+                            onPointerDown={(e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                            }}
+                          >
+                            <RiInformation2Line className="size-4 text-text-soft" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="left" hideWhenDetached className="max-w-xs">
+                          Assign an agent so this workflow can send through the agent&apos;s connected channels and
+                          route replies back automatically.
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                    <RiArrowRightSLine
+                      aria-hidden
+                      className="size-4 shrink-0 text-text-sub transition-transform duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong"
+                    />
                   </div>
-                  <span className="text-text-sub inline-flex shrink-0 items-center gap-0 pl-1 text-label-xs font-medium">
-                    {!workflow.agent?.identifier ? 'Setup' : null}
-                    <RiArrowRightSLine className="size-4" />
-                  </span>
-                </div>
-                {workflow.agent?.identifier ? (
                   <WorkflowAgentAssignmentSummary agentIdentifier={workflow.agent.identifier} />
-                ) : (
-                  <p className="text-text-soft text-label-2xs leading-3.5">
-                    Let your user reply and continue with an agent
-                  </p>
-                )}
-              </div>
+                </div>
+              ) : (
+                <SetupRow
+                  title="Send & reply via agent"
+                  tooltipContent="Assign an agent so this workflow can send through the agent's connected channels and route replies back automatically."
+                  description="Let your user reply and continue with an agent"
+                  className="px-3 py-4"
+                />
+              )}
             </Link>
           ) : null}
         </SidebarContent>

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -20,7 +20,6 @@ import {
   RiCodeSSlashLine,
   RiDeleteBin2Line,
   RiErrorWarningFill,
-  RiInformation2Line,
   RiListView,
   RiMore2Fill,
   RiRobot2Line,
@@ -56,7 +55,6 @@ import { Switch } from '@/components/primitives/switch';
 import { Tag } from '@/components/primitives/tag';
 import { TagInput } from '@/components/primitives/tag-input';
 import { Textarea } from '@/components/primitives/textarea';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { usePromotionalBanner } from '@/components/promotional/coming-soon-banner';
 import { SidebarContent, SidebarHeader } from '@/components/side-navigation/sidebar';
 import { workflowSchema } from '@/components/workflow-editor/schema';
@@ -801,48 +799,21 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
             )}
           />
           {isWorkflowAgentAssignmentEnabled ? (
-            <div className="group border-t border-stroke-weak">
-              {workflow.agent?.identifier ? (
-                <div className="flex w-full min-w-0 flex-col gap-1.5 px-3 py-4">
-                  <div className="flex w-full min-w-0 items-center gap-1.5">
-                    <Link to={ROUTES.EDIT_WORKFLOW_AGENT} className="flex min-w-0 flex-1 items-center gap-2">
-                      <span className="text-label-xs text-text-strong">Send & reply via agent</span>
-                    </Link>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className="text-text-soft inline-flex size-4 shrink-0 items-center justify-center"
-                        >
-                          <RiInformation2Line className="size-4 text-text-soft" />
-                          <span className="sr-only">About send and reply via agent</span>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="left" hideWhenDetached className="max-w-xs">
-                        Assign an agent so this workflow can send through the agent&apos;s connected channels and route
-                        replies back automatically.
-                      </TooltipContent>
-                    </Tooltip>
-                    <Link to={ROUTES.EDIT_WORKFLOW_AGENT} className="inline-flex shrink-0 items-center">
-                      <RiArrowRightSLine
-                        aria-hidden
-                        className="size-4 shrink-0 text-text-sub transition-transform duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong"
-                      />
-                    </Link>
-                  </div>
-                  <Link to={ROUTES.EDIT_WORKFLOW_AGENT}>
+            <div className="border-t border-stroke-weak">
+              <SetupRow
+                to={ROUTES.EDIT_WORKFLOW_AGENT}
+                title="Send & reply via agent"
+                tooltipContent="Assign an agent so this workflow can send through the agent's connected channels and route replies back automatically."
+                showSetupLabel={!workflow.agent?.identifier}
+                description={
+                  workflow.agent?.identifier ? (
                     <WorkflowAgentAssignmentSummary agentIdentifier={workflow.agent.identifier} />
-                  </Link>
-                </div>
-              ) : (
-                <SetupRow
-                  to={ROUTES.EDIT_WORKFLOW_AGENT}
-                  title="Send & reply via agent"
-                  tooltipContent="Assign an agent so this workflow can send through the agent's connected channels and route replies back automatically."
-                  description="Let your user reply and continue with an agent"
-                  className="px-3 py-4 transition-colors hover:bg-bg-weak"
-                />
-              )}
+                  ) : (
+                    'Let your user reply and continue with an agent'
+                  )
+                }
+                className="px-3 py-4 transition-colors hover:bg-bg-weak"
+              />
             </div>
           ) : null}
         </SidebarContent>

--- a/apps/dashboard/src/components/workflow-editor/setup-row.tsx
+++ b/apps/dashboard/src/components/workflow-editor/setup-row.tsx
@@ -9,6 +9,7 @@ type SetupRowProps = {
   description: React.ReactNode;
   className?: string;
   to?: string;
+  showSetupLabel?: boolean;
 };
 
 type SetupRowInfoTooltipProps = {
@@ -34,47 +35,45 @@ function SetupRowInfoTooltip({ title, tooltipContent }: SetupRowInfoTooltipProps
   );
 }
 
-export function SetupRow({ title, tooltipContent, description, className, to }: SetupRowProps) {
-  const actionContent = (
-    <>
-      <span className="text-text-sub inline-flex shrink-0 items-center text-xs font-medium transition-colors duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong">
-        Setup
-      </span>
-      <RiArrowRightSLine
-        aria-hidden
-        className="size-4 shrink-0 text-text-sub transition-transform duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong"
-      />
-    </>
-  );
+export function SetupRow({
+  title,
+  tooltipContent,
+  description,
+  className,
+  to,
+  showSetupLabel = true,
+}: SetupRowProps) {
+  const linkAriaLabel = typeof description === 'string' ? `${title}. ${description}` : title;
 
   return (
-    <div className={cn('group flex w-full min-w-0 flex-col gap-1.5', className)}>
-      <div className="flex w-full min-w-0 items-center gap-1.5">
-        {to ? (
-          <Link to={to} className="flex min-w-0 flex-1 items-center gap-2">
-            <span className="text-label-xs text-text-strong">{title}</span>
-          </Link>
-        ) : (
+    <div className={cn('group relative flex w-full min-w-0 flex-col gap-1.5', to && 'cursor-pointer', className)}>
+      {to ? <Link to={to} className="absolute inset-0 z-0" aria-label={linkAriaLabel} /> : null}
+      <div className="relative z-10 flex w-full min-w-0 flex-col gap-1.5 pointer-events-none">
+        <div className="flex w-full min-w-0 items-center gap-1.5">
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <span className="text-label-xs text-text-strong">{title}</span>
           </div>
-        )}
-        <SetupRowInfoTooltip title={title} tooltipContent={tooltipContent} />
-        {to ? (
-          <Link to={to} className="inline-flex shrink-0 items-center">
-            {actionContent}
-          </Link>
+          <div className="pointer-events-auto">
+            <SetupRowInfoTooltip title={title} tooltipContent={tooltipContent} />
+          </div>
+          <div className="inline-flex shrink-0 items-center">
+            {showSetupLabel ? (
+              <span className="text-text-sub inline-flex shrink-0 items-center text-xs font-medium transition-colors duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong">
+                Setup
+              </span>
+            ) : null}
+            <RiArrowRightSLine
+              aria-hidden
+              className="size-4 shrink-0 text-text-sub transition-transform duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong"
+            />
+          </div>
+        </div>
+        {typeof description === 'string' ? (
+          <span className="text-text-soft text-xs">{description}</span>
         ) : (
-          <div className="inline-flex shrink-0 items-center">{actionContent}</div>
+          description
         )}
       </div>
-      {to ? (
-        <Link to={to} className="text-text-soft text-xs">
-          {description}
-        </Link>
-      ) : (
-        <span className="text-text-soft text-xs">{description}</span>
-      )}
     </div>
   );
 }

--- a/apps/dashboard/src/components/workflow-editor/setup-row.tsx
+++ b/apps/dashboard/src/components/workflow-editor/setup-row.tsx
@@ -1,4 +1,5 @@
 import { RiArrowRightSLine, RiInformation2Line } from 'react-icons/ri';
+import { Link } from 'react-router-dom';
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/primitives/tooltip';
 import { cn } from '@/utils/ui';
 
@@ -7,47 +8,73 @@ type SetupRowProps = {
   tooltipContent: React.ReactNode;
   description: React.ReactNode;
   className?: string;
+  to?: string;
 };
 
-export function SetupRow({ title, tooltipContent, description, className }: SetupRowProps) {
-  const stopRowNavigation = (e: React.SyntheticEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-  };
+type SetupRowInfoTooltipProps = {
+  title: string;
+  tooltipContent: React.ReactNode;
+};
+
+function SetupRowInfoTooltip({ title, tooltipContent }: SetupRowInfoTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" className="text-text-soft inline-flex size-4 shrink-0 items-center justify-center">
+          <RiInformation2Line className="size-4 text-text-soft" />
+          <span className="sr-only">About {title}</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side="left" hideWhenDetached>
+          {tooltipContent}
+        </TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+}
+
+export function SetupRow({ title, tooltipContent, description, className, to }: SetupRowProps) {
+  const actionContent = (
+    <>
+      <span className="text-text-sub inline-flex shrink-0 items-center text-xs font-medium transition-colors duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong">
+        Setup
+      </span>
+      <RiArrowRightSLine
+        aria-hidden
+        className="size-4 shrink-0 text-text-sub transition-transform duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong"
+      />
+    </>
+  );
 
   return (
-    <div className={cn('flex w-full min-w-0 flex-col gap-1.5', className)}>
+    <div className={cn('group flex w-full min-w-0 flex-col gap-1.5', className)}>
       <div className="flex w-full min-w-0 items-center gap-1.5">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="text-label-xs text-text-strong">{title}</span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="text-text-soft inline-flex size-4 shrink-0 items-center justify-center"
-                onClick={stopRowNavigation}
-                onPointerDown={stopRowNavigation}
-              >
-                <RiInformation2Line className="size-4 text-text-soft" />
-                <span className="sr-only">About {title}</span>
-              </button>
-            </TooltipTrigger>
-            <TooltipPortal>
-              <TooltipContent side="left" hideWhenDetached>
-                {tooltipContent}
-              </TooltipContent>
-            </TooltipPortal>
-          </Tooltip>
-        </div>
-        <span className="text-text-sub inline-flex shrink-0 items-center text-xs font-medium transition-colors duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong">
-          Setup
-        </span>
-        <RiArrowRightSLine
-          aria-hidden
-          className="size-4 shrink-0 text-text-sub transition-transform duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong"
-        />
+        {to ? (
+          <Link to={to} className="flex min-w-0 flex-1 items-center gap-2">
+            <span className="text-label-xs text-text-strong">{title}</span>
+          </Link>
+        ) : (
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <span className="text-label-xs text-text-strong">{title}</span>
+          </div>
+        )}
+        <SetupRowInfoTooltip title={title} tooltipContent={tooltipContent} />
+        {to ? (
+          <Link to={to} className="inline-flex shrink-0 items-center">
+            {actionContent}
+          </Link>
+        ) : (
+          <div className="inline-flex shrink-0 items-center">{actionContent}</div>
+        )}
       </div>
-      <span className="text-text-soft text-xs">{description}</span>
+      {to ? (
+        <Link to={to} className="text-text-soft text-xs">
+          {description}
+        </Link>
+      ) : (
+        <span className="text-text-soft text-xs">{description}</span>
+      )}
     </div>
   );
 }

--- a/apps/dashboard/src/components/workflow-editor/setup-row.tsx
+++ b/apps/dashboard/src/components/workflow-editor/setup-row.tsx
@@ -22,14 +22,15 @@ export function SetupRow({ title, tooltipContent, description, className }: Setu
           <span className="text-label-xs text-text-strong">{title}</span>
           <Tooltip>
             <TooltipTrigger asChild>
-              <span
-                className="inline-flex shrink-0 cursor-help"
+              <button
+                type="button"
+                className="text-text-soft inline-flex size-4 shrink-0 items-center justify-center"
                 onClick={stopRowNavigation}
                 onPointerDown={stopRowNavigation}
-                onKeyDown={stopRowNavigation}
               >
                 <RiInformation2Line className="size-4 text-text-soft" />
-              </span>
+                <span className="sr-only">About {title}</span>
+              </button>
             </TooltipTrigger>
             <TooltipPortal>
               <TooltipContent side="left" hideWhenDetached>

--- a/apps/dashboard/src/components/workflow-editor/setup-row.tsx
+++ b/apps/dashboard/src/components/workflow-editor/setup-row.tsx
@@ -1,0 +1,52 @@
+import { RiArrowRightSLine, RiInformation2Line } from 'react-icons/ri';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/primitives/tooltip';
+import { cn } from '@/utils/ui';
+
+type SetupRowProps = {
+  title: string;
+  tooltipContent: React.ReactNode;
+  description: React.ReactNode;
+  className?: string;
+};
+
+export function SetupRow({ title, tooltipContent, description, className }: SetupRowProps) {
+  const stopRowNavigation = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
+  return (
+    <div className={cn('flex w-full min-w-0 flex-col gap-1.5', className)}>
+      <div className="flex w-full min-w-0 items-center gap-1.5">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="text-label-xs text-text-strong">{title}</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="inline-flex shrink-0 cursor-help"
+                onClick={stopRowNavigation}
+                onPointerDown={stopRowNavigation}
+                onKeyDown={stopRowNavigation}
+              >
+                <RiInformation2Line className="size-4 text-text-soft" />
+              </span>
+            </TooltipTrigger>
+            <TooltipPortal>
+              <TooltipContent side="left" hideWhenDetached>
+                {tooltipContent}
+              </TooltipContent>
+            </TooltipPortal>
+          </Tooltip>
+        </div>
+        <span className="text-text-sub inline-flex shrink-0 items-center text-xs font-medium transition-colors duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong">
+          Setup
+        </span>
+        <RiArrowRightSLine
+          aria-hidden
+          className="size-4 shrink-0 text-text-sub transition-transform duration-200 ease-out group-hover:translate-x-0.5 group-hover:text-text-strong"
+        />
+      </div>
+      <span className="text-text-soft text-xs">{description}</span>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/workflow-editor/setup-row.tsx
+++ b/apps/dashboard/src/components/workflow-editor/setup-row.tsx
@@ -52,9 +52,9 @@ export function SetupRow({
         <div className="flex w-full min-w-0 items-center gap-1.5">
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <span className="text-label-xs text-text-strong">{title}</span>
-          </div>
-          <div className="pointer-events-auto">
-            <SetupRowInfoTooltip title={title} tooltipContent={tooltipContent} />
+            <div className="pointer-events-auto">
+              <SetupRowInfoTooltip title={title} tooltipContent={tooltipContent} />
+            </div>
           </div>
           <div className="inline-flex shrink-0 items-center">
             {showSetupLabel ? (

--- a/apps/dashboard/src/components/workflow-editor/translation-toggle-section.tsx
+++ b/apps/dashboard/src/components/workflow-editor/translation-toggle-section.tsx
@@ -55,25 +55,17 @@ export function TranslationToggleSection({
   };
 
   if (needsOnboarding) {
-    const handleOnboardingClick = () => {
-      navigate(translationsUrl);
-    };
-
     return (
-      <button
-        type="button"
-        onClick={handleOnboardingClick}
+      <SetupRow
+        to={translationsUrl}
+        title="Enable Translations"
+        tooltipContent="When enabled, allows you to create and manage translations for your workflow content across different languages."
+        description="Set up your target locales first to enable translations"
         className={cn(
-          'group w-full min-w-0 cursor-pointer rounded-none bg-transparent text-left transition-colors hover:bg-bg-weak focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-stroke-strong focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          'w-full min-w-0 rounded-none px-3 py-4 transition-colors hover:bg-bg-weak focus-within:outline-hidden focus-within:ring-2 focus-within:ring-stroke-strong focus-within:ring-offset-2 focus-within:ring-offset-background',
           className
         )}
-      >
-        <SetupRow
-          title="Enable Translations"
-          tooltipContent="When enabled, allows you to create and manage translations for your workflow content across different languages."
-          description="Set up your target locales first to enable translations"
-        />
-      </button>
+      />
     );
   }
 

--- a/apps/dashboard/src/components/workflow-editor/translation-toggle-section.tsx
+++ b/apps/dashboard/src/components/workflow-editor/translation-toggle-section.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { RiArrowRightSLine, RiInformation2Line } from 'react-icons/ri';
+import { RiInformation2Line } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/primitives/tooltip';
 import { TranslationDrawer } from '@/components/translations/translation-drawer/translation-drawer';
 import { TranslationSwitch } from '@/components/translations/translation-switch';
+import { SetupRow } from '@/components/workflow-editor/setup-row';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchOrganizationSettings } from '@/hooks/use-fetch-organization-settings';
 import { LocalizationResourceEnum } from '@/types/translations';
@@ -58,52 +59,20 @@ export function TranslationToggleSection({
       navigate(translationsUrl);
     };
 
-    const stopRowNavigation = (e: React.SyntheticEvent) => {
-      e.stopPropagation();
-    };
-
     return (
       <button
         type="button"
         onClick={handleOnboardingClick}
         className={cn(
-          'group flex w-full min-w-0 cursor-pointer flex-col gap-1.5 rounded-none bg-transparent text-left transition-colors hover:bg-bg-weak focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-stroke-strong focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          'group w-full min-w-0 cursor-pointer rounded-none bg-transparent text-left transition-colors hover:bg-bg-weak focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-stroke-strong focus-visible:ring-offset-2 focus-visible:ring-offset-background',
           className
         )}
       >
-        <div className="flex w-full min-w-0 items-center gap-1.5">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            <span className="text-label-xs text-text-strong">Enable Translations</span>
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="inline-flex cursor-help"
-                  onClick={stopRowNavigation}
-                  onPointerDown={stopRowNavigation}
-                  onKeyDown={stopRowNavigation}
-                >
-                  <RiInformation2Line className="size-4 text-text-soft" />
-                </span>
-              </TooltipTrigger>
-              <TooltipPortal>
-                <TooltipContent side="left" hideWhenDetached>
-                  When enabled, allows you to create and manage translations for your workflow content across different
-                  languages.
-                </TooltipContent>
-              </TooltipPortal>
-            </Tooltip>
-          </div>
-
-          <span className="text-text-sub group-hover:text-text-strong inline-flex shrink-0 items-center text-xs font-medium transition-color duration-200 ease-out  group-hover:translate-x-0.5">
-            Setup
-          </span>
-          <RiArrowRightSLine
-            aria-hidden
-            className="arrow-right-hover-animation size-4 shrink-0 transition-transform duration-200 ease-out text-text-sub hover:text-text-strong group-hover:translate-x-0.5"
-          />
-        </div>
-        <span className="text-foreground-400 text-xs">Set up your target locales first to enable translations</span>
+        <SetupRow
+          title="Enable Translations"
+          tooltipContent="When enabled, allows you to create and manage translations for your workflow content across different languages."
+          description="Set up your target locales first to enable translations"
+        />
       </button>
     );
   }
@@ -139,7 +108,7 @@ export function TranslationToggleSection({
           <button
             type="button"
             onClick={handleManageTranslationsClick}
-            className="text-foreground-400 text-xs hover:text-foreground-600 cursor-pointer text-left transition-colors"
+            className="text-text-soft hover:text-text-sub text-xs cursor-pointer text-left transition-colors"
           >
             View & manage translations ↗
           </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Fixes three UI inconsistencies between the "Enable Translations" and "Send & reply via agent" setup rows in the workflow editor sidebar:

1. **Inconsistent gap between title and info icon** — "Enable Translations" used `gap-2` while "Send & reply via agent" had no gap at all
2. **Different description fonts** — Translation used `text-xs` / `text-foreground-400`; agent used `text-label-2xs` / `text-text-soft` (different size and color tokens)  
3. **Misaligned Setup button and arrow icon** — Different container padding (`px-3 py-4` vs `px-2.5 py-3`), different info icons (`RiInformation2Line` vs `RiInformationLine` with `size-3.5`), and different Setup/arrow layout patterns

## How

Extracted a shared `SetupRow` component (`setup-row.tsx`) that encapsulates the common "setup teaser" pattern:
- Title + info icon with consistent `gap-2` spacing
- Unified `text-text-soft text-xs` description styling  
- Identical Setup text + arrow layout with matching hover animations
- Tooltip with `TooltipPortal` and `side="left"` positioning
- Event propagation handling to prevent parent navigation on icon click

Both `TranslationToggleSection` (onboarding state) and the inline agent section in `ConfigureWorkflowForm` now use this shared component, guaranteeing visual parity.

## Screenshots

### After fix — both rows are now visually identical
![Both setup rows with consistent styling](https://cursor.com/artifacts/c/art-09d3ad26-b11e-49a4-8938-2c05093a466b)

### Tooltips working correctly for both sections
![Enable Translations tooltip](https://cursor.com/artifacts/c/art-afa1feb7-e8f7-41a0-bfb7-6f4d2de68648)
![Send & reply via agent tooltip](https://cursor.com/artifacts/c/art-a3676b5e-7156-4195-b663-93ba54e5dfca)

### Video walkthrough
<a href="https://cursor.com/agents/bc-973c8e42-62bf-4e04-90cf-01c1599390c5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_consistent_setup_rows.mp4"><img src="https://cursor.com/artifacts/c/art-a4da3359-fc7d-4749-8e53-e035da3374e8" alt="demo_consistent_setup_rows.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-973c8e42-62bf-4e04-90cf-01c1599390c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-973c8e42-62bf-4e04-90cf-01c1599390c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared workflow-editor setup row to make the translations and agent setup experiences visually and behaviorally consistent.
- Unifies title, tooltip, description, spacing, and setup-action styling.
- Uses a single full-row navigation target while keeping the tooltip button independently accessible.
- Reuses the shared row for translation onboarding and agent assignment states.
- Updates translation management text to use the current semantic color tokens.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding correctness, accessibility, security, or repository-rule issues identified.

The previously reported accessibility and navigation issues are resolved in the current code: the tooltip is a named semantic button, it is not nested within the link, and each row exposes only one navigation target.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/workflow-editor/setup-row.tsx | Introduces the shared setup-row layout with accessible tooltip and single-overlay navigation. |
| apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx | Replaces the bespoke agent setup row with the shared SetupRow component. |
| apps/dashboard/src/components/workflow-editor/translation-toggle-section.tsx | Reuses SetupRow for translation onboarding and aligns translation-management color tokens. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(dashboard): move info icon back next..."](https://github.com/novuhq/novu/commit/5f6333c49718bf8707ff60b7be515c2c58d982ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60926903)</sub>

<!-- /greptile_comment -->