### PR TITLE
docs(root): usage threshold alerts handover plan

### DIFF
--- a/docs/agents/plans/usage-threshold-alerts.md
+++ b/docs/agents/plans/usage-threshold-alerts.md
@@ -1,0 +1,299 @@
+# Handover: 75% / 90% usage threshold alerts
+
+**Status:** plan only — do not treat this file as implemented.  
+**Audience:** local setup agent implementing the feature.  
+**Base branch:** `next`  
+**Canonical path:** `docs/agents/plans/usage-threshold-alerts.md`  
+**Repos:** `novuhq/novu` (this file + `libs/notifications` + dashboard) and `novuhq/packages-enterprise` (billing producer).
+
+## Local agent: start here
+
+1. Read this entire file before writing code.
+2. Read `.cursor/skills/enterprise-submodule/SKILL.md` before touching `enterprise/` or `.source/`.
+3. Create a Linear ticket (`NV-XXXX`) and use it on both branch names and PR titles (`fixes NV-XXXX`).
+4. Implement **v1 only** (scope below). Do not invent a new usage pipeline, Redis dedup store, or cron.
+5. When done, follow `.cursor/skills/novu-prepare-pr/SKILL.md` and open **two** PRs (monorepo + enterprise), cross-linked.
+
+Paste this as the implementation prompt if needed:
+
+> Implement v1 of `docs/agents/plans/usage-threshold-alerts.md`. Novu is the transport. Billing only triggers `usageLimitsWorkflow`. Dedup via `step.throttle`, not Redis in billing. Dual-repo EE workflow. Do not add a new usage scan cron.
+
+---
+
+## Product (locked)
+
+When an organization uses **75%** of included monthly **workflow runs / events**, send a usage alert. When they use **90%**, send a second, stronger alert.
+
+- Metric: `subscription.events.current / subscription.events.included` (same unit as billing).
+- Not in v1: subscribers, agents, conversations, LLM tokens, API RPS.
+- Recipients (v1): org owner via existing `GetOrganizationOwnerUser` (same as today’s Stripe alert handler).
+- Channels: **email + in-app** through Novu (`usageLimitsWorkflow`).
+- Cadence: **at most once per threshold per billing period per recipient**.
+- If usage jumps from below 75% to ≥90% in one check: **trigger only `threshold: 90`** (do not also send 75%).
+- If 75% ≤ usage < 90%: trigger `threshold: 75` only.
+- FREE copy may say notifications block at 100%. Paid copy must **not** say that (pay-as-you-grow).
+- Community / self-hosted enterprise (`events.included === null`): **never trigger**.
+
+---
+
+## Architecture (locked)
+
+Billing is a **dumb producer**. Novu is the **transport and policy layer**.
+
+```mermaid
+flowchart TB
+  subgraph calculate [When usage is known]
+    Hourly[Hourly CREATE_BILLING_USAGE_RECORDS] --> Stripe[Stripe meter SET]
+    Stripe --> WH[billing.alert.triggered]
+    QT[QuotaThrottlerInterceptor FREE/trial] --> Producer
+    WH --> Producer[Fix AlertTriggeredHandler]
+  end
+  subgraph novu [Novu - libs/notifications]
+    Producer --> Trigger["usageLimitsWorkflow.trigger"]
+    Trigger --> Throttle["step.throttle dynamic until currentPeriodEnd"]
+    Throttle -->|granted| Email[step.email]
+    Throttle -->|granted| InApp[step.inApp redirect billing]
+    Throttle -->|not granted| Drop[children skipped]
+  end
+```
+
+### When to calculate (do not change this)
+
+| Source | When | Why |
+|---|---|---|
+| **Primary** | Stripe `billing.alert.triggered` after hourly `CreateUsageRecords` | Period meter already exists; zero extra aggregation |
+| **Secondary** | `QuotaThrottlerInterceptor` on FREE/trial event triggers | Burst orgs can hit 100% inside the hourly lag; interceptor already has `remaining` / `limit` |
+| **Forbidden** | New all-org cron, per-trigger `GetSubscription` for paid tiers, dashboard GET as the only sender | Extra ClickHouse/Mongo/Stripe load or missed idle orgs |
+
+`CreateUsageRecords` usage window is **UTC day → last completed hour**, not the Stripe billing period. Do **not** compute 75/90 from that range. Use Stripe alert `data.value` + `GetSubscription.events.included`, or `events.current` / `events.included` on the quota path.
+
+### Why throttle, not digest, not billing Redis
+
+- Today `usage-limits` uses a **5-minute digest** (batches then sends). Wrong: we need **send once, drop the rest**.
+- `step.throttle` with `threshold: 1` skips the rest of the workflow (`handleThrottleSkip`).
+- Dynamic window: `dynamicKey: 'payload.currentPeriodEnd'` (ISO-8601). Worker parses this to `targetTime - now` in `add-job.usecase.ts` `parseDynamicDurationValue`.
+- `throttleKey` from `payload.threshold` (`75` vs `90`) so the two alerts do not share a slot.
+- Redis key is already per `subscriberId` + workflow + step + throttleKey. Each owner gets one 75 and one 90 without a billing `SETNX`.
+- Do **not** add `usage-alert:{org}:{period}:{threshold}` in billing.
+
+### Launch constraint (throttle window tier)
+
+Dynamic throttle until period end can be **~31 days**. Tier cap `PLATFORM_MAX_THROTTLE_WINDOW_TIME` is 7 days on Business and unlimited on Enterprise. The **internal Novu org** that owns the `/bridge/novu` workflows must allow a period-length window (Enterprise, or `MAX_THROTTLE_WINDOW_DURATION_IN_MS_NUMBER` override on that environment). If the window is over the cap, the step **fails** (`DEFER_DURATION_LIMIT_EXCEEDED`) and nobody is emailed. Verify this before enabling the flag in production.
+
+---
+
+## What already exists (reuse)
+
+| Piece | Path |
+|---|---|
+| Workflow + email | `libs/notifications/src/workflows/usage-limits/` |
+| Bridge registration | `apps/api/src/app.module.ts` (`NovuModule.register`, `NOVU_INTERNAL_SECRET_KEY`) |
+| Stripe webhook routing | `enterprise/packages/billing/src/usecases/stripe-webhook/stripe-webhook.usecase.ts` → `AlertTriggeredHandler` |
+| Broken producer | `enterprise/packages/billing/src/stripe/handlers/alert.triggered.handler.ts` (hardcoded `freeTierLimit = 10_000`) |
+| Flag | `FeatureFlagsKeysEnum.IS_USAGE_ALERTS_ENABLED` (default **false**) |
+| Event: `billing.alert.triggered` | `enterprise/packages/billing/src/stripe/types.ts` |
+| Hourly meter cron | `enterprise/packages/billing/src/services/billing-usage-cron.service.ts` |
+| Period usage | `GetSubscription` + `GetPlatformNotificationUsage` (usage cache 1h, subscription cache 24h) |
+| FREE quota path | `enterprise/packages/billing/src/guards/quota-throttler.guard.ts` (analytics at ≤10% remaining; **no email**) |
+| Owner lookup | `GetOrganizationOwnerUser` |
+| Quiet-hours delay pattern (v1 optional / v2) | `libs/notifications/src/workflows/usage-report/usage-report.workflow.ts` |
+| Dashboard widget | `apps/dashboard/src/components/side-navigation/usage-card.tsx` (red at **≥80%** today) |
+
+EE sources are **symlinked**: `enterprise/packages/billing/src` → `.source/billing/src`. Edit via the submodule workflow, not by treating `enterprise/` as a normal folder.
+
+---
+
+## v1 scope (implement this)
+
+1. **Workflow** (`libs/notifications`): replace digest with throttle; extend payload; fix email copy; in-app redirect to billing.
+2. **Producer** (EE billing): fix `AlertTriggeredHandler` math; snap to 75 or 90; pass `currentPeriodEnd` and related payload; keep flag gate.
+3. **FREE burst**: in `QuotaThrottlerInterceptor`, when used% crosses 75 or 90, `usageLimitsWorkflow.trigger` with the same payload shape. No local dedup.
+4. **Dashboard**: align `UsageCard` visual thresholds with 75 (warning) and 90 (error). Do not invent new components.
+5. **Tests** for handler percentage/snapping, workflow payload schema, throttler trigger conditions (unit; EE e2e if an existing billing e2e file is the natural home).
+
+## Out of scope (v2 — do not build unless asked)
+
+- Billing topics (`org:{id}:billing`) for multi-admin fan-out.
+- Subscriber preferences / mute 75 but not 90.
+- Quiet-hours `step.delay` (usage-report `_nvDelayDuration` pattern) — allowed as a small follow-up, not required for v1.
+- New Pulse cron that scans all orgs.
+- Conversation/agent/LLM usage emails.
+- Changing Stripe Dashboard alert configuration in code (ops: configure 75% and 90% on the metered price; document in the PR).
+- `libs/internal-sdk` edits.
+
+---
+
+## Implementation steps
+
+### A. Monorepo — `usageLimitsWorkflow`
+
+File: `libs/notifications/src/workflows/usage-limits/usage-limits.workflow.ts`
+
+- Remove `step.digest`.
+- Add `step.throttle('once-per-period', ...)` **before** channel steps:
+
+```ts
+await step.throttle('once-per-period', async () => ({
+  type: 'dynamic' as const,
+  dynamicKey: 'payload.currentPeriodEnd',
+  threshold: 1,
+  throttleKey: String(payload.threshold),
+}));
+```
+
+- Extend `payloadSchema` (zod). Suggested fields:
+
+  - `percentage: number`
+  - `threshold: 75 | 90`
+  - `organizationName: string`
+  - `currentPeriodEnd: string` (ISO-8601, required for dynamic throttle)
+  - `current: number`
+  - `included: number`
+  - `apiServiceLevel: string` (or enum string)
+  - keep `organizationName`
+
+- Email + in-app copy uses `threshold` / `percentage` / `included`. In-app: billing redirect (`https://dashboard.novu.co/settings/billing` or existing dashboard billing route used in `usage-limits/email.tsx`).
+- File: `libs/notifications/src/workflows/usage-limits/email.tsx` — delete hardcoded “30,000” and unconditional “blocked at 100%”. Mention hard block only when `apiServiceLevel` is FREE.
+- Follow repo conventions: named exports, `type` on frontend email props if you touch TS types there, blank line before `return`.
+- After `libs/notifications` changes: `pnpm build` (package change).
+
+Throttle API reference: `packages/framework/src/schemas/steps/actions/throttle.schema.ts` and `packages/novu/src/commands/step/templates/step-file.ts` (`generateThrottleStepFile`).
+
+### B. Enterprise — `AlertTriggeredHandler`
+
+File: `.source/billing/src/stripe/handlers/alert.triggered.handler.ts` (same as `enterprise/packages/billing/...`).
+
+Today:
+
+```ts
+const freeTierLimit = 10_000;
+const usedPercentage = Math.round((data.value / freeTierLimit) * 100);
+```
+
+Change:
+
+1. Inject / call `GetSubscription` for the org (already used everywhere for included events).
+2. If `events.included` is null or 0, return.
+3. `rawPercentage = (data.value / included) * 100`.
+4. Snap: `>= 90` → trigger once with `threshold: 90`; `>= 75` → `threshold: 75`; else return (Stripe may fire other thresholds).
+5. Payload must include `currentPeriodEnd` from subscription (ISO string).
+6. Keep `IS_USAGE_ALERTS_ENABLED` (default false). If off, keep the existing log-only path but log the **corrected** payload.
+7. `to`: same owner subscriber as today (`GetOrganizationOwnerUser` + customer email).
+
+Stripe alerts must be configured in Stripe for 75% and 90% of included events per metered price. Code cannot assume 10k.
+
+### C. Enterprise — FREE/trial quota path
+
+File: `.source/billing/src/guards/quota-throttler.guard.ts`
+
+- After `percentageRemaining` is known, compute used% = `100 - percentageRemaining` (watch divide-by-zero / `limit === 0`).
+- If used% ≥ 75 (snap same as handler) **and** `IS_USAGE_ALERTS_ENABLED`, trigger `usageLimitsWorkflow` with the same payload fields.
+- Need org name, period end, included, current: `GetEventResourceUsage` already has limit/remaining/reset/start. You may need a light org fetch for `name` if not already loaded (`findById` already loads `apiServiceLevel`).
+- Do **not** await a slow extra usage query. Do **not** add Redis dedup.
+- Keep existing analytics at ≤10% remaining.
+- Do not send if `IS_DOCKER_HOSTED` / existing interceptor early-returns.
+- Failure to trigger must not fail the customer request (log and continue), same spirit as trigger-base cache incr.
+
+If `GetSubscription` is too heavy to call from the interceptor just for `currentPeriodEnd`, pass ISO from `resourceUsageDto.reset` (already period end ms) — that is enough for the throttle window.
+
+### D. Dashboard
+
+File: `apps/dashboard/src/components/side-navigation/usage-card.tsx`
+
+- Align `getUsageStatus`: warning at ≥75%, error at ≥90% (or error at ≥75% if `Progress` only has default/error — then use `warning` at 75 and `error` at 90; `UsageStatus` already has `progressVariant: 'error' | 'warning' | 'default'`).
+- Reuse Radix/shadcn `Progress`; no new components.
+- Dashboard-only change does not require `pnpm build`.
+
+### E. Dual-repo git (mandatory for B and C)
+
+Follow `.cursor/skills/enterprise-submodule/SKILL.md`:
+
+1. Branch **both** repos with the **same** conventional name including Linear id, from `next`.
+2. Commit **submodule first**, push `.source`, open enterprise PR vs `next`.
+3. In novu: point submodule at that commit, commit, push, open monorepo PR vs `next`.
+4. Cross-link PR bodies. Do **not** “fix” Validate Submodule Sync by reverting the pointer.
+5. Merge enterprise first, then monorepo.
+
+Cloud agent branch prefix `cursor/...-24bf` does not apply to the local agent; use team convention (`feat/usage-threshold-alerts-fixes-NV-XXXX`).
+
+---
+
+## Testing
+
+**Never** run mocha under `apps/api` without `NODE_ENV=test` (drops `novu-db`). See `.cursor/rules/safe-api-tests.mdc`.
+
+Suggested:
+
+```bash
+# Official API tests (sets NODE_ENV=test)
+cd apps/api && pnpm test -- grep='billing'   # only if this matches existing scripts; otherwise use targeted e2e-ee files
+
+# Isolated unit spec example — --no-config, NODE_ENV=test
+cd apps/api && cross-env NODE_ENV=test NOVU_ENTERPRISE=true CLERK_ENABLED=true \
+  npx mocha --no-config --timeout 30000 --require ts-node/register --exit \
+  'src/path/to/file.spec.ts'
+```
+
+Add/extend:
+
+- Handler unit tests: included 10k vs 30k vs 250k; snap 74 → no send, 75–89 → 75, ≥90 → 90 only; `included === null` → no send.
+- Quota interceptor: FREE/trial sends; paid non-trial does not (existing early return); trigger failure does not 500 the request.
+- Workflow: payload schema accepts new fields; throttle step present (framework/client tests only if that is the repo pattern — prefer not to spin a full worker throttle integration unless one already exists).
+
+Existing EE e2e live under `apps/api/src/app/billing/e2e/*.e2e-ee.ts`. Prefer extending those over a new harness.
+
+Package tests: if `libs/notifications` has no test runner, email render can be asserted with a small unit test next to `email.tsx` **only if** the package already tests that way; otherwise rely on TypeScript + a manual trigger in local dashboard/inbox.
+
+Browser: after dashboard threshold CSS change, verify usage card at <75 / 75–89 / ≥90 (seed or mock subscription). Dev dashboard is port **4201**; do not rebuild/start it if already running.
+
+---
+
+## Acceptance criteria
+
+- [ ] Second `usageLimitsWorkflow.trigger` for the same org owner, same `threshold`, same billing period, does not send a second email (throttle skip in Activity).
+- [ ] 75 then later 90 in the same period both send (different `throttleKey`).
+- [ ] Jump to 92% sends only the 90% variant.
+- [ ] Pro/Business percentage uses Stripe/plan included events, not 10_000.
+- [ ] Email does not say 30,000 for every org; FREE-only block-at-100% language.
+- [ ] `IS_USAGE_ALERTS_ENABLED=false` → no customer email (log-only remains OK).
+- [ ] Paid orgs are not quota-blocked; they can still get Stripe-webhook alerts.
+- [ ] Self-hosted enterprise / unlimited: no trigger.
+- [ ] Internal org throttle window can span the billing period (documented in PR).
+- [ ] Dashboard usage card matches 75 / 90.
+- [ ] Two PRs cross-linked; Linear id in titles.
+
+---
+
+## Ops / launch (not all code)
+
+1. Stripe Billing Alerts: 75% and 90% of included events on each metered notifications price.
+2. Confirm `NOVU_INTERNAL_SECRET_KEY` and bridge workflows deployed.
+3. Confirm internal org throttle tier / LD override.
+4. Enable `IS_USAGE_ALERTS_ENABLED` on a canary org, then wider.
+5. Watch Activity for `STEP_THROTTLED` vs successful email.
+
+---
+
+## Files cheat sheet
+
+| Action | File |
+|---|---|
+| Edit workflow | `libs/notifications/src/workflows/usage-limits/usage-limits.workflow.ts` |
+| Edit email | `libs/notifications/src/workflows/usage-limits/email.tsx` |
+| Edit Stripe producer | `.source/billing/src/stripe/handlers/alert.triggered.handler.ts` |
+| Edit FREE producer | `.source/billing/src/guards/quota-throttler.guard.ts` |
+| Maybe inject GetSubscription | `.source/billing/src/billing.module.ts` (only if constructor deps change) |
+| Dashboard | `apps/dashboard/src/components/side-navigation/usage-card.tsx` |
+| Flag (read only unless new flag needed) | `packages/shared/src/types/feature-flags.ts` — **reuse** `IS_USAGE_ALERTS_ENABLED` |
+| Do not edit | `libs/internal-sdk`, `apps/webhook` |
+
+---
+
+## Conventions reminder
+
+- File names: lowercase dashes.
+- Backend `interface`, frontend `type`.
+- Blank line before every `return`.
+- No nested ternaries.
+- Ask before new npm deps or new dashboard components outside `apps/dashboard/src/components/`.
+- Do not add packages to `minimumReleaseAgeExclude`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Adds an implementation handover at `docs/agents/plans/usage-threshold-alerts.md` so a **local setup agent** can implement 75%/90% usage alerts without the planning thread.

Locked decisions in the plan:

- Billing stays a dumb producer (`AlertTriggeredHandler` + FREE `QuotaThrottlerInterceptor`).
- Novu is the transport (`usageLimitsWorkflow`); **throttle** (not digest, not billing Redis) enforces once per threshold per billing period.
- No new usage-scan cron. Ride hourly Stripe meter + existing FREE quota path.
- v1 vs v2 scope, dual-repo EE steps, tests (`NODE_ENV=test`), and acceptance criteria are spelled out.

Linear MCP was not authenticated in this environment, so there is no `NV-XXXX` on this docs PR. **Create a Linear ticket before the implementation PRs** and put `fixes NV-XXXX` on those titles.

```mermaid
flowchart TB
  Hourly[Hourly Stripe usage SET] --> WH[billing.alert.triggered]
  QT[QuotaThrottler FREE/trial] --> Trigger
  WH --> Trigger[usageLimitsWorkflow.trigger]
  Trigger --> Throttle[step.throttle until currentPeriodEnd]
  Throttle --> Email[email + in-app]
```

### Screenshots

N/A — documentation only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None. Implementation will need a matching `novuhq/packages-enterprise` PR; this handover is monorepo docs only.

### Special notes for your reviewer

Not for product docs / Mintlify. Same pattern as `docs/agents/plans/remove-enabled-integrations.md`.

Give the local agent this prompt:

> Implement v1 of `docs/agents/plans/usage-threshold-alerts.md`. Novu is the transport. Billing only triggers `usageLimitsWorkflow`. Dedup via `step.throttle`, not Redis in billing. Dual-repo EE workflow. Do not add a new usage scan cron.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce76f97b-c1ff-484f-99bd-dd4a087424bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce76f97b-c1ff-484f-99bd-dd4a087424bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an implementation handover for 75% and 90% usage alerts, covering the billing producers, Novu workflow throttling, dashboard thresholds, testing, dual-repository workflow, and launch operations.
- Replaces digest-based batching with per-threshold throttling until the billing-period end.
- Defines paid and FREE/trial producer paths and payload requirements.
- Documents dashboard alignment, test coverage, acceptance criteria, and rollout steps.

<h3>Confidence Score: 4/5</h3>

The documentation is safe to merge after a non-blocking correction to the stated dynamic-throttle tier requirement.

The implementation plan is generally consistent with the existing workflow and throttle behavior, but it incorrectly presents the regular-throttle tier cap as applying to dynamic throttles.

**Files Needing Attention:** docs/agents/plans/usage-threshold-alerts.md

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/agents/plans/usage-threshold-alerts.md | Comprehensive implementation handover, but its dynamic-throttle tier-cap prerequisite does not match the current validator behavior. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TB
  Stripe["Hourly Stripe usage alert"] --> Producer["Billing alert producer"]
  Quota["FREE/trial quota interceptor"] --> Producer
  Producer --> Workflow["usageLimitsWorkflow"]
  Workflow --> Throttle["Dynamic per-threshold throttle"]
  Throttle --> Email["Email"]
  Throttle --> InApp["In-app notification"]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312617%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12617&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Adocs%2Fagents%2Fplans%2Fusage-threshold-alerts.md%3A81%0A**Dynamic%20throttle%20cap%20misstated**%0A%0AThe%20plan%20says%20a%20dynamic%20throttle%20that%20exceeds%20the%20tier%20window%20cap%20fails%20with%20%60DEFER_DURATION_LIMIT_EXCEEDED%60.%20However%2C%20the%20tier%20validator%20applies%20this%20cap%20only%20to%20regular%20throttles%20with%20%60amount%60%20and%20%60unit%60%3B%20dynamic%20throttles%20are%20not%20subject%20to%20that%20validation.%20This%20creates%20an%20unnecessary%20Enterprise%20tier%20or%20environment-override%20prerequisite%20in%20the%20handover%20and%20acceptance%20criteria.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12617&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/agents/plans/usage-threshold-alerts.md:81
**Dynamic throttle cap misstated**

The plan says a dynamic throttle that exceeds the tier window cap fails with `DEFER_DURATION_LIMIT_EXCEEDED`. However, the tier validator applies this cap only to regular throttles with `amount` and `unit`; dynamic throttles are not subject to that validation. This creates an unnecessary Enterprise tier or environment-override prerequisite in the handover and acceptance criteria.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(root): add usage threshold alerts h..."](https://github.com/novuhq/novu/commit/9f3457c304a9e84458133a56a95dd4c94543d4f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62035099)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->