### PR TITLE
feat(chat-sdk-adapter): implement thread.reply() with quoteReply ingest fixes NV-8630

### DIFF
--- a/packages/chat-adapter/README.md
+++ b/packages/chat-adapter/README.md
@@ -197,6 +197,7 @@ Handler coverage: `onNewMention`, `onSubscribedMessage`, `onAction` (button clic
 | Button actions (`onAction`)                              | ✅                             |
 | Inbound reactions (`onReaction`)                         | ✅                             |
 | Post message (markdown)                                  | ✅                             |
+| Quote reply (`thread.reply`)                             | ✅ WhatsApp first              |
 | Rich cards                                               | ✅                             |
 | File attachments (outbound)                              | ✅                             |
 | Edit message (in place)                                  | ✅                             |

--- a/packages/chat-adapter/src/adapter.ts
+++ b/packages/chat-adapter/src/adapter.ts
@@ -30,6 +30,7 @@ import {
   type NovuRawMessage,
   type NovuThreadId,
   type NovuTypedAdapter,
+  type QuoteReplyContext,
   type Signal,
   type ThreadSnapshot,
 } from './types.js';
@@ -353,6 +354,22 @@ export class NovuAdapterImpl implements NovuTypedAdapter {
   // -- Outbound --
 
   async postMessage(threadId: string, message: AdapterPostableMessage): Promise<RawMessage<NovuRawMessage>> {
+    return this.emitOutboundMessage(threadId, message);
+  }
+
+  async reply(
+    threadId: string,
+    messageId: string,
+    message: AdapterPostableMessage
+  ): Promise<RawMessage<NovuRawMessage>> {
+    return this.emitOutboundMessage(threadId, message, { messageId });
+  }
+
+  private async emitOutboundMessage(
+    threadId: string,
+    message: AdapterPostableMessage,
+    quoteReply?: QuoteReplyContext
+  ): Promise<RawMessage<NovuRawMessage>> {
     const decoded = decodeThreadId(threadId);
     const reply = await this.mapper.toReplyContent(message);
     const messageId = mint('msg');
@@ -363,6 +380,7 @@ export class NovuAdapterImpl implements NovuTypedAdapter {
       messageId,
       content: toAgentMessageContent(reply),
       files: toAgentFileRefs(reply.files),
+      ...(quoteReply ? { quoteReply } : {}),
     });
 
     return {

--- a/packages/chat-adapter/src/types.ts
+++ b/packages/chat-adapter/src/types.ts
@@ -234,6 +234,7 @@ export interface AgentReplyPayload {
   resolve?: { summary?: string };
   signals?: Signal[];
   addReactions?: AddReactionPayload[];
+  quoteReply?: QuoteReplyContext;
 }
 
 /** Shape returned by `/agents/:id/reply` when a reply or edit was delivered. */

--- a/playground/nextjs/src/app/api/novu-agent/agent.ts
+++ b/playground/nextjs/src/app/api/novu-agent/agent.ts
@@ -13,7 +13,6 @@ import {
   Fields,
   LinkButton,
   Section,
-  type StateAdapter,
 } from 'chat';
 
 /**
@@ -105,6 +104,12 @@ export function registerHandlers(chat: Chat): void {
       return;
     }
 
+    if (message.text.trim().toLowerCase() === 'quote-reply') {
+      await thread.reply(message, `↩️ Quoted reply to: "${message.text}"`);
+
+      return;
+    }
+
     await thread.post(`echo (${novu.platform}): ${message.text}`);
   });
 
@@ -145,14 +150,14 @@ export function getNovuAgent(): Promise<{ chat: Chat; novu: Adapter }> {
 
       const chat = new Chat({
         userName: 'novu-playground-agent',
-        adapters: { novu: novu as unknown as Adapter },
-        state: createMemoryState() as unknown as StateAdapter,
+        adapters: { novu },
+        state: createMemoryState(),
       });
 
       registerHandlers(chat);
       await chat.initialize();
 
-      return { chat, novu: novu as unknown as Adapter };
+      return { chat, novu };
     })();
   }
 

--- a/playground/nextjs/src/app/novu-agent/page.tsx
+++ b/playground/nextjs/src/app/novu-agent/page.tsx
@@ -119,6 +119,15 @@ export default function NovuAgentPlayground() {
           >
             🎴 Send a card reply
           </button>
+          <button
+            type="button"
+            onClick={() => run({ text: 'quote-reply', event: 'onMessage', ongoing: true })}
+            disabled={loading}
+            style={secondaryButtonStyle}
+            title="Uses thread.reply() and shows quoteReply.messageId in the ingest payload"
+          >
+            ↩️ Quote reply
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Implement `adapter.reply()` on `@novu/chat-sdk-adapter` so Chat SDK bridge agents can call `thread.reply()`
- Outbound ingest events include `quoteReply.messageId` for NV-8626 backend delivery (WhatsApp first)
- Add playground `quote-reply` demo trigger and README feature table row

## Test plan
- [x] `pnpm --filter @novu/chat-sdk-adapter test` — 43/43 passed
- [x] `pnpm --filter @novu/chat-sdk-adapter build`
- [ ] Playground: `/novu-agent` → **↩️ Quote reply** → verify captured ingest payload has `quoteReply.messageId`
- [ ] WhatsApp bridge agent: send message, trigger quote-reply handler, confirm quoted reply in channel


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds quoted-reply support to the Chat SDK adapter and a playground action that demonstrates the resulting ingest payload.

- Adds `NovuAdapterImpl.reply()` and shares outbound message construction with `postMessage()`.
- Includes `quoteReply.messageId` in agent message events for quoted replies.
- Adds a playground handler and UI trigger for exercising `thread.reply()`.
- Documents WhatsApp-first quote-reply support.

<h3>Confidence Score: 4/5</h3>

The implementation appears safe to merge, with a non-blocking gap in automated coverage for the new quoted-reply path.

The payload shape and platform-message identifier flow align with the existing protocol and WhatsApp consumer, but no integration test currently protects the newly added reply forwarding and serialization behavior.

**Files Needing Attention:** packages/chat-adapter/src/adapter.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/chat-adapter/src/adapter.ts | Adds the reply implementation and quote-reply event serialization; behavior is coherent but lacks focused integration coverage. |
| packages/chat-adapter/src/types.ts | Extends the outbound agent reply payload with the protocol-compatible optional quote-reply context. |
| playground/nextjs/src/app/api/novu-agent/agent.ts | Adds the quote-reply demo handler and removes unnecessary adapter and state casts. |
| playground/nextjs/src/app/novu-agent/page.tsx | Adds a playground button that invokes the quote-reply demonstration. |
| packages/chat-adapter/README.md | Documents WhatsApp-first support for thread.reply(). |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant Chat as Chat SDK thread
  participant Adapter as NovuAdapterImpl
  participant Ingest as Agent event ingest
  participant WhatsApp

  User->>Chat: Incoming platform message
  Chat->>Adapter: reply(threadId, platformMessageId, content)
  Adapter->>Ingest: message event + quoteReply.messageId
  Ingest->>WhatsApp: Deliver reply referencing messageId
  WhatsApp-->>User: Quoted reply
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312629%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12629&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fchat-adapter%2Fsrc%2Fadapter.ts%3A360-365%0A**Quoted%20replies%20lack%20coverage**%0A%0AThe%20new%20public%20%60reply%28%29%60%20path%20and%20its%20%60quoteReply.messageId%60%20serialization%20branch%20have%20no%20automated%20coverage.%20Existing%20integration%20coverage%20exercises%20only%20%60thread.post%28%29%60%2C%20so%20an%20argument-forwarding%20or%20payload-shape%20regression%20could%20pass%20the%20adapter%20suite%20while%20breaking%20quoted%20replies.%20Add%20an%20integration%20test%20that%20invokes%20%60thread.reply%28%29%60%20and%20asserts%20that%20the%20captured%20ingest%20event%20contains%20the%20quoted%20platform%20message%20ID%20while%20ordinary%20posts%20omit%20%60quoteReply%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12629&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/chat-adapter/src/adapter.ts:360-365
**Quoted replies lack coverage**

The new public `reply()` path and its `quoteReply.messageId` serialization branch have no automated coverage. Existing integration coverage exercises only `thread.post()`, so an argument-forwarding or payload-shape regression could pass the adapter suite while breaking quoted replies. Add an integration test that invokes `thread.reply()` and asserts that the captured ingest event contains the quoted platform message ID while ordinary posts omit `quoteReply`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(chat-sdk-adapter): implement thread..."](https://github.com/novuhq/novu/commit/ebb40598f059544861de5f51c448ffbfcdf602da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62630063)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->