### PR TITLE
fix(api-service): enable Chat burst concurrency and Slack retry bounds fixes NV-8634

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -6,9 +6,16 @@ import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy } 
 import { CacheService, PinoLogger } from '@novu/application-generic';
 import type { NovuWebChatAdapter } from '@novu/chat-adapter-web-chat';
 import { stripAgentReplyToken } from '@novu/shared';
-import type { Adapter, Chat, Message, ReactionEvent, SlashCommandEvent, Thread } from 'chat';
+import { retryPolicies } from '@slack/web-api';
+import type { Adapter, Chat, Message, MessageContext, ReactionEvent, SlashCommandEvent, Thread } from 'chat';
 import { LRUCache } from 'lru-cache';
 import { resolveWhatsAppAppSecret } from '../../../integrations/usecases/whatsapp/whatsapp-credentials.utils';
+import { AgentConfigResolver, ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
+import { AgentEmailActionTokenService } from '../../email/agent-email-action-token.service';
+import { AgentEmailSender, resolveAgentEmailSenderName } from '../../email/agent-email-sender.service';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
+import { esmImport } from '../../shared/util/esm-import';
 import { WebChatAcceptIdempotencyService } from '../../web-chat/web-chat-accept-idempotency.service';
 import {
   type WebChatPlatformDeliveryContext,
@@ -16,12 +23,6 @@ import {
 } from '../../web-chat/web-chat-platform-delivery.service';
 import { WebChatResumeAuthorizationService } from '../../web-chat/web-chat-resume-authorization.service';
 import { WebChatSessionVerifier } from '../../web-chat/web-chat-session.verifier';
-import { AgentConfigResolver, ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
-import { AgentEmailActionTokenService } from '../../email/agent-email-action-token.service';
-import { AgentEmailSender, resolveAgentEmailSenderName } from '../../email/agent-email-sender.service';
-import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
-import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
-import { esmImport } from '../../shared/util/esm-import';
 import { AgentActionTokenService } from '../action-token/agent-action-token.service';
 import type { InboundReactionEvent } from './inbound-turn.handler';
 import { PlanLimitGateService } from './plan-limit-gate.service';
@@ -62,7 +63,13 @@ interface ChatStateLogger {
 }
 
 export interface InboundCallbacks {
-  onMessage: (agentId: string, config: ResolvedAgentConfig, thread: Thread, message: Message) => Promise<void>;
+  onMessage: (
+    agentId: string,
+    config: ResolvedAgentConfig,
+    thread: Thread,
+    message: Message,
+    context?: MessageContext
+  ) => Promise<void>;
   onAction: (
     agentId: string,
     config: ResolvedAgentConfig,
@@ -87,7 +94,7 @@ export interface InboundCallbacks {
  * the cached instance is dropped and rebuilt — see getOrCreate().
  */
 export interface CachedChat {
-  chat: ChatWithAdapters;
+  chat: ChatWithAdapters | null;
   config: ResolvedAgentConfig;
   adapterFingerprint: string;
 }
@@ -135,7 +142,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
       max: MAX_CACHED_INSTANCES,
       ttl: INSTANCE_TTL_MS,
       dispose: (cached, key) => {
-        cached.chat.shutdown().catch((err) => {
+        cached.chat?.shutdown().catch((err) => {
           this.logger.error(err, `Failed to shut down evicted Chat instance ${key}`);
           captureAgentException(err, {
             component: 'chat-instance-registry',
@@ -160,13 +167,13 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     const freshFingerprint = this.adapterFingerprint(config);
     const existing = this.instances.get(instanceKey);
 
+    if (existing?.adapterFingerprint === freshFingerprint && existing.chat) {
+      existing.config = config;
+
+      return existing.chat;
+    }
+
     if (existing) {
-      if (existing.adapterFingerprint === freshFingerprint) {
-        existing.config = config;
-
-        return existing.chat;
-      }
-
       this.instances.delete(instanceKey);
     }
 
@@ -187,7 +194,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
   async onModuleDestroy() {
     const shutdowns = [...this.instances.entries()].map(async ([key, cached]) => {
       try {
-        await cached.chat.shutdown();
+        await cached.chat?.shutdown();
       } catch (err) {
         this.logger.error(err, `Failed to shut down Chat instance ${key}`);
         captureAgentException(err, {
@@ -210,7 +217,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     adapterFingerprint: string
   ): Promise<ChatWithAdapters> {
     const cached: CachedChat = {
-      chat: null as unknown as ChatWithAdapters,
+      chat: null,
       config,
       adapterFingerprint,
     };
@@ -275,6 +282,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
         logger: this.chatStateLogger(),
       }),
       logger: this.chatStateLogger(),
+      concurrency: { strategy: 'burst' },
     });
   }
 
@@ -323,55 +331,11 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     cached: CachedChat
   ): Promise<Record<string, unknown>> {
     const config = cached.config;
-    const { credentials, connectionAccessToken } = config;
+    const { credentials } = config;
 
     switch (platform) {
-      case AgentPlatformEnum.SLACK: {
-        if (!credentials.signingSecret) {
-          throw new BadRequestException(
-            'Slack agent integration requires a signing secret. Complete Slack app setup for this integration.'
-          );
-        }
-
-        if (!connectionAccessToken) {
-          throw new BadRequestException(
-            'Slack agent integration requires a workspace bot token. Install the app to your Slack workspace via OAuth in the agent setup guide.'
-          );
-        }
-
-        const { createSlackAdapter } = await esmImport('@chat-adapter/slack');
-
-        /**
-         * Multi-workspace mode: a single Novu-hosted Slack app can be installed across many
-         * customer workspaces (the NovuCopilot distribution model), so the bot token must be
-         * resolved per workspace at event time rather than baked into the adapter. The adapter
-         * calls `getInstallation(team_id)` while processing each inbound webhook and binds the
-         * resolved token for the duration of that request (so `users.info` and any in-request
-         * reply use the right workspace token). Outbound calls made in a separate request bind
-         * their token explicitly via `OutboundGateway`.
-         *
-         * `connectionAccessToken` (the first installed workspace's token) is still required above
-         * as a fast-fail guard that at least one workspace is installed, and it keys the adapter
-         * fingerprint so a rebuild happens when installations change.
-         */
-        return {
-          slack: createSlackAdapter({
-            signingSecret: credentials.signingSecret,
-            installationProvider: {
-              getInstallation: async (installationId: string) => {
-                const installation = await this.agentConfigResolver.resolveSlackInstallation(
-                  config.environmentId,
-                  config.organizationId,
-                  config.integrationIdentifier,
-                  installationId
-                );
-
-                return installation ? { botToken: installation.token, botUserId: installation.botUserId } : null;
-              },
-            },
-          }),
-        };
-      }
+      case AgentPlatformEnum.SLACK:
+        return this.buildSlackAdapter(config);
       case AgentPlatformEnum.TEAMS: {
         if (!credentials.clientId || !credentials.secretKey || !credentials.tenantId) {
           throw new BadRequestException(
@@ -534,6 +498,59 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     }
   }
 
+  /**
+   * Multi-workspace mode: a single Novu-hosted Slack app can be installed across many
+   * customer workspaces (the NovuCopilot distribution model), so the bot token must be
+   * resolved per workspace at event time rather than baked into the adapter. The adapter
+   * calls `getInstallation(team_id)` while processing each inbound webhook and binds the
+   * resolved token for the duration of that request (so `users.info` and any in-request
+   * reply use the right workspace token). Outbound calls made in a separate request bind
+   * their token explicitly via `OutboundGateway`.
+   *
+   * `connectionAccessToken` (the first installed workspace's token) is still required
+   * as a fast-fail guard that at least one workspace is installed, and it keys the adapter
+   * fingerprint so a rebuild happens when installations change.
+   */
+  private async buildSlackAdapter(config: ResolvedAgentConfig): Promise<Record<string, unknown>> {
+    const { credentials, connectionAccessToken } = config;
+
+    if (!credentials.signingSecret) {
+      throw new BadRequestException(
+        'Slack agent integration requires a signing secret. Complete Slack app setup for this integration.'
+      );
+    }
+
+    if (!connectionAccessToken) {
+      throw new BadRequestException(
+        'Slack agent integration requires a workspace bot token. Install the app to your Slack workspace via OAuth in the agent setup guide.'
+      );
+    }
+
+    const { createSlackAdapter } = await esmImport('@chat-adapter/slack');
+
+    return {
+      slack: createSlackAdapter({
+        signingSecret: credentials.signingSecret,
+        webClientOptions: {
+          retryConfig: retryPolicies.fiveRetriesInFiveMinutes,
+          timeout: 15_000,
+        },
+        installationProvider: {
+          getInstallation: async (installationId: string) => {
+            const installation = await this.agentConfigResolver.resolveSlackInstallation(
+              config.environmentId,
+              config.organizationId,
+              config.integrationIdentifier,
+              installationId
+            );
+
+            return installation ? { botToken: installation.token, botUserId: installation.botUserId } : null;
+          },
+        },
+      }),
+    };
+  }
+
   private registerEventHandlers(agentId: string, cached: CachedChat) {
     if (!this.inboundCallbacks) {
       this.logger.warn(`[agent:${agentId}] No inbound callbacks registered, skipping event handler setup`);
@@ -542,12 +559,16 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     }
 
     const callbacks = this.inboundCallbacks;
+    const chat = cached.chat;
+    if (!chat) {
+      return;
+    }
 
-    cached.chat.onNewMention(async (thread: Thread, message: Message) => {
+    chat.onNewMention(async (thread: Thread, message: Message, context?: MessageContext) => {
       try {
         await thread.subscribe();
-        rehydrateInboundAttachments(cached.chat.getAdapter(cached.config.platform), message);
-        await callbacks.onMessage(agentId, cached.config, thread, message);
+        this.rehydrateBurstAttachments(cached, message, context);
+        await callbacks.onMessage(agentId, cached.config, thread, message, context);
       } catch (err) {
         this.rethrowWebChatInboundError(cached, err, {
           agentId,
@@ -557,10 +578,10 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
       }
     });
 
-    cached.chat.onSubscribedMessage(async (thread: Thread, message: Message) => {
+    chat.onSubscribedMessage(async (thread: Thread, message: Message, context?: MessageContext) => {
       try {
-        rehydrateInboundAttachments(cached.chat.getAdapter(cached.config.platform), message);
-        await callbacks.onMessage(agentId, cached.config, thread, message);
+        this.rehydrateBurstAttachments(cached, message, context);
+        await callbacks.onMessage(agentId, cached.config, thread, message, context);
       } catch (err) {
         this.rethrowWebChatInboundError(cached, err, {
           agentId,
@@ -570,7 +591,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
       }
     });
 
-    cached.chat.onSlashCommand(async (event: SlashCommandEvent) => {
+    chat.onSlashCommand(async (event: SlashCommandEvent) => {
       try {
         await this.redispatchTelegramCommandAsMessage(cached, event);
       } catch (err) {
@@ -584,7 +605,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
       }
     });
 
-    cached.chat.onAction(async (event) => {
+    chat.onAction(async (event) => {
       try {
         if (!event.thread) {
           this.logger.warn(`[agent:${agentId}] Action received without thread context, skipping`);
@@ -625,7 +646,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
       }
     });
 
-    cached.chat.onReaction(async (event: ReactionEvent) => {
+    chat.onReaction(async (event: ReactionEvent) => {
       try {
         if (event.message) {
           rehydrateInboundAttachments(cached.chat.getAdapter(cached.config.platform), event.message);
@@ -645,6 +666,17 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
         captureAgentException(err, { component: 'chat-instance-registry', operation: 'on-reaction', agentId });
       }
     });
+  }
+
+  private rehydrateBurstAttachments(cached: CachedChat, message: Message, context?: MessageContext): void {
+    const adapter = cached.chat?.getAdapter(cached.config.platform);
+    if (!adapter) {
+      return;
+    }
+    rehydrateInboundAttachments(adapter, message);
+    for (const skipped of context?.skipped ?? []) {
+      rehydrateInboundAttachments(adapter, skipped);
+    }
   }
 
   /**
@@ -682,7 +714,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
    * including dedupe, thread locking, and DM/mention routing.
    */
   private async redispatchTelegramCommandAsMessage(cached: CachedChat, event: SlashCommandEvent): Promise<void> {
-    if (cached.config.platform !== AgentPlatformEnum.TELEGRAM) {
+    if (cached.config.platform !== AgentPlatformEnum.TELEGRAM || !cached.chat) {
       return;
     }
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -649,7 +649,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     chat.onReaction(async (event: ReactionEvent) => {
       try {
         if (event.message) {
-          rehydrateInboundAttachments(cached.chat.getAdapter(cached.config.platform), event.message);
+          rehydrateInboundAttachments(chat.getAdapter(cached.config.platform), event.message);
         }
 
         await callbacks.onReaction(agentId, cached.config, {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -282,8 +282,23 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
         logger: this.chatStateLogger(),
       }),
       logger: this.chatStateLogger(),
-      concurrency: { strategy: 'burst' },
+      concurrency: this.resolveConcurrency(platform),
     });
+  }
+
+  /**
+   * Burst folds a flurry of overlapping webhook messages into one turn, which is
+   * what messaging platforms (Slack/Teams/Telegram/WhatsApp/email) need. Web Chat's
+   * accept contract is different: `createConversation` awaits `chat.processMessage`
+   * synchronously before returning 201 with `messageId` (see
+   * `@novu/chat-adapter-web-chat`'s `handleMessageIngress`), so burst's built-in
+   * debounce wait — which applies even to a lone message on an idle thread — would
+   * add latency to every Web Chat send and can outlive the accept-claim TTL. Web
+   * Chat also never has genuinely overlapping inbound messages (one HTTP request
+   * per send), so it has nothing to fold. Keep it on the SDK default (`drop`).
+   */
+  private resolveConcurrency(platform: AgentPlatformEnum): { strategy: 'burst' } | undefined {
+    return platform === AgentPlatformEnum.WEB_CHAT ? undefined : { strategy: 'burst' };
   }
 
   // The Chat SDK's getLogger(prefix) returns this.logger.child(prefix) when a

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -459,29 +459,6 @@ describe('AgentInboundHandler', () => {
       expect(bridgeExecutor.execute.firstCall.args[0].platformContext.threadId).to.equal(expectedThreadId);
     });
 
-    it('folds skipped burst messages into the latest inbound text before dispatch', async () => {
-      const { handler, bridgeExecutor, conversationService } = makeHandler();
-      const thread = makeSlackDmThread();
-      const latest = makeSlackDmMessage();
-      latest.text = 'how do I reset?';
-      const skipped = [
-        { ...makeSlackDmMessage(), id: 'skipped-1', text: 'hey' },
-        { ...makeSlackDmMessage(), id: 'skipped-2', text: 'quick question' },
-      ];
-
-      await handler.handle('agent1', config as any, thread as any, latest as any, AgentEventEnum.ON_MESSAGE, {
-        skipped: skipped as any,
-        totalSinceLastHandler: 3,
-      });
-
-      expect(conversationService.persistInboundMessage.firstCall.args[0].content).to.equal(
-        'hey\n\nquick question\n\nhow do I reset?'
-      );
-      expect(bridgeExecutor.execute.firstCall.args[0].message.text).to.equal(
-        'hey\n\nquick question\n\nhow do I reset?'
-      );
-    });
-
     it('should dispatch ON_MESSAGE with humanResponse when a conversation HITL ask settles', async () => {
       const settled = {
         identifier: 'hi_1',
@@ -1569,31 +1546,6 @@ describe('AgentInboundHandler', () => {
       expect(thread.post.calledOnce).to.equal(true);
       expect(bridgeExecutor.execute.called).to.equal(false);
       expect(conversationService.createOrGetConversation.called).to.equal(false);
-    });
-
-    it('consumes /start from a skipped burst message instead of dispatching the latest text', async () => {
-      const linkTelegramExecute = sinon.stub().resolves({
-        created: true,
-        subscriberId: 'ext-sub-1',
-        linkScope: { mode: 'agent', agentIdentifier: 'support-agent' },
-      });
-      const { handler, bridgeExecutor, startCodeService } = makeHandler({
-        linkTelegramExecute,
-        startCodeConsume: sinon.stub().resolves({ status: 'consumed', payload: matchingStartPayload }),
-      });
-      const thread = makeTelegramThread();
-      const startMessage = makeStartMessage('/start AbCdEfGhIjKlMnOpQrStUvWxYz012345');
-      const latest = makeStartMessage('hello after start');
-      latest.id = 'msg-2';
-
-      await handler.handle('agent1', telegramConfig as any, thread as any, latest as any, AgentEventEnum.ON_MESSAGE, {
-        skipped: [startMessage as any],
-        totalSinceLastHandler: 2,
-      });
-
-      expect(startCodeService.consumeIfMatches.calledOnce).to.equal(true);
-      expect(thread.post.calledOnce).to.equal(true);
-      expect(bridgeExecutor.execute.called).to.equal(false);
     });
 
     it('replies with the duplicate message when the chat was already linked', async () => {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -459,6 +459,29 @@ describe('AgentInboundHandler', () => {
       expect(bridgeExecutor.execute.firstCall.args[0].platformContext.threadId).to.equal(expectedThreadId);
     });
 
+    it('folds skipped burst messages into the latest inbound text before dispatch', async () => {
+      const { handler, bridgeExecutor, conversationService } = makeHandler();
+      const thread = makeSlackDmThread();
+      const latest = makeSlackDmMessage();
+      latest.text = 'how do I reset?';
+      const skipped = [
+        { ...makeSlackDmMessage(), id: 'skipped-1', text: 'hey' },
+        { ...makeSlackDmMessage(), id: 'skipped-2', text: 'quick question' },
+      ];
+
+      await handler.handle('agent1', config as any, thread as any, latest as any, AgentEventEnum.ON_MESSAGE, {
+        skipped: skipped as any,
+        totalSinceLastHandler: 3,
+      });
+
+      expect(conversationService.persistInboundMessage.firstCall.args[0].content).to.equal(
+        'hey\n\nquick question\n\nhow do I reset?'
+      );
+      expect(bridgeExecutor.execute.firstCall.args[0].message.text).to.equal(
+        'hey\n\nquick question\n\nhow do I reset?'
+      );
+    });
+
     it('should dispatch ON_MESSAGE with humanResponse when a conversation HITL ask settles', async () => {
       const settled = {
         identifier: 'hi_1',
@@ -1546,6 +1569,31 @@ describe('AgentInboundHandler', () => {
       expect(thread.post.calledOnce).to.equal(true);
       expect(bridgeExecutor.execute.called).to.equal(false);
       expect(conversationService.createOrGetConversation.called).to.equal(false);
+    });
+
+    it('consumes /start from a skipped burst message instead of dispatching the latest text', async () => {
+      const linkTelegramExecute = sinon.stub().resolves({
+        created: true,
+        subscriberId: 'ext-sub-1',
+        linkScope: { mode: 'agent', agentIdentifier: 'support-agent' },
+      });
+      const { handler, bridgeExecutor, startCodeService } = makeHandler({
+        linkTelegramExecute,
+        startCodeConsume: sinon.stub().resolves({ status: 'consumed', payload: matchingStartPayload }),
+      });
+      const thread = makeTelegramThread();
+      const startMessage = makeStartMessage('/start AbCdEfGhIjKlMnOpQrStUvWxYz012345');
+      const latest = makeStartMessage('hello after start');
+      latest.id = 'msg-2';
+
+      await handler.handle('agent1', telegramConfig as any, thread as any, latest as any, AgentEventEnum.ON_MESSAGE, {
+        skipped: [startMessage as any],
+        totalSinceLastHandler: 2,
+      });
+
+      expect(startCodeService.consumeIfMatches.calledOnce).to.equal(true);
+      expect(thread.post.calledOnce).to.equal(true);
+      expect(bridgeExecutor.execute.called).to.equal(false);
     });
 
     it('replies with the duplicate message when the chat was already linked', async () => {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -35,6 +35,7 @@ import { AgentEventEnum } from '../../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { parseToolApprovalActionId } from '../../shared/tool-approval/action-id';
+import { parseApprovalReplyVerdict } from '../../shared/tool-approval/reply-based-approval';
 import { getResolvedSubscriberId, type SubscriberResolution } from '../../shared/types/subscriber-resolution';
 import { agentLinkAwaitingInboundConnectionFilter } from '../../shared/util/agent-inbound-connection';
 import { extractMsTeamsTenantId } from '../../shared/util/msteams-activity';
@@ -133,12 +134,37 @@ function buildCapacityReachedCard(platform: AutoProvisionPlatform): CardElement 
   };
 }
 
+/**
+ * Chat SDK burst locks are scoped to the thread/channel, not the author (see
+ * `getLockKey`), so a burst can hold messages from different senders — multiple
+ * participants in a subscribed Slack/Teams thread, or anyone in a Telegram/WhatsApp
+ * group (channel-scoped lock by default). Subscriber resolution, tool-approval actor
+ * identity, and persistence all key off the latest message's author, so a different
+ * author's text/attachments must never be folded in — that would let one participant's
+ * message run under another's identity and permissions.
+ *
+ * A lone whole-message reply verdict (e.g. "yes") is also kept as-is rather than
+ * folded: `parseApprovalReplyVerdict` only recognizes an exact match, so combining it
+ * with adjacent text would silently drop a pending tool approval.
+ */
 function foldInboundBurst(message: Message, messageContext?: MessageContext): void {
   if (!messageContext?.skipped?.length) {
     return;
   }
 
-  const burst = [...messageContext.skipped, message];
+  const sameAuthor = messageContext.skipped.filter((item) => item.author.userId === message.author.userId);
+  if (sameAuthor.length === 0) {
+    return;
+  }
+
+  const burst = [...sameAuthor, message];
+  const verdict = burst.find((item) => parseApprovalReplyVerdict(item.text) !== null);
+  if (verdict) {
+    message.text = verdict.text;
+
+    return;
+  }
+
   message.text = burst
     .map((item) => item.text ?? '')
     .filter((text) => text.trim().length > 0)

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -14,7 +14,7 @@ import {
 import type { AgentAction } from '@novu/framework';
 import { parseApprovalActionId } from '@novu/framework/internal';
 import { ENDPOINT_TYPES, isDashboardWebChatSubscriberId } from '@novu/shared';
-import type { CardElement, EmojiValue, Message, Thread } from 'chat';
+import type { CardElement, EmojiValue, Message, MessageContext, Thread } from 'chat';
 import { ConnectClaimTokenService } from '../../../connect/services/connect-claim-token.service';
 import { parsePositiveIntEnv } from '../../../keyless/keyless-abuse.constants';
 import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
@@ -131,6 +131,19 @@ function buildCapacityReachedCard(platform: AutoProvisionPlatform): CardElement 
       },
     ],
   };
+}
+
+function foldInboundBurst(message: Message, messageContext?: MessageContext): void {
+  if (!messageContext?.skipped?.length) {
+    return;
+  }
+
+  const burst = [...messageContext.skipped, message];
+  message.text = burst
+    .map((item) => item.text ?? '')
+    .filter((text) => text.trim().length > 0)
+    .join('\n\n');
+  message.attachments = burst.flatMap((item) => item.attachments ?? []);
 }
 
 function getMessageRawEvent(message: Message): Record<string, unknown> | undefined {
@@ -281,8 +294,8 @@ export class AgentInboundHandler implements OnModuleInit {
 
   onModuleInit() {
     this.inboundDispatcher.registerInboundCallbacks({
-      onMessage: (agentId, config, thread, message) =>
-        this.handle(agentId, config, thread, message, AgentEventEnum.ON_MESSAGE),
+      onMessage: (agentId, config, thread, message, messageContext) =>
+        this.handle(agentId, config, thread, message, AgentEventEnum.ON_MESSAGE, messageContext),
       onAction: (agentId, config, thread, action, userId, rawEvent) =>
         this.handleAction(agentId, config, thread, action, userId, rawEvent),
       onReaction: (agentId, config, event) => this.handleReaction(agentId, config, event),
@@ -294,109 +307,25 @@ export class AgentInboundHandler implements OnModuleInit {
     config: ResolvedAgentConfig,
     thread: Thread,
     message: Message,
-    event: AgentEventEnum
+    event: AgentEventEnum,
+    messageContext?: MessageContext
   ): Promise<void> {
-    if (await this.consumeTelegramStartLink(agentId, config, thread, message)) {
+    if (await this.consumeTelegramStartLink(agentId, config, thread, message, messageContext)) {
       return;
     }
+
+    foldInboundBurst(message, messageContext);
 
     if (await this.planLimitGate.maybeBlock(agentId, config, thread)) {
       return;
     }
 
-    const emailAuthRaw = config.platform === AgentPlatformEnum.EMAIL ? asRecord(message.raw) : undefined;
-    const isVerifiedEmailSender =
-      config.platform !== AgentPlatformEnum.EMAIL || isInboundEmailSenderVerified(emailAuthRaw);
-
-    // Open-access agents may lookup-or-provision; restricted stay lookup-only.
-    // Keyless email demos stay lookup-only until tool approval.
-    const telegramChatId = config.platform === AgentPlatformEnum.TELEGRAM ? extractTelegramChatId(thread) : undefined;
-    const canAutoProvision = shouldAutoProvisionInbound({
-      platform: config.platform,
-      subscriberAccess: config.subscriberAccess,
-      isManaged: config.isManaged,
-      isKeyless: config.isKeyless,
-      isTelegramDm: telegramChatId != null && telegramChatId === message.author.userId,
-    });
-
-    let resolution: SubscriberResolution;
-    try {
-      if (!isVerifiedEmailSender) {
-        this.logger.warn(
-          {
-            agentId,
-            organizationId: config.organizationId,
-            environmentId: config.environmentId,
-            fromAddress: message.author.userId,
-            dkim: emailAuthRaw?.dkim,
-            spf: emailAuthRaw?.spf,
-            messageId: message.id,
-            subscriberAccess: config.subscriberAccess,
-            isKeyless: config.isKeyless,
-            canAutoProvision,
-          },
-          'Inbound email sender failed DKIM/SPF verification — skipping subscriber resolution so a spoofed From cannot assume an existing identity.'
-        );
-        resolution = { outcome: 'not_found' };
-      } else if (canAutoProvision) {
-        resolution = await this.subscriberResolver.resolveOrProvision({
-          environmentId: config.environmentId,
-          organizationId: config.organizationId,
-          platform: config.platform,
-          platformUserId: message.author.userId,
-          integrationIdentifier: config.integrationIdentifier,
-          agentIdentifier: config.agentIdentifier,
-          authorFullName: message.author.fullName,
-          authorUserName: message.author.userName,
-          // chat-sdk types isBot as `boolean | "unknown"`; treat anything except `true` as a non-bot author.
-          authorIsBot: message.author.isBot === true,
-          // Teams multi-tenant: capture the user's tenant from the inbound activity so the endpoint
-          // records which (possibly external customer) tenant the user belongs to.
-          platformTenantId:
-            config.platform === AgentPlatformEnum.TEAMS ? extractMsTeamsTenantId(message.raw) : undefined,
-        });
-      } else {
-        resolution = await this.resolveSubscriber({
-          agentId,
-          config,
-          platformUserId: message.author.userId,
-          operation: 'resolve-subscriber',
-          authorIsBot: message.author.isBot === true,
-        });
-      }
-    } catch (err) {
-      if (err instanceof BotAuthorSkippedError) {
-        this.logger.debug(
-          `[agent:${agentId}] Inbound from bot author ${config.platform}:${message.author.userId} skipped without dispatch`
-        );
-
-        return;
-      }
-
-      if (err instanceof ConnectOrgSubscriberCapExceededError) {
-        this.logger.warn(
-          { agentId, organizationId: config.organizationId, count: err.count, limit: err.limit },
-          'Connect org at auto-provisioned subscriber cap — posting tier-upgrade card and skipping dispatch.'
-        );
-        await this.postCapacityReachedReply(agentId, config, thread, message);
-
-        return;
-      }
-
-      /**
-       * Only `resolveOrProvision` on open-access Slack / Teams / Telegram /
-       * email / WhatsApp / Sendblue can reach here - the `resolveSubscriber` read path
-       * maps its own failures to an `error` outcome internally and never throws.
-       * For auto-provision platforms an unknown error means we don't know the
-       * subscriber state, so we keep dispatch off and surface the failure rather
-       * than silently degrading to a PLATFORM_USER participant the
-       * removed-anonymous-state contract was meant to eliminate.
-       */
-      captureAgentWarning(err, { component: 'agent-inbound-handler', operation: 'resolve-subscriber', agentId });
-
-      throw err;
+    const inboundSubscriber = await this.resolveInboundSubscriber(agentId, config, thread, message);
+    if (!inboundSubscriber) {
+      return;
     }
 
+    const { resolution, isVerifiedEmailSender } = inboundSubscriber;
     const subscriberId = getResolvedSubscriberId(resolution);
     const isDashboardTester = isDashboardWebChatSubscriberId(subscriberId);
 
@@ -473,26 +402,206 @@ export class AgentInboundHandler implements OnModuleInit {
       resolution: workflowOriginResolution,
     });
 
-    if (config.isKeyless) {
-      const aiEnabled = await this.keylessAbuseGuard.isKeylessAgentAiEnabled(config.organizationId);
-
-      if (!aiEnabled) {
-        await this.postKeylessSignupCta(agentId, config, thread, conversation);
-
-        return;
-      }
-
-      if (await this.connectClaimTokenService.isSignupCtaPosted(conversation._id)) {
-        return;
-      }
-
-      if (await this.isKeylessDemoCapReached(config, conversation._id)) {
-        await this.postKeylessSignupCta(agentId, config, thread, conversation);
-
-        return;
-      }
+    if (await this.maybeStopKeylessInbound(agentId, config, thread, conversation)) {
+      return;
     }
 
+    await this.dispatchInboundTurn({
+      agentId,
+      config,
+      thread,
+      message,
+      event,
+      conversation,
+      platformThreadId,
+      subscriberId,
+      resolution,
+      isVerifiedEmailSender,
+      workflowOrigin,
+    });
+  }
+
+  /**
+   * Record `connectedAt` the first time a real user messages the agent on this
+   * integration. Gated on a genuine inbound message (the caller has already
+   * filtered bot-authored events via `BotAuthorSkippedError`) so the agent's own
+   * proactive messages — e.g. the post-install welcome DM, which Slack echoes
+   * back to our webhook — never mark the integration connected. The conditional
+   * `connectedAt: null` filter makes the write idempotent and fires the
+   * analytics event exactly once. Placeholder epoch timestamps are treated as
+   * unconnected so they can be self-healed on the next genuine inbound message.
+   * Fail-soft: connection bookkeeping must never crash the inbound webhook.
+   */
+  private async markIntegrationConnectedOnFirstMessage(agentId: string, config: ResolvedAgentConfig): Promise<void> {
+    try {
+      const connectedAt = new Date();
+      const { modified } = await this.agentIntegrationRepository.updateOne(
+        {
+          _environmentId: config.environmentId,
+          _organizationId: config.organizationId,
+          _agentId: agentId,
+          _integrationId: config.integrationId,
+          ...agentLinkAwaitingInboundConnectionFilter(),
+        },
+        { $set: { connectedAt } }
+      );
+
+      if (modified === 0) {
+        return;
+      }
+
+      trackAgentIntegrationFirstWebhook(this.analyticsService, {
+        organizationId: config.organizationId,
+        environmentId: config.environmentId,
+        agentId,
+        agentIdentifier: config.agentIdentifier,
+        integrationIdentifier: config.integrationIdentifier,
+        platform: config.platform,
+      });
+    } catch (err) {
+      this.logger.warn(err, `[agent:${agentId}] Failed to mark integration connected on first user message`);
+      captureAgentWarning(err, {
+        component: 'agent-inbound-handler',
+        operation: 'mark-integration-connected',
+        agentId,
+      });
+    }
+  }
+
+  private async resolveInboundSubscriber(
+    agentId: string,
+    config: ResolvedAgentConfig,
+    thread: Thread,
+    message: Message
+  ): Promise<{ resolution: SubscriberResolution; isVerifiedEmailSender: boolean } | null> {
+    const emailAuthRaw = config.platform === AgentPlatformEnum.EMAIL ? asRecord(message.raw) : undefined;
+    const isVerifiedEmailSender =
+      config.platform !== AgentPlatformEnum.EMAIL || isInboundEmailSenderVerified(emailAuthRaw);
+
+    // Open-access agents may lookup-or-provision; restricted stay lookup-only.
+    // Keyless email demos stay lookup-only until tool approval.
+    const telegramChatId = config.platform === AgentPlatformEnum.TELEGRAM ? extractTelegramChatId(thread) : undefined;
+    const canAutoProvision = shouldAutoProvisionInbound({
+      platform: config.platform,
+      subscriberAccess: config.subscriberAccess,
+      isManaged: config.isManaged,
+      isKeyless: config.isKeyless,
+      isTelegramDm: telegramChatId != null && telegramChatId === message.author.userId,
+    });
+
+    try {
+      if (!isVerifiedEmailSender) {
+        this.logger.warn(
+          {
+            agentId,
+            organizationId: config.organizationId,
+            environmentId: config.environmentId,
+            fromAddress: message.author.userId,
+            dkim: emailAuthRaw?.dkim,
+            spf: emailAuthRaw?.spf,
+            messageId: message.id,
+            subscriberAccess: config.subscriberAccess,
+            isKeyless: config.isKeyless,
+            canAutoProvision,
+          },
+          'Inbound email sender failed DKIM/SPF verification — skipping subscriber resolution so a spoofed From cannot assume an existing identity.'
+        );
+
+        return { resolution: { outcome: 'not_found' }, isVerifiedEmailSender };
+      }
+
+      if (canAutoProvision) {
+        return {
+          resolution: await this.subscriberResolver.resolveOrProvision({
+            environmentId: config.environmentId,
+            organizationId: config.organizationId,
+            platform: config.platform,
+            platformUserId: message.author.userId,
+            integrationIdentifier: config.integrationIdentifier,
+            agentIdentifier: config.agentIdentifier,
+            authorFullName: message.author.fullName,
+            authorUserName: message.author.userName,
+            // chat-sdk types isBot as `boolean | "unknown"`; treat anything except `true` as a non-bot author.
+            authorIsBot: message.author.isBot === true,
+            // Teams multi-tenant: capture the user's tenant from the inbound activity so the endpoint
+            // records which (possibly external customer) tenant the user belongs to.
+            platformTenantId:
+              config.platform === AgentPlatformEnum.TEAMS ? extractMsTeamsTenantId(message.raw) : undefined,
+          }),
+          isVerifiedEmailSender,
+        };
+      }
+
+      return {
+        resolution: await this.resolveSubscriber({
+          agentId,
+          config,
+          platformUserId: message.author.userId,
+          operation: 'resolve-subscriber',
+          authorIsBot: message.author.isBot === true,
+        }),
+        isVerifiedEmailSender,
+      };
+    } catch (err) {
+      if (err instanceof BotAuthorSkippedError) {
+        this.logger.debug(
+          `[agent:${agentId}] Inbound from bot author ${config.platform}:${message.author.userId} skipped without dispatch`
+        );
+
+        return null;
+      }
+
+      if (err instanceof ConnectOrgSubscriberCapExceededError) {
+        this.logger.warn(
+          { agentId, organizationId: config.organizationId, count: err.count, limit: err.limit },
+          'Connect org at auto-provisioned subscriber cap — posting tier-upgrade card and skipping dispatch.'
+        );
+        await this.postCapacityReachedReply(agentId, config, thread, message);
+
+        return null;
+      }
+
+      /**
+       * Only `resolveOrProvision` on open-access Slack / Teams / Telegram /
+       * email / WhatsApp / Sendblue can reach here - the `resolveSubscriber` read path
+       * maps its own failures to an `error` outcome internally and never throws.
+       * For auto-provision platforms an unknown error means we don't know the
+       * subscriber state, so we keep dispatch off and surface the failure rather
+       * than silently degrading to a PLATFORM_USER participant the
+       * removed-anonymous-state contract was meant to eliminate.
+       */
+      captureAgentWarning(err, { component: 'agent-inbound-handler', operation: 'resolve-subscriber', agentId });
+
+      throw err;
+    }
+  }
+
+  private async dispatchInboundTurn(args: {
+    agentId: string;
+    config: ResolvedAgentConfig;
+    thread: Thread;
+    message: Message;
+    event: AgentEventEnum;
+    conversation: ConversationEntity;
+    platformThreadId: string;
+    subscriberId: string | null;
+    resolution: SubscriberResolution;
+    isVerifiedEmailSender: boolean;
+    workflowOrigin: Awaited<ReturnType<WorkflowOriginService['resolveForTurn']>>;
+  }): Promise<void> {
+    const {
+      agentId,
+      config,
+      thread,
+      message,
+      event,
+      conversation,
+      platformThreadId,
+      subscriberId,
+      isVerifiedEmailSender,
+      workflowOrigin,
+    } = args;
+    let { resolution } = args;
     const storedAttachments = await this.storeInboundAttachments(config, conversation, message);
     const isFirstMessage = !this.conversationService.getPrimaryChannel(conversation).firstPlatformMessageId;
 
@@ -589,51 +698,35 @@ export class AgentInboundHandler implements OnModuleInit {
     await runtime.dispatch(turn);
   }
 
-  /**
-   * Record `connectedAt` the first time a real user messages the agent on this
-   * integration. Gated on a genuine inbound message (the caller has already
-   * filtered bot-authored events via `BotAuthorSkippedError`) so the agent's own
-   * proactive messages — e.g. the post-install welcome DM, which Slack echoes
-   * back to our webhook — never mark the integration connected. The conditional
-   * `connectedAt: null` filter makes the write idempotent and fires the
-   * analytics event exactly once. Placeholder epoch timestamps are treated as
-   * unconnected so they can be self-healed on the next genuine inbound message.
-   * Fail-soft: connection bookkeeping must never crash the inbound webhook.
-   */
-  private async markIntegrationConnectedOnFirstMessage(agentId: string, config: ResolvedAgentConfig): Promise<void> {
-    try {
-      const connectedAt = new Date();
-      const { modified } = await this.agentIntegrationRepository.updateOne(
-        {
-          _environmentId: config.environmentId,
-          _organizationId: config.organizationId,
-          _agentId: agentId,
-          _integrationId: config.integrationId,
-          ...agentLinkAwaitingInboundConnectionFilter(),
-        },
-        { $set: { connectedAt } }
-      );
-
-      if (modified === 0) {
-        return;
-      }
-
-      trackAgentIntegrationFirstWebhook(this.analyticsService, {
-        organizationId: config.organizationId,
-        environmentId: config.environmentId,
-        agentId,
-        agentIdentifier: config.agentIdentifier,
-        integrationIdentifier: config.integrationIdentifier,
-        platform: config.platform,
-      });
-    } catch (err) {
-      this.logger.warn(err, `[agent:${agentId}] Failed to mark integration connected on first user message`);
-      captureAgentWarning(err, {
-        component: 'agent-inbound-handler',
-        operation: 'mark-integration-connected',
-        agentId,
-      });
+  private async maybeStopKeylessInbound(
+    agentId: string,
+    config: ResolvedAgentConfig,
+    thread: Thread,
+    conversation: ConversationEntity
+  ): Promise<boolean> {
+    if (!config.isKeyless) {
+      return false;
     }
+
+    const aiEnabled = await this.keylessAbuseGuard.isKeylessAgentAiEnabled(config.organizationId);
+
+    if (!aiEnabled) {
+      await this.postKeylessSignupCta(agentId, config, thread, conversation);
+
+      return true;
+    }
+
+    if (await this.connectClaimTokenService.isSignupCtaPosted(conversation._id)) {
+      return true;
+    }
+
+    if (await this.isKeylessDemoCapReached(config, conversation._id)) {
+      await this.postKeylessSignupCta(agentId, config, thread, conversation);
+
+      return true;
+    }
+
+    return false;
   }
 
   /** Telegram `/start <code>` is control input; when present it is always consumed here. */
@@ -641,18 +734,21 @@ export class AgentInboundHandler implements OnModuleInit {
     agentId: string,
     config: ResolvedAgentConfig,
     thread: Thread,
-    message: Message
+    message: Message,
+    messageContext?: MessageContext
   ): Promise<boolean> {
     if (config.platform !== AgentPlatformEnum.TELEGRAM) {
       return false;
     }
 
-    const startToken = extractTelegramStartToken(message.text);
-    if (!startToken) {
-      return false;
+    for (const inbound of [...(messageContext?.skipped ?? []), message]) {
+      const startToken = extractTelegramStartToken(inbound.text);
+      if (startToken) {
+        return this.handleTelegramSubscriberLink(agentId, config, thread, inbound, startToken);
+      }
     }
 
-    return this.handleTelegramSubscriberLink(agentId, config, thread, message, startToken);
+    return false;
   }
 
   /**


### PR DESCRIPTION
### What changed? Why was the change needed?

https://linear.app/novu/issue/NV-8634/managed-agents-concurrency-slack-client-hardening

After the Chat SDK 4.40.0 bump, overlapping inbound messages were dropped (`drop` is the SDK default) and Slack `WebClient` could retry 429s for ~30 minutes.

- Enable Chat `concurrency: { strategy: 'burst' }` so a flurry folds into one turn (SDK defaults cover debounce and lock lifetime).
- Fold skipped burst texts/attachments onto the latest inbound message; consume Telegram `/start` from the burst before dispatch.
- Bound Slack adapter `webClientOptions` to `fiveRetriesInFiveMinutes` and a 15s timeout.

### Test plan

- [ ] Burst of overlapping inbound messages is folded into one turn (texts joined, attachments flattened)
- [ ] Telegram `/start <code>` in a skipped burst message is consumed and does not dispatch the latest text
- [ ] Slack inbound still delivers; a 429 does not hold a turn for ~30 minutes
- [ ] Existing inbound paths (plan limit, keyless, subscriber resolution) still behave as before


Made with [Cursor](https://cursor.com)









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables burst processing for external messaging channels, folds same-author burst content into one inbound turn, handles Telegram start commands within skipped messages, and bounds Slack WebClient retries.
- Preserves exact approval replies instead of concatenating them with adjacent burst messages.
- Prevents cross-author message and attachment folding in shared threads.
- Excludes Web Chat from burst handling to avoid debounce latency, but that exclusion leaves concurrent Web Chat sends vulnerable to the default drop behavior.
- Refactors subscriber resolution and keyless gating without changing their intended control flow.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because concurrent Web Chat sends can still be silently dropped.

Web Chat's idempotency claims are per message rather than per conversation, so distinct requests can concurrently reach the same Chat thread; selecting the SDK's default drop strategy then defeats the PR's message-preservation goal. The earlier approval-folding finding is no longer outstanding because the current code preserves an exact approval verdict and its thread was resolved.

**Files Needing Attention:** apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts | Configures platform-specific concurrency and bounded Slack retries, but selecting the default drop strategy for Web Chat can lose overlapping sends. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Safely folds same-author bursts, preserves approval verdicts, consumes Telegram start commands, and extracts existing subscriber and keyless control flow. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Concurrent Web Chat send A] --> C[Per-message accept claim A]
  B[Concurrent Web Chat send B] --> D[Per-message accept claim B]
  C --> E[Same conversation thread]
  D --> E
  E --> F[Chat SDK default drop strategy]
  F --> G[One message handled]
  F --> H[Overlapping message discarded]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312628%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12628&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fconversation-runtime%2Fingress%2Fchat-instance.registry.ts%3A301%0A**Web%20Chat%20Drops%20Overlaps**%0A%0AWeb%20Chat%20now%20uses%20the%20SDK's%20default%20%60drop%60%20strategy%2C%20but%20separate%20HTTP%20sends%20for%20the%20same%20conversation%20can%20overlap%20because%20the%20accept%20lock%20is%20scoped%20to%20each%20client%20message%20ID%20rather%20than%20the%20conversation.%20Concurrent%20sends%20with%20distinct%20IDs%20can%20therefore%20reach%20%60processMessage%60%20on%20the%20same%20thread%2C%20causing%20the%20SDK%20to%20discard%20one%20message%20while%20another%20turn%20is%20active.%20Keep%20both%20messages%20or%20serialize%20Web%20Chat%20ingress%20per%20conversation%20without%20exceeding%20the%20accept-claim%20lifetime.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts:301
**Web Chat Drops Overlaps**

Web Chat now uses the SDK's default `drop` strategy, but separate HTTP sends for the same conversation can overlap because the accept lock is scoped to each client message ID rather than the conversation. Concurrent sends with distinct IDs can therefore reach `processMessage` on the same thread, causing the SDK to discard one message while another turn is active. Keep both messages or serialize Web Chat ingress per conversation without exceeding the accept-claim lifetime.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(api-service): exclude Web Chat from ..."](https://github.com/novuhq/novu/commit/f801b70e06cff363f19d44ac665a32e19938dedd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62586349)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Agent platform and AI integrations](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agent-platform.md)

<!-- /greptile_comment -->