### PR TITLE
fix(novu): stop scoping Slack Connect OAuth with agent context fixes NV-8785

### DIFF
--- a/packages/human/src/api/setup.spec.ts
+++ b/packages/human/src/api/setup.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { HumanApiClient } from './client';
+import { generateConnectOauthUrl } from './setup';
+
+function clientWith(axios: Record<string, ReturnType<typeof vi.fn>>): HumanApiClient {
+  return { axios } as unknown as HumanApiClient;
+}
+
+describe('generateConnectOauthUrl', () => {
+  it('requests a subscriber-scoped install without an agent context', async () => {
+    const post = vi.fn().mockResolvedValue({ data: { data: { url: 'https://slack.com/oauth/v2/authorize' } } });
+
+    const url = await generateConnectOauthUrl(clientWith({ post }), {
+      integrationIdentifier: 'slack-main',
+      agentIdentifier: 'my-agent',
+      subscriberId: 'user_1',
+    });
+
+    expect(url).toEqual('https://slack.com/oauth/v2/authorize');
+    // An `agent:<identifier>` context key would scope the resulting SLACK_USER endpoint,
+    // hiding it from every unscoped workflow trigger. Setup, invite, and link-channel
+    // all go through this helper.
+    expect(post).toHaveBeenCalledWith('/v1/integrations/channel-connections/oauth', {
+      integrationIdentifier: 'slack-main',
+      subscriberId: 'user_1',
+      connectionMode: 'subscriber',
+      autoLinkUser: true,
+    });
+  });
+});

--- a/packages/human/src/api/setup.ts
+++ b/packages/human/src/api/setup.ts
@@ -202,7 +202,6 @@ export async function generateConnectOauthUrl(
       subscriberId: input.subscriberId,
       connectionMode: 'subscriber',
       autoLinkUser: true,
-      context: { agent: input.agentIdentifier },
     }
   );
   const body = unwrap(res.data);

--- a/packages/novu/src/commands/connect/api/connect-oauth-url.spec.ts
+++ b/packages/novu/src/commands/connect/api/connect-oauth-url.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ConnectApiClient } from './client';
+import { generateConnectOauthUrl } from './integrations';
+
+function clientWith(axios: Record<string, ReturnType<typeof vi.fn>>): ConnectApiClient {
+  return { axios } as unknown as ConnectApiClient;
+}
+
+describe('generateConnectOauthUrl', () => {
+  it('requests a subscriber-scoped install without an agent context', async () => {
+    const post = vi.fn().mockResolvedValue({ data: { data: { url: 'https://slack.com/oauth/v2/authorize' } } });
+
+    const url = await generateConnectOauthUrl(clientWith({ post }), {
+      integrationIdentifier: 'slack-main',
+      agentIdentifier: 'my-agent',
+      subscriberId: 'user_1',
+    });
+
+    expect(url).toEqual('https://slack.com/oauth/v2/authorize');
+    // An `agent:<identifier>` context key would scope the resulting SLACK_USER endpoint,
+    // hiding it from every unscoped workflow trigger.
+    expect(post).toHaveBeenCalledWith('/v1/integrations/channel-connections/oauth', {
+      integrationIdentifier: 'slack-main',
+      subscriberId: 'user_1',
+      connectionMode: 'subscriber',
+      autoLinkUser: true,
+    });
+  });
+});

--- a/packages/novu/src/commands/connect/api/integrations.ts
+++ b/packages/novu/src/commands/connect/api/integrations.ts
@@ -300,9 +300,6 @@ export async function generateConnectOauthUrl(client: ConnectApiClient, input: C
       // oauth.v2.access response. That endpoint is what welcome-message
       // queries to know which Slack user to DM.
       autoLinkUser: true,
-      // Carry the agent identifier on the connection for observability /
-      // future scoping. Optional in subscriber mode.
-      context: { agent: input.agentIdentifier },
     }
   );
   const body = res.data;


### PR DESCRIPTION
### What changed? Why was the change needed?

Subscriber-mode Slack Connect OAuth (`generateConnectOauthUrl`) was sending `context: { agent: <agentIdentifier> }`. That stored an `agent:<identifier>` context key on the resulting `SLACK_USER` endpoint, so unscoped workflow triggers could not resolve the connected Slack user (welcome DMs, HITL replies).

Stop sending agent context on subscriber-mode OAuth in the CLI (`packages/novu`) and `@novu/human` so the endpoint stays unscoped.

Linear: [NV-8785](https://linear.app/novu/issue/NV-8785/stop-scoping-slack-connect-oauth-with-agent-context)

```mermaid
sequenceDiagram
  participant CLI as CLI / human skill
  participant API as Channel connections OAuth
  participant EP as SLACK_USER endpoint
  participant WF as Unscoped workflow trigger

  CLI->>API: POST oauth (subscriber mode, no agent context)
  API->>EP: Create endpoint without agent:<id> scope
  WF->>EP: Resolve Slack user
  EP-->>WF: Found
```

### Test plan

- [x] `pnpm --filter novu exec vitest run src/commands/connect/api/connect-oauth-url.spec.ts`
- [ ] Connect Slack via CLI / human skill for a subscriber
- [ ] Confirm the created endpoint is not agent-scoped
- [ ] Trigger an unscoped workflow and verify the Slack user is resolved (welcome DM / HITL)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A — no `enterprise/` changes.

### Special notes for your reviewer

`agentIdentifier` is still accepted by `generateConnectOauthUrl` for other call sites; it is no longer forwarded as OAuth `context`.

</details>

Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stops subscriber-mode Slack Connect OAuth requests from attaching agent context, allowing unscoped workflows to resolve the resulting Slack user endpoint.
- Removes `context.agent` from the OAuth payload in both the CLI and `@novu/human` implementations.
- Adds regression tests asserting that both implementations send subscriber-scoped OAuth requests without agent context.
- The test added since the previous review fully addresses the earlier missing-coverage finding for `packages/human`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because both OAuth implementations now produce the intended unscoped payload and have matching regression coverage.

No actionable new defects remain, and the previously reported missing regression coverage for the `packages/human` OAuth helper has been fully added.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/human/src/api/setup.ts | Removes agent context from subscriber-mode OAuth requests so generated Slack user endpoints remain unscoped. |
| packages/human/src/api/setup.spec.ts | Adds regression coverage for the human setup, invite, and link-channel helper’s context-free OAuth payload. |
| packages/novu/src/commands/connect/api/integrations.ts | Removes agent context from the CLI’s subscriber-mode Slack Connect OAuth request. |
| packages/novu/src/commands/connect/api/connect-oauth-url.spec.ts | Verifies the CLI OAuth request retains subscriber connection fields while omitting agent context. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Client as CLI / @novu/human
  participant OAuth as Channel Connections OAuth
  participant Endpoint as SLACK_USER endpoint
  participant Workflow as Unscoped workflow

  Client->>OAuth: Request subscriber connection without agent context
  OAuth->>Endpoint: Create unscoped Slack user endpoint
  Workflow->>Endpoint: Resolve subscriber
  Endpoint-->>Workflow: Slack user found
```

<sub>Reviews (2): Last reviewed commit: ["Add test for generateConnectOauthUrl"](https://github.com/novuhq/novu/commit/f660f215679401746da69ee5268b903e96ffb4ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61264034)</sub>

<!-- /greptile_comment -->