### PR TITLE
refactor(framework,api-service): remove biome-ignore-all from AgentEvent transport files fixes NV-8789

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.spec.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint: pre-existing test helper typing; NV-8557 asserts eventsUrl is always set
 import { AgentEventEnum } from '@novu/framework/internal';
 import { expect } from 'chai';
 import sinon from 'sinon';

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint: pre-existing anti-slop in history mapping; NV-8557 always advertises eventsUrl
 import { isIP } from 'node:net';
 import { Injectable } from '@nestjs/common';
 import {

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint: pre-existing anti-slop in this module; NV-8557 only removes LegacyPostTransport
 import type { AgentEvent, AgentFileRef, AgentMessageContent, AgentRunOutcome } from '@novu/agent-event-protocol';
 import type { CardElement, ChatElement, Emoji } from 'chat';
 import { type AgentRuntimeContext, RUNTIME_CONTEXT_BRAND } from './agent.runtime';
@@ -19,13 +18,16 @@ import type {
   AgentToolCall,
   DeleteMessagePayload,
   FileRef,
+  HumanApproveRenderArgs,
   HumanApproveRenderFn,
   HumanAskApproveOptions,
   HumanAskApproveRenderOptions,
   HumanAskOptions,
+  HumanAskRenderArgs,
   HumanAskRenderFn,
   HumanAskRenderOptions,
   HumanChooseOptions,
+  HumanChooseRenderArgs,
   HumanChooseRenderFn,
   HumanChooseRenderOptions,
   HumanChrome,
@@ -33,6 +35,7 @@ import type {
   HumanOptionInput,
   HumanSignalCard,
   HumanTellOptions,
+  HumanTellRenderArgs,
   HumanTellRenderFn,
   HumanTellRenderOptions,
   MessageContent,
@@ -74,12 +77,19 @@ type HumanQueuedOpts = {
 
 type HumanRenderFn = HumanAskRenderFn | HumanApproveRenderFn | HumanChooseRenderFn | HumanTellRenderFn;
 
-function humanChromeFactory(type: HumanChrome['type']) {
-  return (overrides?: Record<string, unknown>) => ({ type, ...overrides });
+type HumanRenderArg = HumanAskRenderArgs | HumanApproveRenderArgs | HumanChooseRenderArgs | HumanTellRenderArgs;
+
+function humanChromeFactory<T extends HumanChrome['type']>(type: T) {
+  return (overrides?: Omit<Extract<HumanChrome, { type: T }>, 'type'>) =>
+    ({ type, ...overrides }) as Extract<HumanChrome, { type: T }>;
 }
 
 /** Per-kind render context (`*Card()` factory + minted `actionIds`) passed to a `{ render }` fn. */
-function buildHumanRenderArg(kind: HumanInteractionKind, requestId: string): Record<string, unknown> {
+function buildHumanRenderArg(kind: 'ask', requestId: string): HumanAskRenderArgs;
+function buildHumanRenderArg(kind: 'approve', requestId: string): HumanApproveRenderArgs;
+function buildHumanRenderArg(kind: 'choose', requestId: string): HumanChooseRenderArgs;
+function buildHumanRenderArg(kind: 'tell', requestId: string): HumanTellRenderArgs;
+function buildHumanRenderArg(kind: HumanInteractionKind, requestId: string): HumanRenderArg {
   switch (kind) {
     case 'ask':
       return { requestId, askCard: humanChromeFactory('human-ask-card') };
@@ -489,7 +499,7 @@ export class AgentContextImpl implements AgentRuntimeContext {
   }
 
   asMessageContext(): AgentMessageContext {
-    return this as unknown as AgentMessageContext;
+    return this as AgentMessageContext;
   }
 
   async reply(content: MessageContent, options?: { files?: FileRef[] }): Promise<ReplyHandle> {
@@ -660,10 +670,7 @@ export class AgentContextImpl implements AgentRuntimeContext {
   private queueRendered(kind: HumanInteractionKind, opts: HumanQueuedOpts | undefined, render: HumanRenderFn): string {
     const requestId = mint('hr');
     this._pendingHumanRenders.push(async () => {
-      const invoke = render as unknown as (
-        arg: Record<string, unknown>
-      ) => HumanChrome | ChatElement | Promise<HumanChrome | ChatElement>;
-      const rendered = await invoke(buildHumanRenderArg(kind, requestId));
+      const rendered = await this.invokeHumanRender(kind, requestId, render);
       if (isHumanChrome(rendered)) {
         this.pushRenderedChrome(kind, requestId, rendered, opts);
 
@@ -674,6 +681,28 @@ export class AgentContextImpl implements AgentRuntimeContext {
     });
 
     return requestId;
+  }
+
+  private invokeHumanRender(
+    kind: HumanInteractionKind,
+    requestId: string,
+    render: HumanRenderFn
+  ): Promise<HumanChrome | ChatElement> {
+    switch (kind) {
+      case 'ask':
+        return Promise.resolve((render as HumanAskRenderFn)(buildHumanRenderArg('ask', requestId)));
+      case 'approve':
+        return Promise.resolve((render as HumanApproveRenderFn)(buildHumanRenderArg('approve', requestId)));
+      case 'choose':
+        return Promise.resolve((render as HumanChooseRenderFn)(buildHumanRenderArg('choose', requestId)));
+      case 'tell':
+        return Promise.resolve((render as HumanTellRenderFn)(buildHumanRenderArg('tell', requestId)));
+      default: {
+        const exhaustive: never = kind;
+
+        return Promise.resolve(exhaustive);
+      }
+    }
   }
 
   private pushRenderedChrome(

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint: pre-existing anti-slop in this suite; NV-8557 retargets posts to ingest
 import { jsx } from 'chat/jsx-runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -16,18 +15,41 @@ import { buildApprovalActionId } from './tool-approval/action-id';
 
 const EVENTS_URL = 'https://api.novu.co/v1/agents/events/ingest';
 
-type WireEvent = { type: string; [key: string]: any };
+type WireEvent = { type: string; [key: string]: unknown };
 type IngestBatch = { events?: Array<{ conversationId?: string; event: WireEvent }> };
 
-function ingestBatchesFromFetch(fetchMock: { mock: { calls: any[] } }): IngestBatch[] {
+type ProjectedIngestBody = {
+  conversationId?: string;
+  reply?: {
+    markdown?: string;
+    card?: unknown;
+    files?: unknown;
+    toolApprovalCard?: { type: 'tool-approval-card' };
+  };
+  toolApprovalRequest?: {
+    approvalId?: unknown;
+    toolCallId?: unknown;
+    name?: unknown;
+    input?: unknown;
+  };
+  signals?: unknown[];
+  edit?: { messageId?: unknown; content?: unknown };
+  deleteMessages?: Array<{ messageId: string }>;
+  addReactions?: Array<{ messageId: string; emojiName?: unknown }>;
+  typing?: 'stop' | { status?: unknown } | Record<string, never>;
+  error?: boolean;
+  resolve?: { summary?: unknown };
+};
+
+function ingestBatchesFromFetch(fetchMock: { mock: { calls: unknown[] } }): IngestBatch[] {
   return fetchMock.mock.calls
-    .filter((call: any[]) => call[0] === EVENTS_URL)
-    .map(([, init]: any[]) => JSON.parse(init.body) as IngestBatch);
+    .filter((call): call is [string, { body: string }] => Array.isArray(call) && call[0] === EVENTS_URL)
+    .map(([, init]) => JSON.parse(init.body) as IngestBatch);
 }
 
-function projectIngestBatch(batch: IngestBatch): Record<string, any> {
+function projectIngestBatch(batch: IngestBatch): ProjectedIngestBody {
   const events = batch.events ?? [];
-  const body: Record<string, any> = {};
+  const body: ProjectedIngestBody = {};
 
   if (events[0]?.conversationId) {
     body.conversationId = events[0].conversationId;
@@ -98,11 +120,11 @@ function projectIngestBatch(batch: IngestBatch): Record<string, any> {
   return body;
 }
 
-function asReplyBodiesFromFetch(fetchMock: { mock: { calls: any[] } }): Array<Record<string, any>> {
+function asReplyBodiesFromFetch(fetchMock: { mock: { calls: unknown[] } }): ProjectedIngestBody[] {
   return ingestBatchesFromFetch(fetchMock).map(projectIngestBatch);
 }
 
-function asReplyBodiesFromPosts(posts: Array<Record<string, unknown>>): Array<Record<string, any>> {
+function asReplyBodiesFromPosts(posts: Array<Record<string, unknown>>): ProjectedIngestBody[] {
   return posts.map((body) => projectIngestBatch(body as IngestBatch));
 }
 
@@ -214,11 +236,14 @@ describe('agent dispatch via NovuRequestHandler', () => {
       (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/events/ingest'
     );
     expect(replyCall).toBeDefined();
+    if (!replyCall) {
+      throw new Error('expected ingest fetch call');
+    }
     const replyBody = asReplyBodiesFromFetch(fetchMock)[0];
-    expect(replyBody.reply.markdown).toBe('Echo: Hello bot!');
+    expect(replyBody.reply?.markdown).toBe('Echo: Hello bot!');
     expect(replyBody.conversationId).toBe('conv-456');
 
-    const replyHeaders = replyCall![1].headers;
+    const replyHeaders = replyCall[1].headers;
     expect(replyHeaders.Authorization).toBe('ApiKey test-secret-key');
   });
 
@@ -594,8 +619,8 @@ describe('agent dispatch via NovuRequestHandler', () => {
   it('should reject object-form HITL helpers without card.title', () => {
     const ctx = new AgentContextImpl(createMockBridgeRequest(), 'test-secret-key');
 
-    expect(() => ctx.approve({ card: { subtitle: 'no title' } as unknown as { title: string } })).toThrow('card.title');
-    expect(() => ctx.ask({ card: { body: 'no title' } as unknown as { title: string } })).toThrow('card.title');
+    expect(() => ctx.approve({ card: { subtitle: 'no title' } as { title: string } })).toThrow('card.title');
+    expect(() => ctx.ask({ card: { body: 'no title' } as { title: string } })).toThrow('card.title');
   });
 
   it('should queue renderApprove chrome with requestId action identifiers', async () => {
@@ -1738,7 +1763,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
 
     expect(getResult).toBe(42);
-    expect(currentSnapshot!).toEqual({});
+    expect(currentSnapshot).toEqual({});
   });
 
   it('should dispatch onAction event with action data on ctx', async () => {
@@ -2486,7 +2511,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
   });
 
   it('should log delivery errors without leaking the response body', async () => {
-    const longBody = '<!DOCTYPE html>' + '<p>error</p>'.repeat(500);
+    const longBody = `<!DOCTYPE html>${'<p>error</p>'.repeat(500)}`;
     fetchMock.mockResolvedValue({ ok: false, status: 502, text: () => Promise.resolve(longBody) });
 
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -3141,7 +3166,10 @@ describe('tool approval', () => {
       p.deleteMessages?.some((d: { messageId: string }) => d.messageId === 'm_prev')
     );
     expect(deletePost).toBeTruthy();
-    expect(replyBodies.indexOf(deletePost!)).toBe(1);
+    if (!deletePost) {
+      throw new Error('expected delete post');
+    }
+    expect(replyBodies.indexOf(deletePost)).toBe(1);
     expect(replyBodies.find((p) => p.edit?.messageId === 'm_prev')).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

- Removes all four `biome-ignore-all` suppressions from #12606 (NV-8557) in `agent.context.ts`, `agent.test.ts`, `bridge-executor.service.ts`, and `bridge-executor.service.spec.ts`
- Replaces `as unknown as` human-render dispatch with typed overloads + per-kind `invokeHumanRender` switch
- Adds `ProjectedIngestBody` test helper type; fixes non-null assertions and template literal lint in `agent.test.ts`

**No Biome rule changes in this PR.** NV-8788 (#12605) already landed on `next`. After #12606 merges, rebase this branch onto `next` so CI picks up those relaxed rules.

## Test plan

- [x] `pnpm exec biome check` passes on all four files with `next`'s Biome config (NV-8788)
- [ ] Merge after #12606 lands, then rebase onto `next`





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes file-wide Biome suppressions from the AgentEvent transport files while preserving existing behavior.
- Replaces the human-render double cast with typed render arguments and per-interaction dispatch.
- Strengthens test helper types and removes lint-triggering assertions and string construction.
- Removes the suppressions from the bridge executor implementation and tests without changing runtime behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no new actionable issues introduced since the previous review.

The current changes preserve human-render runtime behavior while improving static typing, and there are no changes since the previous review or outstanding rule violations affecting merge safety.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/framework/src/resources/agent/agent.context.ts | Introduces typed human-render argument factories and kind-specific invocation while preserving the existing dispatch flow. |
| packages/framework/src/resources/agent/agent.test.ts | Tightens ingest test helper types and replaces lint-suppressed assertions with explicit guards and optional access. |
| apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts | Removes the file-wide Biome suppression without changing service logic. |
| apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.spec.ts | Removes the file-wide Biome suppression without changing test behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(framework,api-service): remove ..."](https://github.com/novuhq/novu/commit/67e40a56f1d4a8cbd2b2630585597bfb79bc9b13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61761016)</sub>

<!-- /greptile_comment -->