### PR TITLE
fix(api): return 200 from set-primary to match its documented response

### DIFF
--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -403,6 +403,7 @@ export class IntegrationsController {
   }
 
   @Post('/:integrationId/set-primary')
+  @HttpCode(HttpStatus.OK)
   @OAuthAccessible()
   @ApiResponse(IntegrationResponseDto)
   @ApiNotFoundResponse({


### PR DESCRIPTION
Refs novuhq/novu-ts#125

## Problem

`POST /v1/integrations/:integrationId/set-primary` documents a 200 (`@ApiResponse`) but has no `@HttpCode` override, so Nest returns its POST default **201** on the wire. SDKs generated from the spec (novu-ts) accept only 200 for `integrations.setAsPrimary` and throw `SDKError` on a successful write. Five sibling routes in this same controller already carry `@HttpCode(HttpStatus.OK)`; this one missed the convention.

## Fix

Add `@HttpCode(HttpStatus.OK)` to `setIntegrationAsPrimary`. The spec stays at 200 - changing the spec to 201 would break every current SDK.

## Note

The same reporter also saw `integrations.update()` throw on success with a 201. Nest's PUT default is 200, so that 201 likely comes from a layer outside this OSS controller (EE/proxy) - flagged, not fixed here.

> Built by breken, your AI support engineer - breken.ai - this one's on us.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the successful response from the set-primary integration endpoint with its documented API contract.
- Adds an explicit `HttpStatus.OK` response code to avoid NestJS’s default HTTP 201 for POST routes.
- Preserves the existing response body and error behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and correctly aligns the endpoint’s runtime status with its documented HTTP 200 response.

The decorator and status enum are already imported, the handler has no competing manual status handling, and the same response-code pattern is used by sibling controller routes.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/integrations/integrations.controller.ts | Adds the established `@HttpCode(HttpStatus.OK)` decorator to the set-primary endpoint with no issues identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): return 200 from set-primary to..."](https://github.com/novuhq/novu/commit/363e996055d9656b7f206f0afe1b6b89c1424e73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61930813)</sub>

<!-- /greptile_comment -->