### PR TITLE
fix(novu): keep Web Chat Tailwind intact on merge hosts fixes NV-8783

### DIFF
--- a/packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.spec.ts
@@ -79,7 +79,7 @@ describe('scaffoldWebChatProject', () => {
 
     const page = fs.readFileSync(path.join(projectDir, 'app', 'page.tsx'), 'utf8');
     expect(page).not.toContain('localhost:3000');
-    expect(page).toContain('...(apiUrl ? { apiUrl } : {})');
+    expect(page).toContain('...(backendUrl ? { backendUrl } : {})');
     expect(page).toContain('...(socketUrl ? { socketUrl } : {})');
   });
 

--- a/packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.ts
+++ b/packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.ts
@@ -108,6 +108,7 @@ async function mergeWebChatIntoProject(projectDir: string, input: ScaffoldWebCha
   const dependenciesChanged = ensureWebChatDependencies(resolved, input.apiUrl, input.region);
   const toolchainBootstrapped = bootstrapTailwindToolchainIfAbsent(resolved);
   ensureWebChatNextConfig(resolved);
+  ensureWebChatMergeHostLayout(resolved);
   const componentsDir = path.join(resolved, 'components', 'web-chat');
   fs.mkdirSync(componentsDir, { recursive: true });
   copyTemplateComponents(componentsDir);
@@ -154,6 +155,19 @@ function bootstrapTailwindToolchainIfAbsent(projectDir: string): boolean {
   fs.writeFileSync(path.join(projectDir, 'postcss.config.mjs'), STANDALONE_POSTCSS_CONFIG, 'utf8');
 
   return true;
+}
+
+/**
+ * Bridge scaffolds ship a layout with no --font-geist variables and import host
+ * globals after Web Chat CSS. A host `* { padding: 0 }` reset then strips Tailwind
+ * utilities (suggestion pills, composer). Align with the playground: Geist on
+ * <html>, web-chat globals only — do not import host CSS after the theme.
+ */
+function ensureWebChatMergeHostLayout(projectDir: string): void {
+  const layoutPath = path.join(projectDir, 'app', 'layout.tsx');
+  if (fs.existsSync(layoutPath)) {
+    fs.writeFileSync(layoutPath, MERGE_LAYOUT, 'utf8');
+  }
 }
 
 function ensureWebChatDependencies(projectDir: string, apiUrl: string, region?: CloudRegionEnum): boolean {
@@ -597,7 +611,6 @@ function renderChatPage(opts: { standalone: boolean; configImport: string }): st
 import { NovuProvider } from '@novu/react';
 import { WebChat } from '@/components/web-chat/web-chat';
 import { config } from '@/config';
-import '@/components/web-chat/globals.css';
 
 export default function Page() {
   return (
@@ -616,29 +629,25 @@ export default function Page() {
 
   return `'use client';
 
-import { Inter } from 'next/font/google';
 import { NovuProvider } from '@novu/react';
 import { WebChat } from '@/components/web-chat/web-chat';
-import '@/components/web-chat/globals.css';
-
-const inter = Inter({ subsets: ['latin'], display: 'swap' });
 
 export default function WebChatPage() {
   const applicationIdentifier = process.env.NEXT_PUBLIC_NOVU_APP_ID ?? '';
   const subscriberId = process.env.NEXT_PUBLIC_NOVU_SUBSCRIBER_ID ?? '';
-  const apiUrl = process.env.NEXT_PUBLIC_NOVU_BACKEND_URL;
+  const backendUrl = process.env.NEXT_PUBLIC_NOVU_BACKEND_URL;
   const socketUrl = process.env.NEXT_PUBLIC_NOVU_SOCKET_URL;
+  const socketType = process.env.NEXT_PUBLIC_NOVU_SOCKET_TYPE as 'cloud' | 'self-hosted' | undefined;
 
   return (
     <NovuProvider
       applicationIdentifier={applicationIdentifier}
       subscriberId={subscriberId}
-      {...(apiUrl ? { apiUrl } : {})}
+      {...(backendUrl ? { backendUrl } : {})}
       {...(socketUrl ? { socketUrl } : {})}
+      {...(socketType ? { socketOptions: { socketType } } : {})}
     >
-      <div className={inter.className}>
-        <WebChat />
-      </div>
+      <WebChat />
     </NovuProvider>
   );
 }
@@ -932,21 +941,61 @@ export function detectWebChatProjectKind(projectDir: string): 'empty' | 'project
   return detectBridgeProject(projectDir).kind;
 }
 
-const STANDALONE_LAYOUT = `import { Inter } from 'next/font/google';
+const STANDALONE_LAYOUT = `import type { Metadata } from 'next';
+import { Geist, Geist_Mono } from 'next/font/google';
+import '@/components/web-chat/globals.css';
 
-const inter = Inter({ subsets: ['latin'], display: 'swap' });
+const geist = Geist({
+  subsets: ['latin'],
+  variable: '--font-geist',
+});
 
-export const metadata = {
+const geistMono = Geist_Mono({
+  subsets: ['latin'],
+  variable: '--font-geist-mono',
+});
+
+export const metadata: Metadata = {
   title: 'Novu Web Chat',
   description: 'A standalone Web Chat example powered by Novu.',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={inter.className} suppressHydrationWarning>
-        {children}
-      </body>
+    <html lang="en" className={\`\${geist.variable} \${geistMono.variable}\`} suppressHydrationWarning>
+      <body suppressHydrationWarning>{children}</body>
+    </html>
+  );
+}
+`;
+
+const MERGE_LAYOUT = `import type { Metadata } from 'next';
+import { Geist, Geist_Mono } from 'next/font/google';
+import '@/components/web-chat/globals.css';
+
+const geist = Geist({
+  subsets: ['latin'],
+  variable: '--font-geist',
+});
+
+const geistMono = Geist_Mono({
+  subsets: ['latin'],
+  variable: '--font-geist-mono',
+});
+
+export const metadata: Metadata = {
+  title: 'Novu Agent',
+  description: 'Conversational AI agent powered by Novu',
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en" className={\`\${geist.variable} \${geistMono.variable}\`}>
+      <body>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- Merge connect now writes a playground-aligned `app/layout.tsx`: Geist vars on `<html>`, import only `@/components/web-chat/globals.css`.
- Host `app/globals.css` (`* { padding: 0 }`) is no longer imported after Tailwind, so suggestion pills and composer keep their padding.
- Merge page uses `backendUrl` / optional `socketType` like playground.

## Test plan
- [ ] `npx` local CLI: `node packages/novu/dist/src/index.js connect --runtime ai-sdk --channel web-chat --api-url http://localhost:3000 --connect-dashboard-url http://localhost:4201 --dashboard-url http://localhost:4201 --agent-identifier <id>`
- [ ] New project `app/layout.tsx` has Geist + web-chat globals, no `import './globals.css'`
- [ ] Welcome pills have padding; font matches playground
- [ ] Existing Tailwind host is still not rewritten beyond layout (PostCSS bootstrap path unchanged)


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns generated standalone and merged Web Chat projects with the playground layout and provider configuration.
- Moves Web Chat global CSS loading into generated root layouts.
- Applies Geist font variables and prevents host global CSS from overriding Web Chat Tailwind utilities.
- Updates merged pages to use `backendUrl` and optional socket transport configuration.
- Updates the provider-property assertion, but does not cover the new merge-layout behavior.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking test gap around the core merge-layout behavior.

The changed runtime behavior is consistent with the fresh bridge templates and current provider API, but existing tests never create a layout and therefore cannot catch regressions in the fix.

**Files Needing Attention:** packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.ts, packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.spec.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.ts | Replaces fresh bridge layouts with a Web Chat-specific Geist layout and aligns generated provider configuration; the layout branch lacks direct test coverage. |
| packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.spec.ts | Updates the backend property assertion but does not create or validate the layout modified by the fix. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312592%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12592&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fpipeline%2Fweb-chat%2Fscaffold-web-chat.ts%3A168-170%0A**Merge%20layout%20remains%20untested**%0A%0AThe%20merge%20tests%20never%20create%20%60app%2Flayout.tsx%60%2C%20so%20this%20new%20branch%20is%20always%20skipped.%20A%20regression%20that%20stops%20replacing%20the%20layout%2C%20omits%20the%20Web%20Chat%20stylesheet%2C%20or%20generates%20invalid%20layout%20content%20would%20still%20pass%20the%20suite.%20Add%20a%20merge%20fixture%20with%20a%20bridge%20layout%20and%20assert%20the%20generated%20Geist%20variables%20and%20Web%20Chat%20CSS%20import.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12592&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/novu/src/commands/connect/pipeline/web-chat/scaffold-web-chat.ts:168-170
**Merge layout remains untested**

The merge tests never create `app/layout.tsx`, so this new branch is always skipped. A regression that stops replacing the layout, omits the Web Chat stylesheet, or generates invalid layout content would still pass the suite. Add a merge fixture with a bridge layout and assert the generated Geist variables and Web Chat CSS import.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(novu): keep Web Chat Tailwind intact..."](https://github.com/novuhq/novu/commit/2323061f90711655e9a91975192f4f7a654ab906) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61187045)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->