### PR TITLE
chore(root): gate Biome anti-slop lint on changed files fixes NV-8784

### DIFF
--- a/.github/workflows/contributor-checks.yml
+++ b/.github/workflows/contributor-checks.yml
@@ -55,6 +55,10 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: false
+          fetch-depth: 50
+
+      - name: Fetch comparison branch
+        run: git fetch origin "${{ github.base_ref }}" --depth=50
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -74,8 +78,8 @@ jobs:
       - name: Reset Nx cache
         run: npx nx reset || true
 
-      - name: Lint
-        run: pnpm run lint
+      - name: Lint changed files
+        run: pnpm exec biome ci --changed --since=origin/${{ github.base_ref }} --no-errors-on-unmatched --reporter=github --max-diagnostics=none
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/contributor-checks.yml
+++ b/.github/workflows/contributor-checks.yml
@@ -55,10 +55,10 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: false
-          fetch-depth: 50
+          fetch-depth: 0
 
       - name: Fetch comparison branch
-        run: git fetch origin "${{ github.base_ref }}" --depth=50
+        run: git fetch origin "${{ github.base_ref }}"
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -48,15 +48,15 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          fetch-depth: 50
+          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Fetch comparison branch
         run: |
           if [[ -n "${{ github.event.pull_request.base.ref }}" ]]; then
-            git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=50
+            git fetch origin "${{ github.event.pull_request.base.ref }}"
           else
-            git fetch origin next --depth=50
+            git fetch origin next
           fi
 
       - uses: ./.github/actions/setup-project-minimal

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -42,6 +42,34 @@ jobs:
           access-token: ${{ secrets.LD_ACCESS_TOKEN }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+  lint-changed:
+    name: Lint changed files
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 50
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Fetch comparison branch
+        run: |
+          if [[ -n "${{ github.event.pull_request.base.ref }}" ]]; then
+            git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=50
+          else
+            git fetch origin next --depth=50
+          fi
+
+      - uses: ./.github/actions/setup-project-minimal
+
+      - name: Biome on changed files
+        run: |
+          if [[ -n "${{ github.event.pull_request.base.ref }}" ]]; then
+            since="origin/${{ github.event.pull_request.base.ref }}"
+          else
+            since="origin/next"
+          fi
+          pnpm exec biome ci --changed --since="$since" --no-errors-on-unmatched --reporter=github --max-diagnostics=none
+
   get-affected:
     name: Get Affected Packages
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -167,7 +195,7 @@ jobs:
         env:
           NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
-          targets: lint,build,test
+          targets: build,test
           parallel: 5
           projects: ${{join(fromJson(needs.get-affected.outputs.test-providers), ',')}}
 
@@ -207,7 +235,7 @@ jobs:
           LOG_LEVEL: "info"
           NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
-          targets: lint,build,test
+          targets: build,test
           projects: ${{join(fromJson(needs.get-affected.outputs.test-packages), ',')}}
 
   test_unit_libs:
@@ -228,7 +256,7 @@ jobs:
         env:
           NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
-          targets: lint,build,test
+          targets: build,test
           projects: ${{join(fromJson(needs.get-affected.outputs.test-libs), ',')}}
 
   test_unit_services:
@@ -270,11 +298,11 @@ jobs:
           args: ""
 
       - uses: mansagroup/nrwl-nx-action@a531870269e0c1eeb7af6247c4a206c31cae82cc # v3
-        name: Lint and build and test
+        name: Build and test
         env:
           NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
-          targets: lint,build,test
+          targets: build,test
           projects: ${{matrix.projectName}}
           args: ""
 
@@ -337,6 +365,7 @@ jobs:
     needs:
       - dependency-review
       - find-flags
+      - lint-changed
       - get-affected
       - test_unit_providers
       - test_unit_packages

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,9 +1,4 @@
 module.exports = {
   '*.{e2e,e2e-ee,spec}.{js,ts}': ['stop-only --file'],
-  '**/*.{ts,tsx,js,jsx,json}': (files) => {
-    const filtered = files.filter((file) => !file.includes('/internal-sdk/'));
-    if (filtered.length === 0) return [];
-
-    return [`biome check --write --no-errors-on-unmatched --diagnostic-level=error ${filtered.join(' ')}`];
-  },
+  '**/*.{ts,tsx,js,jsx,json}': () => ['biome check --write --staged --no-errors-on-unmatched --diagnostic-level=error'],
 };

--- a/biome-plugins/no-chained-type-assertions.grit
+++ b/biome-plugins/no-chained-type-assertions.grit
@@ -1,0 +1,7 @@
+language js(typescript)
+
+`($value as $inner) as $outer` where {
+  not $inner <: `const`,
+  not $outer <: `const`,
+  register_diagnostic(span=$outer, message="This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.", severity="error")
+}

--- a/biome-plugins/no-chained-type-assertions.grit
+++ b/biome-plugins/no-chained-type-assertions.grit
@@ -1,7 +1,10 @@
 language js(typescript)
 
-`($value as $inner) as $outer` where {
+or {
+  `($value as $inner) as $outer`,
+  `$value as $inner as $outer`
+} as $assertion where {
   not $inner <: `const`,
   not $outer <: `const`,
-  register_diagnostic(span=$outer, message="This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.", severity="error")
+  register_diagnostic(span=$assertion, message="This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.", severity="error")
 }

--- a/biome-plugins/no-conditional-empty-object-spread.grit
+++ b/biome-plugins/no-conditional-empty-object-spread.grit
@@ -1,0 +1,9 @@
+language js(typescript)
+
+`{ ...$conditional }` where {
+  $conditional <: or {
+    `($condition ? {} : $value)`,
+    `($condition ? $value : {})`
+  },
+  register_diagnostic(span=$conditional, message="This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.", severity="error")
+}

--- a/biome-plugins/no-known-value-widening.grit
+++ b/biome-plugins/no-known-value-widening.grit
@@ -1,0 +1,11 @@
+language js(typescript)
+
+or {
+  `const $name: unknown = $value`,
+  `const $name: any = $value`,
+  `const $name: object = $value`,
+  `const $name: Record<$key, unknown> = $value`,
+  `const $name: Record<$key, any> = $value`
+} as $binding where {
+  register_diagnostic(span=$binding, message="This explicit broad type can discard known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.", severity="error")
+}

--- a/biome-plugins/no-module-mocking.grit
+++ b/biome-plugins/no-module-mocking.grit
@@ -7,9 +7,5 @@ or {
   `jest.mock($args)`,
   `jest.doMock($args)`
 } as $call where {
-  register_diagnostic(
-    span = $call,
-    severity = "error",
-    message = "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation."
-  )
+  register_diagnostic(span=$call, severity="error", message="Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.")
 }

--- a/biome-plugins/no-module-mocking.grit
+++ b/biome-plugins/no-module-mocking.grit
@@ -1,0 +1,15 @@
+language js(typescript)
+
+or {
+  `vi.mock($args)`,
+  `vi.doMock($args)`,
+  `vi.unstable_mockModule($args)`,
+  `jest.mock($args)`,
+  `jest.doMock($args)`
+} as $call where {
+  register_diagnostic(
+    span = $call,
+    severity = "error",
+    message = "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation."
+  )
+}

--- a/biome-plugins/no-object-parameters.grit
+++ b/biome-plugins/no-object-parameters.grit
@@ -1,0 +1,10 @@
+language js(typescript)
+
+`function $name($params) { $body }` where {
+  $params <: contains `: object`,
+  register_diagnostic(
+    span = $params,
+    severity = "error",
+    message = "This parameter uses the broad `object` type. Accept a named owner type and parse external input at its boundary before calling this function."
+  )
+}

--- a/biome-plugins/no-object-parameters.grit
+++ b/biome-plugins/no-object-parameters.grit
@@ -2,9 +2,5 @@ language js(typescript)
 
 `function $name($params) { $body }` where {
   $params <: contains `: object`,
-  register_diagnostic(
-    span = $params,
-    severity = "error",
-    message = "This parameter uses the broad `object` type. Accept a named owner type and parse external input at its boundary before calling this function."
-  )
+  register_diagnostic(span=$params, severity="error", message="This parameter uses the broad `object` type. Accept a named owner type and parse external input at its boundary before calling this function.")
 }

--- a/biome-plugins/no-reflect-apply.grit
+++ b/biome-plugins/no-reflect-apply.grit
@@ -1,0 +1,5 @@
+language js(typescript)
+
+`Reflect.apply($args)` as $call where {
+  register_diagnostic(span=$call, message="Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.", severity="error")
+}

--- a/biome-plugins/no-reflect-get.grit
+++ b/biome-plugins/no-reflect-get.grit
@@ -1,0 +1,5 @@
+language js(typescript)
+
+`Reflect.get($args)` as $call where {
+  register_diagnostic(span=$call, message="Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.", severity="error")
+}

--- a/biome-plugins/no-runtime-typeof.grit
+++ b/biome-plugins/no-runtime-typeof.grit
@@ -1,0 +1,5 @@
+language js(typescript)
+
+`typeof $value` as $check where {
+  register_diagnostic(span=$check, message="A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.", severity="error")
+}

--- a/biome-plugins/no-shape-in-symbol-names.grit
+++ b/biome-plugins/no-shape-in-symbol-names.grit
@@ -1,0 +1,15 @@
+language js(typescript)
+
+or {
+  `const $name = $value`,
+  `let $name = $value`,
+  `var $name = $value`,
+  `function $name($params) { $body }`,
+  `class $name { $body }`,
+  `type $name = $value`,
+  `interface $name { $body }`,
+  `import $name from $source`
+} where {
+  $name <: r"(?i).*shape.*",
+  register_diagnostic(span=$name, message="Rename this symbol for its domain role; `shape` describes structure rather than ownership.", severity="error")
+}

--- a/biome-plugins/no-unknown-parameters.grit
+++ b/biome-plugins/no-unknown-parameters.grit
@@ -1,0 +1,10 @@
+language js(typescript)
+
+`function $name($params) { $body }` where {
+  $params <: contains `: unknown`,
+  register_diagnostic(
+    span = $params,
+    severity = "error",
+    message = "This parameter leaves input unparsed. Accept a named domain type; parse unknown input at its I/O boundary."
+  )
+}

--- a/biome-plugins/no-unknown-parameters.grit
+++ b/biome-plugins/no-unknown-parameters.grit
@@ -2,9 +2,5 @@ language js(typescript)
 
 `function $name($params) { $body }` where {
   $params <: contains `: unknown`,
-  register_diagnostic(
-    span = $params,
-    severity = "error",
-    message = "This parameter leaves input unparsed. Accept a named domain type; parse unknown input at its I/O boundary."
-  )
+  register_diagnostic(span=$params, severity="error", message="This parameter leaves input unparsed. Accept a named domain type; parse unknown input at its I/O boundary.")
 }

--- a/biome-plugins/no-unknown-returns.grit
+++ b/biome-plugins/no-unknown-returns.grit
@@ -1,0 +1,10 @@
+language js(typescript)
+
+or {
+  `function $name($params): unknown { $body }`,
+  `function $name($params): Promise<unknown> { $body }`,
+  `const $name = ($params): unknown => $body`,
+  `const $name = ($params): Promise<unknown> => $body`
+} as $function where {
+  register_diagnostic(span=$function, message="This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.", severity="error")
+}

--- a/biome-plugins/no-unknown-type-aliases.grit
+++ b/biome-plugins/no-unknown-type-aliases.grit
@@ -1,0 +1,5 @@
+language js(typescript)
+
+`type $name = unknown` as $alias where {
+  register_diagnostic(span=$alias, message="This type alias hides `unknown`. Keep `unknown` explicit at the parsing boundary or use the parsed owner type.", severity="error")
+}

--- a/biome-plugins/no-unsafe-dictionary-type.grit
+++ b/biome-plugins/no-unsafe-dictionary-type.grit
@@ -1,0 +1,18 @@
+language js(typescript)
+
+or {
+  `Record<string, unknown>`,
+  `Record<number, unknown>`,
+  `Record<symbol, unknown>`,
+  `Record<PropertyKey, unknown>`,
+  `Record<string, any>`,
+  `Record<number, any>`,
+  `Record<symbol, any>`,
+  `Record<PropertyKey, any>`,
+  `Record<string, object>`,
+  `Record<number, object>`,
+  `Record<symbol, object>`,
+  `Record<PropertyKey, object>`
+} as $dictionary where {
+  register_diagnostic(span=$dictionary, message="This dictionary value type gives callers no concrete contract. Use an owner/schema-derived value type and parse external payloads before insertion.", severity="error")
+}

--- a/biome-plugins/no-widen-then-assert.grit
+++ b/biome-plugins/no-widen-then-assert.grit
@@ -1,0 +1,15 @@
+language js(typescript)
+
+or {
+  `($value as unknown) as $outer`,
+  `($value as any) as $outer`,
+  `$value as unknown as $outer`,
+  `$value as any as $outer`
+} as $assertion where {
+  not $outer <: `const`,
+  register_diagnostic(
+    span = $assertion,
+    severity = "error",
+    message = "This assertion widens to unknown/any and then asserts a precise type. Parse untrusted input at its boundary."
+  )
+}

--- a/biome-plugins/no-widen-then-assert.grit
+++ b/biome-plugins/no-widen-then-assert.grit
@@ -7,9 +7,5 @@ or {
   `$value as any as $outer`
 } as $assertion where {
   not $outer <: `const`,
-  register_diagnostic(
-    span = $assertion,
-    severity = "error",
-    message = "This assertion widens to unknown/any and then asserts a precise type. Parse untrusted input at its boundary."
-  )
+  register_diagnostic(span=$assertion, severity="error", message="This assertion widens to unknown/any and then asserts a precise type. Parse untrusted input at its boundary.")
 }

--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,8 @@
   "vcs": {
     "enabled": true,
     "clientKind": "git",
-    "useIgnoreFile": true
+    "useIgnoreFile": true,
+    "defaultBranch": "origin/next"
   },
   "files": {
     "ignoreUnknown": false,
@@ -32,6 +33,22 @@
       "!packages/add-inbox/vitest.config.js"
     ]
   },
+  "plugins": [
+    "./biome-plugins/no-chained-type-assertions.grit",
+    "./biome-plugins/no-conditional-empty-object-spread.grit",
+    "./biome-plugins/no-known-value-widening.grit",
+    "./biome-plugins/no-module-mocking.grit",
+    "./biome-plugins/no-object-parameters.grit",
+    "./biome-plugins/no-reflect-apply.grit",
+    "./biome-plugins/no-reflect-get.grit",
+    "./biome-plugins/no-runtime-typeof.grit",
+    "./biome-plugins/no-shape-in-symbol-names.grit",
+    "./biome-plugins/no-unknown-parameters.grit",
+    "./biome-plugins/no-unknown-returns.grit",
+    "./biome-plugins/no-unknown-type-aliases.grit",
+    "./biome-plugins/no-unsafe-dictionary-type.grit",
+    "./biome-plugins/no-widen-then-assert.grit"
+  ],
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
@@ -62,7 +79,15 @@
         "useButtonType": "off"
       },
       "complexity": {
-        "noForEach": "warn"
+        "noBannedTypes": "error",
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            "maxAllowedComplexity": 20
+          }
+        },
+        "noForEach": "warn",
+        "noUselessTypeConstraint": "error"
       },
       "correctness": {
         "noEmptyCharacterClassInRegex": "warn",
@@ -78,6 +103,7 @@
         "noBlankTarget": "warn"
       },
       "style": {
+        "noNonNullAssertion": "error",
         "useArrayLiterals": "error",
         "useAsConstAssertion": "error",
         "noCommonJs": "warn",
@@ -107,7 +133,7 @@
         "noControlCharactersInRegex": "warn",
         "noDoubleEquals": "warn",
         "noDuplicateTestHooks": "warn",
-        "noExplicitAny": "warn",
+        "noExplicitAny": "error",
         "noExportsInTest": "warn",
         "noFallthroughSwitchClause": "warn",
         "noImplicitAnyLet": "warn",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "install:with-ee": "pnpm install && pnpm symlink:submodules",
     "jarvis": "node scripts/jarvis.js",
     "lint-staged": "lint-staged",
-    "lint": "nx run-many --target=lint --all --exclude=nextjs",
+    "lint": "biome lint --changed --since=origin/next --no-errors-on-unmatched",
     "lint:fix": "biome check --write .",
     "format": "biome format .",
     "format:fix": "biome format --write .",


### PR DESCRIPTION
## Summary
- Add local Biome Grit rules that reject low-evidence TypeScript patterns, plus cognitive complexity 20 (`error`).
- Commit hook and PR CI lint **changed files only** (`--staged` / `--changed --since` the PR base). Package-wide `nx lint` is no longer the PR gate.
- `pnpm lint` now means files vs `origin/next`. `pnpm check` is still the full-repo command and is not a CI gate.

Linear: https://linear.app/novu/issue/NV-8784/gate-biome-anti-slop-lint-on-changed-files

## New rules

Biome scans the **whole file** it opens. Commit and CI fail only on files you change.

### Grit (`biome-plugins/`)

| Rule | What it rejects |
|---|---|
| `no-chained-type-assertions` | Nested casts: `(x as A) as B` |
| `no-widen-then-assert` | `x as unknown as T` / `x as any as T` |
| `no-conditional-empty-object-spread` | `{ ...(cond ? {} : value) }` to hide a missing field |
| `no-known-value-widening` | `const x: unknown \| any \| object \| Record<…> = knownValue` |
| `no-module-mocking` | `vi.mock` / `jest.mock` (and `doMock` / `unstable_mockModule`) |
| `no-object-parameters` | `function foo(x: object)` (arrows and methods can miss) |
| `no-unknown-parameters` | `function foo(x: unknown)` (arrows and methods can miss) |
| `no-unknown-returns` | `: unknown` / `: Promise<unknown>` on a function or arrow |
| `no-unknown-type-aliases` | `type Foo = unknown` |
| `no-unsafe-dictionary-type` | `Record<string, unknown \| any \| object>` and the number/symbol/PropertyKey variants |
| `no-runtime-typeof` | Any `typeof` check |
| `no-reflect-get` | `Reflect.get(...)` |
| `no-reflect-apply` | `Reflect.apply(...)` |
| `no-shape-in-symbol-names` | A name that contains `shape` (`userShape`, `Shape`, …) |

### Native Biome (`error`)

| Rule | What it rejects |
|---|---|
| `noExcessiveCognitiveComplexity` | A function with complexity above **20** |
| `noBannedTypes` | Broad types such as `Function` / `{}` |
| `noUselessTypeConstraint` | `<T extends any>` / `<T extends unknown>` |
| `noNonNullAssertion` | `value!` |
| `noExplicitAny` | `any` (still **off** in `*.spec` / `*.test` / `*.e2e`) |
| `useAsConstAssertion` | `"active" as "active"` instead of `as const` |

### Not in this drop

| Rule | Why |
|---|---|
| `require-safety-comment-for-type-assertion` | Grit on Biome 2.2 cannot read comments |
| `noMisleadingReturnType` / `noUnsafeTypeAssertion` / `useReduceTypeParameter` | Need Biome `>=2.5.9` |
| `no-service-constructor-imports` | Effect only |

## Test plan
- [ ] Open a file that already has `any` / `typeof` / `vi.mock` and change one line. Confirm the commit hook fails on that file.
- [ ] Commit a change in a clean file. Confirm the hook and CI stay green.
- [ ] Confirm IDE squiggles still appear on untouched files when you open them.
- [ ] Confirm `pnpm check` still scans the whole repo and is not required for the PR to pass.

Made with [Cursor](https://cursor.com)







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces repository-local Biome anti-slop rules and changes local and CI linting to inspect files changed relative to the PR base.
- Registers Grit plugins and stricter native Biome diagnostics.
- Adds a dedicated changed-file lint job to PR workflows and removes redundant package-wide Nx lint targets.
- Updates lint-staged and the root lint script to use Git-aware staged or changed-file selection.
- The previously reported shallow-history failure is fixed by full-history checkout and explicit base-branch fetching.
- The chained-assertion rule now covers both parenthesized and ordinary assertion chains.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both previous findings addressed and no actionable new regressions established.

Full-history checkout and explicit base fetching resolve the shallow merge-base failure, while the chained-assertion matcher now covers both syntax forms identified previously. No remaining blocking or non-blocking findings were confirmed.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/on-pr.yml | Adds a required changed-file Biome job with complete Git history and removes Nx lint from package test jobs. |
| .github/workflows/contributor-checks.yml | Fetches full comparison history and replaces repository-wide linting with a PR-base changed-file Biome check. |
| .lintstagedrc.js | Runs one staged-aware Biome check for supported staged source and configuration files. |
| biome.json | Registers local Grit plugins, configures the default comparison branch, and promotes selected native rules to errors. |
| package.json | Redefines the root lint command as a Biome check of files changed from origin/next. |
| biome-plugins/no-chained-type-assertions.grit | Rejects both parenthesized and unparenthesized chained TypeScript assertions. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Change[Changed or staged files] --> Select{Execution context}
  Select -->|Commit hook| Staged[Biome check --staged]
  Select -->|Pull request| PRBase[Fetch PR base]
  Select -->|Local lint| NextBase[Compare with origin/next]
  PRBase --> CI[Biome ci --changed --since base]
  NextBase --> Lint[Biome lint --changed]
  Staged --> Rules[Native rules and Grit plugins]
  CI --> Rules
  Lint --> Rules
  Rules --> Gate{Error diagnostics?}
  Gate -->|Yes| Fail[Fail lint gate]
  Gate -->|No| Pass[Pass lint gate]
```

<sub>Reviews (4): Last reviewed commit: ["fix(root): format Grit plugins so biome ..."](https://github.com/novuhq/novu/commit/eb3c169de5074749a7d2f9ff3e4cec5df4c41011) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61220265)</sub>

**Context used:**

- Knowledge Base — [Local development and deployment](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/local-development-and-deployment.md)

<!-- /greptile_comment -->