### PR TITLE
chore(docs): update LinkedIn company URL to novuco fixes DOC-442

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1195,7 +1195,7 @@
     "socials": {
       "x": "https://x.com/novuhq",
       "github": "https://github.com/novuhq/novu",
-      "linkedin": "https://linkedin.com/company/novuhq"
+      "linkedin": "https://www.linkedin.com/company/novuco"
     },
     "links": [
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Docs footer LinkedIn social still pointed at the old company page (`linkedin.com/company/novuhq`). Updated it to the current company URL: [linkedin.com/company/novuco](https://www.linkedin.com/company/novuco).

Linear: [DOC-442](https://linear.app/novu/issue/DOC-442/update-novu-linkedin-company-url-to-linkedincomcompanynovuco)

### Audit

Repo-wide search for `linkedin.com/company`:

| Location | Status |
| --- | --- |
| `docs/docs.json` footer socials | Updated `novuhq` → `novuco` |
| `apps/api/.../layout-templates.ts` | Already `novuco` |
| `libs/notifications/.../usage-report/email.tsx` | Already `novuco` |

No other Novu company LinkedIn URLs in this monorepo.

### Test plan

- [x] Confirmed `docs/docs.json` parses and footer socials LinkedIn is `https://www.linkedin.com/company/novuco`
- [x] Confirmed no remaining `linkedin.com/company/novuhq` references

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

Marketing website (`novuhq/website-new`) is outside this monorepo and was not changed here.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1788269914996919?thread_ts=1788269914.996919&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-f69c1542-35b6-5e1b-9632-5511d9d29bba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f69c1542-35b6-5e1b-9632-5511d9d29bba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the documentation footer’s LinkedIn link from the former `novuhq` company page to the current `novuco` company page.
- Changes only the LinkedIn social URL in `docs/docs.json`.
- Aligns the company handle with existing Novu LinkedIn references elsewhere in the repository.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the focused URL update is consistent with existing repository references and introduces no identified functional issue.

The only changed value remains a valid HTTPS LinkedIn company URL and uses the same `novuco` handle already referenced elsewhere in the repository.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/docs.json | Updates the footer LinkedIn destination to the current Novu company URL without changing the surrounding documentation configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docs): update LinkedIn company URL..."](https://github.com/novuhq/novu/commit/25bc5b3bc4970bfd40c1221831207e1e21a8cff3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62525108)</sub>

<!-- /greptile_comment -->