### PR TITLE
chore(root): relax Biome anti-slop rules that reject valid TypeScript fixes NV-8788

### DIFF
--- a/biome-plugins/no-known-value-widening.grit
+++ b/biome-plugins/no-known-value-widening.grit
@@ -3,9 +3,7 @@ language js(typescript)
 or {
   `const $name: unknown = $value`,
   `const $name: any = $value`,
-  `const $name: object = $value`,
-  `const $name: Record<$key, unknown> = $value`,
-  `const $name: Record<$key, any> = $value`
+  `const $name: object = $value`
 } as $binding where {
   register_diagnostic(span=$binding, message="This explicit broad type can discard known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.", severity="error")
 }

--- a/biome-plugins/no-runtime-typeof.grit
+++ b/biome-plugins/no-runtime-typeof.grit
@@ -1,5 +1,0 @@
-language js(typescript)
-
-`typeof $value` as $check where {
-  register_diagnostic(span=$check, message="A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.", severity="error")
-}

--- a/biome-plugins/no-unsafe-dictionary-type.grit
+++ b/biome-plugins/no-unsafe-dictionary-type.grit
@@ -1,10 +1,6 @@
 language js(typescript)
 
 or {
-  `Record<string, unknown>`,
-  `Record<number, unknown>`,
-  `Record<symbol, unknown>`,
-  `Record<PropertyKey, unknown>`,
   `Record<string, any>`,
   `Record<number, any>`,
   `Record<symbol, any>`,

--- a/biome.json
+++ b/biome.json
@@ -37,11 +37,9 @@
     "./biome-plugins/no-chained-type-assertions.grit",
     "./biome-plugins/no-conditional-empty-object-spread.grit",
     "./biome-plugins/no-known-value-widening.grit",
-    "./biome-plugins/no-module-mocking.grit",
     "./biome-plugins/no-object-parameters.grit",
     "./biome-plugins/no-reflect-apply.grit",
     "./biome-plugins/no-reflect-get.grit",
-    "./biome-plugins/no-runtime-typeof.grit",
     "./biome-plugins/no-shape-in-symbol-names.grit",
     "./biome-plugins/no-unknown-parameters.grit",
     "./biome-plugins/no-unknown-returns.grit",
@@ -419,6 +417,10 @@
           }
         }
       }
+    },
+    {
+      "includes": ["**/*.{ts,tsx,js,jsx}", "!**/*.test.{ts,tsx,js}", "!**/*.spec.{ts,tsx,js}", "!**/*.e2e.{ts,js}"],
+      "plugins": ["./biome-plugins/no-module-mocking.grit"]
     },
     {
       "includes": [


### PR DESCRIPTION
## Summary
- Drop `no-runtime-typeof`. `typeof x === 'string'` is a correct discriminant; the workaround is weaker.
- Narrow `no-unsafe-dictionary-type` to `Record<*, any | object>` so `Record<string, unknown>` stays legal for unparsed maps.
- Drop the `Record<…>` arms from `no-known-value-widening` so it stays consistent.
- Scope `no-module-mocking` to non-test files (same split as `noExplicitAny`). `vi.mock` in specs no longer fails CI on first touch.

The rest of the NV-8784 set stays (`as unknown as`, `object` / `unknown` params, Reflect, naming, empty-object spread, stock `noNonNullAssertion` / `noExplicitAny`).

## Test plan
- [x] `typeof value === 'string'` no longer fails Biome
- [x] `Record<string, unknown>` no longer fails; `Record<string, any>` and `Record<string, object>` still do
- [x] `const x: unknown = 'x'` still fails; `const x: Record<string, unknown> = { a: 1 }` does not
- [x] `vi.mock` fails in a production `.ts` file and does not fail in `*.spec.ts`


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes several custom Biome diagnostics that reject valid TypeScript patterns:
- Allows runtime `typeof` checks and `Record<..., unknown>`.
- Keeps unsafe dictionary diagnostics for `Record<..., any | object>`.
- Restricts module-mocking diagnostics to production files, with a small JSX test-glob coverage gap.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after considering a non-blocking test-file glob gap affecting future JSX tests.

The rule relaxations remain internally consistent, but `*.test.jsx` and `*.spec.jsx` files can still receive production-only module-mocking diagnostics.

**Files Needing Attention:** biome.json

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| biome.json | Moves module-mocking enforcement into a non-test override, but omits JSX test/spec files from its exclusions. |
| biome-plugins/no-known-value-widening.grit | Removes redundant Record-specific widening patterns while retaining broad explicit variable-type checks. |
| biome-plugins/no-unsafe-dictionary-type.grit | Allows unknown-valued dictionaries while continuing to reject any- and object-valued dictionaries. |
| biome-plugins/no-runtime-typeof.grit | Deletes the global diagnostic that rejected every runtime typeof expression. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312605%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12605&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Abiome.json%3A422%0A**JSX%20Tests%20Remain%20Included**%0A%0AThe%20override%20covers%20JSX%20files%20but%20does%20not%20exclude%20%60*.test.jsx%60%20or%20%60*.spec.jsx%60.%20Those%20are%20valid%20test%20filenames%2C%20so%20adding%20a%20module%20mock%20to%20one%20will%20still%20trigger%20%60no-module-mocking%60%2C%20contrary%20to%20the%20test-file%20exemption%20introduced%20here.%20Include%20%60jsx%60%20in%20both%20exclusion%20groups.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%22includes%22%3A%20%5B%22**%2F*.%7Bts%2Ctsx%2Cjs%2Cjsx%7D%22%2C%20%22!**%2F*.test.%7Bts%2Ctsx%2Cjs%2Cjsx%7D%22%2C%20%22!**%2F*.spec.%7Bts%2Ctsx%2Cjs%2Cjsx%7D%22%2C%20%22!**%2F*.e2e.%7Bts%2Cjs%7D%22%5D%2C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12605&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
biome.json:422
**JSX Tests Remain Included**

The override covers JSX files but does not exclude `*.test.jsx` or `*.spec.jsx`. Those are valid test filenames, so adding a module mock to one will still trigger `no-module-mocking`, contrary to the test-file exemption introduced here. Include `jsx` in both exclusion groups.

```suggestion
      "includes": ["**/*.{ts,tsx,js,jsx}", "!**/*.test.{ts,tsx,js,jsx}", "!**/*.spec.{ts,tsx,js,jsx}", "!**/*.e2e.{ts,js}"],
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(root): relax Biome anti-slop rules..."](https://github.com/novuhq/novu/commit/b7cde70939e09ef9fb3d9c239c88177f809a0d30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61585246)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->