### PR TITLE
feat(docs): add migration guides for new Dashboard, including overview, feature comparison, and workflow conversion

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -993,6 +993,16 @@
                     "pages": ["guides/framework/using-translations"]
                   },
                   {
+                    "group": "Migration to New Dashboard",
+                    "expanded": false,
+                    "pages": [
+                      "guides/migration-to-new-dashboard/overview",
+                      "guides/migration-to-new-dashboard/feature-comparison",
+                      "guides/migration-to-new-dashboard/workflow-conversion",
+                      "guides/migration-to-new-dashboard/application-and-cutover"
+                    ]
+                  },
+                  {
                     "group": "Migrate to Novu",
                     "pages": [
                       "guides/migrate-from-courier-to-novu",

--- a/docs/guides.mdx
+++ b/docs/guides.mdx
@@ -27,6 +27,14 @@ Novu provides various ways to integrate with external services to trigger notifi
   </Card>
 </Columns>
 
+### Dashboard migration
+
+<Columns cols={2}>
+  <Card title="Migrate to the new Dashboard" icon="refresh-cw" href="/guides/migration-to-new-dashboard/overview">
+    Convert legacy workflows, templates, variants, layouts, translations, tenant behavior, and Notification Center clients to the current Dashboard.
+  </Card>
+</Columns>
+
 ### Incoming webhook guides
 
 Webhooks enable real-time event-driven communication between applications, making integrations more efficient and responsive.

--- a/docs/guides/migration-to-new-dashboard/application-and-cutover.mdx
+++ b/docs/guides/migration-to-new-dashboard/application-and-cutover.mdx
@@ -109,17 +109,19 @@ Use the Production Application Identifier in the production Inbox client and the
 
 Legacy and new workflows have different identifiers, so a preference attached to the legacy workflow does not automatically become a preference for its replacement. Copy preferences after the replacement workflow is published and active in Production, and before the application deploy moves traffic to the new workflow ID.
 
-For every workflow pair:
+Exclude critical workflows from the copy job. Both [update subscriber preferences](/api-reference/subscribers/update-subscriber-preferences) and [bulk update subscriber preferences](/api-reference/subscribers/bulk-update-subscriber-preferences) reject critical workflows. If a bulk request includes even one critical workflow, the entire batch fails, so preferences for the non-critical workflows in that request are not copied either.
+
+For every non-critical workflow pair:
 
 1. Record the legacy and new workflow IDs.
-2. Record whether the workflow is critical.
-3. Record its default channel preferences.
-4. Read each subscriber's stored preference for the legacy workflow with [retrieve subscriber preferences](/api-reference/subscribers/retrieve-subscriber-preferences).
-5. Write the same channel settings against the new workflow ID with [update subscriber preferences](/api-reference/subscribers/update-subscriber-preferences) or [bulk update subscriber preferences](/api-reference/subscribers/bulk-update-subscriber-preferences).
-6. Select subscribers with global and workflow-specific overrides.
-7. Compare their effective preferences before and after the copy.
-8. Verify enabled and disabled channels through controlled triggers.
-9. Confirm that critical workflows still ignore subscriber preference changes.
+2. Record its default channel preferences.
+3. Read each subscriber's stored preference for the legacy workflow with [retrieve subscriber preferences](/api-reference/subscribers/retrieve-subscriber-preferences).
+4. Write the same channel settings against the new workflow ID with the single or bulk update endpoint. Send only non-critical workflow IDs in each request.
+5. Select subscribers with global and workflow-specific overrides.
+6. Compare their effective preferences before and after the copy.
+7. Verify enabled and disabled channels through controlled triggers.
+
+Handle critical workflow pairs separately. Do not write subscriber preference overrides for them. After the replacement is published and active, confirm that it still bypasses subscriber preference changes and delivers on the workflow's default channels.
 
 Run the copy against Production credentials, make it re-runnable, and log each subscriber and workflow pair so a partial run can be resumed.
 
@@ -174,7 +176,7 @@ Send a controlled trigger to an internal subscriber and confirm the rendered out
   <Step>
 ## Copy subscriber preferences
 
-Run the preference copy for every workflow pair, then compare representative subscribers before continuing. Copy preferences after the replacement workflow exists in Production and before production traffic moves to it.
+Run the preference copy for every non-critical workflow pair, then compare representative subscribers before continuing. Copy preferences after the replacement workflow exists in Production and before production traffic moves to it. Do not include critical workflows in the copy job. Verify their preference-bypass behavior separately.
   </Step>
 
   <Step>

--- a/docs/guides/migration-to-new-dashboard/application-and-cutover.mdx
+++ b/docs/guides/migration-to-new-dashboard/application-and-cutover.mdx
@@ -1,0 +1,265 @@
+---
+title: "Migrate the Application and Cut Over to New Workflows"
+sidebarTitle: "Application and cutover"
+description: "Update Novu Inbox integrations, switch workflow IDs, publish resources, migrate preferences, verify production delivery, and roll back safely."
+---
+
+Application migration has two independent parts:
+
+1. Update server-side trigger producers to use the replacement workflow IDs and payload contracts.
+2. Update client applications from the legacy Notification Center to the current Inbox SDK and notification model.
+
+Complete both parts in a non-production environment before scheduling the production cutover.
+
+## Update trigger producers
+
+Create a checked-in or release-managed mapping of legacy workflow IDs to new workflow IDs.
+
+| Application event | Legacy workflow ID | New workflow ID | Payload owner |
+| --- | --- | --- | --- |
+| Order confirmed | `order-confirmed` | `order-confirmed-v2` | Orders service |
+| Password reset | `password-reset` | `password-reset-v2` | Identity service |
+
+Search application code, job definitions, webhook handlers, automation platforms, and infrastructure configuration for every legacy ID. A workflow might be triggered outside the primary application repository.
+
+For each call site:
+
+- Replace the workflow ID only after the replacement workflow has passed Development validation.
+- Send all fields required by the new payload schema.
+- Preserve `subscriberId`, topic keys, actor or context data, transaction IDs, and provider overrides that remain valid.
+- Replace the legacy `tenant` input with the context contract selected during workflow conversion.
+- Remove legacy layout overrides only after their replacement has been tested.
+- Keep Development and Production API credentials separate.
+
+<Warning>
+  Do not deploy a new workflow ID before that workflow is published and active in the same target environment. Triggers sent to a workflow ID that is missing or inactive do not fall back to the legacy workflow.
+</Warning>
+
+### Review server-side SDK usage
+
+Legacy Node.js integrations commonly use `@novu/node`. The current server SDK is `@novu/api`, and its trigger method accepts an object containing `workflowId`, `to`, `payload`, and other trigger fields.
+
+Do not combine the SDK upgrade and workflow cutover without testing the request shape. If you upgrade the SDK:
+
+- Replace the package and client initialization using the [TypeScript SDK guide](/platform/sdks/server/typescript).
+- Convert positional or legacy trigger arguments to the current request object.
+- Confirm how the current SDK represents subscribers, topics, actors, contexts, transaction IDs, and overrides.
+- Run the same contract tests used for the migrated payload schema.
+
+Review current method signatures for Python, Go, PHP, .NET, and Java in the [server-side SDK documentation](/platform/sdks). An unchanged package name does not guarantee that a legacy method signature or response type is current.
+
+### Replace legacy management automation
+
+Search CI jobs, release scripts, and internal tools for legacy workflow management and Changes API calls. The legacy Changes mechanism is not the current publication model.
+
+- Replace Changes API promotion with the [environment publish flow](/platform/developer/environments#publish-changes-to-other-environments).
+- Update workflow, subscriber, topic, context, and Inbox management calls against the current [API reference](/api-reference).
+- Use a publish dry run when automating resource publication.
+- Confirm that automation passes public workflow and layout identifiers, not internal database IDs.
+
+Trigger endpoint compatibility does not imply that every legacy management endpoint or response model is current.
+
+## Migrate from Notification Center to Inbox
+
+Every client that still uses the legacy Notification Center must move to Inbox before you trigger replacement workflows that subscribers see in-app.
+
+Use [Choose the Inbox package](/platform/inbox/migration-guide#choose-the-inbox-package) for the host path, then the matching quickstart for the install. React Native uses the [React Native SDK](/platform/sdks/react-native).
+
+### Complete the client migration
+
+The package replacement is only the entry point. Use the [Inbox migration guide](/platform/inbox/migration-guide#choose-the-inbox-package) for the notification object, actions, tabs, appearance, localization, and HMAC changes.
+
+Before cutover, verify that every client:
+
+- Uses the Production Application Identifier
+- Uses the current notification object and mutation methods
+- Replaces `feedIdentifier` filters with workflow tags
+- Preserves notification and action click behavior
+- Preserves preferences, localization, appearance, and HMAC authentication
+- Handles loading, empty, error, read, unread, archived, snoozed, and long-content states
+- Removes the legacy Notification Center package, web component, iframe script, or headless client after Inbox is live
+
+## Prepare each environment
+
+Publishing does not copy all resources.
+
+### Publishable resources
+
+Review and publish:
+
+- Workflows
+- Layouts
+- Translations
+
+### Environment-specific resources
+
+Create or verify separately:
+
+- Application Identifier and secret API key
+- Provider integrations and credentials
+- Subscribers and their channel credentials
+- Topics and memberships
+- Webhook endpoints
+- Activity data
+- Environment variables
+
+Use the Production Application Identifier in the production Inbox client and the Production secret key only in trusted server-side services.
+
+## Migrate subscriber preferences
+
+Legacy and new workflows have different identifiers, so a preference attached to the legacy workflow does not automatically become a preference for its replacement. Copy preferences after the replacement workflow is published and active in Production, and before the application deploy moves traffic to the new workflow ID.
+
+For every workflow pair:
+
+1. Record the legacy and new workflow IDs.
+2. Record whether the workflow is critical.
+3. Record its default channel preferences.
+4. Read each subscriber's stored preference for the legacy workflow with [retrieve subscriber preferences](/api-reference/subscribers/retrieve-subscriber-preferences).
+5. Write the same channel settings against the new workflow ID with [update subscriber preferences](/api-reference/subscribers/update-subscriber-preferences) or [bulk update subscriber preferences](/api-reference/subscribers/bulk-update-subscriber-preferences).
+6. Select subscribers with global and workflow-specific overrides.
+7. Compare their effective preferences before and after the copy.
+8. Verify enabled and disabled channels through controlled triggers.
+9. Confirm that critical workflows still ignore subscriber preference changes.
+
+Run the copy against Production credentials, make it re-runnable, and log each subscriber and workflow pair so a partial run can be resumed.
+
+Test the current Preferences or Subscription UI after the copy. A correct data migration is insufficient if the client filters, labels, or updates the wrong workflow identifier.
+
+## Create a cutover runbook
+
+Legacy and replacement workflows use different workflow IDs in the same environment, so they can exist side by side. Nothing needs to be paused and no maintenance window is required. Traffic moves to the replacement workflow at the moment your application starts sending the new workflow ID.
+
+Keep every legacy workflow active until the replacement has been running in Production for an agreed stabilization period. An active legacy workflow is the rollback path.
+
+Record a named owner and expected completion time for every step.
+
+### Before cutover
+
+- All replacement workflows pass Development validation.
+- Workflow IDs are mapped to every trigger producer.
+- Payload schemas match deployed caller behavior.
+- Layouts and translations are ready to publish.
+- Production provider integrations and webhooks pass connection tests.
+- Inbox changes pass browser and application tests.
+- The preference copy job is written, tested, and re-runnable.
+- Current plan limits cover the legacy and replacement workflows running together.
+- A rollback release or configuration change is ready.
+- Monitoring queries and controlled Production subscribers are identified.
+
+### Cutover sequence
+
+<Steps>
+  <Step>
+## Publish replacement resources to Production
+
+From Development, publish the selected replacement workflows, layouts, and translations. Verify the resource identifiers and the publish result.
+
+Legacy workflows stay active. They keep serving current traffic because your application still sends the legacy workflow IDs.
+  </Step>
+
+  <Step>
+## Verify Production configuration
+
+Confirm provider integrations, environment variables, webhooks, API credentials, and Inbox Application Identifier. These resources are not made correct by workflow publication.
+  </Step>
+
+  <Step>
+## Activate the replacement workflows
+
+Activate each replacement workflow in Production so it can accept triggers. It receives no traffic until the application sends its workflow ID.
+
+Send a controlled trigger to an internal subscriber and confirm the rendered output before any customer traffic reaches the workflow.
+  </Step>
+
+  <Step>
+## Copy subscriber preferences
+
+Run the preference copy for every workflow pair, then compare representative subscribers before continuing. Copy preferences after the replacement workflow exists in Production and before production traffic moves to it.
+  </Step>
+
+  <Step>
+## Deploy the application release
+
+Deploy the server-side workflow ID change and the Inbox client migration. Production traffic moves to the replacement workflows as instances roll out.
+
+A gradual rollout is optional. If your deployment supports it, move a subset of instances or a feature-flagged traffic segment first, then check the Activity feed and provider results before completing the rollout.
+  </Step>
+
+  <Step>
+## Confirm legacy traffic has stopped
+
+Watch the Activity feed until no legacy workflow ID receives new triggers. Queued or scheduled events created before the deploy can still carry legacy workflow IDs, and the active legacy workflow processes them correctly.
+  </Step>
+</Steps>
+
+### Retire the legacy workflows
+
+Do this as a separate change, not as part of cutover. After the replacement workflows have run in Production for the agreed stabilization period, typically several weeks and at least one full cycle of the longest Delay or Digest window:
+
+1. Confirm the legacy workflow has received no triggers for the entire period.
+2. Deactivate it, and promote the pending status change when the legacy Dashboard requires it.
+3. Keep it deactivated for an additional observation period before deleting it.
+4. Delete it only after preference, Activity, and reporting checks are complete.
+
+### Production smoke test
+
+For each critical path, verify:
+
+| Check | Expected result |
+| --- | --- |
+| Trigger response | Accepted once with the expected transaction ID |
+| Workflow selection | New workflow ID executed and legacy workflow did not |
+| Schema | Payload accepted without discarded or mistyped fields |
+| Conditions | Exactly the intended conditional path executed |
+| Content | Subject, body, variables, locale, and layout match the approved output |
+| Provider | Intended Production integration delivered the message |
+| Inbox | Notification appears with correct subject, body, data, actions, tags, and state |
+| Preferences | Disabled channels remain disabled and critical behavior is preserved |
+| Observability | Activity shows expected step states and no unexplained skips or failures |
+| Webhooks | Delivery and preference events reach the Production endpoint once per event |
+
+## Monitor after cutover
+
+Monitor for at least the longest Delay or Digest window used by the migrated workflows. A short smoke test cannot validate executions that remain pending.
+
+Track:
+
+- Trigger rejection rate, especially schema validation errors
+- Runs of legacy workflow IDs
+- Duplicate notifications
+- Step skips and condition mismatches
+- Provider failures and missing credentials
+- HTTP step failures and latency
+- Digest batch size and release time
+- Delay completion time
+- Inbox connection and rendering errors
+- Subscriber preference changes
+- Webhook delivery failures and retries
+
+Account for the Activity feed retention limit on your plan. Export or record evidence before it expires.
+
+## Roll back safely
+
+Rollback is a deploy, not an outage, because the legacy workflow is still active and still accepts its own workflow ID. Roll back per affected workflow unless a shared client or credential change requires a wider rollback.
+
+1. Restore the legacy workflow ID in application configuration or deploy the rollback release.
+2. Confirm through the Activity feed that new triggers execute the legacy workflow.
+3. Deactivate the replacement workflow only after its in-flight executions have completed or been accounted for.
+4. Preserve the failed replacement-workflow Activity records for diagnosis.
+5. Correct and revalidate the workflow in Development before attempting cutover again.
+
+Events queued with the replacement workflow ID before the rollback still carry that ID, and application configuration changes do not rewrite them. Let the replacement workflow drain those events, or cancel them according to the queue's delivery guarantees.
+
+Pending Delay and Digest executions in the replacement workflow do not move to the legacy workflow. Decide whether to let them complete or cancel them, and account for subscribers who would otherwise receive both the pending replacement notification and a new legacy notification.
+
+## Completion criteria
+
+The migration is complete when:
+
+- Production code contains no active trigger path for a legacy workflow ID.
+- Legacy workflows have received no triggers for the full stabilization period and have been deactivated as a separate change.
+- New workflows have passed monitoring through their longest pending execution window.
+- Subscriber preferences and Inbox behavior are correct.
+- Production integrations and webhooks report expected delivery.
+- Rollback artifacts are retained for the agreed stabilization period.
+- The workflow mapping and operational runbook are stored with the owning service documentation.

--- a/docs/guides/migration-to-new-dashboard/feature-comparison.mdx
+++ b/docs/guides/migration-to-new-dashboard/feature-comparison.mdx
@@ -1,0 +1,74 @@
+---
+title: "Legacy and New Dashboard Feature Comparison"
+sidebarTitle: "Feature comparison"
+description: "Identify the Novu legacy Dashboard features that must be rebuilt, preserved, or adopted during migration to the new Dashboard."
+---
+
+Use this page as a migration delta index. It identifies behavior that can break during cutover and links to the page that owns the implementation details.
+
+Current plan entitlements and limits can change. Confirm your plan on the [pricing page](https://novu.co/pricing) and check [platform limits](/platform/developer/limits) before creating replacement resources.
+
+## Migration-blocking differences
+
+| Area | Legacy Dashboard | New Dashboard | Required action |
+| --- | --- | --- | --- |
+| Workflow ID | The trigger identifier could be changed. | The public workflow ID is immutable after creation. | Choose the replacement ID before publishing and maintain an explicit ID map. |
+| Workflow groups | Groups organized workflows. | Tags organize workflows and drive Inbox filters and subscriptions. | Convert meaningful groups to tags. |
+| Step variants | One step contained a root variant and conditional variants. | Each step has one configuration. Step conditions decide whether it runs. | [Replace variants with mutually exclusive conditional steps](/guides/migration-to-new-dashboard/workflow-conversion#replace-variants-with-conditional-flow). |
+| Webhook conditions | A condition could call a webhook and inspect its response. | An HTTP step calls the service and exposes declared response fields to later conditions. | [Convert webhook response conditions](/guides/migration-to-new-dashboard/workflow-conversion#webhook-response-conditions). |
+| Payload variables | Templates could use arbitrary trigger payload fields without a workflow schema. | Dashboard payload variables must exist in the JSON Schema-based payload schema. Schema enforcement is a separate option. | [Build the payload contract](/guides/migration-to-new-dashboard/workflow-conversion#build-the-payload-contract-first). |
+| Template engine | Handlebars rendered variables, helpers, conditions, and loops. | LiquidJS renders template content. | [Convert Handlebars expressions](/guides/migration-to-new-dashboard/workflow-conversion#convert-handlebars-to-liquidjs). |
+| Payload namespace | Payload fields were commonly referenced directly, such as `{{orderId}}`. | Payload fields use `payload.*`, such as `{{ payload.orderId }}`. | Update references and declare each field in the payload schema. |
+| Digest variables | Legacy content used `step.events` and `step.total_count`. | Digest results use `steps.<step-id>.events`, `eventCount`, and summary fields. | Update paths and test zero, one, and multiple events. |
+| Path-based Delay | The Scheduled delay read an ISO date from a top-level payload key configured as `delayPath`. | The Dynamic delay reads a declared payload variable that holds either an ISO-8601 timestamp or a `{ "amount", "unit" }` duration object. | [Rebuild the legacy scheduled delay as a Dynamic delay](/guides/migration-to-new-dashboard/workflow-conversion#delay). |
+| Digest backoff | Regular digest used a backoff type with `backoffAmount` and `backoffUnit`. | Regular digest expresses the same behavior as a look-back window on the **Start digest** option. | Recreate the repeat-event window and test the first-event delivery path. |
+| Email layouts | Layouts inserted content with `{{{body}}}` and could define payload-style variables. | Layouts require `{{content}}`. They support `subscriber`, `context`, `env`, and `content`, but not `payload`, `steps`, or `workflow`. | [Move payload-dependent markup into the Email step](/guides/migration-to-new-dashboard/workflow-conversion#migrate-email-layouts). |
+| Layout selection | A default layout or trigger-time `layoutIdentifier` override could select the wrapper. | Each Email step selects a layout or no layout. | Replace dynamic layout selection with conditional Email steps or separate workflows. |
+| Translations | Independent groups used `{{i18n "group.key"}}`. | Translations belong to a workflow or layout and use `{{t.key}}`. Locale files require `language_REGION`. | [Remap translation groups and expressions](/guides/migration-to-new-dashboard/workflow-conversion#migrate-translations). |
+| Tenants | `tenant.*` supplied reusable data, variants, preferences, and provider routing. | Contexts supply reusable multi-tenant data. Workflow conditions and integration routing remain separate controls. | [Map each tenant use to a context-based replacement](/guides/migration-to-new-dashboard/workflow-conversion#replace-tenants-with-contexts). |
+| In-app custom data | Legacy messages exposed `payload`. | Inbox notifications expose the In-app step Data object as `data`. | Move client-required fields to Data and update client field access. |
+| In-app feeds | `feedIdentifier` and stores separated tabs. | Workflow tags filter Inbox tabs. | Add tags before switching clients. |
+| Notification object | Legacy clients used `_id`, `content`, `payload`, `cta`, and legacy read or seen fields. | Inbox uses the current notification model and methods. | Follow the [Inbox migration guide](/platform/inbox/migration-guide). |
+| React client | `@novu/notification-center` rendered the Notification Center. | `@novu/react` renders `<Inbox />`. | Follow [React Inbox migration](/platform/inbox/migration-guide#react) and the [React quickstart](/platform/quickstart/react). |
+| Angular client | The Angular wrapper embedded the legacy Notification Center. | Angular mounts `NovuUI` from `@novu/js/ui`. | Follow [Angular Inbox migration](/platform/inbox/migration-guide#angular) and the [Angular quickstart](/platform/quickstart/angular). |
+| Vue client | The Vue wrapper embedded the legacy Notification Center. | Vue mounts `NovuUI` from `@novu/js/ui`. | Follow [Vue Inbox migration](/platform/inbox/migration-guide#vue) and the [Vue quickstart](/platform/quickstart/vue). |
+| Vanilla JS client | Web Component, iframe, or `@novu/headless` integrations rendered or queried the legacy feed. | `@novu/js/ui` mounts Inbox and `@novu/js` supports headless clients. | Follow [Vanilla JS Inbox migration](/platform/inbox/migration-guide#vanilla-js) and the [Vanilla JS quickstart](/platform/quickstart/vanilla-js). |
+| React Native client | Legacy mobile integrations used the previous notification client model. | `@novu/react-native` provides the current Inbox client. | Follow the [React Native SDK](/platform/sdks/react-native). |
+| Environment promotion | The Changes page promoted pending differences. | The publish flow promotes selected workflows and associated publishable resources from Development. | Replace Changes API and release automation with [environment publishing](/platform/developer/environments#publish-changes-to-other-environments). |
+| Environment resources | Legacy resources were largely environment-specific. | Workflows, layouts, and translations are publishable. Integrations, keys, subscribers, topics, webhooks, and Activity remain environment-specific. | Verify environment-specific resources independently before cutover. |
+| Server Node.js SDK | Legacy applications commonly used `@novu/node`. | The current SDK is `@novu/api` with a request-object trigger model. | Review SDK migration separately from the workflow ID change. |
+| Management APIs | Legacy automation used v1 workflow, tenant, feed, Inbox, and Changes endpoints. | Current management uses v2 resources, contexts, Inbox APIs, and publishing. | Inventory direct API consumers against the current [API reference](/api-reference). |
+
+## Behavior to preserve
+
+These capabilities still exist, but they require parity testing because copied configuration is not proof of equivalent execution:
+
+| Capability | What to verify |
+| --- | --- |
+| Workflow status and critical behavior | Active state, subscriber preference bypass, and intended channel defaults |
+| Sequential channel and action steps | Step order, dependent results, skip behavior, and failure behavior |
+| Email, In-app, SMS, Push, and Chat | Rendered content, subscriber credentials, provider selection, and overrides |
+| Delay and Digest | Fixed duration, digest window type, calendar schedule, grouping key, time zone, and downstream variables |
+| Subscriber profiles and credentials | Stable `subscriberId`, custom data, locale, phone, email, device tokens, and chat credentials |
+| Subscriber preferences | Global and per-workflow settings, copied to the replacement workflow ID |
+| Topics | Topic keys, memberships, fan-out, and workflow-run usage |
+| Integrations | Production credentials, primary or conditional routing, and provider webhooks |
+| API credentials | Correct Application Identifier in clients and secret key on trusted servers |
+| Activity and delivery tracking | Expected step states, provider events, and plan-based retention |
+| HMAC Inbox authentication | Server-generated hashes and current client properties |
+| RBAC, SSO, and organization access | Release owners can publish and manage environment configuration |
+
+## Optional capabilities in the new Dashboard
+
+Do not add new behavior during a parity migration unless it has its own requirements and tests.
+
+- [Throttle step](/platform/workflow/add-and-configure-steps/configure-action-steps/throttle)
+- [HTTP step](/platform/workflow/add-and-configure-steps/configure-action-steps/http-step)
+- [Calendar-based Scheduled delay](/platform/workflow/add-and-configure-steps/configure-action-steps/delay#scheduled-delay), which resumes at a recurring minute, hour, day, week, or month rather than at a payload-supplied timestamp
+- [Duration objects in Dynamic delay](/platform/workflow/add-and-configure-steps/configure-action-steps/delay#dynamic-delay), which accept a relative `{ "amount", "unit" }` value in addition to an ISO-8601 timestamp
+- [Extend to subscriber schedule](/platform/inbox/features/schedule) on Delay and Digest steps
+- Workflow severity
+- [Outbound webhooks](/platform/developer/webhooks)
+- [Email activity tracking](/platform/integrations/email/activity-tracking)
+
+Continue with [workflow conversion](/guides/migration-to-new-dashboard/workflow-conversion) after every applicable migration-blocking row has an owner.

--- a/docs/guides/migration-to-new-dashboard/overview.mdx
+++ b/docs/guides/migration-to-new-dashboard/overview.mdx
@@ -1,0 +1,97 @@
+---
+title: "Migrate from the Legacy Dashboard to the New Dashboard"
+sidebarTitle: "Migration overview"
+description: "Plan and execute a controlled migration from legacy Novu workflows to the new Dashboard without changing the notifications delivered to subscribers."
+---
+
+This guide covers the migration of workflows created in the legacy Dashboard to workflows that use the current Dashboard and workflow engine.
+
+The migration creates new workflows instead of converting the existing workflows in place. You validate the new workflows in Development, publish them to Production, copy subscriber preferences, and then update your application to trigger the new workflow IDs.
+
+Because the legacy and new workflows use different workflow IDs in the same environment, they run side by side. The legacy workflows stay active and keep serving traffic until your application deploy switches the workflow IDs, so the migration requires no notification downtime and no maintenance window. Legacy workflows are deactivated or deleted later, as a separate change.
+
+<Note>
+  This guide covers cloud organizations that move from the legacy Dashboard to the new Dashboard. If you operate a self-hosted v0 installation, follow the [self-hosted v0 to v2 migration guide](/community/self-hosting-novu/v0-to-v2-migration).
+</Note>
+
+## Migration goals
+
+A successful migration preserves subscriber-facing behavior while moving workflow configuration to the current data model.
+
+- Every production legacy workflow has a corresponding new workflow.
+- Each channel delivers equivalent content and uses the intended provider.
+- Step order, conditions, delays, digests, and subscriber preferences continue to produce the intended behavior.
+- Your application triggers only the new workflow IDs after cutover.
+- Applications that display in-app notifications use the current Inbox SDK.
+
+## Terminology
+
+This guide uses the following terms:
+
+| Term | Meaning |
+| --- | --- |
+| Legacy workflow | A workflow created in the legacy Dashboard and executed by the legacy workflow engine. |
+| New workflow | A workflow created for the current Dashboard and workflow engine. |
+| Legacy workflow ID | The trigger identifier used by your application before migration. |
+| New workflow ID | The trigger identifier of the replacement workflow. A common convention is the legacy identifier with a `-v2` suffix. |
+| Development | The environment where you inspect, edit, and test the new workflows. |
+| Production | The environment that serves production traffic. Workflow, layout, and translation changes are published to this environment. |
+
+## Before you start
+
+Assign an owner from application engineering and an owner who can approve notification content. Include a team member with permission to publish workflows to Production.
+
+Collect the following information before validation:
+
+- Every legacy production workflow ID and the source locations that trigger it
+- The channel and action steps in each workflow, in execution order
+- Step conditions and variant conditions
+- Payload examples from real application calls
+- Handlebars expressions and Novu-specific helpers used by each template
+- Layout assignments, layout variables, and trigger-time layout overrides
+- Translation groups, locale files, and subscriber locale formats
+- Tenant-based content, workflow preference overrides, and provider routing
+- Subscriber preferences that must be copied
+- In-app feeds and the client applications that consume them
+- Environment-specific integrations, API keys, webhooks, subscribers, and topics
+- Expected provider, rendered content, and delivery behavior for at least one test case per path
+
+Do not change production trigger identifiers during the validation phase.
+
+## Migration stages
+
+### Pre-migration preparation
+
+Each legacy Production workflow needs an inactive replacement workflow in Development. The replacement normally keeps the workflow name, uses the legacy workflow ID with a `-v2` suffix, and reproduces the step order, content, conditions, and an initial payload schema.
+
+A replacement workflow that mirrors the legacy definition is a starting point. It does not prove behavioral equivalence.
+
+### Phase 1: Convert and validate
+
+Use the [feature comparison](/guides/migration-to-new-dashboard/feature-comparison) to find migration-blocking differences. Then follow [Convert legacy workflows](/guides/migration-to-new-dashboard/workflow-conversion) to rebuild payload contracts, templates, variants, layouts, translations, conditions, and tenant behavior.
+
+Keep replacement workflows inactive in Development except during controlled tests. Record the payload, subscriber, condition path, rendered output, provider result, and reviewer for each test. Legacy workflows are unaffected by this work because Development and Production are separate environments.
+
+Migrate every in-app client before cutover. Use the [Inbox migration guide](/platform/inbox/migration-guide#choose-the-inbox-package) for React, Angular, Vue, and Vanilla JS, then complete the [application and cutover](/guides/migration-to-new-dashboard/application-and-cutover#migrate-from-notification-center-to-inbox) checks.
+
+### Phase 2: Publish and cut over
+
+Follow the single [production cutover runbook](/guides/migration-to-new-dashboard/application-and-cutover#create-a-cutover-runbook) to publish resources, activate the replacement workflows, copy preferences, deploy the new workflow IDs, and verify Production while the legacy workflows remain active.
+
+Retire the legacy workflows only after the stabilization period described in [Retire the legacy workflows](/guides/migration-to-new-dashboard/application-and-cutover#retire-the-legacy-workflows).
+
+The authoritative [rollback procedure](/guides/migration-to-new-dashboard/application-and-cutover#roll-back-safely) is maintained with that runbook.
+
+## Continue the migration
+
+<Columns cols={2}>
+  <Card title="Compare legacy and new features" href="/guides/migration-to-new-dashboard/feature-comparison">
+    Identify every behavior that is preserved, replaced, added, plan-dependent, or no longer available.
+  </Card>
+  <Card title="Convert workflow configuration" href="/guides/migration-to-new-dashboard/workflow-conversion">
+    Convert schemas, variables, Handlebars, variants, layouts, translations, conditions, and action steps.
+  </Card>
+  <Card title="Migrate the app and cut over" href="/guides/migration-to-new-dashboard/application-and-cutover">
+    Update Inbox code, publish resources, copy preferences, switch workflow IDs, and verify Production.
+  </Card>
+</Columns>

--- a/docs/guides/migration-to-new-dashboard/workflow-conversion.mdx
+++ b/docs/guides/migration-to-new-dashboard/workflow-conversion.mdx
@@ -1,0 +1,348 @@
+---
+title: "Convert Legacy Workflows for the New Dashboard"
+sidebarTitle: "Convert workflows"
+description: "Convert legacy Novu payload variables, Handlebars templates, variants, layouts, translations, conditions, tenants, and action steps to the new workflow model."
+---
+
+Convert one workflow at a time. Start from a captured legacy definition and finish with test evidence for every execution path.
+
+## Build the payload contract first
+
+Legacy workflows accepted payload variables without a declared workflow schema. The new Dashboard uses the payload schema to make fields available to templates, conditions, grouping keys, and dynamic action-step settings.
+
+<Warning>
+  A payload schema and schema enforcement are separate controls. You must declare a payload field before using it as a Dashboard variable. You can leave enforcement disabled while callers are being updated, but an undeclared field is not a substitute for a migration plan.
+</Warning>
+
+For each legacy workflow:
+
+1. Capture successful production payloads from every trigger producer.
+2. List each field referenced by content, conditions, variants, delay or digest configuration, and provider overrides.
+3. Resolve inconsistent types. For example, do not define `orderId` as an integer if one producer sends it as a string.
+4. Add nested objects and array item types.
+5. Mark a field required only if every valid trigger must provide it.
+6. Add defaults only when a missing value has an unambiguous meaning.
+7. Import a representative JSON object or create the properties in **Manage workflow schema**.
+8. Preview the workflow with minimum and maximum valid values.
+9. Enable schema enforcement after all trigger producers conform.
+
+For example, a legacy trigger payload:
+
+```json
+{
+  "orderId": "order-123",
+  "customerTier": "gold",
+  "items": [
+    {
+      "name": "Keyboard",
+      "quantity": 1
+    }
+  ]
+}
+```
+
+should define `orderId` as a string, `customerTier` as an enum or string, and `items` as an array of objects with typed `name` and `quantity` properties.
+
+See [Configure workflow](/platform/workflow/configure-workflow#payload-schema) for supported schema types and constraints.
+
+## Convert Handlebars to LiquidJS
+
+Do not perform a global brace replacement. Handlebars helpers and Liquid tags have different parsing, scoping, truthiness, and formatting behavior.
+
+### Variable paths
+
+| Legacy expression | Current expression | Notes |
+| --- | --- | --- |
+| `{{orderId}}` | `{{ payload.orderId }}` | Declare `orderId` in the payload schema. |
+| `{{subscriber.firstName}}` | `{{ subscriber.firstName }}` | The namespace remains, but verify null behavior. |
+| `{{subscriber.data.plan}}` | `{{ subscriber.data.plan }}` | Custom subscriber data remains under `data`. |
+| `{{tenant.data.logo}}` | `{{ context.tenant.data.logo }}` | The exact path depends on the context key and data shape you create. |
+| `{{step.events}}` | `{{ steps.digest-step.events }}` | Replace `digest-step` with the actual Digest step ID. |
+| `{{step.total_count}}` | `{{ steps.digest-step.eventCount }}` | The current name uses `eventCount`. |
+| `{{branding.logo}}` | `{{ context.brand.data.logo }}` or `{{ env.BRAND_LOGO_URL }}` | Choose context for reusable tenant data or an environment variable for environment-wide configuration. |
+
+### Conditions and loops
+
+<CodeGroup>
+```handlebars title="Legacy Handlebars"
+{{#if showDiscount}}
+  Save {{discountPercent}}%
+{{else}}
+  View your order
+{{/if}}
+```
+
+```liquid title="Current LiquidJS"
+{% if payload.showDiscount %}
+  Save {{ payload.discountPercent }}%
+{% else %}
+  View your order
+{% endif %}
+```
+</CodeGroup>
+
+<CodeGroup>
+```handlebars title="Legacy Handlebars"
+{{#each items}}
+  {{@index}}: {{this.name}}
+{{/each}}
+```
+
+```liquid title="Current LiquidJS"
+{% for item in payload.items %}
+  {{ forloop.index0 }}: {{ item.name }}
+{% endfor %}
+```
+</CodeGroup>
+
+When comparing string values, use single quotes in Liquid conditions:
+
+```liquid
+{% if payload.customerTier == 'gold' %}
+  Priority support is included.
+{% endif %}
+```
+
+Do not assume every Novu-specific Handlebars helper has a direct Liquid equivalent. Use the documented Liquid filters for case conversion, dates, numbers, and pluralization. Precompute a display-ready value in application code when exact output parity is not available. In particular, redesign templates that depend on legacy `groupBy`, implicit `with` context, or different date-format tokens.
+
+Use the variable picker where possible. It inserts the current namespace and reduces errors caused by renamed fields. See [Personalize content](/platform/workflow/add-notification-content/personalize-content) for the supported namespaces, conditions, loops, and filters.
+
+### Choose the email editing model
+
+The code editor accepts Liquid variables, tags, and filters directly in HTML. The block editor stores structured nodes and inserts variables through its variable controls. Some block attributes use selected variable paths rather than handwritten `{{ ... }}` expressions.
+
+For an exact legacy HTML migration:
+
+1. Start with the code editor.
+2. Convert Handlebars to LiquidJS in the source.
+3. Compare the rendered HTML and text output with the legacy message.
+
+Use the block editor when you intend to rebuild the email as structured content. Configure Repeat, Digest, and conditional blocks through their controls. Do not paste code-editor Liquid into every block attribute and assume it has the same representation.
+
+Switching editor modes can reset content. Back up the migrated source before changing modes.
+
+## Replace variants with conditional flow
+
+Legacy variants selected alternate content or configuration inside one step. The new editor models each alternative as an independent step with its own condition.
+
+Assume a legacy Email step has:
+
+- A Gold variant when `customerTier` equals `gold`
+- A Silver variant when `customerTier` equals `silver`
+- A root variant for every other value
+
+Create three Email steps:
+
+The expressions below describe rules in the Dashboard condition builder. They are not Liquid template syntax.
+
+| Step ID | Condition | Content |
+| --- | --- | --- |
+| `email-gold` | `payload.customerTier = "gold"` | Content from the Gold variant |
+| `email-silver` | `payload.customerTier = "silver"` | Content from the Silver variant |
+| `email-default` | `payload.customerTier not in ["gold", "silver"]` | Content from the root variant |
+
+All three steps are evaluated in sequence. Their conditions must be mutually exclusive. Otherwise, one trigger can execute more than one replacement step.
+
+<Warning>
+  Include missing or null values in the fallback design. A `not in` rule might not match a missing property. If the field is required, enforce it in the payload schema. If it is optional, test a trigger that omits it and add an explicit fallback condition supported by the field type.
+</Warning>
+
+Apply the same pattern to variants of action steps:
+
+- A legacy Delay variant becomes a separate conditional Delay step.
+- A legacy Digest variant becomes a separate conditional Digest path.
+- All downstream steps must have conditions that prevent execution after the wrong action path.
+
+For complex variant trees, separate workflows are often easier to verify than a long linear sequence of duplicated conditional steps. Choose separate workflows when the paths have different step order, different action semantics, or independent ownership.
+
+## Convert step conditions
+
+Recreate conditions from their intent, not only their labels.
+
+### Payload and subscriber conditions
+
+Map legacy fields to current namespaced fields:
+
+- Payload: `payload.<declared-property>`
+- Standard subscriber fields: `subscriber.firstName`, `subscriber.email`, `subscriber.locale`, or another supported field
+- Custom subscriber fields: `subscriber.data.<property>`
+
+The current condition builder supports nested `AND` and `OR` groups. Match the legacy grouping exactly and test boundary values for numeric, range, empty, null, `in`, and string operators.
+
+### Webhook response conditions
+
+Replace a legacy webhook condition with:
+
+1. An HTTP step before the dependent steps
+2. A response schema that declares every consumed field
+3. A condition that reads `steps.<http-step-id>.<response-field>`
+4. An explicit failure policy
+
+If the old webhook returned `{ "eligible": true }`, a later Email step can use a condition on `steps.check-eligibility.eligible`.
+
+Test timeout, non-2xx, malformed response, and false-result paths. A successful preview request does not create Activity feed evidence, so also run the complete workflow.
+
+### Previous message state
+
+For fallback delivery:
+
+1. Send the in-app step.
+2. Add enough Delay time for the subscriber to interact.
+3. Add a condition to the later step using the exact ID of the in-app step.
+4. Test read, unread, seen, and unseen outcomes independently.
+
+Do not rename referenced step IDs without updating every template and condition that consumes their results.
+
+## Migrate email layouts
+
+Legacy layouts and current layouts have different content contracts.
+
+| Concern | Legacy layout | Current layout |
+| --- | --- | --- |
+| Email content insertion | `{{{body}}}` | `{{content}}` |
+| Available variables | Layout variables could include payload-style values configured on the layout | Only `subscriber`, `context`, `env`, and `content` are available. `payload`, `steps`, and `workflow` are not supported. |
+| Selection | Organization default, step assignment, and legacy trigger-time layout override | Select a layout or no layout on each Email step |
+| Editing | HTML-focused legacy editor | Block editor or code editor |
+| Translations | Referenced external translation groups | Enabled and managed on the layout |
+
+Use this conversion order:
+
+1. Copy the legacy HTML to a backup file.
+2. Replace `{{{body}}}` with `{{content}}`.
+3. Find every payload or tenant-dependent expression.
+4. Move workflow payload-dependent markup into the Email step.
+5. Replace stable global values with static layout content.
+6. Replace environment-specific values with `env.*`.
+7. Replace reusable tenant or brand values with `context.*`.
+8. Convert remaining Handlebars expressions to LiquidJS.
+9. Enable and migrate layout translations if the layout contains localized text.
+10. Select the layout explicitly on every migrated Email step.
+11. Preview long content, empty optional fields, mobile width, links, images, and dark-mode-sensitive styles.
+
+If legacy triggers choose `layoutIdentifier` dynamically, decide whether to use separate conditional Email steps or separate workflows. Do not leave the legacy override in application code without proving that the current delivery path supports the intended result.
+
+See [Email layouts](/platform/workflow/add-notification-content/channels-template-editors#email-layouts).
+
+## Migrate translations
+
+Legacy translation groups were independent resources referenced with the `i18n` Handlebars helper. Current translations belong to a workflow or layout and use the `t` namespace.
+
+Example:
+
+<CodeGroup>
+```handlebars title="Legacy Handlebars"
+{{i18n "marketing.welcome_message"}}
+```
+
+```liquid title="Current LiquidJS"
+{{t.welcome_message}}
+```
+</CodeGroup>
+
+For each group:
+
+1. Identify which workflows and layouts use the group.
+2. Copy the required keys into each owning workflow or layout.
+3. Remove the legacy group prefix from expressions when it is no longer part of the current JSON key path.
+4. Rewrite helper parameters and nested variables using LiquidJS.
+5. Rename files to `language_REGION.json`.
+6. Set the default and target locales.
+7. Import the default locale, then each target locale.
+8. Preview with subscribers that have each locale.
+9. Test fallback behavior for missing keys and unsupported locales.
+10. Publish translation resources with their workflows and layouts.
+
+An edit to the default locale can mark target locales outdated. Resolve outdated translations before Production publication.
+
+See [Translations](/platform/workflow/advanced-features/translations).
+
+## Replace tenants with contexts
+
+Map each legacy tenant use separately:
+
+| Legacy tenant use | Current replacement |
+| --- | --- |
+| `tenant.data.*` in content | A named context and `context.<key>.data.*` |
+| Tenant condition on a variant or step | A condition on the context identifier or data |
+| Tenant-specific content | Conditional steps, Liquid content logic, or separate workflows |
+| Tenant-specific workflow preferences | Recreate with the supported current preference model and verify per subscriber |
+| Tenant-specific provider selection | Use integration routing conditions based on the corresponding context. The first matching active integration is selected, with the primary integration as fallback where the channel supports it. |
+| Tenant branding | Context data for tenant values, plus layouts or Inbox appearance for presentation |
+
+Keep context data reusable and stable. Keep event-specific data in the payload. The current platform limits the number of contexts per trigger, so check [Limits](/platform/developer/limits) before mapping one legacy tenant into several context objects.
+
+Provider routing and workflow step conditions are separate controls. Recreate a tenant-based integration condition in **Integrations**, then recreate content or orchestration conditions on the workflow steps. Test the matching integration, the fallback integration, and a trigger with no tenant context.
+
+See [Contexts](/platform/workflow/advanced-features/contexts).
+
+## Review action steps
+
+### Delay
+
+Both dashboards support a fixed delay and a payload-driven delay. Map the legacy type before changing anything else.
+
+| Legacy delay | New delay | Conversion notes |
+| --- | --- | --- |
+| Regular, with amount and unit | Fixed delay | Keep the same amount and unit. |
+| Scheduled, with a `delayPath` payload key | Dynamic delay | The legacy value came from a top-level payload key holding an ISO date. Select the equivalent payload variable, declare it in the payload schema, and keep sending a future timestamp. |
+
+The Dynamic delay also accepts a `{ "amount": 30, "unit": "minutes" }` duration object. Treat that as a follow-up change, because the legacy step only accepted an ISO date.
+
+The new Scheduled delay is calendar-based and uses a recurring minute, hour, day, week, or month. It is not the replacement for the legacy Scheduled delay. Use it only when you intend to change behavior.
+
+Enabling extension to the subscriber's schedule changes delivery time. Leave it disabled if exact legacy timing is required during migration.
+
+A dynamic delay fails the workflow when the variable is missing, is not a valid ISO date or duration object, or resolves to a past time. Test each of those cases before cutover.
+
+### Digest
+
+Both dashboards support a regular window, a repeat-event start, and a scheduled window.
+
+| Legacy digest | New digest | Conversion notes |
+| --- | --- | --- |
+| Regular, with amount and unit | Regular window with **Start digest** set to immediately | Keep the same amount and unit, and confirm the plan limit for the window length. |
+| Backoff, with `backoffAmount` and `backoffUnit` | Regular window with **Start digest** set to when events repeat | The first event is delivered immediately and later events in the window are digested. Test both paths. |
+| Timed, with a time, weekday, or month-day configuration | Scheduled window | Recreate the calendar rule and confirm delivery in the subscriber's time zone. |
+
+Also confirm subscriber grouping, the optional payload aggregation key, extension to the subscriber schedule, and every downstream reference to digest events and counts.
+
+The aggregation key must exist in the payload schema. Test multiple events for one subscriber, the same subscriber with different aggregation keys, and different subscribers with the same key.
+
+### Throttle
+
+Throttle is new relative to the primary legacy action-step model. Do not add it merely because it is available. If you adopt it, define:
+
+- Fixed or dynamic window
+- Execution threshold
+- Subscriber and optional payload grouping
+- Behavior for critical workflows
+
+### HTTP
+
+Use HTTP to replace legacy webhook-condition enrichment or to fetch application state. Define response schemas, signatures, timeout behavior, and whether workflow execution continues after failure.
+
+See [Add and configure steps](/platform/workflow/add-and-configure-steps) for current step behavior and plan-dependent duration limits.
+
+## Validate channel parity
+
+Use the current [channel template editor reference](/platform/workflow/add-notification-content/channels-template-editors) to validate each copied channel. Keep this page focused on conversion rules rather than duplicating channel configuration.
+
+For every channel in a legacy workflow, record the rendered content, provider, credentials, overrides, condition result, and delivery result. For In-app steps, also confirm Data, actions, tags, avatar, and sanitization. Complete the client-side field and feed migration in the [Inbox migration guide](/platform/inbox/migration-guide#choose-the-inbox-package).
+
+## Workflow validation record
+
+Create one record per workflow with:
+
+| Field | Required evidence |
+| --- | --- |
+| Workflow mapping | Legacy ID, new ID, owner, and reviewer |
+| Schema | Sample minimum payload, sample complete payload, and enforcement state |
+| Content | Preview or provider output for each channel and locale |
+| Conditions | Matching and non-matching test for every path |
+| Variants | Exactly one replacement step executed for each legacy variant case |
+| Actions | Measured Delay, Digest, Throttle, or HTTP behavior |
+| Layout | Selected layout, rendered output, and no unsupported payload references |
+| Multi-tenancy | Context content, preference, and routing result |
+| Activity | Workflow run ID or transaction ID and final step statuses |
+
+After all workflow records pass, continue with [application migration and production cutover](/guides/migration-to-new-dashboard/application-and-cutover).

--- a/docs/platform/inbox/migration-guide.mdx
+++ b/docs/platform/inbox/migration-guide.mdx
@@ -1,31 +1,31 @@
 ---
 title: 'Migrate to the New Inbox'
-description: "Migrate from the legacy @novu/notification-center package to the new @novu/react Inbox with a step-by-step guide covering setup and props."
+description: "Migrate from the legacy Notification Center to Inbox for React, Angular, Vue, and Vanilla JS, including package, mount, and notification-object changes."
 ---
 
 <Note>
-  - Use [@novu/react](/platform/sdks/react) Inbox React component and
-  [@novu/js](/platform/sdks/javascript) headless package with new dashboard workflows and [@novu/framework](/platform/workflow)-based workflows.
+  Use Inbox with workflows from the current Dashboard or [@novu/framework](/platform/workflow).
 
-   - With legacy dashboard based workflows, use
-  [@novu/notification-center](https://v0.x-docs.novu.co/notification-center/client/react/get-started) package.
+  - React: [@novu/react](/platform/sdks/react)
+  - Angular, Vue, Vanilla JS, and headless clients: [@novu/js](/platform/sdks/javascript)
+
+  The legacy [@novu/notification-center](https://v0.x-docs.novu.co/notification-center/client/react/get-started) package, including its Angular, Vue, web component, iframe, and headless clients, is for legacy Dashboard workflows only.
 </Note>
 
-The `@novu/react` package introduces a more flexible and customizable way to display notifications in your application. This guide outlines the key differences between the `@novu/notification-center` package and the new `@novu/react` package. 
+Inbox replaces the legacy Notification Center. The notification object, action handlers, tabs, appearance, localization, and HMAC options are the same across hosts. The mount path differs by framework.
 
-Follow the steps below to migrate your application to the latest Inbox version.
+Review the breaking changes, then use the React, Angular, Vue, or Vanilla JS section that matches your application.
 
-## Why you should upgrade to `@novu/react`
+## Why you should upgrade
 
-- **Customization**: The `@novu/react` package provides more customization options for the appearance and behavior of the notification components.
-- **Flexibility**: The new package offers more flexibility in handling notifications and integrating with third-party libraries.
-- **Performance**: It is optimized for performance and provides a smoother user experience.
-- **Bundle Size**: The new package has a smaller bundle size and improved tree-shaking capabilities.
-- **Compatibility with the `@novu/framework`**: The `@novu/react` package is designed to work seamlessly with the `@novu/framework` package for creating and managing notifications.
+- Appearance and layout options that replace the legacy `styles` API
+- A notification object that includes archive, snooze, severity, and action methods
+- A smaller client surface: `@novu/react` for React, `@novu/js` for every other host
+- Compatibility with current Dashboard workflows and `@novu/framework`
 
 ## Breaking Changes
 
-The `@novu/react` package introduces several breaking changes compared to the `@novu/notification-center` package. Here are the key differences:
+These changes apply to every host. React uses component props. Angular, Vue, and Vanilla JS pass the same fields to `NovuUI` options and `mountComponent` props.
 
 ### Components
 
@@ -39,8 +39,8 @@ The `@novu/react` package introduces several breaking changes compared to the `@
 
 ### Notification
 
-- Removal of `seen` , `lastSeenDate`, `content`, `templateIdentifier`, `payload`, `cta` properties from the Notification object.
-- We have introduced `archive` functionality to the Notification object.
+- Removal of `seen`, `lastSeenDate`, `content`, `templateIdentifier`, `payload`, `cta` properties from the Notification object.
+- Archive, snooze, and severity support were added to the Notification object.
 
 ```diff title="Notification object"
 type Notification = {
@@ -59,7 +59,7 @@ type Notification = {
 + channelType: ChannelType;
 
 - payload: Record<string, unknown>;
-+ data?: Record<string, unknown>;
++ data?: NotificationData;
 
 - subscriber: Subscriber;
 + to: Subscriber;
@@ -68,40 +68,47 @@ type Notification = {
 - lastSeenDate: string;
 - templateIdentifier: string;
 
++ transactionId: string;
 + subject?: string;
 + isRead: boolean;
 + isSeen: boolean;
 + isArchived: boolean;
 + isSnoozed: boolean;
++ snoozedUntil?: string | null;
 + readAt?: string | null;
 + archivedAt?: string | null;
++ firstSeenAt?: string | null;
++ deliveredAt?: string[];
 + avatar?: string;
 + tags?: string[];
-+ avatar?: string;
-+ workflow: Workflow;
-+ deliveredAt: string | null;
-+ firstSeenAt: string | null;
++ workflow?: Workflow;
++ severity: SeverityLevelEnum;
 
-updatedAt: string;
 createdAt: string;
 };
 ```
 
 ```ts title="Types"
 type Workflow = {
-  critical: boolean;
   id: string;
   identifier: string;
   name: string;
-  tags: string[];
+  critical: boolean;
+  tags?: string[];
+  severity: SeverityLevelEnum;
 };
 
 type Subscriber = {
-  id: string;
+  id?: string;
+  subscriberId: string;
   firstName?: string;
   lastName?: string;
+  email?: string;
+  phone?: string;
   avatar?: string;
-  subscriberId: string;
+  locale?: string;
+  timezone?: string;
+  data?: Record<string, unknown>;
 };
 
 type Redirect = {
@@ -116,15 +123,65 @@ type Action = {
 };
 ```
 
-## Getting started
+<Note>
+  The legacy `_id` is the notification identifier and is not the same value as `transactionId`, which identifies the workflow trigger.
+</Note>
 
-To begin, install the `@novu/react` package.
+### Subscriber prop
 
-```package-install
-npm install @novu/react
+The `subscriberId` prop is deprecated. Pass `subscriber` with either a subscriber ID string or a subscriber object.
+
+```diff
+- <Inbox applicationIdentifier="YOUR_APP_ID" subscriberId="YOUR_SUBSCRIBER_ID" />
++ <Inbox applicationIdentifier="YOUR_APP_ID" subscriber="YOUR_SUBSCRIBER_ID" />
 ```
 
+## Choose the Inbox package
+
+| Host | Uninstall | Install | Mount Inbox | Setup |
+| --- | --- | --- | --- | --- |
+| [React](#react) | `@novu/notification-center` | `@novu/react` | `<Inbox />` | [React quickstart](/platform/quickstart/react) |
+| [Angular](#angular) | Angular Notification Center wrapper | `@novu/js` | `NovuUI` from `@novu/js/ui` | [Angular quickstart](/platform/quickstart/angular) |
+| [Vue](#vue) | Vue Notification Center wrapper | `@novu/js` | `NovuUI` from `@novu/js/ui` | [Vue quickstart](/platform/quickstart/vue) |
+| [Vanilla JS](#vanilla-js) | Web component, iframe script, or `@novu/headless` | `@novu/js` | `NovuUI` from `@novu/js/ui`, or `@novu/js` for a custom headless client | [Vanilla JS quickstart](/platform/quickstart/vanilla-js) |
+
+There is no native Angular or Vue Inbox package. Those applications mount the same UI through `@novu/js`. React Native uses [@novu/react-native](/platform/sdks/react-native).
+
+The breaking changes, tabs, appearance, actions, and notification methods on this page apply to every host. React uses component props. Angular, Vue, and Vanilla JS pass the same fields to `NovuUI` options and `mountComponent` props.
+
+## React
+
+Uninstall `@novu/notification-center` and install `@novu/react`. Replace `NovuProvider`, `PopoverNotificationCenter`, and `NotificationBell` with `<Inbox />`.
+
+Use `subscriber`, not the deprecated `subscriberId` prop. The [React examples below](#basic-usage) map the remaining components, fields, and handlers. For HMAC, localization, and layout, follow the [React Inbox quickstart](/platform/quickstart/react).
+
+## Angular
+
+Uninstall the Angular Notification Center wrapper and install `@novu/js`. There is no native Angular Inbox package.
+
+Mount Inbox with `NovuUI` from `@novu/js/ui` on an existing header, navbar, or sidebar element. Use a template reference such as `#novuInbox`, mount in `ngAfterViewInit`, and unmount in `ngOnDestroy`. Pass `appearance`, `tabs`, `localization`, and click handlers in the constructor options or in `mountComponent` props.
+
+Follow the [Angular Inbox quickstart](/platform/quickstart/angular) for the install.
+
+## Vue
+
+Uninstall the Vue Notification Center wrapper and install `@novu/js`. There is no native Vue Inbox package.
+
+Mount Inbox with `NovuUI` from `@novu/js/ui` from `onMounted` against a template `ref`, and unmount in `onUnmounted`. Inbox does not support server-side rendering. For Nuxt, wrap the component in `<ClientOnly>` and follow the [Nuxt Inbox quickstart](/platform/quickstart/nuxt).
+
+Follow the [Vue Inbox quickstart](/platform/quickstart/vue) for the install.
+
+## Vanilla JS
+
+Uninstall the web component, iframe embed, or `@novu/headless` client and install `@novu/js`.
+
+Mount Inbox with `NovuUI` from `@novu/js/ui` after `DOMContentLoaded` on an existing element. A bundler is required for the `@novu/js/ui` import. For a plain HTML page, follow the [Vanilla JS Inbox quickstart](/platform/quickstart/vanilla-js), which loads the UI bundle and stylesheet.
+
+For a custom feed without the prebuilt UI, replace `@novu/headless` with `@novu/js` and rebuild queries, counts, and mutation methods against the current notification object. See the [JavaScript SDK](/platform/sdks/javascript).
+
 ## Basic usage
+
+The examples below use `@novu/react`. For Angular, Vue, and Vanilla JS, pass the same options to `NovuUI` and the same handlers in `mountComponent` props.
 
 ### Legacy implementation with `@novu/notification-center`
 
@@ -663,13 +720,15 @@ Add tags on the workflow Tags field. One tag can be used for multiple workflows.
 
 2. Use those tags in the `tabs` prop of the `Inbox` component.
 
+Each tab takes a `filter` object that supports `tags`, `data`, and `severity`. The older `value` array is deprecated, so replace `value: ['security']` with `filter: { tags: ['security'] }`.
+
 ```tsx
 import { Inbox } from '@novu/react';
 
 const tabs = [
-  { label: 'All Notifications', value: [] },
-  { label: 'Security', value: ['security'] },
-  { label: 'Promotions', value: ['promotions'] },
+  { label: 'All Notifications', filter: {} },
+  { label: 'Security', filter: { tags: ['security'] } },
+  { label: 'Promotions', filter: { tags: ['promotions'] } },
 ];
 
 function InboxWithTabs() {
@@ -694,11 +753,21 @@ The process remains the same as before. For more information, refer to [Secure y
 
 ## Handling notifications
 
-Handle notifications using the methods provided by the notification object.
+Legacy mutation hooks such as `useUpdateAction` are replaced by methods on the notification object.
 
-### Marking notifications as read
+| Method | Replaces | Description |
+| --- | --- | --- |
+| `read()` | `useMarkNotificationAsRead` | Marks the notification as read. |
+| `unread()` | `useMarkNotificationAsUnRead` | Marks the notification as unread. |
+| `archive()` | No legacy equivalent | Archives the notification. |
+| `unarchive()` | No legacy equivalent | Restores an archived notification. |
+| `snooze(snoozeUntil)` | No legacy equivalent | Snoozes the notification until an ISO 8601 timestamp. |
+| `unsnooze()` | No legacy equivalent | Cancels an active snooze. |
+| `completePrimary()` and `completeSecondary()` | `useUpdateAction` with `MessageActionStatusEnum.DONE` | Marks an action button as completed. |
+| `revertPrimary()` and `revertSecondary()` | `useUpdateAction` with `MessageActionStatusEnum.PENDING` | Returns an action button to its pending state. |
+| `delete()` | No legacy equivalent | Deletes the notification. |
 
-Mark notifications as read using the `read` method provided by the notification object.
+Each method returns a promise, so handle failures rather than assuming the change succeeded.
 
 ```tsx
 import { Inbox } from '@novu/react';
@@ -708,28 +777,10 @@ function Novu() {
     notification.read();
   };
 
-  return (
-    <Inbox
-      applicationIdentifier="YOUR_APP_ID"
-      subscriber="YOUR_SUBSCRIBER_ID"
-      onNotificationClick={handleNotificationClick}
-    />
-  );
-}
-
-export default Novu;
-```
-
-### Marking notifications as unread
-
-Mark notifications as unread using the `unread` method provided by the notification object.
-
-```tsx
-import { Inbox } from '@novu/react';
-
-function Novu() {
-  const handleNotificationClick = (notification) => {
-    notification.unread();
+  const handlePrimaryActionClick = async (notification) => {
+    // Call your own API first, then record the action in Novu.
+    await acceptFriendRequest(notification.data?.requestId);
+    await notification.completePrimary();
   };
 
   return (
@@ -737,54 +788,7 @@ function Novu() {
       applicationIdentifier="YOUR_APP_ID"
       subscriber="YOUR_SUBSCRIBER_ID"
       onNotificationClick={handleNotificationClick}
-    />
-  );
-}
-
-export default Novu;
-```
-
-### Marking notifications as archive
-
-Mark notifications as archive using the `archive` method provided by the notification object.
-
-```tsx
-import { Inbox } from '@novu/react';
-
-function Novu() {
-  const handleNotificationClick = (notification) => {
-    notification.archive();
-  };
-
-  return (
-    <Inbox
-      applicationIdentifier="YOUR_APP_ID"
-      subscriber="YOUR_SUBSCRIBER_ID"
-      onNotificationClick={handleNotificationClick}
-    />
-  );
-}
-
-export default Novu;
-```
-
-### Marking notifications as unarchive
-
-Mark notifications as unarchive using the `unarchive` method provided by the notification object.
-
-```tsx
-import { Inbox } from '@novu/react';
-
-function Novu() {
-  const handleNotificationClick = (notification) => {
-    notification.unarchive();
-  };
-
-  return (
-    <Inbox
-      applicationIdentifier="YOUR_APP_ID"
-      subscriber="YOUR_SUBSCRIBER_ID"
-      onNotificationClick={handleNotificationClick}
+      onPrimaryActionClick={handlePrimaryActionClick}
     />
   );
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a comprehensive migration guide for moving from Novu's legacy Dashboard and workflow engine to the current platform.
- Introduces an overview and a legacy-to-current feature comparison.
- Documents workflow conversion for schemas, templates, variants, layouts, translations, tenants, delays, and digests.
- Provides an application cutover, preference migration, monitoring, rollback, and retirement runbook.
- Expands the Inbox migration documentation and adds the new guides to documentation navigation.
- The previously identified critical-workflow preference issue is fully addressed.

<h3>Confidence Score: 5/5</h3>

The documentation changes appear safe to merge, with the previous preference-migration defect fully corrected and no new actionable issues identified.

The guide now keeps critical workflows out of preference update requests and directs operators to verify their preference-bypass behavior separately, resolving the manually closed previous finding. No blocking or non-blocking defects remain.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/docs.json | Adds the four Dashboard migration pages to the Guides navigation. |
| docs/guides.mdx | Adds a guide-directory card linking readers to the new migration documentation. |
| docs/guides/migration-to-new-dashboard/overview.mdx | Defines the migration scope, terminology, prerequisites, stages, and links to detailed procedures. |
| docs/guides/migration-to-new-dashboard/feature-comparison.mdx | Maps legacy Dashboard capabilities to their current equivalents and required migration actions. |
| docs/guides/migration-to-new-dashboard/workflow-conversion.mdx | Documents conversion of workflow schemas, templates, conditions, layouts, translations, tenant behavior, and action steps. |
| docs/guides/migration-to-new-dashboard/application-and-cutover.mdx | Provides the production cutover and rollback runbook, including corrected handling of critical workflow preferences. |
| docs/platform/inbox/migration-guide.mdx | Expands client migration guidance for moving from the legacy Notification Center to Inbox. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Inventory legacy workflows] --> B[Create replacement workflows]
  B --> C[Convert schemas and content]
  C --> D[Validate in Development]
  D --> E[Publish resources to Production]
  E --> F[Activate replacement workflows]
  F --> G[Copy non-critical preferences]
  G --> H[Deploy new workflow IDs and Inbox clients]
  H --> I[Monitor through longest Delay or Digest window]
  I --> J[Retire legacy workflows after stabilization]
  H -->|Rollback| K[Restore legacy workflow IDs]
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;next&#39; into feature/v2-migr..."](https://github.com/novuhq/novu/commit/805de46bb79964747e978ec19ff6518e0e4ec04a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60940412)</sub>

<!-- /greptile_comment -->